### PR TITLE
fix(components/typeahead): use onmousedown instead of onclick

### DIFF
--- a/packages/components/src/AppHeaderBar/__snapshots__/AppHeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/AppHeaderBar/__snapshots__/AppHeaderBar.snapshot.test.js.snap
@@ -7218,7 +7218,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                       >
                         <li
                           id="react-autowhatever-42-section-0-item-0"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >
@@ -7258,7 +7258,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                         </li>
                         <li
                           id="react-autowhatever-42-section-0-item-1"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >
@@ -7350,7 +7350,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                       >
                         <li
                           id="react-autowhatever-42-section-1-item-0"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >
@@ -7410,7 +7410,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                       >
                         <li
                           id="react-autowhatever-42-section-2-item-0"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >
@@ -7442,7 +7442,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                         </li>
                         <li
                           id="react-autowhatever-42-section-2-item-1"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >
@@ -7474,7 +7474,7 @@ exports[`Storyshots AppHeaderBar with search results 1`] = `
                         </li>
                         <li
                           id="react-autowhatever-42-section-2-item-2"
-                          onClick={[Function]}
+                          onMouseDown={[Function]}
                           role="option"
                           style={Object {}}
                         >

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -11750,7 +11750,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     >
                       <li
                         id="react-autowhatever-42-section-0-item-0"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >
@@ -11790,7 +11790,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                       </li>
                       <li
                         id="react-autowhatever-42-section-0-item-1"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >
@@ -11886,7 +11886,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     >
                       <li
                         id="react-autowhatever-42-section-1-item-0"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >
@@ -11950,7 +11950,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                     >
                       <li
                         id="react-autowhatever-42-section-2-item-0"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >
@@ -11982,7 +11982,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                       </li>
                       <li
                         id="react-autowhatever-42-section-2-item-1"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >
@@ -12014,7 +12014,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                       </li>
                       <li
                         id="react-autowhatever-42-section-2-item-2"
-                        onClick={[Function]}
+                        onMouseDown={[Function]}
                         role="option"
                         style={Object {}}
                       >

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -51,7 +51,7 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 			icon,
 		},
 		itemProps: {
-			onClick: rest.onSelect,
+			onMouseDown: rest.onSelect,
 		},
 		renderInputComponent,
 		renderItemsContainer: renderItemsContainerFactory(

--- a/packages/components/src/Typeahead/Typeahead.test.js
+++ b/packages/components/src/Typeahead/Typeahead.test.js
@@ -165,7 +165,7 @@ describe('Typeahead', () => {
 
 			// when
 			const typeaheadInstance = mount(typeahead);
-			typeaheadInstance.find('Item').at(0).simulate('click');
+			typeaheadInstance.find('Item').at(0).simulate('mouseDown');
 
 			// then
 			expect(onSelect).toBeCalled();

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -67,7 +67,7 @@ exports[`Typeahead items should render typeahead results with match 1`] = `
         >
           <li
             id="react-autowhatever-my-search-section-0-item-0"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >
@@ -107,7 +107,7 @@ exports[`Typeahead items should render typeahead results with match 1`] = `
           </li>
           <li
             id="react-autowhatever-my-search-section-0-item-1"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >
@@ -199,7 +199,7 @@ exports[`Typeahead items should render typeahead results with match 1`] = `
         >
           <li
             id="react-autowhatever-my-search-section-1-item-0"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >
@@ -303,7 +303,7 @@ exports[`Typeahead items should render typeahead with results 1`] = `
         >
           <li
             id="react-autowhatever-my-search-section-0-item-0"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >
@@ -327,7 +327,7 @@ exports[`Typeahead items should render typeahead with results 1`] = `
           </li>
           <li
             id="react-autowhatever-my-search-section-0-item-1"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >
@@ -379,7 +379,7 @@ exports[`Typeahead items should render typeahead with results 1`] = `
         >
           <li
             id="react-autowhatever-my-search-section-1-item-0"
-            onClick={undefined}
+            onMouseDown={undefined}
             role="option"
             style={Object {}}
           >

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1232,15 +1232,15 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap-sass@3.3.7, bootstrap-sass@^3.3.7:
+bootstrap-sass@3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.82.0:
-  version "0.82.0"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.82.0.tgz#6951514707fda802a2eb4adab22d4f5749bf399c"
+bootstrap-talend-theme@^0.83.1:
+  version "0.83.1"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.83.1.tgz#89ad7c1f7bd31570a49b3b3474b253086a660b06"
   dependencies:
-    bootstrap-sass "^3.3.7"
+    bootstrap-sass "3.3.7"
 
 brace-expansion@^1.1.7:
   version "1.1.8"
@@ -6019,9 +6019,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-talend-icons@^0.82.0:
-  version "0.82.0"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.82.0.tgz#ae91e3fb71205d592d54d97623aad099d783064c"
+talend-icons@^0.83.1:
+  version "0.83.1"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.83.1.tgz#9b1339dd1b05d03bfa01e389d53d38941852d09d"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
onBlur is called before onClick when clicking on an list item ; so the click event is not trigged.

**What is the chosen solution to this problem?**
Using onMouseDown solves this issue. The click action is now called before the blur one.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

