### PR TITLE
fix(components/treeview): badge invisible on depth>1

### DIFF
--- a/packages/components/src/TreeView/TreeView.component.js
+++ b/packages/components/src/TreeView/TreeView.component.js
@@ -16,7 +16,6 @@ import theme from './TreeView.scss';
  * @param addActionLabel optional, specifies tooltip label for 'add' button
  * @param itemSelectCallback required, tree item click event callback function
  * @param itemToggleCallback required, tree item expand/collapse event callback function
- * @param showCounter optional, flags that counter badge should be displayed
  *
  * const defaultProps = {
  * 	structure: [{
@@ -52,7 +51,6 @@ const TreeView = ({
 	addActionLabel,
 	itemSelectCallback,
 	itemToggleCallback,
-	showCounter,
 }) => (
 	<div className={theme['tc-treeview']}>
 		<header className={theme['tc-treeview-header']}>
@@ -75,7 +73,6 @@ const TreeView = ({
 					item={item}
 					itemSelectCallback={itemSelectCallback}
 					itemToggleCallback={itemToggleCallback}
-					showCounter={showCounter}
 					key={i}
 				/>)}
 			</ul>
@@ -91,7 +88,6 @@ TreeView.propTypes = {
 	addActionLabel: PropTypes.string,
 	itemSelectCallback: PropTypes.func.isRequired,
 	itemToggleCallback: PropTypes.func.isRequired,
-	showCounter: PropTypes.bool,
 };
 
 TreeView.defaultProps = {

--- a/packages/components/src/TreeView/TreeView.test.js
+++ b/packages/components/src/TreeView/TreeView.test.js
@@ -27,13 +27,13 @@ const defaultProps = {
 		],
 		toggled: true,
 		counter: 101,
+		showCounter: true,
 	}],
 	headerText: 'some elements',
 	addAction: () => null,
 	addActionLabel: 'add element',
 	itemSelectCallback: () => null,
 	itemToggleCallback: () => null,
-	showCounter: true,
 };
 
 describe('TreeView', () => {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -19,7 +19,6 @@ function getActionHandler(func, item) {
  * @param id, for qa purposes
  * @param item required, item to display
  * 		  item.actions optional, array with actions' to be displayed meta-info
- * @param showCounter optional, flags that counter badge should be shown
  * @param itemSelectCallback required, callback function to trigger once item was clicked
  * @param itemToggleCallback required, callback function to trigger once item was clicked
  * @param depth optional, depth of an item in a tree
@@ -30,7 +29,6 @@ function getActionHandler(func, item) {
 function TreeViewItem({
 	id,
 	item,
-	showCounter,
 	depth = 0,
 	itemSelectCallback,
 	itemToggleCallback,
@@ -41,6 +39,7 @@ function TreeViewItem({
 		hidden,
 		name,
 		children = [],
+		showCounter,
 		actions,
 		icon = 'talend-folder',
 		counter = children.length,
@@ -121,10 +120,10 @@ TreeViewItem.propTypes = {
 			icon: PropTypes.string,
 		})),
 		counter: PropTypes.number,
+		showCounter: PropTypes.bool,
 	}).isRequired,
 	itemSelectCallback: PropTypes.func.isRequired,
 	itemToggleCallback: PropTypes.func.isRequired,
-	showCounter: PropTypes.bool,
 	depth: PropTypes.number,
 };
 

--- a/packages/components/stories/TreeView.js
+++ b/packages/components/stories/TreeView.js
@@ -27,16 +27,17 @@ const structure = [
 const structureWithActions = [
 	{
 		name: 'hitmonlee',
-		toggled: false,
+		toggled: true,
 		actions: [{
 			action: action('itemRemoveCallback'),
 			icon: 'talend-trash',
 			label: 'remove element',
 		}],
-		children: [{ name: 'raichu' }],
-		counter: 0,
+		children: [{ name: 'raichu', showCounter: true, counter: 111 }],
+		counter: -1,
+		showCounter: true,
 	},
-	{ name: 'pikachu', toggled: true, counter: 911 },
+	{ name: 'pikachu', toggled: true, counter: 911, showCounter: true },
 ];
 
 const defaultProps = {
@@ -118,11 +119,6 @@ cornerCaseLongName.structure = [{
 	toggled: true,
 }];
 
-const withCounter = {
-	...withRemoval,
-	showCounter: true,
-};
-
 const style = { width: '300px', border: '1px solid #eee', marginLeft: '10px' };
 
 storiesOf('TreeView', module)
@@ -168,7 +164,7 @@ storiesOf('TreeView', module)
 			</div>
 		</div>
 	))
-	.addWithInfo('with remove action', () => (
+	.addWithInfo('with remove action and counter', () => (
 		<div>
 			<h1>TreeView</h1>
 			<h3>Definition</h3>
@@ -207,20 +203,6 @@ storiesOf('TreeView', module)
 			<div style={style}>
 				<IconsProvider />
 				<TreeView {...cornerCaseLongName} />
-			</div>
-		</div>
-	))
-	.addWithInfo('with counter', () => (
-		<div>
-			<h1>TreeView</h1>
-			<h3>Definition</h3>
-			<p>
-				A view component to display any tree structure, like folders or categories.
-			</p>
-			<h3>Default property-set with showCounter: true </h3>
-			<div style={style}>
-				<IconsProvider />
-				<TreeView {...withCounter} />
 			</div>
 		</div>
 	));


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
TreeView renders children and does not pass all required properties to them. Resulting any TreeViewItem fails to render badge with counter, when { withCounter: true } option is on.


**What is the new behavior?**
Fixed, just provide a showCounter flag on item you want badge on.

**Does this PR introduce a breaking change?**

- [x] Meh... it's not used in any project so.. not breaking, but change
