### PR TITLE
fix(components/List): set max width

### DIFF
--- a/packages/components/.storybook/head.html
+++ b/packages/components/.storybook/head.html
@@ -13,11 +13,6 @@
         background: #ff69b4;
     }
 
-    .tc-list-fixed-name-column .tc-list-display-table tr > td:first-child + td {
-        width: 400px;
-        max-width: 400px;
-    }
-
     .tc-list-small-container {
         height: 200px;
     }

--- a/packages/components/src/List/DisplayTable/DisplayTable.scss
+++ b/packages/components/src/List/DisplayTable/DisplayTable.scss
@@ -89,6 +89,7 @@ $tc-list-table-header-height: 36px !default;
 		.tc-list-display-table-td {
 			display: flex;
 			position: relative;
+			max-width: 300px;
 
 			.cell {
 				flex-shrink: 1;
@@ -114,7 +115,7 @@ $tc-list-table-header-height: 36px !default;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			white-space: nowrap;
-			display: inline-block;
+			display: inherit;
 		}
 	}
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

<img width="1139" alt="screen shot 2017-03-21 at 16 11 16" src="https://cloud.githubusercontent.com/assets/19857479/24154297/0ecf42ec-0e51-11e7-8136-3c83ce0d824c.png">
<img width="1136" alt="screen shot 2017-03-21 at 16 11 23" src="https://cloud.githubusercontent.com/assets/19857479/24154298/0f380dc2-0e51-11e7-99f3-69874afbc7dc.png">

You need to set the max width in your project (it was in the story head.html)

**What is the new behavior?**

no more custom set in the head.html, the list is setting the max-width it self.

<img width="1131" alt="screen shot 2017-03-21 at 16 11 49" src="https://cloud.githubusercontent.com/assets/19857479/24154319/1ea92e9e-0e51-11e7-97ab-5a47be092ba1.png">


**Does this PR introduce a breaking change?**

- [x] No
