### PR TITLE
fix(components): svg are focusable with IE11

### DIFF
--- a/packages/components/src/Actions/Action/__snapshots__/Action.test.js.snap
+++ b/packages/components/src/Actions/Action/__snapshots__/Action.test.js.snap
@@ -11,6 +11,7 @@ exports[`Action should apply transformation on icon 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -33,6 +34,7 @@ exports[`Action should display a Progress indicator if set 1`] = `
 >
   <svg
     className=""
+    focusable="false"
     viewBox="0 0 50 50"
   >
     <circle
@@ -66,6 +68,7 @@ exports[`Action should display a disabled Icon 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -89,6 +92,7 @@ exports[`Action should pass all props to the Button 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -112,6 +116,7 @@ exports[`Action should render a button 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -136,6 +141,7 @@ exports[`Action should render action with html property name = props.name if set
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -162,6 +168,7 @@ exports[`Action should reverse icon/label 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -96,6 +96,7 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -149,6 +150,7 @@ exports[`ActionDropdown should render a button with icon 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-file-excel-o"
+        focusable="false"
         title={null}
       />
     </span>
@@ -179,6 +181,7 @@ exports[`ActionDropdown should render a button with icon 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -227,6 +230,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-file-excel-o"
+        focusable="false"
         title={null}
       />
       <span>
@@ -260,6 +264,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -336,6 +341,7 @@ exports[`ActionDropdown should render a button with label 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use

--- a/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
+++ b/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
@@ -14,6 +14,7 @@ exports[`Actions should render actions 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-asterisk"
+      focusable="false"
       title={null}
     />
     <span>
@@ -30,6 +31,7 @@ exports[`Actions should render actions 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-file-excel-o"
+      focusable="false"
       title={null}
     />
     <span>
@@ -46,6 +48,7 @@ exports[`Actions should render actions 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-star"
+      focusable="false"
       title={null}
     />
     <span>
@@ -70,6 +73,7 @@ exports[`Actions should render actions 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-excel-o"
+          focusable="false"
           title={null}
         />
         <span>
@@ -217,6 +221,7 @@ exports[`Actions should render actions with "link" theme 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-asterisk"
+      focusable="false"
       title={null}
     />
     <span>
@@ -233,6 +238,7 @@ exports[`Actions should render actions with "link" theme 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-file-excel-o"
+      focusable="false"
       title={null}
     />
     <span>
@@ -249,6 +255,7 @@ exports[`Actions should render actions with "link" theme 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-star"
+      focusable="false"
       title={null}
     />
     <span>
@@ -273,6 +280,7 @@ exports[`Actions should render actions with "link" theme 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-excel-o"
+          focusable="false"
           title={null}
         />
         <span>
@@ -425,6 +433,7 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-asterisk"
+      focusable="false"
       title={null}
     />
   </button>
@@ -443,6 +452,7 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-file-excel-o"
+      focusable="false"
       title={null}
     />
   </button>
@@ -461,6 +471,7 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-star"
+      focusable="false"
       title={null}
     />
   </button>
@@ -487,6 +498,7 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-excel-o"
+          focusable="false"
           title={null}
         />
       </span>
@@ -636,6 +648,7 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-asterisk"
+      focusable="false"
       title={null}
     />
   </button>
@@ -654,6 +667,7 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-file-excel-o"
+      focusable="false"
       title={null}
     />
   </button>
@@ -672,6 +686,7 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-star"
+      focusable="false"
       title={null}
     />
   </button>
@@ -698,6 +713,7 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-excel-o"
+          focusable="false"
           title={null}
         />
       </span>

--- a/packages/components/src/AppHeaderBar/__snapshots__/AppHeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/AppHeaderBar/__snapshots__/AppHeaderBar.snapshot.test.js.snap
@@ -75,6 +75,7 @@ exports[`Storyshots AppHeaderBar default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -105,6 +106,7 @@ exports[`Storyshots AppHeaderBar default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -153,6 +155,7 @@ exports[`Storyshots AppHeaderBar default 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -1229,6 +1232,7 @@ exports[`Storyshots AppHeaderBar default 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -1358,6 +1362,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1388,6 +1393,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1436,6 +1442,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -1485,6 +1492,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-search"
+                      focusable="false"
                       title={null}
                     />
                   </div>
@@ -1504,6 +1512,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
                      
                     <svg
                       className=""
+                      focusable="false"
                       viewBox="0 0 50 50"
                     >
                       <circle
@@ -2674,6 +2683,7 @@ exports[`Storyshots AppHeaderBar while searching 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -2803,6 +2813,7 @@ exports[`Storyshots AppHeaderBar with no search result 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2833,6 +2844,7 @@ exports[`Storyshots AppHeaderBar with no search result 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2881,6 +2893,7 @@ exports[`Storyshots AppHeaderBar with no search result 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -2930,6 +2943,7 @@ exports[`Storyshots AppHeaderBar with no search result 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-search"
+                      focusable="false"
                       title={null}
                     />
                   </div>
@@ -4101,6 +4115,7 @@ exports[`Storyshots AppHeaderBar with no search result 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -4230,6 +4245,7 @@ exports[`Storyshots AppHeaderBar with search button 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -4260,6 +4276,7 @@ exports[`Storyshots AppHeaderBar with search button 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -4308,6 +4325,7 @@ exports[`Storyshots AppHeaderBar with search button 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -4335,6 +4353,7 @@ exports[`Storyshots AppHeaderBar with search button 1`] = `
                 <i
                   aria-hidden="true"
                   className="fa fa-search"
+                  focusable="false"
                   title={null}
                 />
               </button>
@@ -5510,6 +5529,7 @@ exports[`Storyshots AppHeaderBar with search button 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -5639,6 +5659,7 @@ exports[`Storyshots AppHeaderBar with search input 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -5669,6 +5690,7 @@ exports[`Storyshots AppHeaderBar with search input 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -5717,6 +5739,7 @@ exports[`Storyshots AppHeaderBar with search input 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -5766,6 +5789,7 @@ exports[`Storyshots AppHeaderBar with search input 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-search"
+                      focusable="false"
                       title={null}
                     />
                   </div>
@@ -6929,6 +6953,7 @@ exports[`Storyshots AppHeaderBar with search input 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -7058,6 +7083,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -7088,6 +7114,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -7136,6 +7163,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -7185,6 +7213,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-search"
+                      focusable="false"
                       title={null}
                     />
                   </div>
@@ -7207,6 +7236,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                           <i
                             aria-hidden="true"
                             className="fa fa-filter"
+                            focusable="false"
                             title="icon"
                           />
                           <span
@@ -7336,6 +7366,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                           <i
                             aria-hidden="true"
                             className="fa fa-asterisk"
+                            focusable="false"
                             title="icon"
                           />
                           <span
@@ -7394,6 +7425,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                           <i
                             aria-hidden="true"
                             className="fa fa-asterisk"
+                            focusable="false"
                             title="icon"
                           />
                           <span
@@ -9409,6 +9441,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -9538,6 +9571,7 @@ exports[`Storyshots AppHeaderBar with simple form 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -9568,6 +9602,7 @@ exports[`Storyshots AppHeaderBar with simple form 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -9616,6 +9651,7 @@ exports[`Storyshots AppHeaderBar with simple form 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -11090,6 +11126,7 @@ exports[`Storyshots AppHeaderBar with simple form 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -11219,6 +11256,7 @@ exports[`Storyshots AppHeaderBar without brand link 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -11249,6 +11287,7 @@ exports[`Storyshots AppHeaderBar without brand link 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -11297,6 +11336,7 @@ exports[`Storyshots AppHeaderBar without brand link 1`] = `
                       <i
                         aria-hidden="true"
                         className="fa fa-fw fa-cog"
+                        focusable="false"
                         title={null}
                       />
                       settings
@@ -12321,6 +12361,7 @@ exports[`Storyshots AppHeaderBar without brand link 1`] = `
     </div>
   </div>
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",

--- a/packages/components/src/Badge/__snapshots__/Badge.snap.test.js.snap
+++ b/packages/components/src/Badge/__snapshots__/Badge.snap.test.js.snap
@@ -24,6 +24,7 @@ exports[`Badge should render Badge with icon in outline style 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use
@@ -58,6 +59,7 @@ exports[`Badge should render Badge with icon in solid style 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use

--- a/packages/components/src/CircularProgress/CircularProgress.component.js
+++ b/packages/components/src/CircularProgress/CircularProgress.component.js
@@ -46,6 +46,7 @@ function CircularProgress({ size, light, percent }) {
 
 	return (
 		<svg
+			focusable="false"
 			className={classes}
 			viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}
 		>

--- a/packages/components/src/CircularProgress/__snapshots__/CircularProgress.test.js.snap
+++ b/packages/components/src/CircularProgress/__snapshots__/CircularProgress.test.js.snap
@@ -3,6 +3,7 @@
 exports[`CircularProgress should render as light if set 1`] = `
 <svg
   className=""
+  focusable="false"
   viewBox="0 0 50 50"
 >
   <circle
@@ -24,6 +25,7 @@ exports[`CircularProgress should render as light if set 1`] = `
 exports[`CircularProgress should render at large size if set 1`] = `
 <svg
   className="undefined"
+  focusable="false"
   viewBox="0 0 50 50"
 >
   <circle
@@ -45,6 +47,7 @@ exports[`CircularProgress should render at large size if set 1`] = `
 exports[`CircularProgress should render at small size if set 1`] = `
 <svg
   className=""
+  focusable="false"
   viewBox="0 0 50 50"
 >
   <circle
@@ -66,6 +69,7 @@ exports[`CircularProgress should render at small size if set 1`] = `
 exports[`CircularProgress should render by default at default size 1`] = `
 <svg
   className=""
+  focusable="false"
   viewBox="0 0 50 50"
 >
   <circle
@@ -87,6 +91,7 @@ exports[`CircularProgress should render by default at default size 1`] = `
 exports[`CircularProgress should render with percent if set 1`] = `
 <svg
   className=""
+  focusable="false"
   viewBox="0 0 50 50"
 >
   <circle

--- a/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
+++ b/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
@@ -25,6 +25,7 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
             <i
               aria-hidden="true"
               className="fa fa-check"
+              focusable="false"
               title={null}
             />
             <span
@@ -50,6 +51,7 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
                   <i
                     aria-hidden="true"
                     className="fa fa-cancel"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -66,6 +68,7 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
                   <i
                     aria-hidden="true"
                     className="fa fa-delete"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -94,6 +97,7 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
             <i
               aria-hidden="true"
               className="fa fa-edit"
+              focusable="false"
               title={null}
             />
           </button>
@@ -150,6 +154,7 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -223,6 +228,7 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-check"
+              focusable="false"
               title={null}
             />
             <span
@@ -248,6 +254,7 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-cancel"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -264,6 +271,7 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-delete"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -292,6 +300,7 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-edit"
+              focusable="false"
               title={null}
             />
           </button>
@@ -348,6 +357,7 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -421,6 +431,7 @@ exports[`CollapsiblePanel should render default without content 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-check"
+              focusable="false"
               title={null}
             />
             <span
@@ -446,6 +457,7 @@ exports[`CollapsiblePanel should render default without content 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-cancel"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -462,6 +474,7 @@ exports[`CollapsiblePanel should render default without content 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-delete"
+                    focusable="false"
                     title={null}
                   />
                   <span>
@@ -490,6 +503,7 @@ exports[`CollapsiblePanel should render default without content 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-edit"
+              focusable="false"
               title={null}
             />
           </button>
@@ -613,6 +627,7 @@ exports[`CollapsiblePanel should render themed with textual content 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use

--- a/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
@@ -25,6 +25,7 @@ exports[`Header should render header with one button 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -62,6 +63,7 @@ exports[`Header should render header with one button and indicate the component 
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use

--- a/packages/components/src/Enumeration/Header/__snapshots__/headerInput.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/headerInput.snapshot.test.js.snap
@@ -31,6 +31,7 @@ exports[`Header should render header input with error 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use
@@ -53,6 +54,7 @@ exports[`Header should render header input with error 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use
@@ -89,6 +91,7 @@ exports[`Header should render header input with two buttons 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use
@@ -111,6 +114,7 @@ exports[`Header should render header input with two buttons 1`] = `
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use

--- a/packages/components/src/Enumeration/Header/__snapshots__/headerSelected.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/headerSelected.snapshot.test.js.snap
@@ -22,6 +22,7 @@ exports[`Header should render header with trash icon in case of multiple selecti
     <svg
       aria-hidden="true"
       className="tc-svg-icon"
+      focusable="false"
       title={null}
     >
       <use

--- a/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
@@ -84,6 +84,7 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -144,6 +145,7 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -166,6 +168,7 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -226,6 +229,7 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -248,6 +252,7 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use

--- a/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
@@ -29,6 +29,7 @@ exports[`Enumeration should render with header in add state and list in default 
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -51,6 +52,7 @@ exports[`Enumeration should render with header in add state and list in default 
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -151,6 +153,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -173,6 +176,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -233,6 +237,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -255,6 +260,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -315,6 +321,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -337,6 +344,7 @@ exports[`Enumeration should render with header in add state and list in default 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -382,6 +390,7 @@ exports[`Enumeration should render with header in default state and first item i
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -474,6 +483,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -496,6 +506,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -556,6 +567,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -578,6 +590,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -638,6 +651,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -660,6 +674,7 @@ exports[`Enumeration should render with header in default state and first item i
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -706,6 +721,7 @@ exports[`Enumeration should render with header in default state, list in default
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -807,6 +823,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -829,6 +846,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -889,6 +907,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -911,6 +930,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -971,6 +991,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -993,6 +1014,7 @@ exports[`Enumeration should render with header in default state, list in default
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1039,6 +1061,7 @@ exports[`Enumeration should render with header in search state and list in defau
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -1061,6 +1084,7 @@ exports[`Enumeration should render with header in search state and list in defau
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -1158,6 +1182,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1180,6 +1205,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1237,6 +1263,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1259,6 +1286,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1316,6 +1344,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1338,6 +1367,7 @@ exports[`Enumeration should render with header in search state and list in defau
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1470,6 +1500,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1492,6 +1523,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1552,6 +1584,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1574,6 +1607,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1634,6 +1668,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1656,6 +1691,7 @@ exports[`Enumeration should render with header in selected state with trash icon
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1701,6 +1737,7 @@ exports[`Enumeration should render with header without items 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -36,6 +36,7 @@ exports[`Storyshots HeaderBar default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -82,6 +83,7 @@ exports[`Storyshots HeaderBar default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -104,6 +106,7 @@ exports[`Storyshots HeaderBar default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -136,6 +139,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -169,6 +173,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -202,6 +207,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -235,6 +241,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -261,6 +268,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -287,6 +295,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -1580,6 +1589,7 @@ exports[`Storyshots HeaderBar default 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -1912,6 +1922,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1990,6 +2001,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                    
                   <svg
                     className=""
+                    focusable="false"
                     viewBox="0 0 50 50"
                   >
                     <circle
@@ -2024,6 +2036,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -2056,6 +2069,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2089,6 +2103,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2122,6 +2137,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2155,6 +2171,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2181,6 +2198,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2207,6 +2225,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -3432,6 +3451,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -3764,6 +3784,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -3809,6 +3830,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -3870,6 +3892,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -3892,6 +3915,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -3924,6 +3948,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -3957,6 +3982,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -3990,6 +4016,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -4023,6 +4050,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -4049,6 +4077,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -4075,6 +4104,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -5530,6 +5560,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -5862,6 +5893,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -5908,6 +5940,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -5930,6 +5963,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -5962,6 +5996,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -5995,6 +6030,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -6028,6 +6064,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -6061,6 +6098,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -6087,6 +6125,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -6113,6 +6152,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -7430,6 +7470,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -7762,6 +7803,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -7855,6 +7897,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -7887,6 +7930,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -7920,6 +7964,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -7953,6 +7998,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -7986,6 +8032,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -8012,6 +8059,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -8038,6 +8086,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -9264,6 +9313,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -9596,6 +9646,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -9682,6 +9733,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -9714,6 +9766,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -9747,6 +9800,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -9780,6 +9834,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -9813,6 +9868,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -9839,6 +9895,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -9865,6 +9922,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -11089,6 +11147,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",
@@ -11421,6 +11480,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -11502,6 +11562,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                         <svg
                           aria-hidden="true"
                           className="tc-svg-icon"
+                          focusable="false"
                           title="icon"
                         >
                           <use
@@ -11635,6 +11696,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                         <svg
                           aria-hidden="true"
                           className="tc-svg-icon"
+                          focusable="false"
                           title="icon"
                         >
                           <use
@@ -11697,6 +11759,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                         <svg
                           aria-hidden="true"
                           className="tc-svg-icon"
+                          focusable="false"
                           title="icon"
                         >
                           <use
@@ -11827,6 +11890,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -11859,6 +11923,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -11892,6 +11957,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -11925,6 +11991,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -11958,6 +12025,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -11984,6 +12052,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -12010,6 +12079,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -13988,6 +14058,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
     }
   />
   <svg
+    focusable="false"
     style={
       Object {
         "display": "none",

--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -37,6 +37,7 @@ export const TRANSFORMS = Object.keys(FA_TRANSFORMS);
  */
 function Icon({ className, name, title, transform }) {
 	const accessibility = {
+		focusable: 'false', // IE11
 		'aria-hidden': 'true',
 		title: title || null,
 	};

--- a/packages/components/src/Icon/__snapshots__/Icon.test.js.snap
+++ b/packages/components/src/Icon/__snapshots__/Icon.test.js.snap
@@ -4,6 +4,7 @@ exports[`Icon should render fontawesome 1`] = `
 <i
   aria-hidden="true"
   className="fa fa-bars"
+  focusable="false"
   title={null}
 />
 `;
@@ -12,6 +13,7 @@ exports[`Icon should render from custom font 1`] = `
 <i
   aria-hidden="true"
   className="icon-test"
+  focusable="false"
   title={null}
 />
 `;
@@ -20,6 +22,7 @@ exports[`Icon should render from svg 1`] = `
 <svg
   aria-hidden="true"
   className="tc-svg-icon"
+  focusable="false"
   title={null}
 >
   <use
@@ -32,6 +35,7 @@ exports[`Icon should render with provided className 1`] = `
 <svg
   aria-hidden="true"
   className="tc-svg-icon custom-class"
+  focusable="false"
   title={null}
 >
   <use

--- a/packages/components/src/IconsProvider/IconsProvider.component.js
+++ b/packages/components/src/IconsProvider/IconsProvider.component.js
@@ -19,7 +19,7 @@ function IconsProvider({ defaultIcons, icons }) {
 	const ids = Object.keys(iconset);
 	const style = { display: 'none' };
 	return (
-		<svg xmlns="http://www.w3.org/2000/svg" style={style}>
+		<svg xmlns="http://www.w3.org/2000/svg" focusable="false" style={style}>
 			{ids.map((id, index) => (
 				<symbol key={index} id={id}>
 					{iconset[id]}

--- a/packages/components/src/IconsProvider/__snapshots__/IconsProvider.test.js.snap
+++ b/packages/components/src/IconsProvider/__snapshots__/IconsProvider.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`IconsProvider should override talend icons by using defaultIcons props 1`] = `
 <svg
+  focusable="false"
   style={
     Object {
       "display": "none",
@@ -21,6 +22,7 @@ exports[`IconsProvider should override talend icons by using defaultIcons props 
 
 exports[`IconsProvider should override talend icons by using defaultIcons props and render custom icon 1`] = `
 <svg
+  focusable="false"
   style={
     Object {
       "display": "none",
@@ -47,6 +49,7 @@ exports[`IconsProvider should override talend icons by using defaultIcons props 
 
 exports[`IconsProvider should render default talend-icons 1`] = `
 <svg
+  focusable="false"
   style={
     Object {
       "display": "none",
@@ -1969,6 +1972,7 @@ exports[`IconsProvider should render default talend-icons 1`] = `
 
 exports[`IconsProvider should render default talend-icons and custom icons defined on icons prop 1`] = `
 <svg
+  focusable="false"
   style={
     Object {
       "display": "none",

--- a/packages/components/src/List/Content/Item/__snapshots__/Item.snapshot.test.js.snap
+++ b/packages/components/src/List/Content/Item/__snapshots__/Item.snapshot.test.js.snap
@@ -103,6 +103,7 @@ exports[`Item should render with actions 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-edit"
+        focusable="false"
         title={null}
       />
     </button>
@@ -130,6 +131,7 @@ exports[`Item should render with actions 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-trash-o"
+        focusable="false"
         title={null}
       />
     </button>
@@ -262,6 +264,7 @@ exports[`Item should render with icon 1`] = `
     <i
       aria-hidden="true"
       className="fa fa-file-excel-o"
+      focusable="false"
       title={null}
     />
   </div>

--- a/packages/components/src/List/Content/__snapshots__/Content.snapshot.test.js.snap
+++ b/packages/components/src/List/Content/__snapshots__/Content.snapshot.test.js.snap
@@ -44,6 +44,7 @@ exports[`Content should render 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-excel-o"
+            focusable="false"
             title={null}
           />
         </div>
@@ -118,6 +119,7 @@ exports[`Content should render 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-pdf-o"
+            focusable="false"
             title={null}
           />
         </div>
@@ -298,6 +300,7 @@ exports[`Content should render with display mode if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-excel-o"
+            focusable="false"
             title={null}
           />
         </div>
@@ -372,6 +375,7 @@ exports[`Content should render with display mode if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-pdf-o"
+            focusable="false"
             title={null}
           />
         </div>
@@ -552,6 +556,7 @@ exports[`Content should render with id if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-excel-o"
+            focusable="false"
             title={null}
           />
         </div>
@@ -626,6 +631,7 @@ exports[`Content should render with id if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-pdf-o"
+            focusable="false"
             title={null}
           />
         </div>

--- a/packages/components/src/List/DisplayLarge/__snapshots__/DisplayLarge.test.js.snap
+++ b/packages/components/src/List/DisplayLarge/__snapshots__/DisplayLarge.test.js.snap
@@ -45,6 +45,7 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -63,6 +64,7 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>
@@ -353,6 +355,7 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -371,6 +374,7 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>
@@ -661,6 +665,7 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -679,6 +684,7 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>
@@ -941,6 +947,7 @@ exports[`DisplayLarge should render with defined title property 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-excel-o tc-list-icon"
+          focusable="false"
           title={null}
         />
         <button
@@ -972,6 +979,7 @@ exports[`DisplayLarge should render with defined title property 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -990,6 +998,7 @@ exports[`DisplayLarge should render with defined title property 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>
@@ -1069,6 +1078,7 @@ exports[`DisplayLarge should render with defined title property 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-file-pdf-o tc-list-icon"
+          focusable="false"
           title={null}
         />
         <button
@@ -1281,6 +1291,7 @@ exports[`DisplayLarge should render with id if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -1299,6 +1310,7 @@ exports[`DisplayLarge should render with id if provided 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>
@@ -1589,6 +1601,7 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
           <i
             aria-hidden="true"
             className="fa fa-edit"
+            focusable="false"
             title={null}
           />
         </button>
@@ -1607,6 +1620,7 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
           <i
             aria-hidden="true"
             className="fa fa-trash-o"
+            focusable="false"
             title={null}
           />
         </button>

--- a/packages/components/src/List/DisplayTable/__snapshots__/DisplayTable.snapshot.test.js.snap
+++ b/packages/components/src/List/DisplayTable/__snapshots__/DisplayTable.snapshot.test.js.snap
@@ -155,6 +155,7 @@ exports[`DisplayTable should render column actions 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -173,6 +174,7 @@ exports[`DisplayTable should render column actions 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -205,6 +207,7 @@ exports[`DisplayTable should render column actions 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -227,6 +230,7 @@ exports[`DisplayTable should render column actions 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -742,6 +746,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -760,6 +765,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -792,6 +798,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -814,6 +821,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -850,6 +858,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -872,6 +881,7 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -1410,6 +1420,7 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -1428,6 +1439,7 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -1878,6 +1890,7 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -1896,6 +1909,7 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -2247,6 +2261,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -2416,6 +2431,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -2434,6 +2450,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -2466,6 +2483,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2488,6 +2506,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2524,6 +2543,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -2546,6 +2566,7 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -3084,6 +3105,7 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -3102,6 +3124,7 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -3499,6 +3522,7 @@ exports[`DisplayTable should render with defined title property 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-file-excel-o tc-list-icon"
+                    focusable="false"
                     title={null}
                   />
                   <button
@@ -3534,6 +3558,7 @@ exports[`DisplayTable should render with defined title property 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -3552,6 +3577,7 @@ exports[`DisplayTable should render with defined title property 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -3661,6 +3687,7 @@ exports[`DisplayTable should render with defined title property 1`] = `
                   <i
                     aria-hidden="true"
                     className="fa fa-file-pdf-o tc-list-icon"
+                    focusable="false"
                     title={null}
                   />
                   <button
@@ -4024,6 +4051,7 @@ exports[`DisplayTable should render with id if provided 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -4042,6 +4070,7 @@ exports[`DisplayTable should render with id if provided 1`] = `
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -4492,6 +4521,7 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                     <i
                       aria-hidden="true"
                       className="fa fa-edit"
+                      focusable="false"
                       title={null}
                     />
                   </button>
@@ -4510,6 +4540,7 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                     <i
                       aria-hidden="true"
                       className="fa fa-trash-o"
+                      focusable="false"
                       title={null}
                     />
                   </button>

--- a/packages/components/src/List/DisplayTile/__snapshots__/DisplayTile.test.js.snap
+++ b/packages/components/src/List/DisplayTile/__snapshots__/DisplayTile.test.js.snap
@@ -480,6 +480,7 @@ exports[`DisplayTile should render 3 tiles which render a title buttons 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-excel-o tc-list-icon"
+            focusable="false"
             title={null}
           />
           <button
@@ -556,6 +557,7 @@ exports[`DisplayTile should render 3 tiles which render a title buttons 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-pdf-o tc-list-icon"
+            focusable="false"
             title={null}
           />
           <button
@@ -714,6 +716,7 @@ exports[`DisplayTile should render 3 tiles with id as title by setting 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-excel-o tc-list-icon"
+            focusable="false"
             title={null}
           />
           <span
@@ -792,6 +795,7 @@ exports[`DisplayTile should render 3 tiles with id as title by setting 1`] = `
           <i
             aria-hidden="true"
             className="fa fa-file-pdf-o tc-list-icon"
+            focusable="false"
             title={null}
           />
           <span

--- a/packages/components/src/List/Toolbar/Filter/__snapshots__/Filter.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/Filter/__snapshots__/Filter.snapshot.test.js.snap
@@ -16,6 +16,7 @@ exports[`Filter should render 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -34,6 +35,7 @@ exports[`Filter should render filter input with default placeholder 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -71,6 +73,7 @@ exports[`Filter should render filter input with default placeholder 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -91,6 +94,7 @@ exports[`Filter should render filter input with given placeholder 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -128,6 +132,7 @@ exports[`Filter should render filter input with given placeholder 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -155,6 +160,7 @@ exports[`Filter should render highlighted filter 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -181,6 +187,7 @@ exports[`Filter should render id if provided 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use
@@ -206,6 +213,7 @@ exports[`Filter should render only toggle icon 1`] = `
   <svg
     aria-hidden="true"
     className="tc-svg-icon"
+    focusable="false"
     title={null}
   >
     <use

--- a/packages/components/src/List/Toolbar/Pagination/__snapshots__/Pagination.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/Pagination/__snapshots__/Pagination.snapshot.test.js.snap
@@ -112,6 +112,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-backward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -136,6 +137,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play fa-rotate-180"
+        focusable="false"
         title={null}
       />
     </a>
@@ -185,6 +187,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play"
+        focusable="false"
         title={null}
       />
     </a>
@@ -209,6 +212,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-forward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -328,6 +332,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       <i
         aria-hidden="true"
         className="fa fa-backward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -352,6 +357,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       <i
         aria-hidden="true"
         className="fa fa-play fa-rotate-180"
+        focusable="false"
         title={null}
       />
     </a>
@@ -401,6 +407,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       <i
         aria-hidden="true"
         className="fa fa-play"
+        focusable="false"
         title={null}
       />
     </a>
@@ -425,6 +432,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       <i
         aria-hidden="true"
         className="fa fa-forward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -633,6 +641,7 @@ exports[`Pagination should render 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-backward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -651,6 +660,7 @@ exports[`Pagination should render 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play fa-rotate-180"
+        focusable="false"
         title={null}
       />
     </a>
@@ -694,6 +704,7 @@ exports[`Pagination should render 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play"
+        focusable="false"
         title={null}
       />
     </a>
@@ -712,6 +723,7 @@ exports[`Pagination should render 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-forward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -825,6 +837,7 @@ exports[`Pagination should render id if provided 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-backward"
+        focusable="false"
         title={null}
       />
     </a>
@@ -843,6 +856,7 @@ exports[`Pagination should render id if provided 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play fa-rotate-180"
+        focusable="false"
         title={null}
       />
     </a>
@@ -886,6 +900,7 @@ exports[`Pagination should render id if provided 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-play"
+        focusable="false"
         title={null}
       />
     </a>
@@ -904,6 +919,7 @@ exports[`Pagination should render id if provided 1`] = `
       <i
         aria-hidden="true"
         className="fa fa-forward"
+        focusable="false"
         title={null}
       />
     </a>

--- a/packages/components/src/List/Toolbar/SelectDisplayMode/__snapshots__/SelectDisplayMode.test.js.snap
+++ b/packages/components/src/List/Toolbar/SelectDisplayMode/__snapshots__/SelectDisplayMode.test.js.snap
@@ -22,6 +22,7 @@ exports[`SelectDisplayMode should render 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -54,6 +55,7 @@ exports[`SelectDisplayMode should render 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -79,6 +81,7 @@ exports[`SelectDisplayMode should render 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -104,6 +107,7 @@ exports[`SelectDisplayMode should render 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -140,6 +144,7 @@ exports[`SelectDisplayMode should render id if provided 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -172,6 +177,7 @@ exports[`SelectDisplayMode should render id if provided 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -197,6 +203,7 @@ exports[`SelectDisplayMode should render id if provided 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -222,6 +229,7 @@ exports[`SelectDisplayMode should render id if provided 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -258,6 +266,7 @@ exports[`SelectDisplayMode should render with displayMode = large 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -290,6 +299,7 @@ exports[`SelectDisplayMode should render with displayMode = large 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -315,6 +325,7 @@ exports[`SelectDisplayMode should render with displayMode = large 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -340,6 +351,7 @@ exports[`SelectDisplayMode should render with displayMode = large 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -376,6 +388,7 @@ exports[`SelectDisplayMode should render with displayMode = table 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -408,6 +421,7 @@ exports[`SelectDisplayMode should render with displayMode = table 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -433,6 +447,7 @@ exports[`SelectDisplayMode should render with displayMode = table 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -458,6 +473,7 @@ exports[`SelectDisplayMode should render with displayMode = table 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -494,6 +510,7 @@ exports[`SelectDisplayMode should render with displayMode = tile 1`] = `
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -526,6 +543,7 @@ exports[`SelectDisplayMode should render with displayMode = tile 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -551,6 +569,7 @@ exports[`SelectDisplayMode should render with displayMode = tile 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -576,6 +595,7 @@ exports[`SelectDisplayMode should render with displayMode = tile 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -21,6 +21,7 @@ exports[`Toolbar should render actions toolbar 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -63,6 +64,7 @@ exports[`Toolbar should render actions toolbar with selected items 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -119,6 +121,7 @@ exports[`Toolbar should render display mode selector 1`] = `
             <svg
               aria-hidden="true"
               className="tc-svg-icon"
+              focusable="false"
               title={null}
             >
               <use
@@ -151,6 +154,7 @@ exports[`Toolbar should render display mode selector 1`] = `
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -176,6 +180,7 @@ exports[`Toolbar should render display mode selector 1`] = `
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -201,6 +206,7 @@ exports[`Toolbar should render display mode selector 1`] = `
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -251,6 +257,7 @@ exports[`Toolbar should render filter form 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -388,6 +395,7 @@ exports[`Toolbar should render pagination 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-backward"
+              focusable="false"
               title={null}
             />
           </a>
@@ -406,6 +414,7 @@ exports[`Toolbar should render pagination 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-play fa-rotate-180"
+              focusable="false"
               title={null}
             />
           </a>
@@ -449,6 +458,7 @@ exports[`Toolbar should render pagination 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-play"
+              focusable="false"
               title={null}
             />
           </a>
@@ -467,6 +477,7 @@ exports[`Toolbar should render pagination 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-forward"
+              focusable="false"
               title={null}
             />
           </a>

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -328,6 +328,7 @@ exports[`List should render 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -360,6 +361,7 @@ exports[`List should render 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -385,6 +387,7 @@ exports[`List should render 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -410,6 +413,7 @@ exports[`List should render 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -623,6 +627,7 @@ exports[`List should render 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-backward"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -641,6 +646,7 @@ exports[`List should render 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-play fa-rotate-180"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -684,6 +690,7 @@ exports[`List should render 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-play"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -702,6 +709,7 @@ exports[`List should render 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-forward"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -722,6 +730,7 @@ exports[`List should render 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -1068,6 +1077,7 @@ exports[`List should render id if provided 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1100,6 +1110,7 @@ exports[`List should render id if provided 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1125,6 +1136,7 @@ exports[`List should render id if provided 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1150,6 +1162,7 @@ exports[`List should render id if provided 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -1363,6 +1376,7 @@ exports[`List should render id if provided 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-backward"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -1381,6 +1395,7 @@ exports[`List should render id if provided 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-play fa-rotate-180"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -1424,6 +1439,7 @@ exports[`List should render id if provided 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-play"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -1442,6 +1458,7 @@ exports[`List should render id if provided 1`] = `
               <i
                 aria-hidden="true"
                 className="fa fa-forward"
+                focusable="false"
                 title={null}
               />
             </a>
@@ -1463,6 +1480,7 @@ exports[`List should render id if provided 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use

--- a/packages/components/src/Notification/__snapshots__/Notification.snap.test.js.snap
+++ b/packages/components/src/Notification/__snapshots__/Notification.snap.test.js.snap
@@ -27,6 +27,7 @@ exports[`Notification should render 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -51,6 +52,7 @@ exports[`Notification should render 1`] = `
           <svg
             aria-hidden="true"
             className="tc-svg-icon"
+            focusable="false"
             title={null}
           >
             <use
@@ -83,6 +85,7 @@ exports[`Notification should render 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -113,6 +116,7 @@ exports[`Notification should render 1`] = `
             <svg
               aria-hidden="true"
               className="tc-svg-icon"
+              focusable="false"
               title={null}
             >
               <use
@@ -143,6 +147,7 @@ exports[`Notification should render 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use
@@ -186,6 +191,7 @@ exports[`Notification should render 1`] = `
         <svg
           aria-hidden="true"
           className="tc-svg-icon"
+          focusable="false"
           title={null}
         >
           <use

--- a/packages/components/src/ObjectViewer/__snapshots__/ObjectViewer.test.js.snap
+++ b/packages/components/src/ObjectViewer/__snapshots__/ObjectViewer.test.js.snap
@@ -12,6 +12,7 @@ exports[`Storyshots ObjectViewer flat default 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -1126,6 +1127,7 @@ exports[`Storyshots ObjectViewer flat with handler 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -2469,6 +2471,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -2521,6 +2524,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2603,6 +2607,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -2657,6 +2662,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -2759,6 +2765,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -2793,6 +2800,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                                   <svg
                                     aria-hidden="true"
                                     className="tc-svg-icon"
+                                    focusable="false"
                                     title={null}
                                   >
                                     <use
@@ -2854,6 +2862,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -2936,6 +2945,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -2990,6 +3000,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -3024,6 +3035,7 @@ exports[`Storyshots ObjectViewer list default 1`] = `
                                   <svg
                                     aria-hidden="true"
                                     className="tc-svg-icon"
+                                    focusable="false"
                                     title={null}
                                   >
                                     <use
@@ -3880,6 +3892,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -3933,6 +3946,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -4013,6 +4027,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -4067,6 +4082,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -4169,6 +4185,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -4203,6 +4220,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                                   <svg
                                     aria-hidden="true"
                                     className="tc-svg-icon"
+                                    focusable="false"
                                     title={null}
                                   >
                                     <use
@@ -4265,6 +4283,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -4347,6 +4366,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -4401,6 +4421,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}
                           >
                             <use
@@ -4435,6 +4456,7 @@ exports[`Storyshots ObjectViewer list with handler 1`] = `
                                   <svg
                                     aria-hidden="true"
                                     className="tc-svg-icon"
+                                    focusable="false"
                                     title={null}
                                   >
                                     <use
@@ -5504,6 +5526,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -5625,6 +5648,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -5678,6 +5702,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -5779,6 +5804,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -5813,6 +5839,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -5917,6 +5944,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -5975,6 +6003,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -6009,6 +6038,7 @@ exports[`Storyshots ObjectViewer table default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -6863,6 +6893,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -6986,6 +7017,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -7040,6 +7072,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -7142,6 +7175,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -7176,6 +7210,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -7284,6 +7319,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -7344,6 +7380,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -7378,6 +7415,7 @@ exports[`Storyshots ObjectViewer table with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -8445,6 +8483,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -8493,6 +8532,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -8527,6 +8567,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -8609,6 +8650,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -8663,6 +8705,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -8765,6 +8808,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -8799,6 +8843,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                                       <svg
                                         aria-hidden="true"
                                         className="tc-svg-icon"
+                                        focusable="false"
                                         title={null}
                                       >
                                         <use
@@ -8861,6 +8906,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -8943,6 +8989,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -8997,6 +9044,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -9031,6 +9079,7 @@ exports[`Storyshots ObjectViewer tree default 1`] = `
                                       <svg
                                         aria-hidden="true"
                                         className="tc-svg-icon"
+                                        focusable="false"
                                         title={null}
                                       >
                                         <use
@@ -9862,6 +9911,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -9911,6 +9961,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -9945,6 +9996,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -10025,6 +10077,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -10079,6 +10132,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -10181,6 +10235,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -10215,6 +10270,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                                       <svg
                                         aria-hidden="true"
                                         className="tc-svg-icon"
+                                        focusable="false"
                                         title={null}
                                       >
                                         <use
@@ -10277,6 +10333,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                       <svg
                         aria-hidden="true"
                         className="tc-svg-icon"
+                        focusable="false"
                         title={null}
                       >
                         <use
@@ -10359,6 +10416,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -10413,6 +10471,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                               <svg
                                 aria-hidden="true"
                                 className="tc-svg-icon"
+                                focusable="false"
                                 title={null}
                               >
                                 <use
@@ -10447,6 +10506,7 @@ exports[`Storyshots ObjectViewer tree with handler 1`] = `
                                       <svg
                                         aria-hidden="true"
                                         className="tc-svg-icon"
+                                        focusable="false"
                                         title={null}
                                       >
                                         <use

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -12,6 +12,7 @@ exports[`Storyshots SidePanel default 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -95,6 +96,7 @@ exports[`Storyshots SidePanel default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -117,6 +119,7 @@ exports[`Storyshots SidePanel default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -142,6 +145,7 @@ exports[`Storyshots SidePanel default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -167,6 +171,7 @@ exports[`Storyshots SidePanel default 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1261,6 +1266,7 @@ exports[`Storyshots SidePanel docked 1`] = `
   >
     <div>
       <svg
+        focusable="false"
         style={
           Object {
             "display": "none",
@@ -1343,6 +1349,7 @@ exports[`Storyshots SidePanel docked 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1369,6 +1376,7 @@ exports[`Storyshots SidePanel docked 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1395,6 +1403,7 @@ exports[`Storyshots SidePanel docked 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -1421,6 +1430,7 @@ exports[`Storyshots SidePanel docked 1`] = `
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use

--- a/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
+++ b/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
@@ -28,6 +28,7 @@ exports[`Status should render a label 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-cancel"
+          focusable="false"
           title={null}
         />
         <span>
@@ -44,6 +45,7 @@ exports[`Status should render a label 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-delete"
+          focusable="false"
           title={null}
         />
         <span>
@@ -62,6 +64,7 @@ exports[`Status should render a label with Icon 1`] = `
   <i
     aria-hidden="true"
     className="fa fa-check"
+    focusable="false"
     title={null}
   />
   <span
@@ -87,6 +90,7 @@ exports[`Status should render a label with Icon 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-cancel"
+          focusable="false"
           title={null}
         />
         <span>
@@ -103,6 +107,7 @@ exports[`Status should render a label with Icon 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-delete"
+          focusable="false"
           title={null}
         />
         <span>
@@ -121,6 +126,7 @@ exports[`Status should render a label with Icon without actions 1`] = `
   <i
     aria-hidden="true"
     className="fa fa-check"
+    focusable="false"
     title={null}
   />
   <span
@@ -146,6 +152,7 @@ exports[`Status should render a label with a continuous circular progress 1`] = 
 >
   <svg
     className=""
+    focusable="false"
     viewBox="0 0 50 50"
   >
     <circle
@@ -185,6 +192,7 @@ exports[`Status should render a label with a continuous circular progress 1`] = 
         <i
           aria-hidden="true"
           className="fa fa-cancel"
+          focusable="false"
           title={null}
         />
         <span>
@@ -201,6 +209,7 @@ exports[`Status should render a label with a continuous circular progress 1`] = 
         <i
           aria-hidden="true"
           className="fa fa-delete"
+          focusable="false"
           title={null}
         />
         <span>
@@ -218,6 +227,7 @@ exports[`Status should render a label with a fixed circular progress 1`] = `
 >
   <svg
     className=""
+    focusable="false"
     viewBox="0 0 50 50"
   >
     <circle
@@ -257,6 +267,7 @@ exports[`Status should render a label with a fixed circular progress 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-cancel"
+          focusable="false"
           title={null}
         />
         <span>
@@ -273,6 +284,7 @@ exports[`Status should render a label with a fixed circular progress 1`] = `
         <i
           aria-hidden="true"
           className="fa fa-delete"
+          focusable="false"
           title={null}
         />
         <span>

--- a/packages/components/src/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/components/src/TreeView/__snapshots__/TreeView.test.js.snap
@@ -26,6 +26,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
       <svg
         aria-hidden="true"
         className="tc-svg-icon"
+        focusable="false"
         title={null}
       >
         <use
@@ -71,6 +72,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -85,6 +87,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
             <svg
               aria-hidden="true"
               className="tc-svg-icon"
+              focusable="false"
               title={null}
             >
               <use
@@ -123,6 +126,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
               <svg
                 aria-hidden="true"
                 className="tc-svg-icon"
+                focusable="false"
                 title={null}
               >
                 <use
@@ -166,6 +170,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -180,6 +185,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use
@@ -214,6 +220,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -246,6 +253,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                     <svg
                       aria-hidden="true"
                       className="tc-svg-icon"
+                      focusable="false"
                       title={null}
                     >
                       <use
@@ -294,6 +302,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                   <svg
                     aria-hidden="true"
                     className="tc-svg-icon"
+                    focusable="false"
                     title={null}
                   >
                     <use
@@ -308,6 +317,7 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                 <svg
                   aria-hidden="true"
                   className="tc-svg-icon"
+                  focusable="false"
                   title={null}
                 >
                   <use

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -51,6 +51,7 @@ exports[`Typeahead items should render typeahead results with match 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-filter"
+              focusable="false"
               title="icon"
             />
             <span
@@ -180,6 +181,7 @@ exports[`Typeahead items should render typeahead results with match 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-asterisk"
+              focusable="false"
               title="icon"
             />
             <span
@@ -282,6 +284,7 @@ exports[`Typeahead items should render typeahead with results 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-filter"
+              focusable="false"
               title="icon"
             />
             <span
@@ -355,6 +358,7 @@ exports[`Typeahead items should render typeahead with results 1`] = `
             <i
               aria-hidden="true"
               className="fa fa-asterisk"
+              focusable="false"
               title="icon"
             />
             <span
@@ -507,6 +511,7 @@ exports[`Typeahead with toggle should render button 1`] = `
   <i
     aria-hidden="true"
     className="fa fa-search"
+    focusable="false"
     title={null}
   />
 </button>

--- a/packages/forms/src/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
@@ -296,6 +296,7 @@ exports[`EnumerationWidget delete all 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -366,6 +367,7 @@ exports[`EnumerationWidget delete all 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -763,6 +765,7 @@ exports[`EnumerationWidget should be in add mode 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}>
                             <use
                               xlinkHref="#talend-check" />
@@ -832,6 +835,7 @@ exports[`EnumerationWidget should be in add mode 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}>
                             <use
                               xlinkHref="#talend-cross" />
@@ -1224,6 +1228,7 @@ exports[`EnumerationWidget should be in default mode 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -1294,6 +1299,7 @@ exports[`EnumerationWidget should be in default mode 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -1693,6 +1699,7 @@ exports[`EnumerationWidget should be in default mode 2`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -1763,6 +1770,7 @@ exports[`EnumerationWidget should be in default mode 2`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -2208,6 +2216,7 @@ exports[`EnumerationWidget should be in edit mode 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -2278,6 +2287,7 @@ exports[`EnumerationWidget should be in edit mode 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -2743,6 +2753,7 @@ exports[`EnumerationWidget should be in edit mode 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-check" />
@@ -2812,6 +2823,7 @@ exports[`EnumerationWidget should be in edit mode 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-cross" />
@@ -3100,6 +3112,7 @@ exports[`EnumerationWidget should be in search mode 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}>
                             <use
                               xlinkHref="#talend-cross" />
@@ -3496,6 +3509,7 @@ exports[`EnumerationWidget should delete an item 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -3566,6 +3580,7 @@ exports[`EnumerationWidget should delete an item 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -3984,6 +3999,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -4054,6 +4070,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -4514,6 +4531,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                               size="small">
                                               <svg
                                                 className=""
+                                                focusable="false"
                                                 viewBox="0 0 50 50">
                                                 <circle
                                                   cx={25}
@@ -4857,6 +4875,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}>
                             <use
                               xlinkHref="#talend-trash" />
@@ -5369,6 +5388,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -5438,6 +5458,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -5797,6 +5818,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                           <svg
                             aria-hidden="true"
                             className="tc-svg-icon"
+                            focusable="false"
                             title={null}>
                             <use
                               xlinkHref="#talend-trash" />
@@ -6345,6 +6367,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -6414,6 +6437,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -6619,6 +6643,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -6688,6 +6713,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -7025,6 +7051,7 @@ exports[`EnumerationWidget upload file should add a upload icon 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -7095,6 +7122,7 @@ exports[`EnumerationWidget upload file should add a upload icon 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-download" />
@@ -7165,6 +7193,7 @@ exports[`EnumerationWidget upload file should add a upload icon 1`] = `
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -7613,6 +7642,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                             size="small">
                             <svg
                               className=""
+                              focusable="false"
                               viewBox="0 0 50 50">
                               <circle
                                 cx={25}
@@ -8146,6 +8176,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -8215,6 +8246,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -8418,6 +8450,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -8487,6 +8520,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -8884,6 +8918,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-search" />
@@ -8954,6 +8989,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-download" />
@@ -9024,6 +9060,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                             <svg
                               aria-hidden="true"
                               className="tc-svg-icon"
+                              focusable="false"
                               title={null}>
                               <use
                                 xlinkHref="#talend-plus" />
@@ -9561,6 +9598,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -9630,6 +9668,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />
@@ -9833,6 +9872,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-pencil" />
@@ -9902,6 +9942,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                               <svg
                                                 aria-hidden="true"
                                                 className="tc-svg-icon"
+                                                focusable="false"
                                                 title={null}>
                                                 <use
                                                   xlinkHref="#talend-trash" />


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)
IE11 can focus on SVG elements


**What is the new behavior?**
IE11 acts like any normal browser and it can only focus on focusable elements


**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
http://stackoverflow.com/questions/18646111/disable-onfocus-event-for-svg-element

Will fix https://jira.talendforge.org/browse/TDP-3723