### PR TITLE
fix(cmf): import collection reducer from default

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.66.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.66.1 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.66.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.66.1 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.66.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.66.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.66.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.66.1 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.66.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.66.1 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.66.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.66.1 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.66.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.66.1 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.66.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.66.1 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/cmf/src/reducers/index.js
+++ b/packages/cmf/src/reducers/index.js
@@ -6,7 +6,7 @@
  */
 import { combineReducers } from 'redux';
 
-import { collectionsReducers } from './collectionsReducers';
+import collectionsReducers from './collectionsReducers';
 import { componentsReducers } from './componentsReducers';
 import { settingsReducers } from './settingsReducers';
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

The current collection reducer is undefined. Only a console.error is printed ... (thanks redux)
<img width="656" alt="screen shot 2017-03-15 at 15 11 57" src="https://cloud.githubusercontent.com/assets/19857479/23953178/1bd9d518-0994-11e7-947c-a383c45f3afa.png">

**What is the new behavior?**

fix the import path


**Does this PR introduce a breaking change?**

- [x] No
