### PR TITLE
feat(components/Enumeration): added customizable label property in He…

### DIFF
--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -68,6 +68,7 @@ Enumeration.propTypes = {
 	onAddKeyDown: PropTypes.func,
 	inputPlaceholder: PropTypes.string,
 	inputValue: PropTypes.string,
+	label: PropTypes.string,
 	...ItemEditPropTypes,
 };
 
@@ -93,7 +94,7 @@ ItemsEnumeration.propTypes = {
 function HeaderEnumeration({
 		displayMode, headerError, onInputChange, onAddKeyDown,
 		headerInput, headerDefault, headerSelected, items, required,
-		inputValue, inputRef,
+		inputValue, inputRef, label,
 	}) {
 	switch (displayMode) {
 	case DISPLAY_MODE_SEARCH: {
@@ -124,6 +125,7 @@ function HeaderEnumeration({
 		const propsDefault = {
 			headerDefault,
 			required,
+			label,
 		};
 
 		return <Header {...propsDefault} />;
@@ -154,6 +156,7 @@ HeaderEnumeration.propTypes = {
 	required: Enumeration.propTypes.required,
 	inputValue: Enumeration.propTypes.inputValue,
 	inputRef: Enumeration.propTypes.inputRef,
+	label: Enumeration.propTypes.label,
 };
 
 export default Enumeration;

--- a/packages/components/src/Enumeration/Enumeration.snapshot.test.js
+++ b/packages/components/src/Enumeration/Enumeration.snapshot.test.js
@@ -441,4 +441,70 @@ describe('Enumeration', () => {
 		).toJSON();
 		expect(wrapper).toMatchSnapshot();
 	});
+
+	it('should render with header in default state with custom label', () => {
+		const props = {
+			displayMode: 'DISPLAY_MODE_DEFAULT',
+			required: true,
+			headerDefault: [{
+				label: 'Add item',
+				icon: 'talend-plus',
+				id: 'add',
+				onClick: jest.fn(), // no click callback
+			}],
+			headerInput: [{
+				disabled: false,
+				label: 'Validate',
+				icon: 'talend-check',
+				id: 'validate',
+				onClick: jest.fn(), // no click callback
+			}, {
+				label: 'Abort',
+				icon: 'talend-cross',
+				id: 'abort',
+				onClick: jest.fn(), // no click callback
+			}],
+			headerSelected: [{
+				label: 'Selected value',
+				id: 'select',
+				onClick: jest.fn(), // no click callback
+			}],
+			items: Array(3).fill('').map((item, index) => ({
+				values: [`Lorem ipsum dolor sit amet ${index}`],
+			})),
+			itemsProp: {
+				key: 'values',
+				onSubmitItem: jest.fn(), // no click callback
+				onAbortItem: jest.fn(), // no click callback
+				onSelectItem: jest.fn(), // no click click callback
+				getItemHeight: () => 42,
+				actionsDefault: [{
+					disabled: false,
+					label: 'Edit',
+					icon: 'talend-pencil',
+					id: 'edit',
+					onClick: jest.fn(), // no click callback
+				}, {
+					label: 'Delete',
+					icon: 'talend-trash',
+					id: 'delete',
+					onClick: jest.fn(), // no click callback
+				}],
+				actionsEdit: [{
+					disabled: false,
+					label: 'Validate',
+					icon: 'talend-check',
+					id: 'validate',
+					onClick: jest.fn(), // no click callback
+				}],
+			},
+			onAddChange: jest.fn(), // no click callback
+			onAddKeyDown: jest.fn(), // no click callback
+			label: 'Users',
+		};
+		const wrapper = renderer.create(
+			<Enumeration {...props} />
+		).toJSON();
+		expect(wrapper).toMatchSnapshot();
+	});
 });

--- a/packages/components/src/Enumeration/Header/Header.component.js
+++ b/packages/components/src/Enumeration/Header/Header.component.js
@@ -49,10 +49,10 @@ function getAction(action, index) {
 	);
 }
 
-function Header({ headerDefault, required, label }) {
+function Header({ headerDefault, required, label = 'Values' }) {
 	return (
 		<header className={headerClasses()}>
-			<span>{label || 'Values'}{required && '*'}</span>
+			<span>{label}{required && '*'}</span>
 			<div className="actions">
 				{headerDefault.map(getAction)}
 			</div>

--- a/packages/components/src/Enumeration/Header/Header.component.js
+++ b/packages/components/src/Enumeration/Header/Header.component.js
@@ -49,10 +49,10 @@ function getAction(action, index) {
 	);
 }
 
-function Header({ headerDefault, required }) {
+function Header({ headerDefault, required, label }) {
 	return (
 		<header className={headerClasses()}>
-			<span>Values{required && '*'}</span>
+			<span>{label || 'Values'}{required && '*'}</span>
 			<div className="actions">
 				{headerDefault.map(getAction)}
 			</div>
@@ -63,6 +63,7 @@ function Header({ headerDefault, required }) {
 Header.propTypes = {
 	headerDefault: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)).isRequired,
 	required: PropTypes.bool,
+	label: PropTypes.string,
 };
 
 export default Header;

--- a/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
@@ -653,6 +653,326 @@ exports[`Enumeration should render with header in default state and first item i
 </div>
 `;
 
+exports[`Enumeration should render with header in default state with custom label 1`] = `
+<div
+  className="undefined tc-enumeration"
+>
+  <header
+    className="undefined tc-enumeration-header"
+  >
+    <span>
+      Users
+      *
+    </span>
+    <div
+      className="actions"
+    >
+      <button
+        className="btn btn-link"
+        disabled={false}
+        onClick={[Function]}
+        onFocus={[Function]}
+        onMouseDown={[Function]}
+        onMouseOver={[Function]}
+        role="link"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          className="tc-svg-icon"
+          focusable="false"
+          title={null}
+        >
+          <use
+            xlinkHref="#talend-plus"
+          />
+        </svg>
+      </button>
+    </div>
+  </header>
+  <ul
+    className="undefined tc-enumeration-items"
+    onScroll={[Function]}
+  >
+    <div
+      id="autoSizer"
+    >
+      <div
+        aria-label="grid"
+        className="ReactVirtualized__Grid ReactVirtualized__List undefined"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 30,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 30,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      >
+        <div
+          className="ReactVirtualized__Grid__innerScrollContainer"
+          style={
+            Object {
+              "height": 126,
+              "maxHeight": 126,
+              "maxWidth": 30,
+              "overflow": "hidden",
+              "pointerEvents": "",
+              "position": "relative",
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="tc-enumeration-item"
+              id="0-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
+                onMouseOver={[Function]}
+                role={null}
+                type="button"
+              >
+                <span>
+                  Lorem ipsum dolor sit amet 0
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 42,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="tc-enumeration-item"
+              id="1-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
+                onMouseOver={[Function]}
+                role={null}
+                type="button"
+              >
+                <span>
+                  Lorem ipsum dolor sit amet 1
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 84,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="tc-enumeration-item"
+              id="2-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                onFocus={[Function]}
+                onMouseDown={[Function]}
+                onMouseOver={[Function]}
+                role={null}
+                type="button"
+              >
+                <span>
+                  Lorem ipsum dolor sit amet 2
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ul>
+</div>
+`;
+
 exports[`Enumeration should render with header in default state, list in default state and required component 1`] = `
 <div
   className="undefined tc-enumeration"

--- a/packages/components/stories/Enumeration.js
+++ b/packages/components/stories/Enumeration.js
@@ -170,6 +170,11 @@ editItemPropsWithError.items[0] = {
 	error: 'an error occured',
 };
 
+const customLabelProps = {
+	...props,
+	label: 'Users',
+};
+
 storiesOf('Enumeration', module)
 	.addWithInfo('default', () => (
 		<div>
@@ -240,6 +245,15 @@ storiesOf('Enumeration', module)
 			<IconsProvider />
 			<Enumeration
 				{...editItemPropsWithError}
+			/>
+		</div>
+	))
+	.addWithInfo('with custom label', () => (
+		<div>
+			<p>Should be 'Users' instead of 'Values'</p>
+			<IconsProvider />
+			<Enumeration
+				{...customLabelProps}
 			/>
 		</div>
 	));


### PR DESCRIPTION
…ader.component

**What is the problem this PR is trying to solve?**

In order to finish new TMC module 'Projects' we need to implement a drawer with a list of users authorized to work with selected project. This list based on Enumeration component, but default label 'Values*' is not acceptable. We need to have possibility to define custom label (like 'Users') 

**What is the chosen solution to this problem?**

Add custom property.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

