### PR TITLE
fix(components/Drawer): removed second scrollbar from drawer

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -134,7 +134,7 @@ function Drawer({
 	return (
 		<DrawerContainer stacked={stacked} className={className} style={style}>
 			<DrawerTitle title={title} onCancelAction={onCancelAction} />
-			<div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, overflow: 'auto' }}>
+			<div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, overflow: 'hidden' }}>
 				<DrawerContent>
 					{children}
 				</DrawerContent>

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -16,7 +16,7 @@ exports[`Drawer should render 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
-          "overflow": "auto",
+          "overflow": "hidden",
         }
       }
     >
@@ -49,7 +49,7 @@ exports[`Drawer should render stacked 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
-          "overflow": "auto",
+          "overflow": "hidden",
         }
       }
     >
@@ -82,7 +82,7 @@ exports[`Drawer should render using custom className 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
-          "overflow": "auto",
+          "overflow": "hidden",
         }
       }
     >
@@ -119,7 +119,7 @@ exports[`Drawer should render using custom styles 1`] = `
           "display": "flex",
           "flexDirection": "column",
           "flexGrow": 1,
-          "overflow": "auto",
+          "overflow": "hidden",
         }
       }
     >


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**

- [x] The commit(s) message(s) follows our
  [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md#commit-message-format)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?** (You can also link to an open issue here)

Two scrollbars
http://talend.surge.sh/components/?selectedKind=Drawer&selectedStory=Default&full=0&down=1&left=1&panelRight=0&downPanel=kadirahq%2Fstorybook-addon-actions%2Factions-panel

**What is the new behavior?**

Second scrollbar removed.

**Does this PR introduce a breaking change?**

- [ ] Yes
- [x] No

