### PR TITLE
Docs(contribution): added branch naming examples

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,14 @@ Here are the label definitions for this workflow (label name : color code) :
 * Need review                : #fef2c0
 * Reviewing                  : #fbca04
 
+#### Git branch naming example
+
+| Pull request title | Branch name |
+| ------------- |:-------------:|
+| feat(CMF): upgrade react-router to v4 | feat/cmf/router/upgrade-to-v4-ftw |
+| feat(CMF): upgrade react-router to v4 | feat/cmf/upgrade-router-to-v4-ftw |
+| feat(CMF): upgrade react-router to v4 | feat/upgrade-cmf-react-router-to-v4 |
+
 ## Git Commit Guidelines
 
 We have very precise rules over how our git commit messages can be formatted.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,11 +39,15 @@ Here are the label definitions for this workflow (label name : color code) :
 
 #### Git branch naming example
 
+General nomenclature:
+
+`{ * fix/feat/docs/... } / { optional packagename } / { optional subcomponent } / { * short description }`
+
 | Pull request title | Branch name |
 | ------------- |:-------------:|
-| feat(CMF): upgrade react-router to v4 | feat/cmf/router/upgrade-to-v4-ftw |
-| feat(CMF): upgrade react-router to v4 | feat/cmf/upgrade-router-to-v4-ftw |
-| feat(CMF): upgrade react-router to v4 | feat/upgrade-cmf-react-router-to-v4 |
+| feat(CMF): upgrade react-router to v4 | `feat/cmf/router/upgrade-to-v4-ftw` |
+| docs(contribution): added example of commit message | `docs/contibution/example-commit-msg` |
+| refactor(readme): removed duplicated readme | `refactor/remove-duped-readme` |
 
 ## Git Commit Guidelines
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format) github editor didn't give me option on commit message
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?**
No example in docs

**What is the new behavior?**
New example in docs for naming branches!

**Does this PR introduce a breaking change?**
- [x] No