### PR TITLE
fix(cmf): attachRef behavior

### DIFF
--- a/packages/cmf/__tests__/settings.test.js
+++ b/packages/cmf/__tests__/settings.test.js
@@ -1,5 +1,6 @@
 import {
 	mapStateToViewProps,
+	attachRef,
 } from '../src/settings';
 import mock from '../src/mock';
 
@@ -14,7 +15,6 @@ describe('mapStateToViewProps', () => {
 			'SidePanel#default': sidemenu,
 		};
 		const props = mapStateToViewProps(state, { view: 'homepage' });
-		console.log(props);
 		expect(props.sidemenu).not.toEqual(sidemenu);
 		expect(props.sidemenu.foo).toEqual(sidemenu.foo);
 		expect(props.sidemenu.baz).toBe(false);
@@ -30,5 +30,27 @@ describe('mapStateToViewProps', () => {
 			mapStateToViewProps(state, { view: 'homepage' });
 		};
 		expect(shouldThrow).toThrow(new Error('CMF/Settings: Reference \'myref\' not found'));
+	});
+});
+
+describe('attachRef', () => {
+	it('should not do anything if obj parameter is not an object', () => {
+		const testFunction = () => '';
+		expect(attachRef({}, 'string')).toEqual('string');
+		expect(attachRef({}, 1)).toEqual(1);
+		expect(attachRef({}, true)).toEqual(true);
+		expect(attachRef({}, testFunction)).toEqual(testFunction);
+		expect(attachRef({}, undefined)).toEqual(undefined);
+		expect(attachRef({}, null)).toEqual(null);
+	});
+
+	it('should try to resolve _ref if obj is an object', () => {
+		const state = Object.assign(
+			mock.state(),
+			{ cmf: { settings: { ref: { stuff: 'res' } } } }
+		);
+		expect(attachRef(state, { _ref: 'stuff' })).toEqual(
+			{ 0: 'r', 1: 'e', 2: 's' }
+		);
 	});
 });

--- a/packages/cmf/src/settings.js
+++ b/packages/cmf/src/settings.js
@@ -10,21 +10,21 @@ import invariant from 'invariant';
  * if an object try to find _ref property and resolve it
  */
 export function attachRef(state, obj) {
-	if (obj !== null && typeof obj === 'object') {
-		let props = Object.assign({}, obj);
-		if (props._ref) {
-			const ref = state.cmf.settings.ref[props._ref];
-			invariant(ref, `CMF/Settings: Reference '${props._ref}' not found`);
-			props = Object.assign(
+	if (obj === null || typeof obj !== 'object') {
+		return obj;
+	}
+	let props = Object.assign({}, obj);
+	if (props._ref) {
+		const ref = state.cmf.settings.ref[props._ref];
+		invariant(ref, `CMF/Settings: Reference '${props._ref}' not found`);
+		props = Object.assign(
 			{},
 			state.cmf.settings.ref[props._ref],
 			obj
 		);
-			delete props._ref;
-		}
-		return props;
+		delete props._ref;
 	}
-	return obj;
+	return props;
 }
 
 export function attachRefs(state, props) {

--- a/packages/cmf/src/settings.js
+++ b/packages/cmf/src/settings.js
@@ -6,19 +6,25 @@
 /* eslint no-underscore-dangle: ["error", {"allow": ["_ref"] }]*/
 import invariant from 'invariant';
 
+/**
+ * if an object try to find _ref property and resolve it
+ */
 export function attachRef(state, obj) {
-	let props = Object.assign({}, obj);
-	if (props._ref) {
-		const ref = state.cmf.settings.ref[props._ref];
-		invariant(ref, `CMF/Settings: Reference '${props._ref}' not found`);
-		props = Object.assign(
+	if (obj !== null && typeof obj === 'object') {
+		let props = Object.assign({}, obj);
+		if (props._ref) {
+			const ref = state.cmf.settings.ref[props._ref];
+			invariant(ref, `CMF/Settings: Reference '${props._ref}' not found`);
+			props = Object.assign(
 			{},
 			state.cmf.settings.ref[props._ref],
 			obj
 		);
-		delete props._ref;
+			delete props._ref;
+		}
+		return props;
 	}
-	return props;
+	return obj;
 }
 
 export function attachRefs(state, props) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When attachRef is called with obj as a primitive not being an object, for example a string, said string was convert to an object before being returned.

triggering following problems, if a action creator id was present at the root of the configuration given to attachRefs the id was transformed into an object, being not resolvable by the action resolver.

**What is the chosen solution to this problem?**
detect if obj given to attachRef is indeed an object and not another primitive, return passed parameter to caller.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

