### PR TITLE
fix(forms/datalist): remove difference check between user input and internal state on select

### DIFF
--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
@@ -252,11 +252,9 @@ class DatalistWidget extends React.Component {
 
 	selectItem(itemIndex) {
 		const selectedItem = this.state.items[itemIndex];
-		if ((selectedItem && selectedItem !== this.state.value) || (this.props.options.restricted)) {
-			this.setValue(selectedItem);
-			this.resetSuggestions();
-			this.props.onChange(selectedItem);
-		}
+		this.setValue(selectedItem);
+		this.resetSuggestions();
+		this.props.onChange(selectedItem);
 	}
 
 	render() {

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
@@ -252,7 +252,7 @@ class DatalistWidget extends React.Component {
 
 	selectItem(itemIndex) {
 		const selectedItem = this.state.items[itemIndex];
-		if (selectedItem && selectedItem !== this.state.value) {
+		if ((selectedItem && selectedItem !== this.state.value) || (this.props.options.restricted)) {
 			this.setValue(selectedItem);
 			this.resetSuggestions();
 			this.props.onChange(selectedItem);

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
@@ -163,28 +163,6 @@ describe('DatalistWidget', () => {
 		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 
-	it('should not change the value if it is the same', () => {
-		// given
-		const onChange = jest.fn();
-		const value = 'aze';
-		const wrapper = mount(
-			<DatalistWidget
-				id="myWidget"
-				value={value}
-				required
-				schema={schema}
-				onChange={onChange}
-			/>
-		);
-		wrapper.find('input').at(0).simulate('focus'); // to display suggestions
-
-		// when
-		wrapper.find('#react-autowhatever-myWidget--item-0').simulate('mouseDown');
-
-		// then
-		expect(onChange).not.toBeCalled();
-	});
-
 	it('should reset value on unknown value input blur', () => {
 		// given
 		const onChange = jest.fn();
@@ -252,49 +230,5 @@ describe('DatalistWidget', () => {
 		// then
 		expect(onChange).toBeCalled();
 		expect(onChange.mock.calls[0][0]).toBe(value);
-	});
-
-	it('should not trigger onChange if value is not changed on unrestricted mode', () => {
-		const onChange = jest.fn();
-		const value = 'banane';
-		const wrapper = mount(
-			<DatalistWidget
-				id="myWidget"
-				required
-				schema={schema}
-				value={value}
-				onChange={onChange}
-				options={{ restricted: false }}
-			/>
-		);
-		const input = wrapper.find('input').at(0);
-
-		// when
-		input.simulate('blur', { target: { value } });
-
-		// then
-		expect(onChange).not.toBeCalled();
-	});
-
-	it('should trigger onChange if value is not changed on restricted mode', () => {
-		const onChange = jest.fn();
-		const value = 'banane';
-		const wrapper = mount(
-			<DatalistWidget
-				id="myWidget"
-				required
-				schema={schema}
-				value={value}
-				onChange={onChange}
-				options={{ restricted: true }}
-			/>
-		);
-		const input = wrapper.find('input').at(0);
-
-		// when
-		input.simulate('blur', { target: { value } });
-
-		// then
-		expect(onChange).not.toBeCalled();
 	});
 });

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
@@ -254,7 +254,29 @@ describe('DatalistWidget', () => {
 		expect(onChange.mock.calls[0][0]).toBe(value);
 	});
 
-	it('should not trigger onChange if value is not changed', () => {
+	it('should not trigger onChange if value is not changed on unrestricted mode', () => {
+		const onChange = jest.fn();
+		const value = 'banane';
+		const wrapper = mount(
+			<DatalistWidget
+				id="myWidget"
+				required
+				schema={schema}
+				value={value}
+				onChange={onChange}
+				options={{ restricted: false }}
+			/>
+		);
+		const input = wrapper.find('input').at(0);
+
+		// when
+		input.simulate('blur', { target: { value } });
+
+		// then
+		expect(onChange).not.toBeCalled();
+	});
+
+	it('should trigger onChange if value is not changed on restricted mode', () => {
 		const onChange = jest.fn();
 		const value = 'banane';
 		const wrapper = mount(


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When typing the exact sentance on one of the slectable element available
Then navigating to it with up/down key.
Then hitting enter, the selection and change does not trigger

**What is the chosen solution to this problem?**
remove an equality check onSelect for the restricted mode. 

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

