### PR TITLE
fix(containers/notifications): add reducer

### DIFF
--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -45,6 +45,7 @@
     "babel-preset-react": "^6.11.1",
     "bootstrap-sass": "^3.3.7",
     "bootstrap-talend-theme": "^0.63.0",
+    "bson-objectid": "^1.1.5",
     "classnames": "2",
     "codacy-coverage": "^2.0.0",
     "cpx": "^1.5.0",
@@ -103,8 +104,8 @@
     "react": "^15.4.2",
     "react-bootstrap": "0",
     "react-cmf": "^0.63.0",
-    "react-talend-components": "^0.63.0",
     "react-redux": "^4.4.6",
+    "react-talend-components": "^0.63.0",
     "reselect": "^2.5.4"
   },
   "dependencies": {},

--- a/packages/containers/src/Notification/Notification.container.js
+++ b/packages/containers/src/Notification/Notification.container.js
@@ -2,7 +2,7 @@ import React, { PropTypes } from 'react';
 import { List, Map } from 'immutable';
 import { Notification as Component } from 'react-talend-components';
 
-import { statePropTypes, stateWillMount } from '../state';
+import { statePropTypes, initState } from '../state';
 
 export const DEFAULT_STATE = new Map({
 	notifications: new List(),
@@ -15,8 +15,8 @@ class Notification extends React.Component {
 		...statePropTypes,
 	};
 
-	componentWillMount() {
-		stateWillMount(this.props);
+	componentDidMount() {
+		initState(this.props);
 	}
 
 	render() {

--- a/packages/containers/src/Notification/Notification.test.js
+++ b/packages/containers/src/Notification/Notification.test.js
@@ -62,4 +62,16 @@ describe('Notification.pushNotification', () => {
 		expect(notifications.size).toBe(1);
 		expect(notifications.get(0).message).toBe('hello world');
 	});
+	it('should change the state if no notification', () => {
+		const state = store.state();
+		state.cmf.components = fromJS({
+			Notification: {
+				Notification: {
+					notifications: [],
+				},
+			},
+		});
+		const newState = pushNotification(state);
+		expect(newState).toBe(state);
+	});
 });

--- a/packages/containers/src/Notification/Notification.test.js
+++ b/packages/containers/src/Notification/Notification.test.js
@@ -1,13 +1,13 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Provider } from 'react-cmf/lib/mock';
-import { Map } from 'immutable';
-
+import { store, Provider } from 'react-cmf/lib/mock';
+import { fromJS, Map } from 'immutable';
 import Container, { DEFAULT_STATE } from './Notification.container';
 import Connected, {
 	mapDispatchToProps,
 	mapStateToProps,
 } from './Notification.connect';
+import pushNotification from './pushNotification';
 
 describe('Container Notification', () => {
 	it('should render', () => {
@@ -45,3 +45,21 @@ describe('Connected Notification', () => {
 	});
 });
 
+describe('Notification.pushNotification', () => {
+	it('should add a Notification in the state', () => {
+		const state = store.state();
+		state.cmf.components = fromJS({
+			Notification: {
+				Notification: {
+					notifications: [],
+				},
+			},
+		});
+		const notification = { message: 'hello world' };
+		const newState = pushNotification(state, notification);
+		expect(newState).not.toBe(state);
+		const notifications = newState.cmf.components.getIn(['Notification', 'Notification', 'notifications']);
+		expect(notifications.size).toBe(1);
+		expect(notifications.get(0).message).toBe('hello world');
+	});
+});

--- a/packages/containers/src/Notification/index.js
+++ b/packages/containers/src/Notification/index.js
@@ -1,3 +1,15 @@
+import objectId from 'bson-objectid';
 import Notification from './Notification.connect';
+
+Notification.push = function pushNotification(state, notification) {
+	const path = ['Notification', 'Notification', 'notifications'];
+	let notifs = state.cmf.components.getIn(path);
+	notifs = notifs.push(Object.assign({
+		id: objectId(),
+	}, notification));
+	const newState = Object.assign({}, state);
+	newState.cmf.components = state.cmf.components.setIn(path, notifs);
+	return newState;
+};
 
 export default Notification;

--- a/packages/containers/src/Notification/index.js
+++ b/packages/containers/src/Notification/index.js
@@ -1,15 +1,5 @@
-import objectId from 'bson-objectid';
 import Notification from './Notification.connect';
+import pushNotification from './pushNotification';
 
-Notification.push = function pushNotification(state, notification) {
-	const path = ['Notification', 'Notification', 'notifications'];
-	let notifs = state.cmf.components.getIn(path);
-	notifs = notifs.push(Object.assign({
-		id: objectId(),
-	}, notification));
-	const newState = Object.assign({}, state);
-	newState.cmf.components = state.cmf.components.setIn(path, notifs);
-	return newState;
-};
-
+Notification.push = pushNotification;
 export default Notification;

--- a/packages/containers/src/Notification/pushNotification.js
+++ b/packages/containers/src/Notification/pushNotification.js
@@ -1,7 +1,8 @@
+import get from 'lodash/get';
 import objectId from 'bson-objectid';
 
 export default function pushNotification(state, notification) {
-	if (!notification.message) {
+	if (!get(notification, 'message')) {
 		return state;
 	}
 	const path = ['Notification', 'Notification', 'notifications'];

--- a/packages/containers/src/Notification/pushNotification.js
+++ b/packages/containers/src/Notification/pushNotification.js
@@ -1,0 +1,15 @@
+import objectId from 'bson-objectid';
+
+export default function pushNotification(state, notification) {
+	if (!notification.message) {
+		return state;
+	}
+	const path = ['Notification', 'Notification', 'notifications'];
+	let notifs = state.cmf.components.getIn(path);
+	notifs = notifs.push(Object.assign({
+		id: objectId(),
+	}, notification));
+	const newState = Object.assign({}, state);
+	newState.cmf.components = state.cmf.components.setIn(path, notifs);
+	return newState;
+}

--- a/packages/containers/yarn.lock
+++ b/packages/containers/yarn.lock
@@ -1263,9 +1263,9 @@ bootstrap-sass@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.61.4:
-  version "0.61.4"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.61.4.tgz#57d1b607c52d49c9b5497d3a901a748f31df9edc"
+bootstrap-talend-theme@^0.63.0:
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.63.0.tgz#8b8cf04e6a36776cce9d338773562e5880ae56af"
   dependencies:
     bootstrap-sass "^3.3.7"
 
@@ -1319,6 +1319,10 @@ bser@^2.0.0:
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.0.0.tgz#9ac78d3ed5d915804fd87acb158bc797147a1719"
   dependencies:
     node-int64 "^0.4.0"
+
+bson-objectid@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bson-objectid/-/bson-objectid-1.1.5.tgz#4b9e210a98c1c4eaa9edf63aca0784cb30b79b5e"
 
 buffer-shims@^1.0.0:
   version "1.0.0"
@@ -1834,13 +1838,13 @@ csso@~2.2.1:
     clap "^1.0.9"
     source-map "^0.5.3"
 
-cssom@0.3.x, "cssom@>= 0.3.0 < 0.4.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.1.tgz#c9e37ef2490e64f6d1baa10fda852257082c25d3"
-
-"cssom@>= 0.3.2 < 0.4.0":
+cssom@0.3.x, "cssom@>= 0.3.2 < 0.4.0":
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.2.tgz#b8036170c79f07a90ff2f16e22284027a243848b"
+
+"cssom@>= 0.3.0 < 0.4.0":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/cssom/-/cssom-0.3.1.tgz#c9e37ef2490e64f6d1baa10fda852257082c25d3"
 
 "cssstyle@>= 0.2.36 < 0.3.0", "cssstyle@>= 0.2.37 < 0.3.0":
   version "0.2.37"
@@ -3244,18 +3248,7 @@ istanbul-lib-hook@^1.0.0-alpha:
   dependencies:
     append-transform "^0.3.0"
 
-istanbul-lib-instrument@^1.0.0-alpha, istanbul-lib-instrument@^1.1.1, istanbul-lib-instrument@^1.1.4:
-  version "1.1.4"
-  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.4.tgz#95be56e5c321456ffdfddc925ad4dcfc28edab9c"
-  dependencies:
-    babel-generator "^6.11.3"
-    babel-template "^6.9.0"
-    babel-traverse "^6.9.0"
-    babel-types "^6.10.2"
-    babylon "^6.8.1"
-    istanbul-lib-coverage "^1.0.0"
-
-istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.4.2:
+istanbul-lib-instrument@^1.0.0-alpha, istanbul-lib-instrument@^1.1.4, istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.4.2:
   version "1.4.2"
   resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.4.2.tgz#0e2fdfac93c1dabf2e31578637dc78a19089f43e"
   dependencies:
@@ -3266,6 +3259,17 @@ istanbul-lib-instrument@^1.3.0, istanbul-lib-instrument@^1.4.2:
     babylon "^6.13.0"
     istanbul-lib-coverage "^1.0.0"
     semver "^5.3.0"
+
+istanbul-lib-instrument@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/istanbul-lib-instrument/-/istanbul-lib-instrument-1.1.4.tgz#95be56e5c321456ffdfddc925ad4dcfc28edab9c"
+  dependencies:
+    babel-generator "^6.11.3"
+    babel-template "^6.9.0"
+    babel-traverse "^6.9.0"
+    babel-types "^6.10.2"
+    babylon "^6.8.1"
+    istanbul-lib-coverage "^1.0.0"
 
 istanbul-lib-report@^1.0.0-alpha, istanbul-lib-report@^1.0.0-alpha.3:
   version "1.0.0-alpha.3"
@@ -3725,14 +3729,14 @@ js-tokens@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-2.0.0.tgz#79903f5563ee778cc1162e6dcf1a0027c97f9cb5"
 
-js-yaml@3.x, js-yaml@^3.4.3, js-yaml@^3.5.1, js-yaml@~3.6.1:
+js-yaml@3.x, js-yaml@^3.5.1, js-yaml@~3.6.1:
   version "3.6.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.6.1.tgz#6e5fe67d8b205ce4d22fad05b7781e8dadcc4b30"
   dependencies:
     argparse "^1.0.7"
     esprima "^2.6.0"
 
-js-yaml@^3.7.0:
+js-yaml@^3.4.3, js-yaml@^3.7.0:
   version "3.8.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.8.1.tgz#782ba50200be7b9e5a8537001b7804db3ad02628"
   dependencies:
@@ -5248,9 +5252,9 @@ react-bootstrap@^0.30.7:
     uncontrollable "^4.0.1"
     warning "^3.0.0"
 
-react-cmf@^0.61.4:
-  version "0.61.4"
-  resolved "https://registry.yarnpkg.com/react-cmf/-/react-cmf-0.61.4.tgz#59db47dfaf0ae1ac9defd83d29bf92931c4ea029"
+react-cmf@^0.63.0:
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/react-cmf/-/react-cmf-0.63.0.tgz#92a9487e8192412f07a85660cb3d267d69132578"
 
 react-debounce-input@^2.4.2:
   version "2.4.2"
@@ -5387,9 +5391,9 @@ react-stubber@^1.0.0:
   dependencies:
     babel-runtime "^6.5.0"
 
-react-talend-components@^0.61.4:
-  version "0.61.4"
-  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.61.4.tgz#71106605d82995e2d1ae326d203acb540fb481f9"
+react-talend-components@^0.63.0:
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.63.0.tgz#9098c193a7cf8a4ef5f3b2a87b7a4d0bfc2b1a2a"
   dependencies:
     lodash "^4.17.4"
     react-autowhatever "^7.0.0"
@@ -6125,9 +6129,9 @@ taffydb@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
-talend-icons@^0.61.4:
-  version "0.61.4"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.61.4.tgz#7633b4d0e13825364b9ba429c3999cd971f3c1e4"
+talend-icons@^0.63.0:
+  version "0.63.0"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.63.0.tgz#5f9edc328964b81d9198c884dd8324a7a972e981"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

If you want to use Notification you have to write your own reducer and know the structure.

**What is the new behavior?**

just import the component and use the reducer

```javascript
import { Notification } from 'react-talend-containers';

...

Notification.push(state, { message: 'hello world' });
```


**Does this PR introduce a breaking change?**

- [x] Yes
- [ ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...

You have a new peer depednencies : 'bson-objectid'
