### PR TITLE
fix(components/typeahead): don't fail on undefined text

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -131,11 +131,11 @@ export const renderSectionTitle = (section) => {
 };
 
 function emphasise(text, value) {
-	if (!value) {
-		return [text];
-	}
 	if (!text) {
 		return '';
+	}
+	if (!value) {
+		return [text];
 	}
 
 	const parts = text.split(new RegExp(`(${value})`, 'gi')).filter(Boolean);

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -134,6 +134,9 @@ function emphasise(text, value) {
 	if (!value) {
 		return [text];
 	}
+	if (!text) {
+		return '';
+	}
 
 	const parts = text.split(new RegExp(`(${value})`, 'gi')).filter(Boolean);
 	return parts.map((part) => {

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -148,7 +148,7 @@ function emphasise(text, value) {
 }
 
 export const renderItem = (item, { value }) => {
-	const title = item.title.trim();
+	const title = item.title ? item.title.trim() : '';
 	return (
 		<div className={theme.item} title={title}>
 			<span className={theme['item-title']}>

--- a/packages/components/stories/Typeahead.js
+++ b/packages/components/stories/Typeahead.js
@@ -53,6 +53,12 @@ const items = [
 				title: 'title 6',
 				description: 'description: Gradu quos cedentium sunt appeterent ita ancoralia instar luna sunt etiam ubi incendente nihil observabant.',
 			},
+			{
+				title: 'without description',
+			},
+			{
+				description: 'without title',
+			},
 		],
 	},
 ];


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If the title or the description is undefined: `Cannot read property 'split' of undefined`

**What is the chosen solution to this problem?**
`emphasise()` returns an empty string if trying to highlight an undefined string.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

