### PR TITLE
feat(components/actionsplitdropdown): should be able to display icons

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-cmf'
 
-> react-cmf@0.85.1 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.86.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.85.1 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.86.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,19 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-components'
 
-> react-talend-components@0.85.1 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.86.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
-
-src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
-  2:8  warning  Commas should be followed by a space   space-after-comma
-  2:9  warning  Selectors must be placed on new lines  single-line-per-selector
-
-src/VirtualizedList/ListTable/ListTable.scss
-  46:10  error  Strings must use single quotes  quotes
-
-✖ 3 problems (1 error, 2 warnings)
-
-Errored while running command 'npm' with arguments 'run lint:style' in 'react-talend-components'
-Errored while running ExecCommand.execute
-Command exited with status 1: npm run lint:style

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -5,10 +5,14 @@ Scoping to packages that match 'react-talend-components'
 > sass-lint -v -q
 
 
+src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
+  2:8  warning  Commas should be followed by a space   space-after-comma
+  2:9  warning  Selectors must be placed on new lines  single-line-per-selector
+
 src/VirtualizedList/ListTable/ListTable.scss
   46:10  error  Strings must use single quotes  quotes
 
-✖ 1 problem (1 error, 0 warnings)
+✖ 3 problems (1 error, 2 warnings)
 
 Errored while running command 'npm' with arguments 'run lint:style' in 'react-talend-components'
 Errored while running ExecCommand.execute

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-containers'
 
-> react-talend-containers@0.85.1 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.86.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.85.1 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.86.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,6 +1,6 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'react-talend-forms'
 
-> react-talend-forms@0.85.1 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.86.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'talend-log'
 
-> talend-log@0.85.1 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.86.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,7 +1,7 @@
 Lerna v2.0.0-beta.36
 Scoping to packages that match 'bootstrap-talend-theme'
 
-> bootstrap-talend-theme@0.85.1 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.86.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
@@ -1,5 +1,4 @@
 import React, { PropTypes } from 'react';
