### PR TITLE
fix(components/ActionDropdown): fix divider in menu

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -8,6 +8,19 @@ import {
 import TooltipTrigger from '../../TooltipTrigger';
 import Icon from '../../Icon';
 
+
+function getMenuItem(item, index) {
+	if (item.divider) {
+		return (<MenuItem key={index} divider />);
+	}
+	return (
+		<MenuItem key={index} eventKey={item} {...item} >
+			{item.icon && (<Icon name={item.icon} />)}
+			{item.label}
+		</MenuItem>
+	);
+}
+
 /**
  * @param {object} props react props
  * @example
@@ -19,6 +32,9 @@ import Icon from '../../Icon';
 			icon: 'talend-icon',
 			label: 'document 1',
 			onClick: action('document 1 click'),
+		},
+		{
+			divider: true,
 		},
 		{
 			label: 'document 2',
@@ -68,15 +84,7 @@ function ActionDropdown(props) {
 			onSelect={onItemSelect}
 			{...rest}
 		>
-			{
-				items.length ?
-					items.map((item, index) => (
-						<MenuItem {...item} key={index} eventKey={item}>
-							{item.icon && (<Icon name={item.icon} />)}
-							{item.label}
-						</MenuItem>
-					)) : (<MenuItem disabled>No options</MenuItem>)
-			}
+			{items.length ? items.map(getMenuItem) : (<MenuItem disabled>No options</MenuItem>)}
 		</DropdownButton>
 	);
 

--- a/packages/components/stories/ActionDropdown.js
+++ b/packages/components/stories/ActionDropdown.js
@@ -1,5 +1,8 @@
 import React from 'react';
-import { storiesOf, action } from '@kadira/storybook';
+import { // eslint-disable-line import/no-extraneous-dependencies
+	storiesOf,
+	action,
+} from '@kadira/storybook';
 
 import { ActionDropdown, IconsProvider } from '../src/index';
 
@@ -13,6 +16,9 @@ const myAction = {
 			icon: 'talend-file-json-o',
 			label: 'document 1',
 			onClick: action('document 1 click'),
+		},
+		{
+			divider: true,
 		},
 		{
 			id: 'context-dropdown-item-document-2',

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1239,9 +1239,9 @@ bootstrap-sass@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.72.2:
-  version "0.72.2"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.72.2.tgz#d164a2d5cc39538b40bf3918b9e0738184ae9a0b"
+bootstrap-talend-theme@^0.72.3:
+  version "0.72.3"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.72.3.tgz#5607cac1d7b576ca5c8c7a0fea43dc13cc16210d"
   dependencies:
     bootstrap-sass "^3.3.7"
 
@@ -5987,9 +5987,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-talend-icons@^0.72.2:
-  version "0.72.2"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.72.2.tgz#4bdabf0091695c6ede2ecdb218c4fb0cb66b8da9"
+talend-icons@^0.72.3:
+  version "0.72.3"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.72.3.tgz#d3c67a5b207de14ea9d038589aed92ad8993a100"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

MenuItem for divider will render children inside. That cause warning

**What is the new behavior?**

MenuItem for divider have no extra data

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

If this PR contains a breaking change, please describe the impact and migration
path for existing applications: ...


**Other information**:
