### PR TITLE
fix(components/status): add space between icon and label

### DIFF
--- a/packages/components/src/Status/Status.scss
+++ b/packages/components/src/Status/Status.scss
@@ -1,5 +1,6 @@
 $tc-status-icon-size: $svg-md-size !default;
 $tc-status-action-min-size: 23px !default;
+$tc-status-space-btn-icon-label: 5px !default;
 
 .tc-status {
 	position: relative;
@@ -10,6 +11,7 @@ $tc-status-action-min-size: 23px !default;
 	> svg {
 		width: $tc-status-icon-size;
 		height: $tc-status-icon-size;
+		margin-right: $tc-status-space-btn-icon-label;
 	}
 
 	&-actions {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is no more space between the icon and the label in the status component.
This was asked in a comment in TDP-3757

**What is the chosen solution to this problem?**
I added 5 px of margin-right

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

