### PR TITLE
fix(form): add control-label to the label

### DIFF
--- a/packages/forms/__tests__/__snapshots__/Form.test.js.snap
+++ b/packages/forms/__tests__/__snapshots__/Form.test.js.snap
@@ -34,6 +34,7 @@ exports[`<Form/> <Form actions/> Renders form with custom css 1`] = `
           type="text"
           value="John Doe" />
         <label
+          className="control-label"
           htmlFor="root_name">
           Name
         </label>
@@ -68,6 +69,7 @@ exports[`<Form/> <Form actions/> Renders form with custom css 1`] = `
           </option>
         </select>
         <label
+          className="control-label"
           htmlFor="root_roles">
           roles
         </label>

--- a/packages/forms/src/templates/FieldTemplate.js
+++ b/packages/forms/src/templates/FieldTemplate.js
@@ -38,7 +38,7 @@ const CustomFieldTemplate = ({
 			<Label className="form-label" label={label} required={required} id={id} />}
 			{children}
 			{!hasLabelBefore && !isToggle && displayLabel &&
-			<Label label={label} required={required} id={id} />}
+			<Label label={label} required={required} id={id} className="control-label" />}
 			{displayLabel && description ? description : null}
 			{errors}
 			{help}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [X] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
The label is not red when the form has an error.


**What is the new behavior?**

![screenshot](http://img11.hostingpics.net/pics/446200labelerror.png)
The label is now red when the form has an error to highlight the error. This change is approved by Maxime. The guidelines will be updated with this change.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [X] No

**Other information**:
