### PR TITLE
fix: remove semicolon from the rendering

### DIFF
--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
@@ -51,7 +51,7 @@ function SelectSortBy({ field, id, isDescending, onChange, options }) {
 						option,
 						index,
 						id,
-					}))};
+					}))}
 				</NavDropdown>)
 			}
 			{selected && (

--- a/packages/components/src/List/Toolbar/SelectSortBy/__snapshots__/SelectSortBy.test.js.snap
+++ b/packages/components/src/List/Toolbar/SelectSortBy/__snapshots__/SelectSortBy.test.js.snap
@@ -62,7 +62,6 @@ exports[`SelectSortBy should render 1`] = `
           Name
         </a>
       </li>
-      ;
     </ul>
   </li>
   <li
@@ -144,7 +143,6 @@ exports[`SelectSortBy should render id if provided 1`] = `
           Name
         </a>
       </li>
-      ;
     </ul>
   </li>
   <li
@@ -257,7 +255,6 @@ exports[`SelectSortBy should render without field selected 1`] = `
           Name
         </a>
       </li>
-      ;
     </ul>
   </li>
 </ul>

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -624,7 +624,6 @@ exports[`Toolbar should render sort selector 1`] = `
                 Name
               </a>
             </li>
-            ;
           </ul>
         </li>
         <li

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -496,7 +496,6 @@ exports[`List should render 1`] = `
                   Name
                 </a>
               </li>
-              ;
             </ul>
           </li>
           <li
@@ -1262,7 +1261,6 @@ exports[`List should render id if provided 1`] = `
                   Name
                 </a>
               </li>
-              ;
             </ul>
           </li>
           <li


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

<img width="239" alt="screen shot 2017-05-22 at 14 17 03" src="https://cloud.githubusercontent.com/assets/19857479/26308463/a3bdadf2-3ef9-11e7-830c-65e294c55ad9.png">


**What is the chosen solution to this problem?**

remove ';'

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