-import classNames from 'classnames';
 import {
 	SplitButton,
 	MenuItem,
@@ -57,7 +56,7 @@ function ActionSplitDropdown(props) {
 			onClick={event => rClick(event, onClick, { label, ...rest }, model)}
 			title={Title}
 			id={uuid.v4()}
-			className={classNames(theme['tc-split-dropdown'])}
+			className={theme['tc-split-dropdown']}
 			{...rest}
 		>
 			{

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
@@ -1,10 +1,13 @@
 import React, { PropTypes } from 'react';
+import classNames from 'classnames';
 import {
 	SplitButton,
 	MenuItem,
 } from 'react-bootstrap';
 import uuid from 'uuid';
 import Icon from '../../Icon';
+import theme from './ActionSplitDropdown.scss';
+
 
 /**
  * @param {object} props react props
@@ -54,13 +57,15 @@ function ActionSplitDropdown(props) {
 			onClick={event => rClick(event, onClick, { label, ...rest }, model)}
 			title={Title}
 			id={uuid.v4()}
+			className={classNames('dropdown')}
 			{...rest}
 		>
 			{
 				items.length ?
 					items.map((item, index) => (
 						<MenuItem {...item} key={index}>
-							{item.label}
+							{ item.icon && <Icon name={item.icon} /> }
+							{ item.label }
 						</MenuItem>
 					)) : <MenuItem disabled>{emptyDropdownLabel}</MenuItem>
 			}
@@ -71,6 +76,7 @@ function ActionSplitDropdown(props) {
 ActionSplitDropdown.propTypes = {
 	icon: PropTypes.string,
 	items: PropTypes.arrayOf(PropTypes.shape({
+		icon: PropTypes.string,
 		label: PropTypes.string,
 		...MenuItem.propTypes,
 	})).isRequired,

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
@@ -1,0 +1,7 @@
+:global(.dropdown-menu) {
+	li>a i,svg {
+		margin-right: 5px;
+		width: 1.6rem;
+		height: 1.6rem;
+	}
+}

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
@@ -2,9 +2,9 @@
 	li>a {
 		i,
 		svg {
-			margin-right: 5px;
-			width: 1.6rem;
-			height: 1.6rem;
+			margin-right: $padding-smaller;
+			width: $svg-md-size;
+			height: $svg-md-size;
 		}
 	}
 }

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.scss
@@ -1,7 +1,10 @@
 .tc-split-dropdown {
-	li>a i,svg {
-		margin-right: 5px;
-		width: 1.6rem;
-		height: 1.6rem;
+	li>a {
+		i,
+		svg {
+			margin-right: 5px;
+			width: 1.6rem;
+			height: 1.6rem;
+		}
 	}
 }

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.test.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.test.js
@@ -50,6 +50,34 @@ describe('ActionSplitDropdown', () => {
 		expect(wrapper).toMatchSnapshot();
 	});
 
+
+	it('should render items with icons', () => {
+		// given
+		const props = {
+			label: 'Add File',
+			icon: 'fa fa-plus',
+			onClick: jest.fn(),
+			items: [
+				{
+					label: 'From Local',
+					onClick: jest.fn(),
+					icon: 'fa fa-plus',
+				},
+				{
+					label: 'From Remote',
+					onClick: jest.fn(),
+					icon: 'fa fa-plus',
+				},
+			],
+		};
+
+		// when
+		const wrapper = renderer.create(<ActionSplitDropdown {...props} />).toJSON();
+
+		// then
+		expect(wrapper).toMatchSnapshot();
+	});
+
 	it('should render "no option" item when items array is empty', () => {
 		// given
 		const props = {

--- a/packages/components/src/Actions/ActionSplitDropdown/__snapshots__/ActionSplitDropdown.test.js.snap
+++ b/packages/components/src/Actions/ActionSplitDropdown/__snapshots__/ActionSplitDropdown.test.js.snap
@@ -5,7 +5,7 @@ exports[`ActionSplitDropdown should render "no option" item when items array is 
   className="dropdown btn-group"
 >
   <button
-    className="btn btn-default"
+    className="dropdown btn btn-default"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -74,7 +74,7 @@ exports[`ActionSplitDropdown should render a button with icon and label 1`] = `
   className="dropdown btn-group"
 >
   <button
-    className="btn btn-default"
+    className="dropdown btn btn-default"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -160,7 +160,7 @@ exports[`ActionSplitDropdown should render a button with label 1`] = `
   className="dropdown btn-group"
 >
   <button
-    className="btn btn-default"
+    className="dropdown btn btn-default"
     disabled={false}
     onClick={[Function]}
     type="button"
@@ -228,6 +228,100 @@ exports[`ActionSplitDropdown should render a button with label 1`] = `
         role="menuitem"
         tabIndex="-1"
       >
+        From Remote
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
+exports[`ActionSplitDropdown should render items with icons 1`] = `
+<div
+  className="dropdown btn-group"
+>
+  <button
+    className="dropdown btn btn-default"
+    disabled={false}
+    onClick={[Function]}
+    type="button"
+  >
+    <span>
+      <i
+        name="fa fa-plus"
+      />
+      <span>
+        Add File
+      </span>
+    </span>
+  </button>
+  <button
+    aria-expanded={false}
+    aria-haspopup={true}
+    aria-label={
+      <span>
+        <Unknown
+          name="fa fa-plus"
+        />
+        <span>
+          Add File
+        </span>
+      </span>
+    }
+    className="dropdown-toggle btn btn-default"
+    disabled={false}
+    id={42}
+    onClick={[Function]}
+    onKeyDown={[Function]}
+    role="button"
+    type="button"
+  >
+     
+    <span
+      className="caret"
+    />
+  </button>
+  <ul
+    aria-labelledby={42}
+    className="dropdown-menu"
+    role="menu"
+  >
+    <li
+      className=""
+      role="presentation"
+      style={undefined}
+    >
+      <a
+        href="#"
+        icon="fa fa-plus"
+        label="From Local"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
+      >
+        <i
+          name="fa fa-plus"
+        />
+        From Local
+      </a>
+    </li>
+    <li
+      className=""
+      role="presentation"
+      style={undefined}
+    >
+      <a
+        href="#"
+        icon="fa fa-plus"
+        label="From Remote"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        role="menuitem"
+        tabIndex="-1"
+      >
+        <i
+          name="fa fa-plus"
+        />
         From Remote
       </a>
     </li>

--- a/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
+++ b/packages/components/src/Actions/__snapshots__/Actions.test.js.snap
@@ -128,7 +128,7 @@ exports[`Actions should render actions 1`] = `
     className="dropdown btn-group"
   >
     <button
-      className="btn btn-default"
+      className="dropdown btn btn-default"
       disabled={false}
       hideLabel={false}
       link={false}
@@ -335,7 +335,7 @@ exports[`Actions should render actions with "link" theme 1`] = `
     className="dropdown btn-group"
   >
     <button
-      className="btn btn-default"
+      className="dropdown btn btn-default"
       disabled={false}
       hideLabel={false}
       link={true}
@@ -538,7 +538,7 @@ exports[`Actions should render actions with defined tooltip placement 1`] = `
     className="dropdown btn-group"
   >
     <button
-      className="btn btn-default"
+      className="dropdown btn btn-default"
       disabled={false}
       hideLabel={true}
       link={true}
@@ -741,7 +741,7 @@ exports[`Actions should render actions with hidden labels and tooltips 1`] = `
     className="dropdown btn-group"
   >
     <button
-      className="btn btn-default"
+      className="dropdown btn btn-default"
       disabled={false}
       hideLabel={true}
       link={false}

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.scss
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.scss
@@ -43,7 +43,7 @@ $tc-list-table-header-color: $black !default;
 		}
 	}
 
-	[class*="tc-list-cell-"] {
+	[class*='tc-list-cell-'] {
 		flex: 1 1 100%;
 	}
 }

--- a/packages/components/stories/ActionSplitDropdown.js
+++ b/packages/components/stories/ActionSplitDropdown.js
@@ -58,7 +58,7 @@ decoratedStories
 				<ActionSplitDropdown {...myAction} />
 			</div>
 			<p>Options with icons</p>
-			<div id="noicon">
+			<div id="icon">
 				<ActionSplitDropdown
 					{...myAction}
 					items={itemsWithIcons}

--- a/packages/components/stories/ActionSplitDropdown.js
+++ b/packages/components/stories/ActionSplitDropdown.js
@@ -1,7 +1,14 @@
 import React from 'react';
 import { storiesOf, action } from '@kadira/storybook';
+import talendIcons from 'talend-icons/dist/react';
 
-import { ActionSplitDropdown } from '../src/index';
+import { ActionSplitDropdown, IconsProvider } from '../src/index';
+
+const icons = {
+	'talend-logo-dp': talendIcons['talend-logo-dp'],
+	'talend-logo-ic': talendIcons['talend-logo-ic'],
+};
+
 
 const myAction = {
 	label: 'Add File',
@@ -11,16 +18,28 @@ const myAction = {
 		{
 			label: 'From Local',
 			onClick: action('From Local click'),
+			icon: 'talend-logo-ic',
 		},
 		{
 			label: 'From Remote',
 			onClick: action('From Remote click'),
+			icon: 'talend-logo-dp',
 		},
 	],
 	emptyDropdownLabel: 'No option',
 };
 
-storiesOf('ActionSplitDropdown', module)
+
+const decoratedStories = storiesOf('ActionSplitDropdown', module)
+	.addDecorator(story => (
+		<div>
+			{story()}
+			<div className="container" style={{ paddingTop: 40 }} />
+			<IconsProvider defaultIcons={icons} />
+		</div>
+	));
+
+decoratedStories
 	.addWithInfo('default', () => (
 		<div>
 			<p>By default :</p>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

