### PR TITLE
feat(components): Adds dropdown elipsis

### DIFF
--- a/packages/components/stories/ActionDropdown.js
+++ b/packages/components/stories/ActionDropdown.js
@@ -8,7 +8,7 @@ import { ActionDropdown, IconsProvider } from '../src/index';
 
 const myAction = {
 	id: 'context-dropdown-related-items',
-	label: 'related items',
+	label: 'related items dlkasjdlasj diasj odijas oij dsaij diasj idsaj',
 	icon: 'talend-file-xls-o',
 	items: [
 		{

--- a/packages/theme/src/theme/_dropdowns.scss
+++ b/packages/theme/src/theme/_dropdowns.scss
@@ -4,10 +4,16 @@
 ////
 
 .dropdown {
+	max-width: 250px;
+
 	&-toggle {
 		padding-left: $padding-normal;
 		padding-right: $padding-normal;
 		transition: 0.1s background-color ease-out;
+		white-space: nowrap;
+		overflow: hidden;
+		text-overflow: ellipsis;
+		min-width: 0;
 
 		.caret {
 			@include dropdown-caret-color($dropdown-caret-color);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The drop-down can be extended indefinitely depending on the text they contain.

**What is the chosen solution to this problem?**
Add an elipsis to the drop-down if it exceeds 250px.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
