### PR TITLE
chore(cmf): throw if register undefined

### DIFF
--- a/packages/cmf/__tests__/registry.test.js
+++ b/packages/cmf/__tests__/registry.test.js
@@ -25,6 +25,16 @@ describe('CMF registry', () => {
 		expect(registry.Registry.getRegistry().okey.foo).toBe('bar');
 	});
 
+	it('addToRegistry should throw if value is undefined', () => {
+		function addUndefined() {
+			registry.addToRegistry('undefined', undefined);
+		}
+		expect(addUndefined).toThrow(
+			`CMF: you can't register undefined in 'undefined'.
+			You may have an import error in your configuration`
+		);
+	});
+
 	it('getFromRegistry should return the item', () => {
 		// given
 		registry.addToRegistry('key', 'value');
@@ -58,8 +68,8 @@ describe('CMF registry', () => {
 		registry.lock();
 
 		// when / then
-		expect(() => registry.addToRegistry('key', 'value')).toThrow(
-			'CMF: The registry is locked, you cannot therefore add \'key\' in it. ' +
+		expect(() => registry.addToRegistry('locked', 'value')).toThrow(
+			'CMF: The registry is locked, you cannot therefore add \'locked\' in it. ' +
 			'Please check your CMF configuration, it should not move after the initial configuration before bootstrap.'
 		);
 	});

--- a/packages/cmf/src/registry.js
+++ b/packages/cmf/src/registry.js
@@ -48,6 +48,12 @@ function addToRegistry(id, item) {
 			'Please check your CMF configuration, you might not want that.'
 		);
 	}
+	if (item === undefined) {
+		throw new Error(
+			`CMF: you can't register undefined in '${id}'.
+			You may have an import error in your configuration`
+		);
+	}
 	registry[id] = item;
 }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

At the moment if you register undefined in a key nothing happens ...
And because with javascript when you are doing a wrong import in an existing file you have undefined as value .. it's a nightmare to follow.

**What is the new behavior?**

If you register undefined it throws an exception.

**Does this PR introduce a breaking change?**

- [x] No

