### PR TITLE
fix(components/collapsiblepanel): Align toggle button for IE11

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.75.1 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.76.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.75.1 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.76.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -4,9 +4,3 @@ Scoping to packages that match 'react-talend-components'
 > react-talend-components@0.75.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
-
-src/CollapsiblePanel/CollapsiblePanel.scss
-  109:1  warning  Space expected between blocks  empty-line-between-blocks
-
-✖ 1 problem (0 errors, 1 warning)
-

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.75.1 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.76.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -4,3 +4,9 @@ Scoping to packages that match 'react-talend-components'
 > react-talend-components@0.75.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
+
+src/CollapsiblePanel/CollapsiblePanel.scss
+  109:1  warning  Space expected between blocks  empty-line-between-blocks
+
+✖ 1 problem (0 errors, 1 warning)
+

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.75.1 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.76.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.75.1 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.76.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.75.1 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.76.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.75.1 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.76.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.75.1 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.76.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -103,7 +103,7 @@ $tc-toggle-color: #555964 !default;
 			> * {
 				@include col-style;
 			}
-			
+
 			&,
 			> * {
 				display: flex;

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -99,12 +99,16 @@ $tc-toggle-color: #555964 !default;
 			align-items: center;
 			font-size: 1.4rem;
 			justify-content: space-between;
-			min-height: 4rem;
 			padding-left: 5px;
 			padding-right: 5px;
 
 			> * {
 				@include col-style;
+			}
+			
+			&,
+			> * {
+				min-height: 4rem;
 			}
 		}
 	}

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -106,7 +106,7 @@ $tc-toggle-color: #555964 !default;
 				@include col-style;
 				display: flex;
 				align-items: center;
-				min-height: 4rem;
+				height: 4rem;
 			}
 		}
 	}

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -92,13 +92,11 @@ $tc-toggle-color: #555964 !default;
 		}
 
 		.panel-title {
-			display: flex;
 			flex-basis: 100%;
+			justify-content: space-between;
 			overflow: hidden;
 			text-decoration: none;
-			align-items: center;
 			font-size: 1.4rem;
-			justify-content: space-between;
 			padding-left: 5px;
 			padding-right: 5px;
 
@@ -108,6 +106,8 @@ $tc-toggle-color: #555964 !default;
 			
 			&,
 			> * {
+				display: flex;
+				align-items: center;
 				min-height: 4rem;
 			}
 		}

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -66,11 +66,7 @@ $tc-toggle-color: #555964 !default;
 		padding-left: 1px;
 	}
 
-	:global(.toggle) {
-		display: flex;
-	}
-
-	svg {
+	.toggle svg {
 		transform-origin: center;
 	}
 

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -92,8 +92,10 @@ $tc-toggle-color: #555964 !default;
 		}
 
 		.panel-title {
-			flex-basis: 100%;
+			display: flex;
+			align-items: center;
 			justify-content: space-between;
+			flex-basis: 100%;
 			overflow: hidden;
 			text-decoration: none;
 			font-size: 1.4rem;
@@ -102,10 +104,6 @@ $tc-toggle-color: #555964 !default;
 
 			> * {
 				@include col-style;
-			}
-
-			&,
-			> * {
 				display: flex;
 				align-items: center;
 				min-height: 4rem;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
IE 11 does not align toggle button to center

**What is the chosen solution to this problem?**
Let's remove `display: flex` for that button

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
Will fix https://jira.talendforge.org/browse/TDP-3757
