### PR TITLE
fix(containers/list): api call of action creator

### DIFF
--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -51,6 +51,7 @@ class List extends React.Component {
 	static contextTypes = {
 		store: PropTypes.object,
 		registry: PropTypes.object,
+		router: PropTypes.object,
 	};
 
 	constructor(props) {

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -97,7 +97,7 @@ class List extends React.Component {
 					api.action.getActionCreatorFunction(
 						this.context,
 						this.props.actions.title,
-					)(p.id),
+					)(event, p, this.context),
 				);
 			};
 		}

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -93,12 +93,12 @@ class List extends React.Component {
 		props.list.titleProps = get(this.props, 'list.titleProps');
 
 		if (props.list.titleProps) {
-			props.list.titleProps.onClick = (e, p) => {
+			props.list.titleProps.onClick = (event, data) => {
 				this.props.dispatch(
 					api.action.getActionCreatorFunction(
 						this.context,
 						this.props.actions.title,
-					)(e, p, this.context),
+					)(event, data, this.context),
 				);
 			};
 		}
@@ -117,16 +117,16 @@ class List extends React.Component {
 			if (props.toolbar.sort) {
 				props.toolbar.sort.isDescending = !state.sortAsc;
 				props.toolbar.sort.field = state.sortOn;
-				props.toolbar.sort.onChange = (e, p) => {
-					this.onSelectSortBy(e, p);
+				props.toolbar.sort.onChange = (event, data) => {
+					this.onSelectSortBy(event, data);
 				};
 			}
 
 			props.toolbar.filter = this.props.toolbar.filter;
 
 			if (props.toolbar.filter) {
-				props.toolbar.filter.onFilter = (e, p) => {
-					this.onFilter(e, p);
+				props.toolbar.filter.onFilter = (event, data) => {
+					this.onFilter(event, data);
 				};
 			}
 

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -98,7 +98,7 @@ class List extends React.Component {
 					api.action.getActionCreatorFunction(
 						this.context,
 						this.props.actions.title,
-					)(event, p, this.context),
+					)(e, p, this.context),
 				);
 			};
 		}

--- a/packages/containers/src/List/List.test.js
+++ b/packages/containers/src/List/List.test.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Provider } from 'react-cmf/lib/mock';
 import Immutable, { Map } from 'immutable';
 
 import Container, { DEFAULT_STATE } from './List.container';
@@ -37,7 +36,7 @@ const toolbar = {
 };
 
 const actions = {
-	// title: 'object:open',
+	title: 'object:open',
 	// left: ['object:add'],
 	// items: ['object:delete'],
 };
@@ -112,6 +111,33 @@ describe('Container List', () => {
 		, { lifecycleExperimental: true });
 		const props = wrapper.props();
 		expect(props.displayMode).toBe('large');
+	});
+
+	it('should ontitle click call action creator', () => {
+		const dispatch = jest.fn();
+		const actionCreator = jest.fn();
+		const context = {
+			registry: {
+				'actionCreator:object:open': actionCreator,
+			},
+		};
+		const wrapper = shallow(
+			<Container {...settings} items={items} dispatch={dispatch} />
+		, {
+			lifecycleExperimental: true,
+			context,
+		});
+		const props = wrapper.props();
+		const onClick = props.list.titleProps.onClick;
+		const e = {};
+		const data = { foo: 'bar' };
+
+		onClick(e, data);
+		const calls = actionCreator.mock.calls;
+		expect(calls.length).toBe(1);
+		expect(calls[0][0]).toBe(e);
+		expect(calls[0][1]).toBe(data);
+		expect(calls[0][2].registry).toBe(context.registry);
 	});
 });
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

The action creator on list title is called with only the id of the item

**What is the new behavior?**

it's called with event, data, context as all the other action creator.


**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...

If you have used it you just have to update your action creator

```javascript
function myactioncreator(id) {}
```

```javascript
function myactioncreator(event, data, context) {
  const id = data.id;
}
```

AFAIK only TFD is using it