### PR TITLE
feat(components/SidePanel): add onSelect to items

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -25,6 +25,7 @@ import theme from './SidePanel.scss';
  *
  */
 function SidePanel(props) {
+	const { selected, onSelect } = props;
 	const actions = props.actions || [];
 
 	const dockedCSS = { [theme.docked]: props.docked };
@@ -39,8 +40,8 @@ function SidePanel(props) {
 		theme['action-list'],
 	);
 	const isActionSelected = (action) => {
-		if (props.selected) {
-			return action.key === props.selected;
+		if (selected) {
+			return action === selected;
 		}
 		return action.active;
 	};
@@ -74,8 +75,8 @@ function SidePanel(props) {
 							role="link"
 							className={theme.link}
 							onClick={(event) => {
-								if (props.onSelect) {
-									props.onSelect(event, action);
+								if (onSelect) {
+									onSelect(event, action);
 								}
 								if (action.onClick) {
 									action.onClick(event);

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -17,8 +17,10 @@ import theme from './SidePanel.scss';
  ];
  <SidePanel
 	 actions={ actions }
-	 onToggleDock={ action('Toggle dock clicked') }
 	 docked={ isDocked }
+	 selected= { selectedItem }
+	 onToggleDock={ action('Toggle dock clicked') }
+	 onSelect={ action('onItemSelect') }
  />
  *
  */
@@ -36,6 +38,12 @@ function SidePanel(props) {
 		'tc-side-panel-list',
 		theme['action-list'],
 	);
+	const isActionSelected = (action) => {
+		if (props.selected) {
+			return action.key === props.selected;
+		}
+		return action.active;
+	};
 
 	return (
 		<nav className={navCSS}>
@@ -54,10 +62,10 @@ function SidePanel(props) {
 				</li>
 				{actions.map(action => (
 					<li
-						key={action.label}
+						key={action.key || action.label}
 						className={classNames(
 							'tc-side-panel-list-item',
-							{ active: !!action.active },
+							{ active: isActionSelected(action) },
 						)}
 					>
 						<Action
@@ -65,7 +73,14 @@ function SidePanel(props) {
 							bsStyle="link"
 							role="link"
 							className={theme.link}
-							onClick={action.onClick}
+							onClick={(event) => {
+								if (props.onSelect) {
+									props.onSelect(event, action);
+								}
+								if (action.onClick) {
+									action.onClick(event);
+								}
+							}}
 							label={action.label}
 							icon={action.icon}
 							hideLabel={props.docked}
@@ -82,13 +97,17 @@ SidePanel.propTypes = {
 	id: React.PropTypes.string,
 	actions: React.PropTypes.arrayOf(
 		React.PropTypes.shape({
-			label: React.PropTypes.string,
+			active: React.PropTypes.bool,
 			icon: React.PropTypes.string,
+			key: React.PropTypes.string,
+			label: React.PropTypes.string,
 			onClick: React.PropTypes.func,
 		}),
 	),
+	onSelect: React.PropTypes.func,
 	onToggleDock: React.PropTypes.func,
 	docked: React.PropTypes.bool,
+	selected: React.PropTypes.string,
 	tooltipPlacement: React.PropTypes.string,
 };
 

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -3371,17 +3371,87 @@ exports[`Storyshots SidePanel with onSelect function 1`] = `
                       <span
                         style={Object {}}
                       >
-                        <span
-                          style={
-                            Object {
-                              "color": "#22a",
-                              "wordBreak": "break-word",
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
                             }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              key
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              datasets
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              label
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              Datasets
+                              "
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              icon
+                            </span>
+                            : 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#22a",
+                                  "wordBreak": "break-word",
+                                }
+                              }
+                            >
+                              "
+                              talend-download
+                              "
+                            </span>
+                            }
+                          </span>
                           }
-                        >
-                          "
-                          datasets
-                          "
                         </span>
                       </span>
                     </span>

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -1207,10 +1207,38 @@ exports[`Storyshots SidePanel default 1`] = `
                 </tr>
                 <tr>
                   <td>
+                    onSelect
+                  </td>
+                  <td>
+                    func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     onToggleDock
                   </td>
                   <td>
                     func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    selected
+                  </td>
+                  <td>
+                    string
                   </td>
                   <td>
                     no
@@ -2413,10 +2441,1311 @@ exports[`Storyshots SidePanel docked 1`] = `
                 </tr>
                 <tr>
                   <td>
+                    onSelect
+                  </td>
+                  <td>
+                    func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
                     onToggleDock
                   </td>
                   <td>
                     func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    selected
+                  </td>
+                  <td>
+                    string
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    tooltipPlacement
+                  </td>
+                  <td>
+                    string
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    <span
+                      style={
+                        Object {
+                          "color": "#22a",
+                          "wordBreak": "break-word",
+                        }
+                      }
+                    >
+                      "
+                      right
+                      "
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;
+
+exports[`Storyshots SidePanel with onSelect function 1`] = `
+<div>
+  <div
+    style={
+      Object {
+        "position": "relative",
+        "zIndex": 0,
+      }
+    }
+  >
+    <div>
+      <svg
+        focusable="false"
+        style={
+          Object {
+            "display": "none",
+          }
+        }
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <symbol
+          id="talend-arrow-left"
+        >
+          <svg
+            version="1.1"
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              points="15,7 4.4,7 8.4,3 7,1.6 0.6,8 7,14.4 8.4,13 4.4,9 15,9 "
+            />
+          </svg>
+        </symbol>
+        <symbol
+          id="talend-dataprep"
+        >
+          <svg
+            viewBox="0 0 32 32"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M14.99976,6a3,3,0,1,0-3-3A3.00082,3.00082,0,0,0,14.99976,6Zm-7,2a2,2,0,1,0-2-2A1.99884,1.99884,0,0,0,7.99976,8Zm16-1.6a2,2,0,1,0-2-2A1.99883,1.99883,0,0,0,23.99976,6.4Zm5.02736,23.85L20.9724,15.74608a3.303,3.303,0,0,0-.9726-1.0078V11.5a1.89446,1.89446,0,0,0,2-1.75,1.8918,1.8918,0,0,0-2-1.75h-8a1.89184,1.89184,0,0,0-2,1.75,1.89449,1.89449,0,0,0,2,1.75v3.23828a3.28838,3.28838,0,0,0-.97168,1.0078L2.97144,30.25A1.07993,1.07993,0,0,0,3.99976,32h24A1.07943,1.07943,0,0,0,29.02712,30.25ZM7.11112,28,9.3328,24h13.335l2.22064,4Z"
+            />
+          </svg>
+        </symbol>
+        <symbol
+          id="talend-download"
+        >
+          <svg
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path
+              d="M16,11v5H0V11H2v3H14V11ZM13.4,7l-1.4-1.4-3,3V0h-2V8.6l-3-3L2.6,7l5.4,5Z"
+            />
+          </svg>
+        </symbol>
+        <symbol
+          id="talend-star"
+        >
+          <svg
+            version="1.1"
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <polygon
+              points="8,0 10.5,5 16,5.8 12,9.7 12.9,15.2 8,12.6 3.1,15.2 4,9.7 0,5.8 5.5,5 "
+            />
+          </svg>
+        </symbol>
+      </svg>
+      <nav
+        className="tc-side-panel"
+      >
+        <ul
+          className="nav nav-pills nav-inverse nav-stacked tc-side-panel-list"
+        >
+          <li
+            className={undefined}
+          >
+            <button
+              aria-describedby={42}
+              className="btn btn-link"
+              disabled={false}
+              onBlur={[Function]}
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOut={[Function]}
+              onMouseOver={[Function]}
+              role={null}
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="tc-svg-icon"
+                focusable="false"
+                title={null}
+              >
+                <use
+                  xlinkHref="#talend-arrow-left"
+                />
+              </svg>
+            </button>
+          </li>
+          <li
+            className="tc-side-panel-list-item"
+          >
+            <button
+              className="btn btn-link"
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="tc-svg-icon"
+                focusable="false"
+                title={null}
+              >
+                <use
+                  xlinkHref="#talend-dataprep"
+                />
+              </svg>
+              <span>
+                Preparations
+              </span>
+            </button>
+          </li>
+          <li
+            className="tc-side-panel-list-item active"
+          >
+            <button
+              className="btn btn-link"
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="tc-svg-icon"
+                focusable="false"
+                title={null}
+              >
+                <use
+                  xlinkHref="#talend-download"
+                />
+              </svg>
+              <span>
+                Datasets
+              </span>
+            </button>
+          </li>
+          <li
+            className="tc-side-panel-list-item"
+          >
+            <button
+              className="btn btn-link"
+              disabled={false}
+              onClick={[Function]}
+              role={null}
+              type="button"
+            >
+              <svg
+                aria-hidden="true"
+                className="tc-svg-icon"
+                focusable="false"
+                title={null}
+              >
+                <use
+                  xlinkHref="#talend-star"
+                />
+              </svg>
+              <span>
+                Favorites
+              </span>
+            </button>
+          </li>
+        </ul>
+      </nav>
+    </div>
+  </div>
+  <a
+    onClick={[Function]}
+    style={
+      Object {
+        "background": "#28c",
+        "borderRadius": "0 0 0 5px",
+        "color": "#fff",
+        "cursor": "pointer",
+        "display": "block",
+        "fontFamily": "sans-serif",
+        "fontSize": 12,
+        "padding": "5px 15px",
+        "position": "fixed",
+        "right": 0,
+        "textDecoration": "none",
+        "top": 0,
+      }
+    }
+  >
+    ?
+  </a>
+  <div
+    style={
+      Object {
+        "background": "white",
+        "bottom": 0,
+        "display": "none",
+        "left": 0,
+        "overflow": "auto",
+        "padding": "0 40px",
+        "position": "absolute",
+        "right": 0,
+        "top": 0,
+      }
+    }
+  >
+    <a
+      onClick={[Function]}
+      style={
+        Object {
+          "background": "#28c",
+          "borderRadius": "0 0 0 5px",
+          "color": "#fff",
+          "cursor": "pointer",
+          "display": "block",
+          "fontFamily": "sans-serif",
+          "fontSize": 12,
+          "padding": "5px 15px",
+          "position": "fixed",
+          "right": 0,
+          "textDecoration": "none",
+          "top": 0,
+        }
+      }
+    >
+      ×
+    </a>
+    <div
+      style={undefined}
+    >
+      <div
+        style={
+          Object {
+            "WebkitFontSmoothing": "antialiased",
+            "color": "#444",
+            "fontFamily": "
+              -apple-system, \\".SFNSText-Regular\\", \\"San Francisco\\", \\"Roboto\\",
+              \\"Segoe UI\\", \\"Helvetica Neue\\", \\"Lucida Grande\\", sans-serif
+            ",
+            "fontSize": 15,
+            "fontWeight": 300,
+            "lineHeight": 1.45,
+          }
+        }
+      >
+        <div
+          style={
+            Object {
+              "borderBottom": "1px solid #eee",
+              "marginBottom": 10,
+            }
+          }
+        >
+          <h1
+            style={
+              Object {
+                "fontSize": 35,
+                "margin": "20px 0 0 0",
+                "padding": 0,
+              }
+            }
+          >
+            SidePanel
+          </h1>
+          <h2
+            style={
+              Object {
+                "fontSize": 22,
+                "fontWeight": 400,
+                "margin": "0 0 10px 0",
+                "padding": 0,
+              }
+            }
+          >
+            with onSelect function
+          </h2>
+        </div>
+        
+        <div>
+          <h1
+            style={
+              Object {
+                "borderBottom": "1px solid #EEE",
+                "fontSize": 25,
+                "margin": "20px 0 0 0",
+                "padding": "0 0 5px 0",
+              }
+            }
+          >
+            Story Source
+          </h1>
+          <pre
+            style={
+              Object {
+                "backgroundColor": "#fafafa",
+                "fontFamily": "Menlo, Monaco, \\"Courier New\\", monospace",
+                "fontSize": ".88em",
+                "lineHeight": 1.5,
+                "overflowX": "scroll",
+                "padding": ".5rem",
+              }
+            }
+          >
+            <div>
+              <div
+                style={
+                  Object {
+                    "paddingLeft": 18,
+                    "paddingRight": 3,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  &lt;
+                  div
+                </span>
+                <span />
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  &gt;
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "paddingLeft": 33,
+                    "paddingRight": 3,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  &lt;
+                  IconsProvider
+                </span>
+                <span>
+                  <span>
+                     
+                    <span
+                      style={Object {}}
+                    >
+                      defaultIcons
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            {
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              talend-arrow-left
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                &lt;svg /&gt;
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              talend-dataprep
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                &lt;svg /&gt;
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span
+                              style={
+                                Object {
+                                  "color": "#666",
+                                }
+                              }
+                            >
+                              talend-download
+                            </span>
+                            : 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                &lt;svg /&gt;
+                              </span>
+                              }
+                            </span>
+                            , 
+                            …
+                            }
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                     
+                  </span>
+                </span>
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  /&gt;
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "paddingLeft": 33,
+                    "paddingRight": 3,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  &lt;
+                  SidePanel
+                </span>
+                <span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span
+                      style={Object {}}
+                    >
+                      actions
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            [
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  key
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  preparations
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  label
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Preparations
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  icon
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  talend-dataprep
+                                  "
+                                </span>
+                                }
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  key
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  datasets
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  label
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Datasets
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  icon
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  talend-download
+                                  "
+                                </span>
+                                }
+                              </span>
+                              }
+                            </span>
+                            , 
+                            <span>
+                              {
+                              <span
+                                style={
+                                  Object {
+                                    "color": "#666",
+                                  }
+                                }
+                              >
+                                {
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  key
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  favorites
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  label
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  Favorites
+                                  "
+                                </span>
+                                , 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#666",
+                                    }
+                                  }
+                                >
+                                  icon
+                                </span>
+                                : 
+                                <span
+                                  style={
+                                    Object {
+                                      "color": "#22a",
+                                      "wordBreak": "break-word",
+                                    }
+                                  }
+                                >
+                                  "
+                                  talend-star
+                                  "
+                                </span>
+                                }
+                              </span>
+                              }
+                            </span>
+                            ]
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span
+                      style={Object {}}
+                    >
+                      onSelect
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#170",
+                              }
+                            }
+                          >
+                            anonymous()
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span
+                      style={Object {}}
+                    >
+                      onToggleDock
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#170",
+                              }
+                            }
+                          >
+                            anonymous()
+                          </span>
+                          }
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span
+                      style={Object {}}
+                    >
+                      selected
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          datasets
+                          "
+                        </span>
+                      </span>
+                    </span>
+                  </span>
+                  <span>
+                    <span>
+                      <br />
+                        
+                    </span>
+                    <span
+                      style={Object {}}
+                    >
+                      tooltipPlacement
+                    </span>
+                    <span>
+                      =
+                      <span
+                        style={Object {}}
+                      >
+                        <span
+                          style={
+                            Object {
+                              "color": "#22a",
+                              "wordBreak": "break-word",
+                            }
+                          }
+                        >
+                          "
+                          top
+                          "
+                        </span>
+                      </span>
+                    </span>
+                    <br />
+                  </span>
+                </span>
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  /&gt;
+                </span>
+              </div>
+              <div
+                style={
+                  Object {
+                    "paddingLeft": 18,
+                    "paddingRight": 3,
+                  }
+                }
+              >
+                <span
+                  style={
+                    Object {
+                      "color": "#777",
+                    }
+                  }
+                >
+                  &lt;/
+                  div
+                  &gt;
+                </span>
+              </div>
+            </div>
+          </pre>
+        </div>
+        <div>
+          <h1
+            style={
+              Object {
+                "borderBottom": "1px solid #EEE",
+                "fontSize": 25,
+                "margin": "20px 0 0 0",
+                "padding": "0 0 5px 0",
+              }
+            }
+          >
+            Prop Types
+          </h1>
+          <div>
+            <h2
+              style={
+                Object {
+                  "margin": "20px 0 0 0",
+                }
+              }
+            >
+              "
+              IconsProvider
+              " Component
+            </h2>
+            <table
+              style={
+                Object {
+                  "borderCollapse": "separate",
+                  "borderSpacing": "10px 5px",
+                  "marginLeft": -10,
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th>
+                    property
+                  </th>
+                  <th>
+                    propType
+                  </th>
+                  <th>
+                    required
+                  </th>
+                  <th>
+                    default
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    defaultIcons
+                  </td>
+                  <td>
+                    object
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    <span>
+                      {
+                      <span
+                        style={
+                          Object {
+                            "color": "#666",
+                          }
+                        }
+                      >
+                        {
+                        <span
+                          style={
+                            Object {
+                              "color": "#666",
+                            }
+                          }
+                        >
+                          talend-activemq
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            &lt;svg /&gt;
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span
+                          style={
+                            Object {
+                              "color": "#666",
+                            }
+                          }
+                        >
+                          talend-activity
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            &lt;svg /&gt;
+                          </span>
+                          }
+                        </span>
+                        , 
+                        <span
+                          style={
+                            Object {
+                              "color": "#666",
+                            }
+                          }
+                        >
+                          talend-aggregate
+                        </span>
+                        : 
+                        <span>
+                          {
+                          <span
+                            style={
+                              Object {
+                                "color": "#666",
+                              }
+                            }
+                          >
+                            &lt;svg /&gt;
+                          </span>
+                          }
+                        </span>
+                        , 
+                        …
+                        }
+                      </span>
+                      }
+                    </span>
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    icons
+                  </td>
+                  <td>
+                    object
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    <span>
+                      {
+                      <span
+                        style={
+                          Object {
+                            "color": "#666",
+                          }
+                        }
+                      >
+                        {
+                        }
+                      </span>
+                      }
+                    </span>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <div>
+            <h2
+              style={
+                Object {
+                  "margin": "20px 0 0 0",
+                }
+              }
+            >
+              "
+              SidePanel
+              " Component
+            </h2>
+            <table
+              style={
+                Object {
+                  "borderCollapse": "separate",
+                  "borderSpacing": "10px 5px",
+                  "marginLeft": -10,
+                }
+              }
+            >
+              <thead>
+                <tr>
+                  <th>
+                    property
+                  </th>
+                  <th>
+                    propType
+                  </th>
+                  <th>
+                    required
+                  </th>
+                  <th>
+                    default
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>
+                    actions
+                  </td>
+                  <td>
+                    other
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    docked
+                  </td>
+                  <td>
+                    bool
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    id
+                  </td>
+                  <td>
+                    string
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    onSelect
+                  </td>
+                  <td>
+                    func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    onToggleDock
+                  </td>
+                  <td>
+                    func
+                  </td>
+                  <td>
+                    no
+                  </td>
+                  <td>
+                    -
+                  </td>
+                </tr>
+                <tr>
+                  <td>
+                    selected
+                  </td>
+                  <td>
+                    string
                   </td>
                   <td>
                     no

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -30,32 +30,54 @@ const actions = [
 	},
 ];
 
+const items = [{
+	key: 'preparations',
+	label: 'Preparations',
+	icon: 'talend-dataprep',
+}, {
+	key: 'datasets',
+	label: 'Datasets',
+	icon: 'talend-download',
+}, {
+	key: 'favorites',
+	label: 'Favorites',
+	icon: 'talend-star',
+}];
+
 storiesOf('SidePanel', module)
-	.addWithInfo('default', () => {
-		return (
-			<div>
-				<IconsProvider defaultIcons={icons} />
-				<SidePanel
-					id="context"
-					actions={actions}
-					onToggleDock={action('Toggle dock clicked')}
-					docked={false}
-					tooltipPlacement="top"
-				/>
-			</div>
-		);
-	})
-	.addWithInfo('docked', () =>
-		(
-			<div>
-				<IconsProvider defaultIcons={icons} />
-				<SidePanel
-					actions={actions}
-					onToggleDock={action('Toggle dock clicked')}
-					docked
-					tooltipPlacement="top"
-				/>
-			</div>
-		)
-	);
+	.addWithInfo('default', () => (
+		<div>
+			<IconsProvider defaultIcons={icons} />
+			<SidePanel
+				id="context"
+				actions={actions}
+				onToggleDock={action('Toggle dock clicked')}
+				docked={false}
+				tooltipPlacement="top"
+			/>
+		</div>
+	))
+	.addWithInfo('docked', () => (
+		<div>
+			<IconsProvider defaultIcons={icons} />
+			<SidePanel
+				actions={actions}
+				onToggleDock={action('Toggle dock clicked')}
+				docked
+				tooltipPlacement="top"
+			/>
+		</div>
+	))
+	.addWithInfo('with onSelect function', () => (
+		<div>
+			<IconsProvider defaultIcons={icons} />
+			<SidePanel
+				actions={items}
+				onSelect={action('onItemSelect')}
+				onToggleDock={action('onToggleDock')}
+				selected="datasets"
+				tooltipPlacement="top"
+			/>
+		</div>
+	));
 

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -75,7 +75,7 @@ storiesOf('SidePanel', module)
 				actions={items}
 				onSelect={action('onItemSelect')}
 				onToggleDock={action('onToggleDock')}
-				selected="datasets"
+				selected={items[1]}
 				tooltipPlacement="top"
 			/>
 		</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Need to add onClick and active props to each item of SidePanel

**What is the chosen solution to this problem?**

Have onSelect and selected props for whole SidePanel

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

