### PR TITLE
fix(form/enumeration): delete a value when search don't reinit to default state

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.71.2 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.72.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.71.2 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.72.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.71.2 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.72.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.71.2 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.72.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.71.2 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.72.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.71.2 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.72.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.71.2 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.72.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.71.2 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.72.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
+++ b/packages/forms/src/widgets/EnumerationWidget/EnumerationWidget.js
@@ -190,12 +190,15 @@ class EnumerationWidget extends React.Component {
 	}
 
 	onDeleteItemHandler() {
-		this.setState({
-			displayMode: DISPLAY_MODE_DEFAULT,
+		const newState = {
 			itemsProp: {
 				...this.state.itemsProp, actionsDefault: this.defaultActions,
 			},
-		});
+		};
+		if (this.state.displayMode !== DISPLAY_MODE_SEARCH) {
+			newState.displayMode = DISPLAY_MODE_DEFAULT;
+		}
+		this.setState(newState);
 	}
 
 	onAbortItem(event, value) {
@@ -282,7 +285,7 @@ class EnumerationWidget extends React.Component {
 		let headerActions;
 		if (this.state.searchCriteria) {
 			headerActions = this.searchInputsActions;
-		}		else {
+		} else {
 			headerActions = this.defaultHeaderActions;
 		}
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

when connected to handler, delete an item reset the list to default state & make some ux issue ( as the searched items are not refresh but the search seems reset )

**What is the new behavior?**

we don't go back to default state when we are in search state

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
