### PR TITLE
fix(TUX-262): show pagination navigation only when necessary

### DIFF
--- a/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
@@ -34,6 +34,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, ...o
 	} = paginationIconProps;
 	const currentPage = Math.ceil(startIndex / itemsPerPage);
 	const pagesLength = Math.ceil(totalResults / itemsPerPage);
+	const isNavigationShown = itemsPerPage > 0 && pagesLength > 1;
 	function onChangeItemsPerPage(value) {
 		return onChange(1, value);
 	}
@@ -73,32 +74,32 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, ...o
 			>
 				{itemsPerPageOptions.map((option, index) => getMenuItem(option, index))}
 			</NavDropdown>
-			{itemsPerPage > 0 && (
+			{isNavigationShown && (
 				<NavItem
 					eventKey={FIRST}
 					id={id && `${id}-nav-to-first`}
 					className={'btn-link'}
-					disabled={startIndex === 1}
+					disabled={startIndex <= 1}
 				>
 					<Icon {...first} />
 				</NavItem>
 			)}
-			{itemsPerPage > 0 && (
+			{isNavigationShown && (
 				<NavItem
 					eventKey={PREV}
 					id={id && `${id}-nav-to-prev`}
 					className={'btn-link'}
-					disabled={startIndex === 1}
+					disabled={startIndex <= 1}
 				>
 					<Icon {...prev} />
 				</NavItem>
 			)}
-			{itemsPerPage > 0 && (
+			{isNavigationShown && (
 				<NavItem disabled>
 					<span className="btn-link">{currentPage}/{pagesLength}</span>
 				</NavItem>
 			)}
-			{itemsPerPage > 0 && (
+			{isNavigationShown && (
 				<NavItem
 					eventKey={NEXT}
 					id={id && `${id}-nav-to-next`}
@@ -108,7 +109,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, ...o
 					<Icon {...next} />
 				</NavItem>
 			)}
-			{itemsPerPage > 0 && (
+			{isNavigationShown && (
 				<NavItem
 					eventKey={LAST}
 					id={id && `${id}-nav-to-last`}

--- a/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
@@ -62,6 +62,49 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, ...o
 		}
 		onChange(from, itemsPerPage);
 	}
+	function getNavigationItems() {
+		return [(
+			<NavItem
+				eventKey={FIRST}
+				id={id && `${id}-nav-to-first`}
+				className={'btn-link'}
+				disabled={startIndex <= 1}
+			>
+				<Icon {...first} />
+			</NavItem>
+		), (
+			<NavItem
+				eventKey={PREV}
+				id={id && `${id}-nav-to-prev`}
+				className={'btn-link'}
+				disabled={startIndex <= 1}
+			>
+				<Icon {...prev} />
+			</NavItem>
+		), (
+			<NavItem disabled>
+				<span className="btn-link">{currentPage}/{pagesLength}</span>
+			</NavItem>
+		), (
+			<NavItem
+				eventKey={NEXT}
+				id={id && `${id}-nav-to-next`}
+				className={'btn-link'}
+				disabled={startIndex + itemsPerPage > totalResults}
+			>
+				<Icon {...next} />
+			</NavItem>
+		), (
+			<NavItem
+				eventKey={LAST}
+				id={id && `${id}-nav-to-last`}
+				className={'btn-link'}
+				disabled={startIndex + itemsPerPage > totalResults}
+			>
+				<Icon {...last} />
+			</NavItem>
+		)];
+	}
 	return (
 		<Nav
 			className={theme['tc-pagination']}
@@ -74,51 +117,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, ...o
 			>
 				{itemsPerPageOptions.map((option, index) => getMenuItem(option, index))}
 			</NavDropdown>
-			{isNavigationShown && (
-				<NavItem
-					eventKey={FIRST}
-					id={id && `${id}-nav-to-first`}
-					className={'btn-link'}
-					disabled={startIndex <= 1}
-				>
-					<Icon {...first} />
-				</NavItem>
-			)}
-			{isNavigationShown && (
-				<NavItem
-					eventKey={PREV}
-					id={id && `${id}-nav-to-prev`}
-					className={'btn-link'}
-					disabled={startIndex <= 1}
-				>
-					<Icon {...prev} />
-				</NavItem>
-			)}
-			{isNavigationShown && (
-				<NavItem disabled>
-					<span className="btn-link">{currentPage}/{pagesLength}</span>
-				</NavItem>
-			)}
-			{isNavigationShown && (
-				<NavItem
-					eventKey={NEXT}
-					id={id && `${id}-nav-to-next`}
-					className={'btn-link'}
-					disabled={startIndex + itemsPerPage > totalResults}
-				>
-					<Icon {...next} />
-				</NavItem>
-			)}
-			{isNavigationShown && (
-				<NavItem
-					eventKey={LAST}
-					id={id && `${id}-nav-to-last`}
-					className={'btn-link'}
-					disabled={startIndex + itemsPerPage > totalResults}
-				>
-					<Icon {...last} />
-				</NavItem>
-			)}
+			{isNavigationShown && getNavigationItems()}
 		</Nav>
 	);
 }

--- a/packages/components/src/List/Toolbar/Pagination/Pagination.snapshot.test.js
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.snapshot.test.js
@@ -68,7 +68,37 @@ describe('Pagination', () => {
 		expect(wrapper).toMatchSnapshot();
 	});
 
-	it('should disable navigation when there is only one page', () => {
+	it('should disable first and previous buttons for first page', () => {
+		// given
+		const props = {
+			startIndex: 1,
+			totalResults: 6,
+			onChange: jest.fn(),
+		};
+		// when
+		const wrapper = renderer.create(
+			<Pagination {...props} />
+		).toJSON();
+		// then
+		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('should disable next and last buttons for last page', () => {
+		// given
+		const props = {
+			startIndex: 6,
+			totalResults: 10,
+			onChange: jest.fn(),
+		};
+		// when
+		const wrapper = renderer.create(
+			<Pagination {...props} />
+		).toJSON();
+		// then
+		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('should not show navigation when there is only one page', () => {
 		// given
 		const props = {
 			startIndex: 1,
@@ -83,7 +113,7 @@ describe('Pagination', () => {
 		expect(wrapper).toMatchSnapshot();
 	});
 
-	it('should disable all navigation when there is no items', () => {
+	it('should not show navigation when there is no items', () => {
 		// given
 		const props = {
 			startItems: 1,

--- a/packages/components/src/List/Toolbar/Pagination/__snapshots__/Pagination.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/Pagination/__snapshots__/Pagination.snapshot.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Pagination should disable all navigation when there is no items 1`] = `
+exports[`Pagination should disable first and previous buttons for first page 1`] = `
 <ul
   className="nav"
   role={null}
@@ -171,12 +171,12 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       >
         1
         /
-        0
+        2
       </span>
     </a>
   </li>
   <li
-    className="btn-link disabled"
+    className="btn-link"
     role="presentation"
     style={undefined}
   >
@@ -185,12 +185,6 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       id={undefined}
       onClick={[Function]}
       role="button"
-      style={
-        Object {
-          "pointerEvents": "none",
-        }
-      }
-      tabIndex={-1}
     >
       <svg
         aria-hidden="true"
@@ -205,7 +199,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
     </a>
   </li>
   <li
-    className="btn-link disabled"
+    className="btn-link"
     role="presentation"
     style={undefined}
   >
@@ -214,12 +208,6 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
       id={undefined}
       onClick={[Function]}
       role="button"
-      style={
-        Object {
-          "pointerEvents": "none",
-        }
-      }
-      tabIndex={-1}
     >
       <svg
         aria-hidden="true"
@@ -236,7 +224,7 @@ exports[`Pagination should disable all navigation when there is no items 1`] = `
 </ul>
 `;
 
-exports[`Pagination should disable navigation when there is only one page 1`] = `
+exports[`Pagination should disable next and last buttons for last page 1`] = `
 <ul
   className="nav"
   role={null}
@@ -329,7 +317,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
     </ul>
   </li>
   <li
-    className="btn-link disabled"
+    className="btn-link"
     role="presentation"
     style={undefined}
   >
@@ -338,12 +326,6 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       id={undefined}
       onClick={[Function]}
       role="button"
-      style={
-        Object {
-          "pointerEvents": "none",
-        }
-      }
-      tabIndex={-1}
     >
       <svg
         aria-hidden="true"
@@ -358,7 +340,7 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
     </a>
   </li>
   <li
-    className="btn-link disabled"
+    className="btn-link"
     role="presentation"
     style={undefined}
   >
@@ -367,12 +349,6 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       id={undefined}
       onClick={[Function]}
       role="button"
-      style={
-        Object {
-          "pointerEvents": "none",
-        }
-      }
-      tabIndex={-1}
     >
       <svg
         aria-hidden="true"
@@ -405,9 +381,9 @@ exports[`Pagination should disable navigation when there is only one page 1`] = 
       <span
         className="btn-link"
       >
-        1
+        2
         /
-        1
+        2
       </span>
     </a>
   </li>
@@ -492,6 +468,196 @@ exports[`Pagination should not render navigation when show all items 1`] = `
       role="button"
     >
       All
+       
+      <span
+        className="caret"
+      />
+    </a>
+    <ul
+      aria-labelledby={42}
+      className="dropdown-menu"
+      role="menu"
+    >
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          5
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          10
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          20
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          50
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`Pagination should not show navigation when there is no items 1`] = `
+<ul
+  className="nav"
+  role={null}
+>
+  <li
+    className="dropdown"
+    style={undefined}
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup={true}
+      className="dropdown-toggle"
+      href="#"
+      id={42}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      5
+       
+      <span
+        className="caret"
+      />
+    </a>
+    <ul
+      aria-labelledby={42}
+      className="dropdown-menu"
+      role="menu"
+    >
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          5
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          10
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          20
+        </a>
+      </li>
+      <li
+        className=""
+        role="presentation"
+        style={undefined}
+      >
+        <a
+          href="#"
+          onClick={[Function]}
+          onKeyDown={[Function]}
+          role="menuitem"
+          tabIndex="-1"
+        >
+          50
+        </a>
+      </li>
+    </ul>
+  </li>
+</ul>
+`;
+
+exports[`Pagination should not show navigation when there is only one page 1`] = `
+<ul
+  className="nav"
+  role={null}
+>
+  <li
+    className="dropdown"
+    style={undefined}
+  >
+    <a
+      aria-expanded={false}
+      aria-haspopup={true}
+      className="dropdown-toggle"
+      href="#"
+      id={42}
+      onClick={[Function]}
+      onKeyDown={[Function]}
+      role="button"
+    >
+      5
        
       <span
         className="caret"

--- a/packages/components/yarn.lock
+++ b/packages/components/yarn.lock
@@ -1236,9 +1236,9 @@ bootstrap-sass@3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.83.1.tgz#89ad7c1f7bd31570a49b3b3474b253086a660b06"
+bootstrap-talend-theme@^0.86.0:
+  version "0.86.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.86.0.tgz#407030323d570dc9085759d10b40a0757ae25022"
   dependencies:
     bootstrap-sass "3.3.7"
 
@@ -6019,9 +6019,9 @@ table@^3.7.8:
     slice-ansi "0.0.4"
     string-width "^2.0.0"
 
-talend-icons@^0.83.1:
-  version "0.83.1"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.83.1.tgz#9b1339dd1b05d03bfa01e389d53d38941852d09d"
+talend-icons@^0.86.0:
+  version "0.86.0"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.86.0.tgz#3377ef2065bf8b764fe1466229333aaa1fec8a13"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When there is no items the pages count is 1/0

**What is the chosen solution to this problem?**

Don't show pagination navigation when there is less than 2 pages

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

