### PR TITLE
docs(theme): Adds theme to import list

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ front-end stack.
 - [ ] Import [react-flow-designer](https://github.com/Talend/react-flow-designer)
 - [ ] Import [icons](https://github.com/Talend/icons)
 - [ ] Import [react-talend-components](https://github.com/Talend/react-talend-components)
+- [ ] Import [bootstrap-theme](https://github.com/Talend/bootstrap-theme)
 - [ ] Import projects issues
 - [ ] Setup projects test
 - [ ] Setup projects storybooks


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

bootstrap-theme isn't mention on the import section of the README.

**What is the new behavior?**

bootstrap-theme is mention on the import section of the README.