### PR TITLE
fix(forms): avoid undefined ref

### DIFF
--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -98,7 +98,7 @@ class Form extends React.Component {
 
 	handleActionClick(onClick) {
 		if (onClick) {
-			return (event, data) => onClick(event, { ...data, ...this.form.state });
+			return (event, data) => onClick(event, { ...data, ...(this.form && this.form.state) });
 		}
 		return () => {};
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Form ref could be null
 
**What is the chosen solution to this problem?**
Avoid error while accessing to form ref state by testing if it is defined

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

