### PR TITLE
fix(components/drawer): fix key generation if a route is available

### DIFF
--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -27,7 +27,10 @@ function WithDrawer({ drawers, children }) {
 			{children}
 			<CSSTransitionGroup transitionAppear className={theme['tc-with-drawer-container']}>
 				{drawers && drawers.map((drawer, key) => (
-					<Drawer.Animation key={key} className="tc-with-drawer-wrapper">
+					<Drawer.Animation
+						key={(drawer.props.route && drawer.props.route.path) || key}
+						className="tc-with-drawer-wrapper"
+					>
 						{drawer}
 					</Drawer.Animation>
 				))}

--- a/packages/components/src/WithDrawer/withDrawer.test.js
+++ b/packages/components/src/WithDrawer/withDrawer.test.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import WithDrawer from './WithDrawer.component';
+import Drawer from './../Drawer';
+
+describe('WithDrawer', () => {
+	it('should inject route as key if available', () => {
+		const drawer = <Drawer route={{ path: 'path' }} >test</Drawer>;
+		const wrapper = shallow(<WithDrawer drawers={[drawer]} />);
+		expect(wrapper.children().children().key()).toEqual('path');
+	});
+
+	it('should inject generated key if route isn\'t available', () => {
+		const drawer = <Drawer>test</Drawer>;
+		const wrapper = shallow(<WithDrawer drawers={[drawer]} />);
+		expect(wrapper.children().children().key()).toEqual('0');
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
with drawer map drawer with a key generated from sequence.
meaning that  when a drawer in second position get unmounted and replaced, the animation is triggered and then canceled with the new same level drawer mounted.

**What is the chosen solution to this problem?**
if a route is available, it is used as key, variable elements in routes are not taken into account, so for the same route with different parameter the drawer doesn't get animated.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

