### PR TITLE
fix(CMF): router inject view props if the component is cmfConnected

### DIFF
--- a/packages/cmf/__tests__/route.test.js
+++ b/packages/cmf/__tests__/route.test.js
@@ -21,9 +21,25 @@ describe('loadComponent behavior', () => {
 			component: 'component',
 			view: 'something',
 		};
-		// console.error('mock', mock.context());
 		route.loadComponents(mock.context(), mockItem);
 		const wrapper = shallow(React.createElement(mockItem.component), { context: mock.context() });
 		expect(wrapper.props().dispatch()).toBe('dispatch');
+	});
+	it('should replace component by regitry one', () => {
+		const mockItem = {
+			component: 'TestContainer',
+			view: 'appmenu',
+		};
+		const obj = { fn: jest.fn() };
+		const component = obj.fn;
+		component.CMFContainer = true;
+		const mockContext = mock.context();
+		mockContext.registry = {
+			'_.route.component:TestContainer': component,
+		};
+		route.loadComponents(mockContext, mockItem);
+		component();
+		expect(obj.fn).toHaveBeenCalled();
+		expect(mockItem.component.displayName).toBe('WithView');
 	});
 });

--- a/packages/cmf/src/route.js
+++ b/packages/cmf/src/route.js
@@ -5,6 +5,7 @@
 
 /* eslint no-underscore-dangle: ["error", {"allow": ["_ref"] }]*/
 
+import React from 'react';
 import { connect } from 'react-redux';
 import registry from './registry';
 import { mapStateToViewProps } from './settings';
@@ -90,11 +91,12 @@ function loadComponents(context, item) {
 		if (item.view && !item.component.CMFContainer) {
 			item.component = connectView(context, item.component, item.view);
 		} else if (item.view && item.component.CMFContainer) {
-			const component = item.component;
-			item.component = (props, rcontext) => component(
-				Object.assign({ view: item.view }, props),
-				rcontext
-			);
+			const WithView = item.component;
+			item.component = (props) => <WithView view={item.view} {...props} />;
+			item.component.displayName = 'WithView';
+			item.component.propTypes = {
+				view: React.PropTypes.string,
+			};
 		}
 	}
 	if (item.components) {

--- a/packages/cmf/src/route.js
+++ b/packages/cmf/src/route.js
@@ -89,6 +89,12 @@ function loadComponents(context, item) {
 		item.component = getComponentFromRegistry(context, item.component);
 		if (item.view && !item.component.CMFContainer) {
 			item.component = connectView(context, item.component, item.view);
+		} else if (item.view && item.component.CMFContainer) {
+			const component = item.component;
+			item.component = (props, rcontext) => component(
+				Object.assign({ view: item.view }, props),
+				rcontext
+			);
 		}
 	}
 	if (item.components) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

issue related to #422
If the component is connected the `view` props is not injected.
so the cmf settings view is not injected.

**What is the chosen solution to this problem?**

If the component is connected using cmfConnect, create a simple factory component `WithView` which inject the view as a props into the connected component.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

