### PR TITLE
feat(cmf): add withExpression component factory

### DIFF
--- a/packages/cmf/README.md
+++ b/packages/cmf/README.md
@@ -175,6 +175,22 @@ Note onResponse and onError accept function:
 * onResponse(response)
 * onError(error)
 
+## Expressions
+
+Expression are registred function use to eval props.
+We use them to handle dynamic configuration like disable buttons if a user doen't have the permission.
+
+Given an existing `MyComponent` you may want to add disabled props expression support just by doing the following:
+
+```javascript
+import { api } from 'react-cmf';
+import MyComponent from './MyComponent';
+
+const MySuperComponent = api.expressions.withExpression(MyComponent, ['disabled']);
+
+return <MySuperComponent disabled="userDontHaveSuperPower" />
+```
+
 ## Tests & mocks
 
 When you are in the context of CMF and you want to test your component you
@@ -218,10 +234,10 @@ you may change the following using simple props:
 
 For 1.0
 
-- [ ] embedable apps
+- [x] embedable apps
 - [ ] higher order configuration (RegistryProvider)
-- [ ] react-router v5
+- [ ] react-router v4
 - [ ] i18n
-- [ ] generator
+- [x] generator
 - [ ] content types
 - [ ] actionCreator should become first class

--- a/packages/cmf/README.md
+++ b/packages/cmf/README.md
@@ -178,7 +178,7 @@ Note onResponse and onError accept function:
 ## Expressions
 
 Expression are registred function use to eval props.
-We use them to handle dynamic configuration like disable buttons if a user doen't have the permission.
+We use them to handle dynamic configuration like disable buttons if a user doesn't have the permission.
 
 Given an existing `MyComponent` you may want to add disabled props expression support just by doing the following:
 

--- a/packages/cmf/__tests__/expression.test.js
+++ b/packages/cmf/__tests__/expression.test.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import { shallow } from 'enzyme';
 import { api } from '../src';
 import expression from '../src/expression';
 
@@ -76,5 +78,34 @@ describe('expression', () => {
 		const msg = 'you must register expression test first';
 		expect(toThrowString).toThrow(msg);
 		expect(toThrowObject).toThrow(msg);
+	});
+
+	it('should getProps eval requested props', () => {
+		const isTrue = () => true;
+		const context = {
+			registry: {
+				'expression:test': isTrue,
+			},
+		};
+		const props = {
+			disabled: 'test',
+		};
+		const newProps = expression.getProps(props, ['disabled'], context);
+		expect(newProps.disabled).toBe(true);
+		expect(newProps.disabled).not.toBe('test');
+	});
+
+	it('should withExpression create a wrapper', () => {
+		const MyComponent = props => <button {...props} />;
+		const WithExpr = expression.withExpression(MyComponent, ['disabled']);
+		const isTrue = () => true;
+		const context = {
+			registry: {
+				'expression:test': isTrue,
+			},
+		};
+		const wrapper = shallow(<WithExpr disabled="test" />, { context });
+		expect(wrapper.props().disabled).toBe(true);
+		expect(wrapper.props().disabled).not.toBe('test');
 	});
 });

--- a/packages/cmf/src/expression.js
+++ b/packages/cmf/src/expression.js
@@ -1,3 +1,4 @@
+import React, { PropTypes } from 'react';
 import invariant from 'invariant';
 import Registry from './registry';
 
@@ -41,8 +42,34 @@ function call(expression, context, payload) {
 	return check({ context, payload }, ...args);
 }
 
+function getProps(props, attrs, context, payload = {}) {
+	const newProps = Object.assign({}, props, payload);
+	attrs.forEach((attr) => {
+		const value = props[attr];
+		if (typeof value === 'string' || typeof value === 'object') {
+			newProps[attr] = call(value, context, newProps);
+		}
+	});
+	return newProps;
+}
+
+function withExpression(Component, attrs) {
+	function WithExpression(props, context) {
+		return <Component {...getProps(props, attrs, context)} />;
+	}
+	WithExpression.contextTypes = {
+		registry: PropTypes.object,
+		router: PropTypes.object,
+		store: PropTypes.object,
+	};
+	WithExpression.displayName = `WithExpression(${Component.displayName || Component.name})`;
+	return WithExpression;
+}
+
 export default {
 	register,
 	get,
 	call,
+	getProps,
+	withExpression,
 };

--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -10,14 +10,7 @@ import { api } from 'react-cmf';
  * * labelExpression
  */
 function evalExpressions(action, context, payload = {}) {
-	const newAction = Object.assign({}, action, payload);
-	const EXPRESSION_ATTRIBUTES = ['available', 'disabled', 'inProgress'];
-	EXPRESSION_ATTRIBUTES.forEach((attr) => {
-		const value = action[attr];
-		if (typeof value === 'string' || typeof value === 'object') {
-			newAction[attr] = api.expression.call(value, context, newAction);
-		}
-	});
+	const newAction = api.expression.getProps(action, ['available', 'disabled', 'inProgress'], context, payload);
 	if (action.labelExpression) {
 		delete newAction.labelExpression;
 		newAction.label = api.expression.call(action.labelExpression, context, newAction);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

expressions are powerfull but when a component exists adding support to it need to really understand how it works.

**What is the chosen solution to this problem?**

Now you can just add api.expressions.withExpressions(Component, ['disabled']) so you have your component which will support expression on `disabled` props

actionAPI expose a evalExpression api which has been refactored to use CMF api.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
