### PR TITLE
fix(container): fixing confirm dialog state path

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.66.2 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.66.3 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.66.2 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.66.3 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.66.2 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.66.3 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.66.2 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.66.3 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.66.2 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.66.3 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.66.2 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.66.3 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.66.2 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.66.3 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.66.2 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.66.3 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/containers/src/ConfirmDialog/ConfirmDialog.test.js
+++ b/packages/containers/src/ConfirmDialog/ConfirmDialog.test.js
@@ -73,7 +73,8 @@ describe('ConfirmDialog.show/hide', () => {
 
 		const newState = showConfirmDialog(state, action);
 		expect(newState).not.toBe(state);
-		const confirmDialoVisibility = newState.cmf.components.getIn(['ConfirmDialog', 'ConfirmDialog', 'show']);
+		const confirmDialoVisibility =
+			newState.cmf.components.getIn(['CMFContainer(ConfirmDialog)', 'ConfirmDialog', 'show']);
 		expect(confirmDialoVisibility).toBeTruthy();
 	});
 
@@ -89,7 +90,8 @@ describe('ConfirmDialog.show/hide', () => {
 
 		const newState = hideConfirmDialog(state);
 		expect(newState).not.toBe(state);
-		const confirmDialogVisibility = newState.cmf.components.getIn(['ConfirmDialog', 'ConfirmDialog', 'show']);
+		const confirmDialogVisibility =
+			newState.cmf.components.getIn(['CMFContainer(ConfirmDialog)', 'ConfirmDialog', 'show']);
 		expect(confirmDialogVisibility).toBeFalsy();
 	});
 });

--- a/packages/containers/src/ConfirmDialog/showHideConfirmDialog.js
+++ b/packages/containers/src/ConfirmDialog/showHideConfirmDialog.js
@@ -1,6 +1,6 @@
 export function showConfirmDialog(state, action) {
 	// adding conf and showing modal
-	const path = ['ConfirmDialog', 'ConfirmDialog'];
+	const path = ['CMFContainer(ConfirmDialog)', 'ConfirmDialog'];
 	const newState = { ...state };
 	newState.cmf.components = state.cmf.components.setIn(
 		path,
@@ -11,7 +11,7 @@ export function showConfirmDialog(state, action) {
 
 export function hideConfirmDialog(state) {
 	// hiding the modal
-	const path = ['ConfirmDialog', 'ConfirmDialog', 'show'];
+	const path = ['CMFContainer(ConfirmDialog)', 'ConfirmDialog', 'show'];
 	const newState = { ...state };
 	newState.cmf.components = state.cmf.components.setIn(path, false);
 	return newState;


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
as the state path is now different when using cmfConnect, there was an issue while trying to access to the previous confirm dialog path


**What is the new behavior?**
it now works again


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
