### PR TITLE
fix: action structure should be in payload

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -1,0 +1,24 @@
+Before 1.0, the stack do NOT follow semver version in releases.
+
+This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
+
+## v0.61.0
+* Component: List
+* PR: [feat(List): filter dock mode](https://github.com/Talend/ui/pull/74)
+* Changes : props.toolbar.onFilter was taking (value, event) args, it's now aligned with other components (event, value)
+
+
+* Action structure must be in payload
+* [PR 135](https://github.com/Talend/ui/pull/135)
+* Changes:
+
+```
+                actions['menu:first'] = {
+                        label: 'First',
+                        icon: 'talend-streams',
+-                       type: 'MENU_TEST',
++                       payload: {
++                               type: 'MENU_',
++                       },
+                };
+```

--- a/packages/cmf/__tests__/action.test.js
+++ b/packages/cmf/__tests__/action.test.js
@@ -76,9 +76,9 @@ describe('CMF action', () => {
 		};
 		const action = actionAPI.getActionObject(context, id, event, data);
 		expect(typeof action).toBe('object');
-		expect(action.id).toBe('menu:article');
-		expect(action.name).toBe('My article');
-		expect(action.icon).toBe('icon-article');
+		expect(action.id).toBe();
+		expect(action.name).toBe();
+		expect(action.icon).toBe();
 		expect(action.data).toBe(data);
 		expect(action.event).toBe(event);
 		expect(action.context).toBe(context);

--- a/packages/cmf/__tests__/action.test.js
+++ b/packages/cmf/__tests__/action.test.js
@@ -76,9 +76,9 @@ describe('CMF action', () => {
 		};
 		const action = actionAPI.getActionObject(context, id, event, data);
 		expect(typeof action).toBe('object');
-		expect(action.id).toBe();
-		expect(action.name).toBe();
-		expect(action.icon).toBe();
+		expect(action.id).toBe(undefined);
+		expect(action.name).toBe(undefined);
+		expect(action.icon).toBe(undefined);
 		expect(action.data).toBe(data);
 		expect(action.event).toBe(event);
 		expect(action.context).toBe(context);

--- a/packages/cmf/src/action.js
+++ b/packages/cmf/src/action.js
@@ -80,7 +80,7 @@ function getActionObject(context, id, event, data) {
 			action,
 		});
 	}
-	return Object.assign({}, action, { event, data, context });
+	return Object.assign({}, action.payload, { event, data, context });
 }
 
 /**

--- a/packages/components/BREAKING_CHANGES_LOG.md
+++ b/packages/components/BREAKING_CHANGES_LOG.md
@@ -1,13 +1,5 @@
 # Breaking changes log
 
-Before 1.0, `react-talend-components` do NOT follow semver version in releases.
-This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
-
-## v0.61.0
-* Component: List
-* PR: [feat(List): filter dock mode](https://github.com/Talend/ui/pull/74)
-* Changes : props.toolbar.onFilter was taking (value, event) args, it's now aligned with other components (event, value)
-
 ## v0.46.1
 * Component: List
 * PR: [fix(List): revert list breaks](https://github.com/Talend/react-talend-components/pull/225)

--- a/packages/components/src/List/ItemTitle/ItemTitle.component.js
+++ b/packages/components/src/List/ItemTitle/ItemTitle.component.js
@@ -14,7 +14,7 @@ const ENTER_KEY = 13;
 function renderButton({ id, value, className, item, onClick }) {
 	const click = (event) => {
 		event.stopPropagation();
-		onClick(event, item);
+		onClick(event, { model: item });
 	};
 
 	return (

--- a/packages/components/src/List/ItemTitle/ItemTitle.test.js
+++ b/packages/components/src/List/ItemTitle/ItemTitle.test.js
@@ -35,7 +35,7 @@ describe('ItemTitle', () => {
 		// then
 		expect(props.titleProps.onClick).toBeCalled();
 		const callArgs = props.titleProps.onClick.mock.calls[0];
-		expect(callArgs[1]).toBe(item);
+		expect(callArgs[1].model).toBe(item);
 	});
 
 	it('should trigger callback on input title blur', () => {

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -12,11 +12,10 @@ const reducer = (state = {}, a) => {
 	return state;
 };
 
-function objectView(...args) {
-	return {
+function objectView(event, data) {
+	return Object.assign({
 		type: 'OBJECT_VIEW',
-		args,
-	};
+	}, data);
 }
 
 const registerActionCreator = api.action.registerActionCreator;
@@ -32,33 +31,45 @@ function loadStories() {
 		actions['menu:first'] = {
 			label: 'First',
 			icon: 'talend-streams',
-			type: 'MENU_',
+			payload: {
+				type: 'MENU_',
+			},
 		};
 		actions['menu:second'] = {
 			label: 'Second',
 			icon: 'talend-dataprep',
-			type: 'MENU_',
+			payload: {
+				type: 'MENU_',
+			},
 		};
 		actions['menu:third'] = {
 			label: 'Configuration',
 			icon: 'talend-cog',
-			type: 'MENU_',
+			payload: {
+				type: 'MENU_',
+			},
 		};
 		actions['object:add'] = {
 			label: 'Add',
 			icon: 'talend-plus',
-			type: 'APP_OBJECT_ADD',
 			bsStyle: 'success',
+			payload: {
+				type: 'APP_OBJECT_ADD',
+			},
 		};
 		actions['object:edit'] = {
 			label: 'Edit',
 			icon: 'talend-pencil',
-			type: 'APP_OBJECT_EDIT',
+			payload: {
+				type: 'APP_OBJECT_EDIT',
+			},
 		};
 		actions['object:delete'] = {
 			label: 'Delete',
 			icon: 'talend-trash',
-			type: 'APP_OBJECT_DELETE',
+			payload: {
+				type: 'APP_OBJECT_DELETE',
+			},
 		};
 
 		const story = storiesOf(example);

--- a/packages/containers/examples/ExampleAction.js
+++ b/packages/containers/examples/ExampleAction.js
@@ -6,8 +6,10 @@ import { Action } from '../src';
 const myAction = {
 	label: 'Click me',
 	icon: 'talend-cog',
-	type: 'MY SUPER REDUX ACTION',
 	onClick: stAction('You clicked me'),
+	payload: {
+		type: 'MY SUPER REDUX ACTION',
+	},
 };
 
 export default function ExampleAction() {

--- a/packages/containers/src/Action/Action.component.js
+++ b/packages/containers/src/Action/Action.component.js
@@ -9,7 +9,7 @@ import { api } from 'react-cmf';
  */
 function Action({ name, ...rest }, context) {
 	const onClick = (event, payload) => {
-		context.store.dispatch(payload.action);
+		context.store.dispatch(payload.action.payload);
 	};
 	if (name) {
 		const action = api.action.getActionInfo(context, name);

--- a/packages/containers/src/Actions/Actions.component.js
+++ b/packages/containers/src/Actions/Actions.component.js
@@ -9,7 +9,7 @@ import { Actions as PureActions } from 'react-talend-components';
  */
 function Actions({ names, ...rest }, context) {
 	const onClick = (event, payload) => {
-		context.store.dispatch(payload.action);
+		context.store.dispatch(payload.action.payload);
 	};
 	const actions = names ? names.map(
 		name => api.action.getActionInfo(context, name),

--- a/packages/containers/src/SidePanel/SidePanel.container.js
+++ b/packages/containers/src/SidePanel/SidePanel.container.js
@@ -36,7 +36,7 @@ class SidePanel extends React.Component {
 		const { actionIds = [], state = DEFAULT_STATE, ...rest } = this.props;
 		const actions = actionIds.map((id) => {
 			const info = api.action.getActionInfo(this.context, id);
-			info.onClick = () => this.context.store.dispatch(info);
+			info.onClick = () => this.context.store.dispatch(info.payload);
 			if (info.cmf) {
 				if (info.cmf.routerReplace) {
 					const route = info.cmf.routerReplace;

--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -8,7 +8,9 @@ export function getActionProps(context, id) {
 				api.action.getActionObject(context, id, event, data)
 			);
 		} else {
-			context.store.dispatch(info);
+			context.store.dispatch(Object.assign({
+				model: info.model,
+			}, info.payload));
 		}
 	};
 	return info;
@@ -27,7 +29,9 @@ export function getActionsProps(context, ids, model) {
 					api.action.getActionObject(context, a.id, event, data)
 				);
 			} else {
-				context.store.dispatch(a);
+				context.store.dispatch(Object.assign({
+					model: a.model,
+				}, a.payload));
 			}
 		};
 	});

--- a/packages/containers/src/mock.settings.json
+++ b/packages/containers/src/mock.settings.json
@@ -10,7 +10,9 @@
             "id": "add",
             "icon":"icon-add-botton-3",
             "name": "Add article",
-            "type": "form/DISPLAY_FORM"
+            "payload": {
+              "type": "form/DISPLAY_FORM"
+            }
           }
         ],
         "primary":[
@@ -18,13 +20,17 @@
             "id": "edit",
             "icon":"icon-edit",
             "name": "Edit article",
-            "type": "form/DISPLAY_FORM"
+            "payload": {
+              "type": "form/DISPLAY_FORM"
+            }
           },
           {
             "id": "delete",
             "icon":"icon-delete",
             "name": "Delete article",
-            "type": "DELETE"
+            "payload": {
+              "type": "form/DISPLAY_FORM"
+            }
           }
         ]
       }
@@ -36,10 +42,12 @@
       "name":"My article",
       "icon": "icon-article",
       "available": "model.actions.delete",
-      "type":"@@router/CALL_HISTORY_METHOD",
       "payload":{
+        "type":"@@router/CALL_HISTORY_METHOD",
+        "payload": {
           "method": "push",
           "args":["/myarticle"]
+        }
       }
     }
   },


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

all action props are spread on the button tag... but type exists on a button.
So we have warning to said button type is invalid.
This also has an other problem we don't know what to dispatch so we also dispatch stuff like icon, ... button props in redux.

**What is the new behavior?**

put all action data in the payload attribute

action has special attributes
* actionCreator
* model
* payload (new, has the type for redux, and all static stuff)

**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
