### PR TITLE
fix(components/httperror): move error code backward

### DIFF
--- a/packages/components/src/HttpError/HttpError.scss
+++ b/packages/components/src/HttpError/HttpError.scss
@@ -20,6 +20,7 @@ $tc-http-error-message-color: #888 !default;
 		line-height: 0.7;
 		color: $tc-http-error-status-color;
 		opacity: 0.1;
+		z-index: -1;
 	}
 
 	&-content {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Error code is before SVG with opacity, we can imagine SVG are transparent.

**What is the chosen solution to this problem?**
Move error code backward

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

