### PR TITLE
fix(forms): Enumeration component : fix deselect edit mode

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -130,16 +130,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   151:5   error  Value must be omitted for boolean attributes  react/jsx-boolean-value
   172:5   error  Value must be omitted for boolean attributes  react/jsx-boolean-value
 
-/home/travis/build/Talend/ui/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
-  156:7  error  Expected indentation of 3 tabs but found 6 spaces  indent
-  157:7  error  Expected indentation of 3 tabs but found 6 spaces  indent
-  158:7  error  Expected indentation of 3 tabs but found 6 spaces  indent
-  159:7  error  Expected indentation of 3 tabs but found 6 spaces  indent
-
-/home/travis/build/Talend/ui/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.test.js
-  166:1  error  Line 166 exceeds the maximum line length of 100  max-len
-
-✖ 117 problems (117 errors, 0 warnings)
+✖ 112 problems (112 errors, 0 warnings)
 
 Errored while running command 'npm' with arguments 'run lint:es' in 'react-talend-forms'
 Errored while running ExecCommand.execute

--- a/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
+++ b/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
@@ -254,9 +254,9 @@ class EnumerationWidget extends React.Component {
 	onSelectItem(item, event) {
 		let itemsSelected = resetItems([...this.state.items]);
 		if (event.ctrlKey || event.metaKey) {
-			itemsSelected = manageCtrlKey(item.index, this.state.items);
+			itemsSelected = manageCtrlKey(item.index, itemsSelected);
 		} else if (event.shiftKey) {
-			itemsSelected = manageShiftKey(item.index, this.state.items);
+			itemsSelected = manageShiftKey(item.index, itemsSelected);
 		} else {
 			itemsSelected = itemsSelected.map(currentItem => ({ ...currentItem, isSelected: false }));
 			itemsSelected[item.index].isSelected = true;

--- a/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
+++ b/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
@@ -153,10 +153,10 @@ class EnumerationWidget extends React.Component {
 		event.stopPropagation();
 
 		if (!this.callActionHandler(ENUMERATION_REMOVE_ACTION, value.index)) {
-      const items = resetItems([...this.state.items]);
-      items[value.index].displayMode = DISPLAY_MODE_DEFAULT;
-      items.splice(value.index, 1);
-      const countItems = items.filter(item => item.isSelected).length;
+			const items = resetItems([...this.state.items]);
+			items[value.index].displayMode = DISPLAY_MODE_DEFAULT;
+			items.splice(value.index, 1);
+			const countItems = items.filter(item => item.isSelected).length;
 
 			let displayMode = this.state.displayMode;
 			if (countItems === 0 && displayMode === DISPLAY_MODE_SELECTED) {

--- a/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.test.js
+++ b/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.test.js
@@ -163,7 +163,31 @@ describe('EnumerationWidget', () => {
 			.simulate('click');
 
 		// then
-		expect(registry.formContext.handleAction).toBeCalledWith(undefined, 'ENUMERATION_REMOVE_ACTION', 0);
+		expect(registry.formContext.handleAction)
+			.toBeCalledWith(undefined, 'ENUMERATION_REMOVE_ACTION', 0);
 		expect(toJson(wrapper)).toMatchSnapshot();
+	});
+
+	it('should deselect edit mode when select other element', () => {
+		// given
+		const wrapper = mount(
+			<EnumerationWidget
+				onChange={jest.fn()}
+				formData={[
+					{ values: ['titi', 'tata'] },
+					{ values: ['toto', 'tutu'] },
+				]}
+			/>);
+
+		// edit item
+		wrapper.find('.tc-enumeration-item-actions').find('.btn-link').at(0)
+			.simulate('click');
+
+		// when select another item
+		wrapper.find('.tc-enumeration-item-label').at(1).simulate('click');
+
+		// should reset all items to default mode
+		expect(wrapper.find('.tc-enumeration-item input').length).toBe(0);
+		expect(wrapper.find('.tc-enumeration-item .btn-default').length).toBe(2);
 	});
 });

--- a/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.test.js
+++ b/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.test.js
@@ -168,7 +168,7 @@ describe('EnumerationWidget', () => {
 		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 
-	it('should deselect edit mode when select other element', () => {
+	it('should deselect edit mode when select other item', () => {
 		// given
 		const wrapper = mount(
 			<EnumerationWidget


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
When select item with ctrl or shift key, and another in edit, the edited item is not reseted


**What is the new behavior?**
When select item with ctrl or shift key, and another in edit, the edited item is reseted


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
