### PR TITLE
docs(README): Removes todo section

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,12 +15,6 @@ front-end stack.
 * Unified stack versions
 * Easy cross packages development
 
-## TODO
-
-- [ ] Import [react-flow-designer](https://github.com/Talend/react-flow-designer)
-- [ ] Setup projects test
-- [ ] Setup projects storybooks
-
 ## The stack
 
 - [react-cmf](https://github.com/Talend/ui/tree/master/cmf)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

The README has an outdated TODO section

**What is the new behavior?**

Removes TODO section since tests and storybooks are back.
Moves the import task to issues.