### PR TITLE
chore(http-server): fix conditional execution

### DIFF
--- a/.travis/after_success_static.sh
+++ b/.travis/after_success_static.sh
@@ -33,7 +33,7 @@ echo "✓ Copy theme showcase to .static"
 
 find .static/
 
-if [ "$TRAVIS_PULL_REQUEST" == 'false' ] && [ "$TRAVIS_BRANCH" == 'master' ]; then
+if [ "$TRAVIS_BRANCH" != 'master' ]; then
 	nohup http-server .static/ -p 1337 >/dev/null 2>&1 &
 	sleep 5
 	echo "✓ Start static server"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
We ran static server only if we were on `master`, my bad.


**What is the new behavior?**
We run static server only if we are on PR.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No