### PR TITLE
fix(components/Drawer): add global classname when stacked

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.68.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.68.1 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.68.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.68.1 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.68.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.68.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.68.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.68.1 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.68.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.68.1 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.68.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.68.1 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.68.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.68.1 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.68.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.68.1 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -30,6 +30,7 @@ function DrawerContainer({ stacked, className, children, ...rest }) {
 		'tc-drawer',
 		{
 			[theme.drawerStacked]: stacked,
+			stacked,
 		});
 	return (
 		<div className={drawerContainerClasses} {...rest}>

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -29,6 +29,14 @@ describe('Drawer', () => {
 		).toJSON();
 		expect(wrapper).toMatchSnapshot();
 	});
+	it('should render stacked', () => {
+		const wrapper = renderer.create(
+			<Drawer stacked>
+				<h1>Hello world</h1>
+			</Drawer>
+		).toJSON();
+		expect(wrapper).toMatchSnapshot();
+	});
 	it('should not render if no children', () => {
 		const wrapper = renderer.create(
 			<Drawer />

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -35,6 +35,39 @@ exports[`Drawer should render 1`] = `
 </div>
 `;
 
+exports[`Drawer should render stacked 1`] = `
+<div
+  className="tc-drawer undefined stacked"
+  style={undefined}
+>
+  <div
+    className={undefined}
+  >
+    <div
+      style={
+        Object {
+          "display": "flex",
+          "flexDirection": "column",
+          "flexGrow": 1,
+          "overflow": "auto",
+        }
+      }
+    >
+      <div
+        className={undefined}
+      >
+        <h1>
+          Hello world
+        </h1>
+      </div>
+      <nav
+        className="tc-actionbar-container nav"
+      />
+    </div>
+  </div>
+</div>
+`;
+
 exports[`Drawer should render using custom className 1`] = `
 <div
   className="my-custom-drawer tc-drawer"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

I can't apply custom style in drawer component when it's stacked.

**What is the new behavior?**

I can select it using '.tc-drawer.stacked'

