### PR TITLE
docs: add travis badge + generator-talend local link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,11 @@
 That repository was created in an effort to simplify the development of Talend's
 front-end stack.
 
+[![Travis CI][travis-ci-image] ][travis-ci-url]
+
+[travis-ci-image]: https://travis-ci.org/Talend/ui.svg?branch=master
+[travis-ci-url]: https://travis-ci.org/Talend/ui
+
 ## Goals
 
 * Single code repository / Multiple packages
@@ -24,3 +29,7 @@ front-end stack.
 - [ ] Setup projects test
 - [ ] Setup projects storybooks
 - [ ] Setup [lerna-semantic-release](https://github.com/atlassian/lerna-semantic-release)
+
+## The stack
+
+- [generator-talend](https://github.com/Talend/ui/tree/master/generator)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

no badge to travis
no link to the generator talend

**What is the new behavior?**

badge to display current global status
link to access the documentation of generator-talend

