### PR TITLE
Fix(components/header): correct full logo width

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -53,7 +53,7 @@ $background-color-on-hover: shade($brand-primary, 30);
 			}
 
 			&.full :global(.tc-svg-icon) {
-				width: 75px;
+				width: 85px;
 			}
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Header full logo has width 75px, but it should be 85px

**What is the chosen solution to this problem?**
update the width of full logo according to guidelines
http://guidelines.talend.com/document/92132#/navigation-layout/app-header

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
