### PR TITLE
chore(storybook): extract common webpack config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,0 +1,38 @@
+const SASS_DATA = '@import \'~bootstrap-talend-theme/src/theme/guidelines\';';
+const autoprefixer = require.main.require('autoprefixer');
+const webpack = require.main.require('webpack');
+
+module.exports = (storybookBaseConfig) => {
+	// remove Uglification plugin to improve build time in CI
+	const uglifyIndex = storybookBaseConfig.plugins.findIndex(
+		element => element instanceof webpack.optimize.UglifyJsPlugin);
+	storybookBaseConfig.plugins.splice(uglifyIndex, 1);
+
+	storybookBaseConfig.module.loaders.push(
+		{
+			test: /\.woff(2)?(\?[a-z0-9=&.]+)?$/,
+			loader: 'url-loader',
+			options: {
+				limit: 50000,
+				mimetype: 'application/font-woff',
+				name: './fonts/[name].[ext]',
+			},
+		},
+		{
+			test: /\.scss$/,
+			loaders: ['style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss', 'sass'],
+		}
+	);
+
+	storybookBaseConfig.postcss = [
+		autoprefixer({
+			browsers: ['last 2 versions'],
+		}),
+	];
+
+	storybookBaseConfig.sassLoader = {
+		data: SASS_DATA,
+	};
+
+	return storybookBaseConfig;
+};

--- a/packages/components/.storybook/webpack.config.js
+++ b/packages/components/.storybook/webpack.config.js
@@ -5,43 +5,17 @@
 // IMPORTANT
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
-const SASS_DATA = "@import '~bootstrap-talend-theme/src/theme/guidelines';";
-const autoprefixer = require('autoprefixer');
-const webpack = require('webpack');
+
+const commonConfiguration = require('../../../.storybook/webpack.config')
 
 module.exports = (storybookBaseConfig) => {
-	const uglifyIndex = storybookBaseConfig.plugins.findIndex(
-		element => element instanceof webpack.optimize.UglifyJsPlugin);
-	storybookBaseConfig.plugins.splice(uglifyIndex, 1);
+	const storybookConfig = commonConfiguration(storybookBaseConfig);
 
-	storybookBaseConfig.module.loaders.push({
-			test: /\.js?$/,
-			include: /node_modules\/(react-storybook-addon-props-combinations)/,
-			loader: 'babel',
-		},
-		{
-			test: /\.woff(2)?(\?[a-z0-9=&.]+)?$/,
-			loader: 'url-loader',
-			options: {
-				limit: 50000,
-				mimetype: 'application/font-woff',
-				name: './fonts/[name].[ext]',
-			},
-		},
-		{
-			test: /\.scss$/,
-			loaders: ['style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]', 'postcss', 'sass'],
-		});
+	storybookConfig.module.loaders.push({
+		test: /\.js?$/,
+		include: /node_modules\/(react-storybook-addon-props-combinations)/,
+		loader: 'babel',
+	});
 
-	storybookBaseConfig.postcss = [
-		autoprefixer({
-			browsers: ['last 2 versions'],
-		}),
-	];
-
-	storybookBaseConfig.sassLoader = {
-		data: SASS_DATA,
-	};
-
-	return storybookBaseConfig;
+	return storybookConfig;
 };

--- a/packages/containers/.storybook/webpack.config.js
+++ b/packages/containers/.storybook/webpack.config.js
@@ -6,37 +6,12 @@
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
 
-const SASS_DATA = "@import '~bootstrap-talend-theme/src/theme/guidelines';";
-const autoprefixer = require('autoprefixer');
-const webpack = require('webpack');
+const commonConfiguration = require('../../../.storybook/webpack.config')
 
 module.exports = (storybookBaseConfig) => {
-	const uglifyIndex = storybookBaseConfig.plugins.findIndex(
-		element => element instanceof webpack.optimize.UglifyJsPlugin);
-	storybookBaseConfig.plugins.splice(uglifyIndex, 1);
+	const storybookConfig = commonConfiguration(storybookBaseConfig);
 
-	storybookBaseConfig.module.loaders.push({
-		test: /\.woff(2)?(\?[a-z0-9=&.]+)?$/,
-		loader: 'url-loader',
-		options: {
-			limit: 50000,
-			mimetype: 'application/font-woff',
-			name: './fonts/[name].[ext]',
-		},
-	}, {
-		test: /\.scss$/,
-		loaders: ['style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!sass'],
-	});
+	// add project custom configuration here
 
-	storybookBaseConfig.postcss = [
-		autoprefixer({
-			browsers: ['last 2 versions'],
-		}),
-	];
-
-	storybookBaseConfig.sassLoader = {
-		data: SASS_DATA,
-	};
-
-	return storybookBaseConfig;
+	return storybookConfig;
 };

--- a/packages/forms/.storybook/webpack.config.js
+++ b/packages/forms/.storybook/webpack.config.js
@@ -1,47 +1,20 @@
-// you can use this file to add your custom webpack plugins, loaders and
-// anything you like.
+// you can use this file to add your custom webpack plugins, loaders and anything you like.
 // This is just the basic way to add addional webpack configurations.
 // For more information refer the docs: https://goo.gl/qPbSyX
 
 // IMPORTANT
-// When you add this file, we won't add the default configurations which is
-// similar
+// When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
 
-const SASS_DATA = "@import '~bootstrap-talend-theme/src/theme/guidelines';";
-const autoprefixer = require('autoprefixer');
-const webpack = require('webpack');
+const commonConfiguration = require('../../../.storybook/webpack.config')
 
 module.exports = (storybookBaseConfig) => {
-	const uglifyIndex = storybookBaseConfig.plugins.findIndex(
-		element => element instanceof webpack.optimize.UglifyJsPlugin);
-	storybookBaseConfig.plugins.splice(uglifyIndex, 1);
+	const storybookConfig = commonConfiguration(storybookBaseConfig);
 
-	storybookBaseConfig.module.loaders.push({
-		test: /\.woff(2)?(\?[a-z0-9=&.]+)?$/,
-		loader: 'url-loader',
-		options: {
-			limit: 50000,
-			mimetype: 'application/font-woff',
-			name: './fonts/[name].[ext]',
-		},
-	}, {
-		test: /\.scss$/,
-		loaders: ['style', 'css?sourceMap&modules&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]!sass'],
-	}, {
+	storybookConfig.module.loaders.push({
 		test: /\.json$/,
 		loader: 'json',
 	});
 
-	storybookBaseConfig.postcss = [
-		autoprefixer({
-			browsers: ['last 2 versions'],
-		}),
-	];
-
-	storybookBaseConfig.sassLoader = {
-		data: SASS_DATA,
-	};
-
-	return storybookBaseConfig;
+	return storybookConfig;
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Components/Forms/Containers storybook webpack config has a lot in common. For now this code is duplicated.

**What is the chosen solution to this problem?**
Extract the common configuration.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

