### PR TITLE
feat(ActionDropdown): add icon to menu item

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -16,6 +16,7 @@ import Icon from '../../Icon';
 	icon: 'fa fa-file-excel-o',
 	items: [
 		{
+			icon: 'talend-icon',
 			label: 'document 1',
 			onClick: action('document 1 click'),
 		},
@@ -62,6 +63,7 @@ function ActionDropdown(props) {
 				items.length ?
 					items.map((item, index) => (
 						<MenuItem {...item} key={index}>
+							{item.icon && (<Icon name={item.icon} />)}
 							{item.label}
 						</MenuItem>
 					)) : (<MenuItem disabled>No options</MenuItem>)
@@ -85,6 +87,7 @@ ActionDropdown.propTypes = {
 	hideLabel: PropTypes.bool,
 	icon: PropTypes.string,
 	items: PropTypes.arrayOf(PropTypes.shape({
+		icon: PropTypes.string,
 		label: PropTypes.string,
 		...MenuItem.propTypes,
 	})).isRequired,

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
@@ -7,6 +7,7 @@ jest.mock('react-dom');
 
 const items = [
 	{
+		icon: 'talend-icon',
 		label: 'document 1',
 		onClick: jest.fn(),
 	},

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
@@ -86,12 +86,22 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
     >
       <a
         href="#"
+        icon="talend-icon"
         label="document 1"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
         tabIndex="-1"
       >
+        <svg
+          aria-hidden="true"
+          className="tc-svg-icon"
+          title={null}
+        >
+          <use
+            xlinkHref="#talend-icon"
+          />
+        </svg>
         document 1
       </a>
     </li>
@@ -159,12 +169,22 @@ exports[`ActionDropdown should render a button with icon 1`] = `
     >
       <a
         href="#"
+        icon="talend-icon"
         label="document 1"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
         tabIndex="-1"
       >
+        <svg
+          aria-hidden="true"
+          className="tc-svg-icon"
+          title={null}
+        >
+          <use
+            xlinkHref="#talend-icon"
+          />
+        </svg>
         document 1
       </a>
     </li>
@@ -230,12 +250,22 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
     >
       <a
         href="#"
+        icon="talend-icon"
         label="document 1"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
         tabIndex="-1"
       >
+        <svg
+          aria-hidden="true"
+          className="tc-svg-icon"
+          title={null}
+        >
+          <use
+            xlinkHref="#talend-icon"
+          />
+        </svg>
         document 1
       </a>
     </li>
@@ -296,12 +326,22 @@ exports[`ActionDropdown should render a button with label 1`] = `
     >
       <a
         href="#"
+        icon="talend-icon"
         label="document 1"
         onClick={[Function]}
         onKeyDown={[Function]}
         role="menuitem"
         tabIndex="-1"
       >
+        <svg
+          aria-hidden="true"
+          className="tc-svg-icon"
+          title={null}
+        >
+          <use
+            xlinkHref="#talend-icon"
+          />
+        </svg>
         document 1
       </a>
     </li>

--- a/packages/components/stories/ActionDropdown.js
+++ b/packages/components/stories/ActionDropdown.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
 
-import { ActionDropdown } from '../src/index';
+import { ActionDropdown, IconsProvider } from '../src/index';
 
 const myAction = {
 	id: 'context-dropdown-related-items',
 	label: 'related items',
-	icon: 'fa fa-file-excel-o',
+	icon: 'talend-file-xls-o',
 	items: [
 		{
 			id: 'context-dropdown-item-document-1',
+			icon: 'talend-file-json-o',
 			label: 'document 1',
 			onClick: action('document 1 click'),
 		},
@@ -43,5 +44,6 @@ storiesOf('ActionDropdown', module)
 					hideLabel
 				/>
 			</div>
+			<IconsProvider />
 		</div>
 	));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

No possibility to add icon to dropdown's menu item

**What is the new behavior?**

There is possible to add icon to droopdown's menu item

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
