### PR TITLE
feat(forms): add Actions from containers

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -31,6 +31,12 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   60:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   61:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
+/home/travis/build/Talend/ui/packages/forms/src/Form.js
+  22:14  error    Unexpected require()                                                                                                        global-require
+  22:14  error    'react-talend-containers' should be listed in the project's dependencies. Run 'npm i -S react-talend-containers' to add it  import/no-extraneous-dependencies
+  22:22  error    Unable to resolve path to module 'react-talend-containers'                                                                  import/no-unresolved
+  24:2   warning  Unexpected console statement                                                                                                no-console
+
 /home/travis/build/Talend/ui/packages/forms/src/templates/FieldTemplate.js
   82:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   83:3  error  Prop type `object` is forbidden  react/forbid-prop-types
@@ -61,5 +67,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   67:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   68:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
-✖ 35 problems (35 errors, 0 warnings)
+✖ 39 problems (38 errors, 1 warning)
 

--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -3,7 +3,6 @@ import React, { PropTypes } from 'react';
 import RJSForm from 'react-jsonschema-form/lib/index';
 
 import { Action } from 'react-talend-components';
-
 import BooleanField from './fields/BooleanField';
 import ObjectField from './fields/ObjectField';
 import StringField from './fields/StringField';
@@ -17,6 +16,14 @@ import DatalistWidget from './widgets/DatalistWidget';
 import EnumerationWidget from './widgets/EnumerationWidget/EnumerationWidget';
 import ColumnsWidget from './widgets/ColumnsWidget';
 import ListViewWidget from './widgets/ListViewWidget/ListViewWidget';
+
+let CMFAction = Action;
+try {
+	CMFAction = require('react-talend-containers').Action;
+} catch (e) {
+	console.warn('react-talend-containers not found fallback to Action from react-talend-components', e);
+}
+
 /**
  * @type {string} After trigger name for field value has changed
  */
@@ -47,19 +54,26 @@ export function renderActionIcon(icon) {
 	return null;
 }
 
-export function renderActions(actions, handleActionClick) {
-	if (actions) {
-		return actions.map((action, index) => (
-			<Action
-				key={index}
-				bsStyle={action.style}
-				label={action.title}
-				{...Object.assign(action, { onClick: handleActionClick(action.onClick) })}
-			>
-				{renderActionIcon(action.icon)}
-				{action.label}
-			</Action>),
-		);
+export function renderActions(actions, handleActionClick, formState) {
+	if (Array.isArray(actions)) {
+		return actions.map((action, index) => {
+			if (typeof action === 'object') {
+				return (
+					<Action
+						key={index}
+						bsStyle={action.style}
+						label={action.title}
+						{...Object.assign(action, { onClick: handleActionClick(action.onClick) })}
+					>
+						{renderActionIcon(action.icon)}
+						{action.label}
+					</Action>
+				);
+			}
+			return (
+				<CMFAction name={action} model={formState} />
+			);
+		});
 	}
 	return (<Action
 		bsStyle="primary"
@@ -160,7 +174,7 @@ class Form extends React.Component {
 			>
 				{this.props.children}
 				<div className={this.props.buttonBlockClass}>
-					{renderActions(this.props.actions, this.handleActionClick)}
+					{renderActions(this.props.actions, this.handleActionClick, this.form && this.form.state)}
 				</div>
 			</RJSForm>
 		);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Action in Form is a pure component.
When we are in a CMF context we want to use Action from react-talend-containers.

**What is the chosen solution to this problem?**

Here we check if the props action is an object -> Action from react-talend-components else use Action from react-talend-containers;

So we can pass `actions=['myfirst', 'another', ...]`

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

