### PR TITLE
fix(container): clearing the search input when clicking on remove filter

### DIFF
--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -83,7 +83,11 @@ class List extends React.Component {
 	}
 
 	onToggle() {
-		this.props.updateState({ filterDocked: !this.props.state.get('filterDocked') });
+		// clearing filter when toggle
+		this.props.updateState({
+			filterDocked: !this.props.state.get('filterDocked'),
+			searchQuery: '',
+		});
 	}
 
 	onSelectDisplayMode(event, payload) {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
When clicking on remove filter it was only modifying the visibility of the input. In addition, the filter was still in place.


**What is the new behavior?**
Now whether the search in toolbar is toggled, the filter is cleared.


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
