### PR TITLE
docs: update talend bootstrap theme links

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -16,7 +16,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/Talend/bootstrap-theme.git"
+    "url": "git+https://github.com/Talend/ui.git"
   },
   "keywords": [
     "bootstrap",
@@ -25,9 +25,9 @@
   "author": "Talend",
   "license": "Apache-2.0",
   "bugs": {
-    "url": "https://github.com/Talend/bootstrap-theme/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
-  "homepage": "https://github.com/Talend/bootstrap-theme#readme",
+  "homepage": "https://github.com/Talend/ui",
   "devDependencies": {
     "autoprefixer": "^6.7.5",
     "babel-cli": "6.24.1",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

links point to the old repository

**What is the chosen solution to this problem?**

update links to UI


