### PR TITLE
fix(components/ActionBar/DrawerFooter): use $concrete for bgcolor

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.scss
+++ b/packages/components/src/ActionBar/ActionBar.scss
@@ -1,4 +1,4 @@
-$tc-action-bar-background-color: lighten($alto, 5%) !default;
+$tc-action-bar-background-color: $concrete !default;
 $tc-action-bar-margin: $padding-small $padding-larger $padding-small 0 !default;
 
 .tc-actionbar-container {

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -4,7 +4,7 @@ $tc-drawer-initial-offset: 1000px !default;
 $tc-drawer-bgcolor: #FFF !default;
 $tc-drawer-transition-duration: 230ms !default;
 $tc-drawer-transition-easing: cubic-bezier(0.18, 0.89, 0.32, 1.28) !default;
-$tc-action-bar-background-color: lighten($alto, 5%) !default;
+$tc-action-bar-background-color: $concrete !default;
 
 @function set-text-color($color) {
 	@if (lightness($color) > 60) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

According to guideline:
http://guidelines.talend.com/document/92132#/navigation-layout/toolbars

> Background color of toolbars is $concrete

Some buttons not visible enough with current background.

**What is the chosen solution to this problem?**

Fixed scss variable

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR



