### PR TITLE
fix(forms): handleActionOnClick return noop

### DIFF
--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -99,7 +99,7 @@ class Form extends React.Component {
 		if (onClick) {
 			return (event, data) => onClick(event, { ...data, ...this.form.state });
 		}
-		return null;
+		return () => {};
 	}
 
 	render() {


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

If a form is defined action without onclick it throw exception.
But for submit action it s a non sens to define onclick because you have defined onSubmit.

**What is the new behavior?**

no need for that

