### PR TITLE
fix(components): stacked drawer use 100% of container horizontal space

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -5,39 +5,13 @@ Scoping to packages that match 'react-talend-components'
 > sass-lint -v -q
 
 
-src/Drawer/Drawer.scss
-  10:3   warning  Mixed tabs and spaces                                                     indentation
-  11:5   warning  Mixed tabs and spaces                                                     indentation
-  11:13  error    Hex values should use the shorthand format - 3 characters where possible  hex-length
-  12:5   warning  Statement must begin on a new line                                        brace-style
-  13:5   warning  Mixed tabs and spaces                                                     indentation
-  13:13  error    Hex values should use the shorthand format - 3 characters where possible  hex-length
-  13:13  warning  Hex notation should all be upper case                                     hex-notation
-  24:14  warning  No unit allowed for values of 0                                           zero-unit
-  24:18  warning  No unit allowed for values of 0                                           zero-unit
-  24:27  warning  No unit allowed for values of 0                                           zero-unit
-  36:34  warning  Whitespace required before {                                              space-before-brace
-  48:2   error    Class '.drawerStacked' should be written in lowercase with hyphens        class-name-format
-  56:1   warning  Space expected between blocks                                             empty-line-between-blocks
-
 src/List/Toolbar/Filter/Filter.scss
   14:7  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
   18:6  warning  Vendor prefixes should not be used                       no-vendor-prefixes
   33:1  warning  Space expected between blocks                            empty-line-between-blocks
   36:1  warning  Space expected between blocks                            empty-line-between-blocks
 
-src/WithDrawer/withDrawer.scss
-   2:5  warning  Mixed tabs and spaces           indentation
-   3:5  warning  Mixed tabs and spaces           indentation
-   4:5  warning  Mixed tabs and spaces           indentation
-   8:5  warning  Mixed tabs and spaces           indentation
-   9:5  warning  Mixed tabs and spaces           indentation
-  10:5  warning  Mixed tabs and spaces           indentation
-  11:5  warning  Mixed tabs and spaces           indentation
-  15:5  warning  Mixed tabs and spaces           indentation
-  16:1  warning  Files must end with a new line  final-newline
-
-✖ 26 problems (4 errors, 22 warnings)
+✖ 4 problems (1 error, 3 warnings)
 
 Errored while running command 'npm' with arguments 'run lint:style' in 'react-talend-components'
 Errored while running ExecCommand.execute

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -29,7 +29,7 @@ function DrawerContainer({ stacked, className, children, ...rest }) {
 		className,
 		'tc-drawer',
 		{
-			[theme.drawerStacked]: stacked,
+			[theme['drawer-stacked']]: stacked,
 			stacked,
 		});
 	return (

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -7,21 +7,22 @@ $tc-drawer-transition-easing: cubic-bezier(0.18, 0.89, 0.32, 1.28) !default;
 $tc-action-bar-background-color: lighten($alto, 5%) !default;
 
 @function set-text-color($color) {
-  @if (lightness($color) > 60) {
-    @return #000000; // Lighter backgorund, return dark color
-  } @else {
-    @return #ffffff; // Darker background, return light color
-  }
+	@if (lightness($color) > 60) {
+		@return #000; // Lighter backgorund, return dark color
+	}
+	@else {
+		@return #FFF; // Darker background, return light color
+	}
 }
 
 .tc-drawer {
 	background-color: $tc-drawer-bgcolor;
+	box-shadow: 0 0 15px 0 rgba(0, 0, 0, 0.3);
 	position: absolute;
 	top: 0;
 	transform: translateX(0%);
 	right: 0;
 	bottom: 0;
-	box-shadow: 0px 0px 15px 0px rgba(0, 0, 0, 0.3);
 	width: 50vw;
 	// should always stay lower than dialog z-index wich is set to 1040
 	z-index: 100;
@@ -33,7 +34,7 @@ $tc-action-bar-background-color: lighten($alto, 5%) !default;
 	}
 }
 
-@media (min-width: $screen-lg-min){
+@media (min-width: $screen-lg-min) {
 	.tc-drawer {
 		width: 30vw;
 	}
@@ -45,14 +46,25 @@ $tc-action-bar-background-color: lighten($alto, 5%) !default;
 	height: 100%;
 }
 
-.drawerStacked {
-	left: 15px;
-	width: initial;
+.drawer-stacked {
+	width: 100%;
+}
+
+:global(.tc-with-drawer-wrapper) > .drawer-stacked +
+:global(.tc-with-drawer-wrapper)  > .drawer-stacked {
+	width: 98%;
+}
+
+:global(.tc-with-drawer-wrapper) > .drawer-stacked +
+:global(.tc-with-drawer-wrapper) > .drawer-stacked +
+:global(.tc-with-drawer-wrapper) > .drawer-stacked {
+	width: 96%;
 }
 
 .tc-drawer-header {
 	padding: $padding-normal;
 	background-color: $brand-primary-lighter;
+
 	h1 {
 		font-size: $font-size-large;
 		margin: 0;

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.scss
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.scss
@@ -24,4 +24,5 @@ $tc-layout-header-height: $navbar-height !default;
 	flex-grow: 1;
 	/*safari need a fixed height (not in %) to manage flex columns to fit container height*/
 	height: calc(100vh - #{$tc-layout-header-height});
+	position: relative;
 }

--- a/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
+++ b/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
@@ -146,7 +146,7 @@ exports[`Layout should render layout with Drawer component 1`] = `
           transitionName="tc-drawer"
         >
           <div
-            className={undefined}
+            className="tc-with-drawer-wrapper"
             drawer={true}
           >
             <div
@@ -165,7 +165,7 @@ exports[`Layout should render layout with Drawer component 1`] = `
             </div>
           </div>
           <div
-            className={undefined}
+            className="tc-with-drawer-wrapper"
             drawer={true}
           >
             <div

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -25,7 +25,7 @@ function WithDrawer({ drawers, children }) {
 			{children}
 			<Drawer.Animation className={theme['tc-with-drawer-container']}>
 				{drawers && drawers.map((drawer, key) => (
-					<div drawer key={key} className={theme['tc-with-drawer-wrapper']}>
+					<div drawer key={key} className="tc-with-drawer-wrapper">
 						{drawer}
 					</div>
 				))}

--- a/packages/components/src/WithDrawer/withDrawer.scss
+++ b/packages/components/src/WithDrawer/withDrawer.scss
@@ -1,16 +1,16 @@
 .tc-with-drawer {
-    height: 100%;
-    position: relative;
-    overflow: hidden;
+	height: 100%;
+	position: initial;
+	overflow: hidden;
 }
 
 .tc-with-drawer-container {
-    height: 100%;
-    position: absolute;
-    top: 0;
-    right: 0;
+	height: 100%;
+	position: absolute;
+	top: 0;
+	right: 0;
 }
 
-.tc-with-drawer-wrapper {
-    height: 100%;
+:global(.tc-with-drawer-wrapper) {
+	height: 100%;
 }


### PR DESCRIPTION
sibling stacked drawer up to three now have an offset of 2%

**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
drawer are using all horizontal space available of a parent minus 15px;

![image](https://cloud.githubusercontent.com/assets/19344650/24861789/35923462-1dfa-11e7-968d-ccd0ce4ad143.png)

**What is the new behavior?**
drawer use all horizontal space available of a parent
if a drawer has simbling they are rendered with a 2% offset
![image](https://cloud.githubusercontent.com/assets/19344650/24861724/ff4385fa-1df9-11e7-82c8-a4ab71a815a3.png)



**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No


**Other information**:
