### PR TITLE
feat(containers/SidePanel): Adds routerPush matching

### DIFF
--- a/packages/cmf/src/mock/settings.js
+++ b/packages/cmf/src/mock/settings.js
@@ -70,6 +70,17 @@ const settings = {
 				},
 			},
 		},
+		'menu:routerPush': {
+			id: 'routerPush',
+			name: 'Menu',
+			icon: 'fa-bars',
+			payload: {
+				type: 'TEST_MENU',
+				cmf: {
+					routerReplace: '/push',
+				},
+			},
+		},
 	},
 	views: {
 		appmenu: {

--- a/packages/containers/src/SidePanel/SidePanel.container.js
+++ b/packages/containers/src/SidePanel/SidePanel.container.js
@@ -13,7 +13,10 @@ export function getActions(actionIds, context) {
 	return actionIds.map((id) => {
 		const info = api.action.getActionInfo(context, id);
 		info.onClick = () => context.store.dispatch(info.payload);
-		const route = get(info, 'payload.cmf.routerReplace');
+		let route = get(info, 'payload.cmf.routerReplace');
+		if (!route) {
+			route = get(info, 'payload.cmf.routerPush');
+		}
 		if (route) {
 			const currentRoute = context.router.location.pathname;
 			if (currentRoute.indexOf(route) !== -1) {

--- a/packages/containers/src/SidePanel/SidePanel.test.js
+++ b/packages/containers/src/SidePanel/SidePanel.test.js
@@ -44,5 +44,9 @@ describe('SidePanel:getActions', () => {
 		context.router = { location: { pathname: '/different' } };
 		const notactive = getActions(['menu:routerReplace'], context)[0];
 		expect(notactive.active).toBe(undefined);
+
+		context.router = { location: { pathname: '/push' } };
+		const push = getActions(['menu:routerPush'], context)[0];
+		expect(push.active).toBe(true);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently the side panel only matches the highlighted link based on the
routerReplace settings.

**What is the chosen solution to this problem?**
It now matches on the routerPush.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR