### PR TITLE
feat(components/HeaderBar): add onSelect to dropdown menuItems

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -64,6 +64,7 @@ function Environment(props) {
 				id={props.id}
 				items={props.items}
 				label={props.label}
+				onSelect={props.onSelect}
 				tooltipPlacement="bottom"
 			/>
 		</li>
@@ -74,6 +75,7 @@ Environment.propTypes = {
 	id: React.PropTypes.string,
 	items: ActionDropdown.propTypes.items,
 	label: ActionDropdown.propTypes.label,
+	onSelect: ActionDropdown.propTypes.onSelect,
 };
 
 function Search(props) {
@@ -106,7 +108,7 @@ Help.propTypes = {
 	onClick: React.PropTypes.func.isRequired,
 };
 
-function User({ id, items, name }) {
+function User({ id, items, name, onSelect }) {
 	return (
 		<li className="tc-header-bar-action separated">
 			<ActionDropdown
@@ -116,6 +118,7 @@ function User({ id, items, name }) {
 				items={items}
 				label={name}
 				noCaret
+				onSelect={onSelect}
 				tooltipPlacement="bottom"
 			/>
 		</li>
@@ -126,9 +129,10 @@ User.propTypes = {
 	id: React.PropTypes.string,
 	items: ActionDropdown.propTypes.items,
 	name: ActionDropdown.propTypes.label,
+	onSelect: ActionDropdown.propTypes.onSelect,
 };
 
-function Products({ id, items }) {
+function Products({ id, items, onSelect }) {
 	return (
 		<li className="tc-header-bar-action">
 			<ActionDropdown
@@ -139,6 +143,7 @@ function Products({ id, items }) {
 				items={items}
 				label="Apps"
 				noCaret
+				onSelect={onSelect}
 				pullRight
 				tooltipPlacement="bottom"
 			/>
@@ -149,6 +154,7 @@ function Products({ id, items }) {
 Products.propTypes = {
 	id: React.PropTypes.string,
 	items: ActionDropdown.propTypes.items,
+	onSelect: ActionDropdown.propTypes.onSelect,
 };
 
 function HeaderBar(props) {

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -1222,8 +1222,6 @@ exports[`Storyshots HeaderBar default 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -1307,8 +1305,6 @@ exports[`Storyshots HeaderBar default 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -1392,13 +1388,35 @@ exports[`Storyshots HeaderBar default 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -3084,8 +3102,6 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -3169,8 +3185,6 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -3254,13 +3268,35 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -5031,8 +5067,6 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -5116,8 +5150,6 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -5201,13 +5233,35 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -7103,8 +7157,6 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -7188,8 +7240,6 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -7273,13 +7323,35 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -8946,8 +9018,6 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -9031,8 +9101,6 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -9116,13 +9184,35 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -10780,8 +10870,6 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -10865,8 +10953,6 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -10950,13 +11036,35 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>
@@ -13691,8 +13799,6 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                                       Data Preparation
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -13776,8 +13882,6 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                                       Integration Cloud
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
@@ -13861,13 +13965,35 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                                       Management Console
                                       "
                                     </span>
-                                    , 
-                                    …
                                     }
                                   </span>
                                   }
                                 </span>
                                 ]
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              onSelect
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#170",
+                                  }
+                                }
+                              >
+                                anonymous()
                               </span>
                               }
                             </span>

--- a/packages/components/stories/HeaderBar.js
+++ b/packages/components/stories/HeaderBar.js
@@ -118,21 +118,19 @@ const props = {
 				icon: 'talend-logo-dp',
 				key: 'tdp',
 				label: 'Data Preparation',
-				onClick: action('onTDPClick'),
 			},
 			{
 				icon: 'talend-logo-ic',
 				key: 'tic',
 				label: 'Integration Cloud',
-				onClick: action('onTICClick'),
 			},
 			{
 				icon: 'talend-logo-mc',
 				key: 'tmc',
 				label: 'Management Console',
-				onClick: action('onTMCClick'),
 			},
 		],
+		onSelect: action('onProductClick'),
 	},
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

On HeaderBar dropdown buttons have no possibility to use onSelect property

**What is the chosen solution to this problem?**

There is possibility to set onSelect property for ActionDropdown in HeaderBar

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

