### PR TITLE
fix(VirtualizedList) : map onToggle instead of onSelect for selection

### DIFF
--- a/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
+++ b/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
@@ -38,7 +38,7 @@ function ListToVirtualizedList(props) {
 			id={props.id}
 			collection={props.items}
 			isSelected={itemProps && itemProps.isSelected}
-			selectionToggle={itemProps && itemProps.onSelect}
+			selectionToggle={itemProps && itemProps.onToggle}
 			sort={adaptOnSort(sort && sort.onChange)}
 			sortBy={sort && sort.field}
 			sortDirection={sort && sort.isDescending ? SORT_BY.DESC : SORT_BY.ASC}
@@ -71,7 +71,7 @@ ListToVirtualizedList.propTypes = {
 	displayMode: PropTypes.oneOf(['large', 'table']),
 	itemProps: PropTypes.shape({
 		isSelected: PropTypes.func,
-		onSelect: PropTypes.func,
+		onToggle: PropTypes.func,
 	}),
 	items: PropTypes.arrayOf(PropTypes.object),
 	sort: PropTypes.shape({

--- a/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.test.js
+++ b/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.test.js
@@ -136,14 +136,14 @@ describe('ListToVirtualizedList', () => {
 		expect(isSelected).toBeCalledWith(props.items[0]);
 	});
 
-	it('should adapt selection onSelect', () => {
+	it('should adapt selection onToggle', () => {
 		// given
-		const onSelect = jest.fn();
+		const onToggle = jest.fn();
 		const event = { target: {} };
 		const virtualizedProps = shallow(
 			<ListToVirtualizedList
 				{...props}
-				itemProps={{ onSelect }}
+				itemProps={{ onToggle }}
 			/>
 		).props();
 
@@ -151,6 +151,6 @@ describe('ListToVirtualizedList', () => {
 		virtualizedProps.selectionToggle(event, props.items[0]);
 
 		// then
-		expect(onSelect).toBeCalledWith(event, props.items[0]);
+		expect(onToggle).toBeCalledWith(event, props.items[0]);
 	});
 });

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -130,8 +130,6 @@ const props = {
 		},
 		itemProps: {
 			classNameKey: 'className',
-			onToggle: action('onToggle'),
-			onToggleAll: action('onToggleAll'),
 		},
 	},
 	toolbar: {
@@ -261,8 +259,9 @@ const itemsForItems = [
 ];
 const itemPropsForItems = {
 	classNameKey: 'className',
-	onToggle: action('onItemSelect'),
 	onOpen: action('onItemOpen'),
+	onSelect: action('onItemSelect'),
+	onToggle: action('onItemToggle'),
 	onToggleAll: action('onToggleAll'),
 	isSelected: item => selected.find(next => next.id === item.id),
 	onCancel: action('onTitleEditCancel'),
@@ -320,11 +319,6 @@ function getActionsProps() {
 }
 
 storiesOf('List', module)
-	.addDecorator(story => (
-		<form>
-			{story()}
-		</form>
-	))
 	.add('Tile', () => {
 		const tprops = {
 			...props,

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -261,7 +261,7 @@ const itemsForItems = [
 ];
 const itemPropsForItems = {
 	classNameKey: 'className',
-	onSelect: action('onItemSelect'),
+	onToggle: action('onItemSelect'),
 	onOpen: action('onItemOpen'),
 	onToggleAll: action('onToggleAll'),
 	isSelected: item => selected.find(next => next.id === item.id),
@@ -719,7 +719,7 @@ storiesOf('List', module)
 				},
 			],
 		};
-		selectedItemsProps.list.itemProps.isSelected = item => selected.find(next => next.id === item.id);
+		selectedItemsProps.list.itemProps = itemPropsForItems;
 		return (
 			<div>
 				<h1>List</h1>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With #625, we added the mapping from List to VirtualizedList for selection feature.
But the selection callback was not the right one (onSelect mapped, but onToggle is the one).
OnSelect props is deprecated, we will remove it when we remove the withContent version of List.

**What is the chosen solution to this problem?**
Map onToggle for selection

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

