### PR TITLE
fix(TFD-1152/Drawer): set title to uppercase

### DIFF
--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -66,6 +66,7 @@ $tc-action-bar-background-color: lighten($alto, 5%) !default;
 		font-size: $font-size-large;
 		margin: 0;
 		color: white;
+		text-transform: uppercase;
 	}
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The guidelines said drawer title in uppercase, but the source code doesn't apply this style.

**What is the chosen solution to this problem?**

Add css text-transform uppercase

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)