### PR TITLE
fix(component): adding esc key management in filter keydown

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.63.1 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.64.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.63.1 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.64.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/packages/components/src/List/Toolbar/Filter/Filter.component.js
+++ b/packages/components/src/List/Toolbar/Filter/Filter.component.js
@@ -16,6 +16,11 @@ function onKeyDown(event, escAction, enterAction) {
 			enterAction(event);
 		}
 		break;
+	case keycode.codes.esc:
+		if (escAction) {
+			escAction(event);
+		}
+		break;
 	default:
 		break;
 	}

--- a/packages/components/src/List/Toolbar/Filter/Filter.test.js
+++ b/packages/components/src/List/Toolbar/Filter/Filter.test.js
@@ -5,13 +5,16 @@ import Filter from './Filter.component';
 
 jest.useFakeTimers();
 
-const defaultProps = {
-	docked: false,
-	onBlur: jest.fn(),
-	onFilter: jest.fn(),
-	onToggle: jest.fn(),
-	ref: 'inputFilter',
-};
+let defaultProps = {};
+beforeEach(() => {
+	defaultProps = {
+		docked: false,
+		onBlur: jest.fn(),
+		onFilter: jest.fn(),
+		onToggle: jest.fn(),
+		ref: 'inputFilter',
+	};
+});
 
 describe('Filter', () => {
 	it('should call onToggle on search icon click', () => {
@@ -55,7 +58,7 @@ describe('Filter', () => {
 		expect(props.onFilter).toBeCalled();
 	});
 
-	it('should call onToggle on input blur', () => {
+	it('should call onBlur on input blur', () => {
 		// given
 		const props = { ...defaultProps };
 		const filterInstance = mount(<Filter {...props} />);
@@ -64,7 +67,7 @@ describe('Filter', () => {
 		filterInstance.find('input').simulate('blur');
 
 		// then
-		expect(props.onToggle).toBeCalled();
+		expect(props.onBlur).toBeCalled();
 	});
 
 	it('should call onToggle on ESC keydown', () => {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
There was no management of esc key, the test was there to check it but there was an issue with the fact that the defaultProps was initialized at the begining of all test so the jest function were the same for all the test.


**What is the new behavior?**
The test were fixed and the esc key was added to the keydown event


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x ] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
