### PR TITLE
fix(components/object-viewer): remove style on hover

### DIFF
--- a/packages/components/src/ObjectViewer/Table/Table.component.js
+++ b/packages/components/src/ObjectViewer/Table/Table.component.js
@@ -1,4 +1,5 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 import toFlat from '../toflat';
 import JSONLike from '../JSONLike';
 import theme from './Table.scss';
@@ -19,8 +20,14 @@ function Table({ flat, data, ...props }) {
 		return null;
 	}
 	const keys = getKeys(data[0], flat);
+	const tableClassName = classNames(
+		theme.table,
+		'tc-object-viewer',
+		'table table-bordered table-striped table-hover',
+	);
+
 	return (
-		<table className="tc-object-viewer table table-bordered table-striped table-hover">
+		<table className={tableClassName}>
 			<thead>
 				<tr>
 					{keys.map((key, index) => (<td key={index}>{key}</td>))}

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -1,3 +1,5 @@
-.tc-object-viewer.table-hover >tbody > tr:hover {
-	font-weight: initial;
+.table {
+	&:global(.table-hover) >tbody > tr:hover {
+		font-weight: initial;
+	}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

If you hover the table view you have font-weight increase to 700;
This behavior comes from table-hover of bootstrap theme.

<img width="867" alt="screen shot 2017-02-02 at 14 16 12" src="https://cloud.githubusercontent.com/assets/19857479/22550806/2fa0b11e-e952-11e6-8493-6b8f19f1aade.png">


**What is the new behavior?**

This effect is removed only for the case of ObjectViewer component.
