### PR TITLE
feat(cmf): component.setState now accept mutator function

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,13 +1,13 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.80.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.81.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
 /home/travis/build/Talend/ui/packages/cmf/src/componentState.js
-  36:3  warning  Unexpected console statement  no-console
+  42:3  warning  Unexpected console statement  no-console
 
 ✖ 1 problem (0 errors, 1 warning)
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.80.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.81.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.80.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.81.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.80.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.81.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.80.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.81.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.80.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.81.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.80.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.81.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.80.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.81.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/cmf/__tests__/componentState.test.js
+++ b/packages/cmf/__tests__/componentState.test.js
@@ -7,6 +7,7 @@ import state, {
 	getStateProps,
 	initState,
 	statePropTypes,
+	applyCallback,
 } from '../src/componentState';
 
 describe('state', () => {
@@ -46,7 +47,9 @@ describe('state', () => {
 		props.setState({ foo: 'baz' });
 		call = dispatch.mock.calls[1][0];
 		const mergeComp = actions.componentsActions.mergeComponentState(
-			'name', 'id', DEFAULT_STATE.set('foo', 'baz'),
+			'name',
+			'id',
+			DEFAULT_STATE.set('foo', 'baz'),
 		);
 		expect(call.type).toBe(mergeComp.type);
 		expect(call.componentName).toBe('name');
@@ -57,6 +60,46 @@ describe('state', () => {
 		call = dispatch.mock.calls[2][0];
 		expect(call.componentName).toBe('name');
 		expect(call.key).toBe('id');
+	});
+
+	it(`should call state if state is a function,
+		via applyCallback`, () => {
+		const dispatch = jest.fn();
+		const callBack = jest.fn();
+		const DEFAULT_STATE = new Map({ foo: 'bar' });
+		const props = getStateAccessors(dispatch, 'name', 'id', DEFAULT_STATE);
+
+		props.setState(callBack);
+		const call = dispatch.mock.calls[0][0];
+		expect(typeof call === 'function').toEqual(true);
+	});
+
+	it('should applyCallback dispatch mergeComponentState', () => {
+		const callback = jest.fn(() => ({ compState: false }));
+		const dispatch = jest.fn();
+		const getState = jest.fn(() => ({
+			cmf: {
+				components: new Map({
+					name: new Map({
+						id: { compState: true },
+					}),
+				}),
+			},
+		}));
+		applyCallback(callback, 'name', 'id')(dispatch, getState);
+		expect(callback.mock.calls[0][0]).toEqual({
+			state: {
+				compState: true,
+			},
+		});
+		expect(dispatch.mock.calls[0][0]).toEqual({
+			type: 'REACT_CMF.COMPONENT_MERGE_STATE',
+			componentName: 'name',
+			key: 'id',
+			componentState: {
+				compState: false,
+			},
+		});
 	});
 
 	it('should getStateProps return state', () => {

--- a/packages/containers/src/Notification/Notification.connect.js
+++ b/packages/containers/src/Notification/Notification.connect.js
@@ -7,19 +7,23 @@ export function componentId(ownProps) {
 	return (ownProps && ownProps.id) || 'Notification';
 }
 
+export function deleteNotification(indexNotification) {
+	return function mutator(prevStateProps) {
+		const notifications = prevStateProps.state.get('notifications');
+		const index = notifications.indexOf(indexNotification);
+		if (index === -1) {
+			invariant(true, `notification not found ${JSON.stringify(indexNotification)}`);
+		}
+		const newNotif = notifications.delete(index);
+		return prevStateProps.state.set('notifications', newNotif);
+	};
+}
+
 export function mergeProps(stateProps, dispatchProps, ownProps) {
 	return Object.assign(
 		{
 			deleteNotification(i) {
-				dispatchProps.setState((prevStateProps) => {
-					const notifications = prevStateProps.state.get('notifications');
-					const index = notifications.indexOf(i);
-					if (index === -1) {
-						invariant(true, `notification not found ${JSON.stringify(i)}`);
-					}
-					const newNotif = notifications.delete(index);
-					return prevStateProps.state.set('notifications', newNotif);
-				});
+				dispatchProps.setState(deleteNotification(i));
 			},
 		},
 		ownProps,

--- a/packages/containers/src/Notification/Notification.connect.js
+++ b/packages/containers/src/Notification/Notification.connect.js
@@ -8,18 +8,24 @@ export function componentId(ownProps) {
 }
 
 export function mergeProps(stateProps, dispatchProps, ownProps) {
-	return Object.assign({
-		deleteNotification(i) {
-			const notifications = stateProps.state.get('notifications');
-			const index = notifications.indexOf(i);
-			if (index === -1) {
-				invariant(true, `notification not found ${JSON.stringify(i)}`);
-			}
-			const newNotif = notifications.delete(index);
-			const newState = stateProps.state.set('notifications', newNotif);
-			dispatchProps.setState(newState);
+	return Object.assign(
+		{
+			deleteNotification(i) {
+				dispatchProps.setState((prevStateProps) => {
+					const notifications = prevStateProps.state.get('notifications');
+					const index = notifications.indexOf(i);
+					if (index === -1) {
+						invariant(true, `notification not found ${JSON.stringify(i)}`);
+					}
+					const newNotif = notifications.delete(index);
+					return prevStateProps.state.set('notifications', newNotif);
+				});
+			},
 		},
-	}, ownProps, stateProps, dispatchProps);
+		ownProps,
+		stateProps,
+		dispatchProps,
+	);
 }
 
 export default cmfConnect({

--- a/packages/containers/src/Notification/Notification.test.js
+++ b/packages/containers/src/Notification/Notification.test.js
@@ -3,19 +3,19 @@ import renderer from 'react-test-renderer';
 import { store, Provider } from 'react-cmf/lib/mock';
 import { fromJS } from 'immutable';
 import Container from './Notification.container';
-import Connected, {
-	mergeProps,
-} from './Notification.connect';
+import Connected, { mergeProps, deleteNotification } from './Notification.connect';
 import pushNotification from './pushNotification';
 import clearNotifications from './clearNotifications';
 
 describe('Container Notification', () => {
 	it('should render', () => {
-		const wrapper = renderer.create(
-			<Provider>
-				<Container />
-			</Provider>,
-		).toJSON();
+		const wrapper = renderer
+			.create(
+				<Provider>
+					<Container />
+				</Provider>,
+			)
+			.toJSON();
 		expect(wrapper).toMatchSnapshot();
 	});
 });
@@ -41,8 +41,14 @@ describe('Connected Notification', () => {
 		expect(typeof props.deleteNotification).toBe('function');
 		props.deleteNotification(message);
 		expect(dispatchProps.setState).toHaveBeenCalledTimes(1);
-		const newState = dispatchProps.setState.mock.calls[0][0];
-		expect(newState.get('notifications').size).toBe(0);
+	});
+
+	it('deleteNotification should delete notification', () => {
+		const message = { message: 'hello world' };
+		const stateProps = {
+			state: fromJS({ notifications: [message] }),
+		};
+		expect(deleteNotification(1)(stateProps).toJS()).toEqual({ notifications: [] });
 	});
 });
 
@@ -59,7 +65,11 @@ describe('Notification.pushNotification', () => {
 		const notification = { message: 'hello world' };
 		const newState = pushNotification(state, notification);
 		expect(newState).not.toBe(state);
-		const notifications = newState.cmf.components.getIn(['Container(Notification)', 'Notification', 'notifications']);
+		const notifications = newState.cmf.components.getIn([
+			'Container(Notification)',
+			'Notification',
+			'notifications',
+		]);
 		expect(notifications.size).toBe(1);
 		expect(notifications.get(0).message).toBe('hello world');
 	});
@@ -69,16 +79,17 @@ describe('Notification.pushNotification', () => {
 		state.cmf.components = fromJS({
 			'Container(Notification)': {
 				Notification: {
-					notifications: [
-						{ message: 'hello world' },
-						{ message: 'hello world2' },
-					],
+					notifications: [{ message: 'hello world' }, { message: 'hello world2' }],
 				},
 			},
 		});
 		const newState = clearNotifications(state);
 		expect(newState).not.toBe(state);
-		const notifications = newState.cmf.components.getIn(['Container(Notification)', 'Notification', 'notifications']);
+		const notifications = newState.cmf.components.getIn([
+			'Container(Notification)',
+			'Notification',
+			'notifications',
+		]);
 		expect(notifications.size).toBe(0);
 	});
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
using dispatchProps.setState trought a setTimeout/setInterval etc function type who mess with javascript pile, to update component state using current state can create some problems since there is no guaranty that the state used trough the setTimeout setInterval is in sync with the latest version in redux.
**What is the chosen solution to this problem?**
dispatchProps.setState can accept now a mutator function receiving the latest state available. This being done a redux-thunk middleware.
Those mutator function accept only one parameter (previousState) and must return a new state

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

