### PR TITLE
feat(cmf): some message will not throw on Production

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.85.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.85.1 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
@@ -14,7 +14,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   120:9  error  Unexpected trailing comma  comma-dangle
 
 /home/travis/build/Talend/ui/packages/cmf/src/componentState.js
-  49:3  warning  Unexpected console statement  no-console
+  52:3  warning  Unexpected console statement  no-console
 
 /home/travis/build/Talend/ui/packages/cmf/src/Dispatcher.js
   85:20  error  Unexpected parentheses around single function argument having a body with no curly braces  arrow-parens

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.85.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.85.1 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.85.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.85.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.85.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.85.1 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.85.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.85.1 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.85.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.85.1 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.85.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.85.1 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.85.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.85.1 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/cmf/src/actions/collectionsActions.js
+++ b/packages/cmf/src/actions/collectionsActions.js
@@ -30,7 +30,10 @@ export const removeCollection = collectionId => (
 		let error = false;
 		if (!state.cmf.collections.get(collectionId)) {
 			error = true;
-			invariant(false, `Can't remove collection ${collectionId} since it doesn't already exist.`);
+			invariant(
+				process.env.NODE_ENV === 'production',
+				`Can't remove collection ${collectionId} since it doesn't already exist.`,
+			);
 		}
 		if (!error) {
 			dispatch({

--- a/packages/cmf/src/componentState.js
+++ b/packages/cmf/src/componentState.js
@@ -25,7 +25,10 @@ export function getStateAccessors(dispatch, name, id, DEFAULT_STATE) {
 	const accessors = {
 		setState(state) {
 			if (!DEFAULT_STATE) {
-				invariant(false, 'you must provide a defaultState to use setState');
+				invariant(
+					process.env.NODE_ENV === 'production',
+					'you must provide a defaultState to use setState',
+				);
 			}
 			if (typeof state === 'function') {
 				dispatch(applyCallback(state, name, id));

--- a/packages/cmf/src/reducers/componentsReducers.js
+++ b/packages/cmf/src/reducers/componentsReducers.js
@@ -52,7 +52,10 @@ export function componentsReducers(state = defaultState, action) {
 		);
 	case ACTIONS.componentsActions.COMPONENT_MERGE_STATE:
 		if (!state.getIn([action.componentName, action.key])) {
-			invariant(false, componentDoesntExists(action));
+			invariant(
+				process.env.NODE_ENV === 'production',
+				componentDoesntExists(action)
+			);
 		}
 
 		return state.mergeIn(
@@ -61,7 +64,10 @@ export function componentsReducers(state = defaultState, action) {
 		);
 	case ACTIONS.componentsActions.COMPONENT_REMOVE_STATE:
 		if (!state.getIn([action.componentName, action.key])) {
-			invariant(false, componentDoesntExists(action));
+			invariant(
+				process.env.NODE_ENV === 'production',
+				componentDoesntExists(action)
+			);
 		}
 
 		return state.deleteIn([action.componentName, action.key]);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in CMF some message where implemented so that some unhealthy operation may come to attention of the developpers, we choose to throw so that the dev will not ignore them.

Problem those operation have 0 inpact on app operation, but may throw in production for nothing
**What is the chosen solution to this problem?**
Add a check of environnement on those messages so that it doesn't throw on production.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

