### PR TITLE
fix(components/TooltipTrigger): noop props and aria-describedby with uuid content

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -131,17 +131,14 @@ exports[`ActionDropdown should render a button with icon 1`] = `
   className="dropdown btn-group btn-group-default"
 >
   <button
-    aria-describedby={42}
     aria-expanded={false}
     aria-haspopup={true}
     className="dropdown-toggle btn btn-default"
     disabled={false}
     id="dropdown-id"
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="button"
     type="button"

--- a/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
+++ b/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
@@ -419,13 +419,10 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
   className="tc-actions btn-group"
 >
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -438,13 +435,10 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     />
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -457,13 +451,10 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     />
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -479,17 +470,14 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     className="dropdown btn-group btn-group-link"
   >
     <button
-      aria-describedby={42}
       aria-expanded={false}
       aria-haspopup={true}
       className="dropdown-toggle btn btn-link"
       disabled={false}
       id="dropdown-id"
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="button"
       type="button"
@@ -634,13 +622,10 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
   className="tc-actions btn-group"
 >
   <button
-    aria-describedby={42}
     className="btn btn-primary"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -653,13 +638,10 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     />
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -672,13 +654,10 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     />
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -694,17 +673,14 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     className="dropdown btn-group btn-group-default"
   >
     <button
-      aria-describedby={42}
       aria-expanded={false}
       aria-haspopup={true}
       className="dropdown-toggle btn btn-default"
       disabled={false}
       id="dropdown-id"
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
       onKeyDown={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="button"
       type="button"

--- a/packages/components/src/Badge/__snapshots__/Badge.snap.test.js.snap
+++ b/packages/components/src/Badge/__snapshots__/Badge.snap.test.js.snap
@@ -10,13 +10,10 @@ exports[`Badge should render Badge with icon in outline style 1`] = `
     Label 1
   </span>
   <button
-    aria-describedby={42}
     className="undefined tc-badge-delete-icon btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -45,13 +42,10 @@ exports[`Badge should render Badge with icon in solid style 1`] = `
     Label 1
   </span>
   <button
-    aria-describedby={42}
     className="undefined tc-badge-delete-icon btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"

--- a/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
+++ b/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
@@ -83,13 +83,10 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
           className=""
         >
           <button
-            aria-describedby={42}
             className="btn btn-link"
             disabled={false}
-            onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
             role="link"
             type="button"
@@ -106,12 +103,8 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             by Charles
@@ -121,23 +114,15 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             on TDP
           </span>
           <span
-            aria-describedby={42}
             className="label label-default"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             XML
@@ -286,13 +271,10 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
           className=""
         >
           <button
-            aria-describedby={42}
             className="btn btn-link"
             disabled={false}
-            onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
             role="link"
             type="button"
@@ -309,12 +291,8 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             by Charles
@@ -324,23 +302,15 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             on TDP
           </span>
           <span
-            aria-describedby={42}
             className="label label-default"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             XML
