### PR TITLE
fix(components/Drawer): proptypes warnings

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.67.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.68.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.67.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.68.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.67.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.68.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.67.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.68.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.67.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.68.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.67.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.68.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.67.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.68.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.67.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.68.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -77,8 +77,8 @@ function DrawerTitle({ title, children, onCancelAction }) {
 
 DrawerTitle.propTypes = {
 	title: PropTypes.string.isRequired,
-	onCancelAction: Action.propTypes,
-	children: PropTypes.nodes,
+	onCancelAction: PropTypes.shape(Action.propTypes),
+	children: PropTypes.node,
 };
 
 function DrawerContent({ children, ...rest }) {
@@ -150,8 +150,8 @@ Drawer.propTypes = {
 	style: PropTypes.object,  // eslint-disable-line react/forbid-prop-types
 	className: PropTypes.string,
 	// footer action, see action bar for api
-	footerActions: PropTypes.arrayOf(Action.propTypes).isRequired,
-	onCancelAction: Action.propTypes,
+	footerActions: PropTypes.shape(ActionBar.propTypes).isRequired,
+	onCancelAction: PropTypes.shape(Action.propTypes),
 };
 
 Drawer.Animation = DrawerAnimation;

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
@@ -39,7 +39,7 @@ function TwoColumns({ one, drawers, children, ...props }) {
 
 TwoColumns.propTypes = {
 	one: React.PropTypes.element,
-	children: React.PropTypes.element,
+	children: React.PropTypes.node,
 	drawers: React.PropTypes.arrayOf(React.PropTypes.node),
 };
 

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -25,7 +25,7 @@ function WithDrawer({ drawers, children }) {
 			{children}
 			<Drawer.Animation className={theme['tc-with-drawer-container']}>
 				{drawers && drawers.map((drawer, key) => (
-					<div drawer key={key} className={theme['tc-with-drawer-wrapper']}>
+					<div key={key} className={theme['tc-with-drawer-wrapper']}>
 						{drawer}
 					</div>
 				))}

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -25,7 +25,7 @@ function WithDrawer({ drawers, children }) {
 			{children}
 			<Drawer.Animation className={theme['tc-with-drawer-container']}>
 				{drawers && drawers.map((drawer, key) => (
-					<div key={key} className={theme['tc-with-drawer-wrapper']}>
+					<div drawer key={key} className={theme['tc-with-drawer-wrapper']}>
 						{drawer}
 					</div>
 				))}


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [ ] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

Currently we have a lot of PropTypes warnings in the browser console.

**What is the new behavior?**

PropTypes for Drawer component fixed, so now most of warnings should gone.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
