### PR TITLE
fix(forms): declare proptypes only if not in production

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -123,18 +123,18 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   77:16  error  'formContext' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/Form.js
-  191:2  error  Prop type `object` is forbidden  react/forbid-prop-types
+  192:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/templates/FieldTemplate.js
-  82:2  error  Prop type `object` is forbidden  react/forbid-prop-types
-  83:2  error  Prop type `object` is forbidden  react/forbid-prop-types
+  82:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  83:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
-  32:2  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
-  33:2  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
-  50:5  error  Unexpected parentheses around single function argument having a body with no curly braces  arrow-parens
-  68:2  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
-  69:2  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
+  34:3  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
+  35:3  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
+  53:5  error  Unexpected parentheses around single function argument having a body with no curly braces  arrow-parens
+  72:3  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
+  73:3  error  Prop type `object` is forbidden                                                            react/forbid-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
   65:42  error  Unary operator '++' used  no-plusplus

--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -180,18 +180,20 @@ export const ActionsPropTypes = PropTypes.arrayOf(PropTypes.shape({
 	title: PropTypes.string,
 }));
 
-Form.propTypes = {
-	data: DataPropTypes.isRequired,
-	onChange: PropTypes.func,
-	onTrigger: PropTypes.func,
-	onSubmit: PropTypes.func,
-	actions: ActionsPropTypes,
-	buttonBlockClass: PropTypes.string,
-	handleAction: PropTypes.func,
-	widgets: PropTypes.object,
-	formContext: PropTypes.func,
-	children: PropTypes.element,
-};
+if (process.env.NODE_ENV !== 'production') {
+	Form.propTypes = {
+		data: DataPropTypes.isRequired,
+		onChange: PropTypes.func,
+		onTrigger: PropTypes.func,
+		onSubmit: PropTypes.func,
+		actions: ActionsPropTypes,
+		buttonBlockClass: PropTypes.string,
+		handleAction: PropTypes.func,
+		widgets: PropTypes.object,
+		formContext: PropTypes.func,
+		children: PropTypes.element,
+	};
+}
 
 Form.defaultProps = {
 	buttonBlockClass: 'form-actions',

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -8,10 +8,13 @@ function Label(props) {
 		<label htmlFor={props.id} className="control-label">{props.label}</label>
 	);
 }
-Label.propTypes = {
-	id: PropTypes.string,
-	label: PropTypes.string,
-};
+
+if (process.env.NODE_ENV !== 'production') {
+	Label.propTypes = {
+		id: PropTypes.string,
+		label: PropTypes.string,
+	};
+}
 
 function FieldTemplate(props) {
 	const groupsClassNames = classNames(

--- a/packages/forms/src/templates/FieldTemplate.js
+++ b/packages/forms/src/templates/FieldTemplate.js
@@ -67,21 +67,22 @@ function CustomFieldTemplate(props) {
 	);
 }
 
-
-CustomFieldTemplate.propTypes = {
-	id: PropTypes.string,
-	classNames: PropTypes.string,
-	label: PropTypes.string,
-	children: PropTypes.node.isRequired,
-	errors: PropTypes.element,
-	help: PropTypes.element,
-	description: PropTypes.element,
-	hidden: PropTypes.bool,
-	required: PropTypes.bool,
-	displayLabel: PropTypes.bool,
-	schema: PropTypes.object,
-	uiSchema: PropTypes.object,
-};
+if (process.env.NODE_ENV !== 'production') {
+	CustomFieldTemplate.propTypes = {
+		id: PropTypes.string,
+		classNames: PropTypes.string,
+		label: PropTypes.string,
+		children: PropTypes.node.isRequired,
+		errors: PropTypes.element,
+		help: PropTypes.element,
+		description: PropTypes.element,
+		hidden: PropTypes.bool,
+		required: PropTypes.bool,
+		displayLabel: PropTypes.bool,
+		schema: PropTypes.object,
+		uiSchema: PropTypes.object,
+	};
+}
 
 CustomFieldTemplate.defaultProps = {
 	hidden: false,

--- a/packages/forms/src/templates/LabelTemplate.js
+++ b/packages/forms/src/templates/LabelTemplate.js
@@ -16,10 +16,12 @@ const Label = (props) => {
 	);
 };
 
-Label.propTypes = {
-	label: PropTypes.string,
-	required: PropTypes.bool,
-	id: PropTypes.string,
-};
+if (process.env.NODE_ENV !== 'production') {
+	Label.propTypes = {
+		label: PropTypes.string,
+		required: PropTypes.bool,
+		id: PropTypes.string,
+	};
+}
 
 export default Label;

--- a/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
+++ b/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
@@ -27,14 +27,17 @@ function Column({ className, schema, formData, onChange, onBlur, registry }) {
 		</div>
 	);
 }
-Column.propTypes = {
-	className: PropTypes.string,
-	schema: PropTypes.object.isRequired,
-	formData: PropTypes.object.isRequired,
-	onChange: PropTypes.func.isRequired,
-	onBlur: PropTypes.func.isRequired,
-	registry: SchemaField.propTypes.registry,
-};
+
+if (process.env.NODE_ENV !== 'production') {
+	Column.propTypes = {
+		className: PropTypes.string,
+		schema: PropTypes.object.isRequired,
+		formData: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		onBlur: PropTypes.func.isRequired,
+		registry: SchemaField.propTypes.registry,
+	};
+}
 
 function onColumnChange(key, onChange, formData) {
 	return function handleChange(change) {
@@ -63,10 +66,12 @@ export default function ColumnsWidget({ name, schema, formData, onChange, onBlur
 	);
 }
 
-ColumnsWidget.propTypes = {
-	name: PropTypes.string,
-	schema: PropTypes.object.isRequired,
-	formData: PropTypes.object.isRequired,
-	onChange: PropTypes.func.isRequired,
-	onBlur: PropTypes.func.isRequired,
-};
+if (process.env.NODE_ENV !== 'production') {
+	ColumnsWidget.propTypes = {
+		name: PropTypes.string,
+		schema: PropTypes.object.isRequired,
+		formData: PropTypes.object.isRequired,
+		onChange: PropTypes.func.isRequired,
+		onBlur: PropTypes.func.isRequired,
+	};
+}

--- a/packages/forms/src/widgets/RadioOrSelectWidget.js
+++ b/packages/forms/src/widgets/RadioOrSelectWidget.js
@@ -20,10 +20,12 @@ function RadioOrSelectWidget(props) {
 	return <Select {...props} />;
 }
 
-RadioOrSelectWidget.propTypes = {
-	options: React.PropTypes.shape({
-		enumOptions: React.PropTypes.array,
-	}),
-};
+if (process.env.NODE_ENV !== 'production') {
+	RadioOrSelectWidget.propTypes = {
+		options: React.PropTypes.shape({
+			enumOptions: React.PropTypes.array,
+		}),
+	};
+}
 
 export default RadioOrSelectWidget;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The columns widget throw error in production because SchemaField.proptypes is undefined

**What is the chosen solution to this problem?**

add proptypes only if env is not production

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)

