### PR TITLE
fix(forms): Adds name to ArrayField add button

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-cmf@0.99.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.100.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.99.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.100.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.99.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.100.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-containers@0.99.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.100.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-forms@0.99.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.100.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> react-talend-forms@0.99.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.100.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> talend-log@0.99.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.100.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> bootstrap-talend-theme@0.99.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.100.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/forms/src/templates/ArrayFieldTemplate.js
+++ b/packages/forms/src/templates/ArrayFieldTemplate.js
@@ -50,7 +50,7 @@ function ArrayFieldTemplate(props) {
 			<IconsProvider />
 			{items && items.map(element => <FieldTemplate element={element} />)}
 			{canAdd &&
-				<button className="btn btn-info" type="button" onClick={onAddClick}>
+				<button className="btn btn-info" type="button" name="new-element" onClick={onAddClick}>
 					NEW ELEMENT
 				</button>}
 		</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The ArrayField add button doesn't have a name.

**What is the chosen solution to this problem?**
Add a name to the the ArrayField add button.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR