### PR TITLE
fix(Icon): fix <use> issue on IE11/Win7

### DIFF
--- a/packages/components/src/Icon/Icon.scss
+++ b/packages/components/src/Icon/Icon.scss
@@ -9,6 +9,10 @@ $tc-icon-size: $svg-md-size !default;
 	width: $tc-icon-size;
 	height: $tc-icon-size;
 	fill: currentColor;
+
+	use {
+		pointer-events: none;
+	}
 }
 
 .spin {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a IE11/Win7 bug with mount/unmount of `<use>` elements.
The result is that the mouse click events are blocked.

**What is the chosen solution to this problem?**
https://stackoverflow.com/questions/29932780/what-would-cause-click-events-to-stop-working-in-internet-explorer-11

Add a css property on `<use>` tag seems to "fix" the problem ¯\_(ツ)_/¯

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

