### PR TITLE
fix(cmf/settings/TFD-1318): fetch settings using http action

### DIFF
--- a/packages/cmf/__tests__/actions/settingsAction.test.js
+++ b/packages/cmf/__tests__/actions/settingsAction.test.js
@@ -38,4 +38,10 @@ describe('CMF settinsActions', () => {
 		expect(action.error.message).toBe(error.message);
 		expect(action.error.stack).toBe(error.stack);
 	});
+
+	it('should fetchSettings return action', () => {
+		const action = settings.fetchSettings();
+		expect(action.type).toBe('GET');
+		expect(action.url).toBe('settings.json');
+	});
 });

--- a/packages/cmf/src/actions/settingsActions.js
+++ b/packages/cmf/src/actions/settingsActions.js
@@ -3,6 +3,8 @@
  */
 import get from 'lodash/get';
 
+import http from './http';
+
 export const REQUEST_SETTINGS = 'REACT_CMF.REQUEST_SETTINGS';
 export const REQUEST_KO = 'REACT_CMF.REQUEST_SETTINGS_KO';
 export const REQUEST_OK = 'REACT_CMF.REQUEST_SETTINGS_OK';
@@ -38,14 +40,8 @@ export function errorWithSettings(error) {
  * @return {function} with the fetch process results
  */
 export function fetchSettings(path = 'settings.json') {
-	return (dispatch) => {
-		dispatch(requestSettings());
-		return fetch(path)
-			.then(response => response.json())
-			.then((json) => {
-				dispatch(receiveSettings(json));
-			}, (error) => {
-				dispatch(errorWithSettings(error));
-			});
-	};
+	return http.get(path, {
+		onResponse: response => receiveSettings(response),
+		onError: error => errorWithSettings(error),
+	});
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

the current fetch settings use a stock fetch API, so we don't have the default options to send cookies.

**What is the chosen solution to this problem?**

Use the http action provided by cmf to fetch the settings;

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