@@ -489,13 +459,10 @@ exports[`CollapsiblePanel should render default without content 1`] = `
           className=""
         >
           <button
-            aria-describedby={42}
             className="btn btn-link"
             disabled={false}
-            onBlur={[Function]}
             onClick={[Function]}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
             role="link"
             type="button"
@@ -512,12 +479,8 @@ exports[`CollapsiblePanel should render default without content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             by Charles
@@ -527,23 +490,15 @@ exports[`CollapsiblePanel should render default without content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             on TDP
           </span>
           <span
-            aria-describedby={42}
             className="label label-default"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             XML
@@ -579,23 +534,15 @@ exports[`CollapsiblePanel should render themed with textual content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Version 1 Version 1
           </span>
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             (Read Only)
@@ -605,12 +552,8 @@ exports[`CollapsiblePanel should render themed with textual content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             03/02/2017 14:44:55
@@ -657,23 +600,15 @@ exports[`CollapsiblePanel should render themed with textual content 1`] = `
             className={undefined}
           >
             <span
-              aria-describedby={42}
               className={undefined}
-              onBlur={[Function]}
-              onClick={null}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
             >
               21 step
             </span>
             <span
-              aria-describedby={42}
               className="text-right"
-              onBlur={[Function]}
-              onClick={null}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
             >
               by Abdelaziz Maalej test 1 test 2 test 1 test 2
@@ -719,23 +654,15 @@ exports[`CollapsiblePanel should render themed without textual content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Version 1 Version 1
           </span>
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             (Read Only)
@@ -745,12 +672,8 @@ exports[`CollapsiblePanel should render themed without textual content 1`] = `
           className=""
         >
           <span
-            aria-describedby={42}
             className={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             03/02/2017 14:44:55

--- a/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
@@ -11,13 +11,10 @@ exports[`Header should render header with one button 1`] = `
     className="actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -49,13 +46,10 @@ exports[`Header should render header with one button and indicate the component 
     className="actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"

--- a/packages/components/src/Enumeration/Header/__snapshots__/headerInput.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/headerInput.snapshot.test.js.snap
@@ -17,13 +17,10 @@ exports[`Header should render header input with error 1`] = `
     duplicate value
   </div>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -40,13 +37,10 @@ exports[`Header should render header input with error 1`] = `
     </svg>
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -77,13 +71,10 @@ exports[`Header should render header input with two buttons 1`] = `
     type="text"
   />
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"
@@ -100,13 +91,10 @@ exports[`Header should render header input with two buttons 1`] = `
     </svg>
   </button>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"

--- a/packages/components/src/Enumeration/Header/__snapshots__/headerSelected.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/headerSelected.snapshot.test.js.snap
@@ -8,13 +8,10 @@ exports[`Header should render header with trash icon in case of multiple selecti
     2 selected values
   </span>
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"

--- a/packages/components/src/Enumeration/Items/Item/__snapshots__/item.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/Item/__snapshots__/item.snapshot.test.js.snap
@@ -6,13 +6,10 @@ exports[`Item should display a selected item 1`] = `
   id="0-item"
 >
   <button
-    aria-describedby={42}
     className="undefined tc-enumeration-item-label btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -33,13 +30,10 @@ exports[`Item should display value with three buttons 1`] = `
   id="0-item"
 >
   <button
-    aria-describedby={42}
     className="undefined tc-enumeration-item-label btn btn-default"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role={null}
     type="button"
@@ -52,25 +46,19 @@ exports[`Item should display value with three buttons 1`] = `
     className="undefined tc-enumeration-item-actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"

--- a/packages/components/src/Enumeration/Items/Item/__snapshots__/itemEdit.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/Item/__snapshots__/itemEdit.snapshot.test.js.snap
@@ -16,25 +16,19 @@ exports[`Item should display input value with error 1`] = `
     className="undefined tc-enumeration-item-actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -64,25 +58,19 @@ exports[`Item should display input value with two buttons 1`] = `
     className="undefined tc-enumeration-item-actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -107,25 +95,19 @@ exports[`Item should display input value with two buttons. The validate button i
     className="undefined tc-enumeration-item-actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={true}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"

--- a/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
@@ -70,13 +70,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
               className="undefined tc-enumeration-item-actions"
             >
               <button
-                aria-describedby={42}
                 className="btn btn-link"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role="link"
                 type="button"
@@ -112,13 +109,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
             id="1-item"
           >
             <button
-              aria-describedby={42}
               className="undefined tc-enumeration-item-label btn btn-default"
               disabled={false}
-              onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
               role={null}
               type="button"
@@ -131,13 +125,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
               className="undefined tc-enumeration-item-actions"
             >
               <button
-                aria-describedby={42}
                 className="btn btn-link"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role="link"
                 type="button"
@@ -154,13 +145,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 </svg>
               </button>
               <button
-                aria-describedby={42}
                 className="btn btn-link"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role="link"
                 type="button"
@@ -196,13 +184,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
             id="2-item"
           >
             <button
-              aria-describedby={42}
               className="undefined tc-enumeration-item-label btn btn-default"
               disabled={false}
-              onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
               role={null}
               type="button"
@@ -215,13 +200,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
               className="undefined tc-enumeration-item-actions"
             >
               <button
-                aria-describedby={42}
                 className="btn btn-link"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role="link"
                 type="button"
@@ -238,13 +220,10 @@ exports[`Items should display one item in edit mode and the other in default 1`]
                 </svg>
               </button>
               <button
-                aria-describedby={42}
                 className="btn btn-link"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role="link"
                 type="button"

--- a/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
@@ -15,13 +15,10 @@ exports[`Enumeration should render with header in add state and list in default 
       type="text"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -38,13 +35,10 @@ exports[`Enumeration should render with header in add state and list in default 
       </svg>
     </button>
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -120,13 +114,10 @@ exports[`Enumeration should render with header in add state and list in default 
               id="0-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -139,13 +130,10 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -162,13 +150,10 @@ exports[`Enumeration should render with header in add state and list in default 
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -204,13 +189,10 @@ exports[`Enumeration should render with header in add state and list in default 
               id="1-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -223,13 +205,10 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -246,13 +225,10 @@ exports[`Enumeration should render with header in add state and list in default 
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -288,13 +264,10 @@ exports[`Enumeration should render with header in add state and list in default 
               id="2-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -307,13 +280,10 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -330,13 +300,10 @@ exports[`Enumeration should render with header in add state and list in default 
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -376,13 +343,10 @@ exports[`Enumeration should render with header in default state and first item i
       className="actions"
     >
       <button
-        aria-describedby={42}
         className="btn btn-link"
         disabled={false}
-        onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        onMouseOut={[Function]}
         onMouseOver={[Function]}
         role="link"
         type="button"
@@ -469,13 +433,10 @@ exports[`Enumeration should render with header in default state and first item i
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={true}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -492,13 +453,10 @@ exports[`Enumeration should render with header in default state and first item i
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -534,13 +492,10 @@ exports[`Enumeration should render with header in default state and first item i
               id="1-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -553,13 +508,10 @@ exports[`Enumeration should render with header in default state and first item i
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -576,13 +528,10 @@ exports[`Enumeration should render with header in default state and first item i
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -618,13 +567,10 @@ exports[`Enumeration should render with header in default state and first item i
               id="2-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -637,13 +583,10 @@ exports[`Enumeration should render with header in default state and first item i
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -660,13 +603,10 @@ exports[`Enumeration should render with header in default state and first item i
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -707,13 +647,10 @@ exports[`Enumeration should render with header in default state, list in default
       className="actions"
     >
       <button
-        aria-describedby={42}
         className="btn btn-link"
         disabled={false}
-        onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        onMouseOut={[Function]}
         onMouseOver={[Function]}
         role="link"
         type="button"
@@ -790,13 +727,10 @@ exports[`Enumeration should render with header in default state, list in default
               id="0-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -809,13 +743,10 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -832,13 +763,10 @@ exports[`Enumeration should render with header in default state, list in default
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -874,13 +802,10 @@ exports[`Enumeration should render with header in default state, list in default
               id="1-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -893,13 +818,10 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -916,13 +838,10 @@ exports[`Enumeration should render with header in default state, list in default
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -958,13 +877,10 @@ exports[`Enumeration should render with header in default state, list in default
               id="2-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -977,13 +893,10 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1000,13 +913,10 @@ exports[`Enumeration should render with header in default state, list in default
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1047,13 +957,10 @@ exports[`Enumeration should render with header in search state and list in defau
       type="text"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -1070,13 +977,10 @@ exports[`Enumeration should render with header in search state and list in defau
       </svg>
     </button>
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -1168,13 +1072,10 @@ exports[`Enumeration should render with header in search state and list in defau
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1191,13 +1092,10 @@ exports[`Enumeration should render with header in search state and list in defau
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1249,13 +1147,10 @@ exports[`Enumeration should render with header in search state and list in defau
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1272,13 +1167,10 @@ exports[`Enumeration should render with header in search state and list in defau
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1330,13 +1222,10 @@ exports[`Enumeration should render with header in search state and list in defau
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1353,13 +1242,10 @@ exports[`Enumeration should render with header in search state and list in defau
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1396,13 +1282,10 @@ exports[`Enumeration should render with header in selected state with trash icon
       2 selected values
     </span>
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -1467,13 +1350,10 @@ exports[`Enumeration should render with header in selected state with trash icon
               id="0-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -1486,13 +1366,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1509,13 +1386,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1551,13 +1425,10 @@ exports[`Enumeration should render with header in selected state with trash icon
               id="1-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -1570,13 +1441,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1593,13 +1461,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1635,13 +1500,10 @@ exports[`Enumeration should render with header in selected state with trash icon
               id="2-item"
             >
               <button
-                aria-describedby={42}
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
-                onBlur={[Function]}
                 onClick={[Function]}
                 onFocus={[Function]}
-                onMouseOut={[Function]}
                 onMouseOver={[Function]}
                 role={null}
                 type="button"
@@ -1654,13 +1516,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-actions"
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1677,13 +1536,10 @@ exports[`Enumeration should render with header in selected state with trash icon
                   </svg>
                 </button>
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -1723,13 +1579,10 @@ exports[`Enumeration should render with header without items 1`] = `
       className="actions"
     >
       <button
-        aria-describedby={42}
         className="btn btn-link"
         disabled={false}
-        onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        onMouseOut={[Function]}
         onMouseOver={[Function]}
         role="link"
         type="button"

--- a/packages/components/src/List/Content/Item/__snapshots__/Item.snapshot.test.js.snap
+++ b/packages/components/src/List/Content/Item/__snapshots__/Item.snapshot.test.js.snap
@@ -89,13 +89,10 @@ exports[`Item should render with actions 1`] = `
     }
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -117,13 +114,10 @@ exports[`Item should render with actions 1`] = `
     }
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"

--- a/packages/components/src/List/DisplayLarge/__snapshots__/DisplayLarge.test.js.snap
+++ b/packages/components/src/List/DisplayLarge/__snapshots__/DisplayLarge.test.js.snap
@@ -15,13 +15,9 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-0-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Hello world
@@ -31,13 +27,10 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -50,13 +43,10 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -142,13 +132,9 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-1-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Foo
@@ -230,13 +216,9 @@ exports[`DisplayLarge shoudl render selected list element with custom selectedCl
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-2-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Bar
@@ -325,13 +307,9 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-0-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Hello world
@@ -341,13 +319,10 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -360,13 +335,10 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -452,13 +424,9 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-1-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Foo
@@ -540,13 +508,9 @@ exports[`DisplayLarge shoudl render selected list element with defaut 'active' c
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-2-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Bar
@@ -635,13 +599,9 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id={undefined}
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Hello world
@@ -651,13 +611,10 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -670,13 +627,10 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -762,13 +716,9 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id={undefined}
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Foo
@@ -850,13 +800,9 @@ exports[`DisplayLarge should render with default title property (name) 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id={undefined}
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Bar
@@ -965,13 +911,10 @@ exports[`DisplayLarge should render with defined title property 1`] = `
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -984,13 +927,10 @@ exports[`DisplayLarge should render with defined title property 1`] = `
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -1261,13 +1201,9 @@ exports[`DisplayLarge should render with id if provided 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-0-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Hello world
@@ -1277,13 +1213,10 @@ exports[`DisplayLarge should render with id if provided 1`] = `
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -1296,13 +1229,10 @@ exports[`DisplayLarge should render with id if provided 1`] = `
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -1388,13 +1318,9 @@ exports[`DisplayLarge should render with id if provided 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-1-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Foo
@@ -1476,13 +1402,9 @@ exports[`DisplayLarge should render with id if provided 1`] = `
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-2-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Bar
@@ -1571,13 +1493,9 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-0-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Hello world
@@ -1587,13 +1505,10 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
         className="tc-actions btn-group"
       >
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -1606,13 +1521,10 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
           />
         </button>
         <button
-          aria-describedby={42}
           className="btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role="link"
           type="button"
@@ -1698,13 +1610,9 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-1-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Foo
@@ -1786,13 +1694,9 @@ exports[`DisplayLarge should render with item custom className if provided 1`] =
         className={undefined}
       >
         <span
-          aria-describedby={42}
           className={undefined}
           id="large-list-2-title"
-          onBlur={[Function]}
-          onClick={null}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
         >
           Bar

--- a/packages/components/src/List/DisplayTable/__snapshots__/DisplayTable.snapshot.test.js.snap
+++ b/packages/components/src/List/DisplayTable/__snapshots__/DisplayTable.snapshot.test.js.snap
@@ -97,12 +97,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -121,13 +117,9 @@ exports[`DisplayTable should render column actions 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -141,13 +133,10 @@ exports[`DisplayTable should render column actions 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -160,13 +149,10 @@ exports[`DisplayTable should render column actions 1`] = `
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -193,13 +179,10 @@ exports[`DisplayTable should render column actions 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="favorite btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -216,13 +199,10 @@ exports[`DisplayTable should render column actions 1`] = `
                     </svg>
                   </button>
                   <button
-                    aria-describedby={42}
                     className="certify btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -250,12 +230,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -271,12 +247,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -292,12 +264,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -318,12 +286,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -342,13 +306,9 @@ exports[`DisplayTable should render column actions 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -365,12 +325,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -386,12 +342,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -407,12 +359,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -428,12 +376,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -454,12 +398,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -478,13 +418,9 @@ exports[`DisplayTable should render column actions 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -501,12 +437,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -522,12 +454,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -543,12 +471,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -564,12 +488,8 @@ exports[`DisplayTable should render column actions 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -688,12 +608,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -712,13 +628,9 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -732,13 +644,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -751,13 +660,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -784,13 +690,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="favorite btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -807,13 +710,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     </svg>
                   </button>
                   <button
-                    aria-describedby={42}
                     className="certify btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -844,13 +744,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="favorite btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -867,13 +764,10 @@ exports[`DisplayTable should render screen reader compatible column actions with
                     </svg>
                   </button>
                   <button
-                    aria-describedby={42}
                     className="certify btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -901,12 +795,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -922,12 +812,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -943,12 +829,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -969,12 +851,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -993,13 +871,9 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -1016,12 +890,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -1037,12 +907,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -1058,12 +924,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1079,12 +941,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1100,12 +958,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1126,12 +980,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -1150,13 +1000,9 @@ exports[`DisplayTable should render screen reader compatible column actions with
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -1173,12 +1019,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -1194,12 +1036,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -1215,12 +1053,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1236,12 +1070,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1257,12 +1087,8 @@ exports[`DisplayTable should render screen reader compatible column actions with
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1362,12 +1188,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -1386,13 +1208,9 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-0-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -1406,13 +1224,10 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -1425,13 +1240,10 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -1455,12 +1267,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1476,12 +1284,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1497,12 +1301,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1523,12 +1323,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -1547,13 +1343,9 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-1-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -1570,12 +1362,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1591,12 +1379,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1612,12 +1396,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1638,12 +1418,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -1662,13 +1438,9 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-2-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -1685,12 +1457,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1706,12 +1474,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1727,12 +1491,8 @@ exports[`DisplayTable should render selected list element with custom selectedCl
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1832,12 +1592,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -1856,13 +1612,9 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-0-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -1876,13 +1628,10 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -1895,13 +1644,10 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -1925,12 +1671,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -1946,12 +1688,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1967,12 +1705,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -1993,12 +1727,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -2017,13 +1747,9 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-1-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -2040,12 +1766,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -2061,12 +1783,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2082,12 +1800,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2108,12 +1822,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -2132,13 +1842,9 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-2-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -2155,12 +1861,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -2176,12 +1878,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2197,12 +1895,8 @@ exports[`DisplayTable should render selected list element with defaut 'active' c
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2373,12 +2067,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -2397,13 +2087,9 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -2417,13 +2103,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2436,13 +2119,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2469,13 +2149,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="favorite btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2492,13 +2169,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     </svg>
                   </button>
                   <button
-                    aria-describedby={42}
                     className="certify btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2529,13 +2203,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="favorite btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2552,13 +2223,10 @@ exports[`DisplayTable should render sortable headers 1`] = `
                     </svg>
                   </button>
                   <button
-                    aria-describedby={42}
                     className="certify btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -2586,12 +2254,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -2607,12 +2271,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2628,12 +2288,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2654,12 +2310,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -2678,13 +2330,9 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -2701,12 +2349,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -2722,12 +2366,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -2743,12 +2383,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -2764,12 +2400,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2785,12 +2417,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2811,12 +2439,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -2835,13 +2459,9 @@ exports[`DisplayTable should render sortable headers 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -2858,12 +2478,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -2879,12 +2495,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   
@@ -2900,12 +2512,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -2921,12 +2529,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -2942,12 +2546,8 @@ exports[`DisplayTable should render sortable headers 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3047,12 +2647,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -3071,13 +2667,9 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -3091,13 +2683,10 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -3110,13 +2699,10 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -3140,12 +2726,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3161,12 +2743,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3182,12 +2760,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3208,12 +2782,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -3232,13 +2802,9 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -3255,12 +2821,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3276,12 +2838,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3297,12 +2855,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3323,12 +2877,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -3347,13 +2897,9 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id={undefined}
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -3370,12 +2916,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3391,12 +2933,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3412,12 +2950,8 @@ exports[`DisplayTable should render with default title property (name) 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3544,13 +3078,10 @@ exports[`DisplayTable should render with defined title property 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -3563,13 +3094,10 @@ exports[`DisplayTable should render with defined title property 1`] = `
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -3593,12 +3121,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Hello world
@@ -3614,12 +3138,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3635,12 +3155,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3656,12 +3172,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3712,12 +3224,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Foo
@@ -3733,12 +3241,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3754,12 +3258,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3775,12 +3275,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3825,12 +3321,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Bar
@@ -3846,12 +3338,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -3867,12 +3355,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3888,12 +3372,8 @@ exports[`DisplayTable should render with defined title property 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -3993,12 +3473,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -4017,13 +3493,9 @@ exports[`DisplayTable should render with id if provided 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-0-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -4037,13 +3509,10 @@ exports[`DisplayTable should render with id if provided 1`] = `
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -4056,13 +3525,10 @@ exports[`DisplayTable should render with id if provided 1`] = `
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -4086,12 +3552,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4107,12 +3569,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4128,12 +3586,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4154,12 +3608,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -4178,13 +3628,9 @@ exports[`DisplayTable should render with id if provided 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-1-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -4201,12 +3647,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4222,12 +3664,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4243,12 +3681,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4269,12 +3703,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -4293,13 +3723,9 @@ exports[`DisplayTable should render with id if provided 1`] = `
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-2-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -4316,12 +3742,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4337,12 +3759,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4358,12 +3776,8 @@ exports[`DisplayTable should render with id if provided 1`] = `
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4463,12 +3877,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   0
@@ -4487,13 +3897,9 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-0-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -4507,13 +3913,10 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                   className="tc-actions btn-group"
                 >
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -4526,13 +3929,10 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                     />
                   </button>
                   <button
-                    aria-describedby={42}
                     className="btn btn-link"
                     disabled={false}
-                    onBlur={[Function]}
                     onClick={[Function]}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                     role="link"
                     type="button"
@@ -4556,12 +3956,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4577,12 +3973,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4598,12 +3990,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4624,12 +4012,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   1
@@ -4648,13 +4032,9 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-1-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -4671,12 +4051,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4692,12 +4068,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4713,12 +4085,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4739,12 +4107,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2
@@ -4763,13 +4127,9 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                   className={undefined}
                 >
                   <span
-                    aria-describedby={42}
                     className={undefined}
                     id="table-list-2-title"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -4786,12 +4146,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   Jean-Pierre DUPONT
@@ -4807,12 +4163,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22
@@ -4828,12 +4180,8 @@ exports[`DisplayTable should render with item custom className if provided 1`] =
                 className="cell"
               >
                 <span
-                  aria-describedby={42}
                   className="item-text"
-                  onBlur={[Function]}
-                  onClick={null}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                 >
                   2016-09-22

--- a/packages/components/src/List/DisplayTile/__snapshots__/DisplayTile.test.js.snap
+++ b/packages/components/src/List/DisplayTile/__snapshots__/DisplayTile.test.js.snap
@@ -18,13 +18,9 @@ exports[`DisplayTile shoudl render selected list element with custom selectedCla
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-0-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Hello world
@@ -91,13 +87,9 @@ exports[`DisplayTile shoudl render selected list element with custom selectedCla
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-1-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Foo
@@ -164,13 +156,9 @@ exports[`DisplayTile shoudl render selected list element with custom selectedCla
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-2-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Bar
@@ -248,13 +236,9 @@ exports[`DisplayTile shoudl render selected list element with defaut 'active' cl
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-0-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Hello world
@@ -321,13 +305,9 @@ exports[`DisplayTile shoudl render selected list element with defaut 'active' cl
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-1-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Foo
@@ -394,13 +374,9 @@ exports[`DisplayTile shoudl render selected list element with defaut 'active' cl
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-2-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Bar
@@ -720,13 +696,9 @@ exports[`DisplayTile should render 3 tiles with id as title by setting 1`] = `
             title={null}
           />
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             1
@@ -799,13 +771,9 @@ exports[`DisplayTile should render 3 tiles with id as title by setting 1`] = `
             title={null}
           />
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             2
@@ -872,13 +840,9 @@ exports[`DisplayTile should render 3 tiles with id as title by setting 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             2
@@ -956,13 +920,9 @@ exports[`DisplayTile should render 3 tiles with name as title by default 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Hello world
@@ -1029,13 +989,9 @@ exports[`DisplayTile should render 3 tiles with name as title by default 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Foo
@@ -1102,13 +1058,9 @@ exports[`DisplayTile should render 3 tiles with name as title by default 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id={undefined}
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Bar
@@ -1186,13 +1138,9 @@ exports[`DisplayTile should render with id if provided 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-0-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Hello world
@@ -1259,13 +1207,9 @@ exports[`DisplayTile should render with id if provided 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-1-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Foo
@@ -1332,13 +1276,9 @@ exports[`DisplayTile should render with id if provided 1`] = `
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-2-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Bar
@@ -1416,13 +1356,9 @@ exports[`DisplayTile should render with item custom className if provided 1`] = 
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-0-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Hello world
@@ -1489,13 +1425,9 @@ exports[`DisplayTile should render with item custom className if provided 1`] = 
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-1-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Foo
@@ -1562,13 +1494,9 @@ exports[`DisplayTile should render with item custom className if provided 1`] = 
           className={undefined}
         >
           <span
-            aria-describedby={42}
             className=""
             id="tile-list-2-title"
-            onBlur={[Function]}
-            onClick={null}
             onFocus={[Function]}
-            onMouseOut={[Function]}
             onMouseOver={[Function]}
           >
             Bar

--- a/packages/components/src/List/Toolbar/Filter/__snapshots__/Filter.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/Filter/__snapshots__/Filter.snapshot.test.js.snap
@@ -2,13 +2,10 @@
 
 exports[`Filter should render 1`] = `
 <button
-  aria-describedby={42}
   className="navbar-right btn btn-link"
   disabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
   role={null}
   type="button"
@@ -59,13 +56,10 @@ exports[`Filter should render filter input with default placeholder 1`] = `
       type="search"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role={null}
       type="button"
@@ -118,13 +112,10 @@ exports[`Filter should render filter input with given placeholder 1`] = `
       type="search"
     />
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role={null}
       type="button"
@@ -146,13 +137,10 @@ exports[`Filter should render filter input with given placeholder 1`] = `
 
 exports[`Filter should render highlighted filter 1`] = `
 <button
-  aria-describedby={42}
   className="navbar-right btn btn-link"
   disabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
   role={null}
   type="button"
@@ -172,14 +160,11 @@ exports[`Filter should render highlighted filter 1`] = `
 
 exports[`Filter should render id if provided 1`] = `
 <button
-  aria-describedby={42}
   className="navbar-right btn btn-link"
   disabled={false}
   id="toolbar-filter"
-  onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
   role={null}
   type="button"
@@ -199,13 +184,10 @@ exports[`Filter should render id if provided 1`] = `
 
 exports[`Filter should render only toggle icon 1`] = `
 <button
-  aria-describedby={42}
   className="navbar-right btn btn-link"
   disabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
   role={null}
   type="button"

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -242,14 +242,11 @@ exports[`Toolbar should render filter form 1`] = `
       className="container-fluid"
     >
       <button
-        aria-describedby={42}
         className="navbar-right btn btn-link"
         disabled={false}
         id="my-toolbar-filter"
-        onBlur={[Function]}
         onClick={[Function]}
         onFocus={[Function]}
-        onMouseOut={[Function]}
         onMouseOver={[Function]}
         role={null}
         type="button"

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -77,12 +77,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     1
@@ -98,12 +94,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -148,12 +140,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     2
@@ -169,12 +157,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -219,12 +203,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     3
@@ -240,12 +220,8 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -732,13 +708,10 @@ exports[`List should render 1`] = `
           </li>
         </ul>
         <button
-          aria-describedby={42}
           className="navbar-right btn btn-link"
           disabled={false}
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role={null}
           type="button"
@@ -830,12 +803,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     1
@@ -851,12 +820,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -901,12 +866,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     2
@@ -922,12 +883,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -972,12 +929,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     3
@@ -993,12 +946,8 @@ exports[`List should render 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar
@@ -1497,14 +1446,11 @@ exports[`List should render id if provided 1`] = `
           </li>
         </ul>
         <button
-          aria-describedby={42}
           className="navbar-right btn btn-link"
           disabled={false}
           id="context-filter"
-          onBlur={[Function]}
           onClick={[Function]}
           onFocus={[Function]}
-          onMouseOut={[Function]}
           onMouseOver={[Function]}
           role={null}
           type="button"
@@ -1596,12 +1542,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     1
@@ -1617,12 +1559,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Hello world
@@ -1667,12 +1605,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     2
@@ -1688,12 +1622,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Foo
@@ -1738,12 +1668,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     3
@@ -1759,12 +1685,8 @@ exports[`List should render id if provided 1`] = `
                   className="cell"
                 >
                   <span
-                    aria-describedby={42}
                     className="item-text"
-                    onBlur={[Function]}
-                    onClick={null}
                     onFocus={[Function]}
-                    onMouseOut={[Function]}
                     onMouseOver={[Function]}
                   >
                     Bar

--- a/packages/components/src/ListView/Header/__snapshots__/Header.snapshot.test.js.snap
+++ b/packages/components/src/ListView/Header/__snapshots__/Header.snapshot.test.js.snap
@@ -11,13 +11,10 @@ exports[`Header should render header with one button 1`] = `
     className="actions"
   >
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"

--- a/packages/components/src/ListView/Header/__snapshots__/headerInput.snapshot.test.js.snap
+++ b/packages/components/src/ListView/Header/__snapshots__/headerInput.snapshot.test.js.snap
@@ -13,13 +13,10 @@ exports[`Header should render filter header 1`] = `
     type="text"
   />
   <button
-    aria-describedby={42}
     className="btn btn-link"
     disabled={false}
-    onBlur={[Function]}
     onClick={[Function]}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     role="link"
     type="button"

--- a/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
@@ -54,12 +54,8 @@ exports[`Progress should render an infinite progress with tooltip 1`] = `
   id="my-progress"
 >
   <div
-    aria-describedby={42}
     className="undefined"
-    onBlur={[Function]}
-    onClick={null}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     style={
       Object {
@@ -108,12 +104,8 @@ exports[`Progress should render progress with tooltip 1`] = `
   id="my-progress"
 >
   <div
-    aria-describedby={42}
     className=""
-    onBlur={[Function]}
-    onClick={null}
     onFocus={[Function]}
-    onMouseOut={[Function]}
     onMouseOver={[Function]}
     style={
       Object {

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -11,8 +11,6 @@ function getTooltipClass() {
 	return classNames({ [theme['tooltip-container']]: true, 'tooltip-container': true });
 }
 
-function noop() {}
-
 /**
  * @param {object} props react props
  * @example
@@ -63,34 +61,26 @@ class TooltipTrigger extends React.Component {
 			const triggerProps = Object.assign({
 				onMouseOver: this.onMouseOver,
 				onFocus: this.onMouseOver,
-				'aria-describedby': this.state.id,
-				// TODO: don't forget to remove this when the PR is ok
-				// this is to keep (lots of) snapshots the same
-				onBlur: noop,
-				onMouseOut: noop,
-				onClick: null,
 			}, childProps);
 			return cloneElement(child, triggerProps);
 		}
-		const props = this.props;
 		const tooltip = (
 			<Tooltip
 				className={getTooltipClass()}
 				id={this.state.id}
 			>
-				{props.label}
+				{this.props.label}
 			</Tooltip>
 		);
-		// TODO: render the Tooltip in a provider so use context
-		// for that.
+		// TODO jmfrancois : render the Tooltip in a provider so use context for that.
 		return (
 			<OverlayTrigger
-				placement={props.tooltipPlacement}
+				placement={this.props.tooltipPlacement}
 				overlay={tooltip}
 				delayShow={400}
 				onExited={this.onMouseOut}
 			>
-				{props.children}
+				{this.props.children}
 			</OverlayTrigger>
 		);
 	}

--- a/packages/components/src/TooltipTrigger/__snapshots__/TooltipTrigger.test.js.snap
+++ b/packages/components/src/TooltipTrigger/__snapshots__/TooltipTrigger.test.js.snap
@@ -2,11 +2,7 @@
 
 exports[`ActionTooltip should render tooltip 1`] = `
 <div
-  aria-describedby={42}
-  onBlur={[Function]}
-  onClick={null}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
 >
   Action

--- a/packages/components/src/TreeView/__snapshots__/TreeView.test.js.snap
+++ b/packages/components/src/TreeView/__snapshots__/TreeView.test.js.snap
@@ -11,14 +11,11 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
       some elements
     </span>
     <button
-      aria-describedby={42}
       className="btn btn-link"
       disabled={false}
       id="id-add"
-      onBlur={[Function]}
       onClick={[Function]}
       onFocus={[Function]}
-      onMouseOut={[Function]}
       onMouseOver={[Function]}
       role="link"
       type="button"
@@ -57,14 +54,11 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
             data-toggled={true}
           >
             <button
-              aria-describedby={42}
               className="btn btn-link"
               disabled={false}
               id="id-0-toggle"
-              onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
               role="link"
               type="button"
@@ -111,14 +105,11 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
               </span>
             </div>
             <button
-              aria-describedby={42}
               className="btn btn-link"
               disabled={false}
               id="id-0-talend-trash"
-              onBlur={[Function]}
               onClick={[Function]}
               onFocus={[Function]}
-              onMouseOut={[Function]}
               onMouseOver={[Function]}
               role="link"
               type="button"
@@ -155,14 +146,11 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                 data-toggled={true}
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
                   id="id-0-0-toggle"
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"
@@ -287,14 +275,11 @@ exports[`TreeView should render normally with all buttons and custom labels 1`] 
                 data-toggled={false}
               >
                 <button
-                  aria-describedby={42}
                   className="btn btn-link"
                   disabled={false}
                   id="id-0-1-toggle"
-                  onBlur={[Function]}
                   onClick={[Function]}
                   onFocus={[Function]}
-                  onMouseOut={[Function]}
                   onMouseOver={[Function]}
                   role="link"
                   type="button"

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -497,13 +497,10 @@ exports[`Typeahead position should render search bar on the right 1`] = `
 
 exports[`Typeahead with toggle should render button 1`] = `
 <button
-  aria-describedby={42}
   className="btn btn-link"
   disabled={false}
-  onBlur={[Function]}
   onClick={[Function]}
   onFocus={[Function]}
-  onMouseOut={[Function]}
   onMouseOver={[Function]}
   role={null}
   type="button"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1239,9 +1239,9 @@ bootstrap-sass@^3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.75.1.tgz#62b6eb1b99b0c931425e98ccb0504ef561225772"
+bootstrap-talend-theme@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.77.0.tgz#b16bcd8690c8b5a960d9a18a5c8f60c7f0f9fff4"
   dependencies:
     bootstrap-sass "^3.3.7"
 
@@ -6020,9 +6020,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-talend-icons@^0.75.1:
-  version "0.75.1"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.75.1.tgz#b80f913dbc3d85c9b1bec4fbc539fdaeac9537f1"
+talend-icons@^0.77.0:
+  version "0.77.0"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.77.0.tgz#1427ef3fbba74a26c25a139b9af06632cc00e610"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Just clean #478

**What is the chosen solution to this problem?**
Remove onClur, onClick, onMouseOut which was null or noop
Update snapshots
Removed aria-describedby with had the uuid which is not meaningful, and which was overriden in audio description by the content of children.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

