### PR TITLE
feat(containers): Form add a way to customize fields

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -17,7 +17,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   2:1  error  'react-test-renderer' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
 /home/travis/build/Talend/ui/packages/containers/src/Form/Form.container.js
-  33:74  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
+  34:74  error  A function with a name starting with an uppercase letter should only be used as a constructor  new-cap
 
 /home/travis/build/Talend/ui/packages/containers/src/Form/Form.test.js
   2:1  error  'enzyme' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies

--- a/packages/containers/src/Form/Form.container.js
+++ b/packages/containers/src/Form/Form.container.js
@@ -2,6 +2,7 @@ import React, { PropTypes } from 'react';
 import { Map } from 'immutable';
 import { componentState } from 'react-cmf';
 import ComponentForm from 'react-talend-forms';
+import ArrayFieldTemplate from 'react-talend-forms/lib/templates/ArrayFieldTemplate';
 import classnames from 'classnames';
 
 export const DEFAULT_STATE = new Map({});
@@ -126,9 +127,11 @@ class Form extends React.Component {
 		});
 		return (
 			<ComponentForm
+				ArrayFieldTemplate={ArrayFieldTemplate}
 				className={className}
 				data={data}
 				actions={this.formActions()}
+				fields={this.props.fields}
 				onTrigger={this.onTrigger}
 				onChange={this.onChange}
 				onSubmit={this.onSubmit}

--- a/packages/containers/src/Form/__snapshots__/Form.test.js.snap
+++ b/packages/containers/src/Form/__snapshots__/Form.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Container(Form) should pass props to Form lib 1`] = `
 Object {
+  "ArrayFieldTemplate": [Function],
   "actions": Array [],
   "buttonBlockClass": "form-actions",
   "className": "tc-form rjsf pristine",
@@ -14,6 +15,7 @@ Object {
       "uiSchema": true,
     },
   },
+  "fields": undefined,
   "onChange": [Function],
   "onSubmit": [Function],
   "onTrigger": [Function],
@@ -23,6 +25,7 @@ Object {
 
 exports[`Container(Form) should render a Form 1`] = `
 <TalendForm
+  ArrayFieldTemplate={[Function]}
   actions={Array []}
   buttonBlockClass="form-actions"
   className="tc-form rjsf pristine"
@@ -37,6 +40,7 @@ exports[`Container(Form) should render a Form 1`] = `
       },
     }
   }
+  fields={undefined}
   onChange={[Function]}
   onSubmit={[Function]}
   onTrigger={[Function]}

--- a/packages/containers/yarn.lock
+++ b/packages/containers/yarn.lock
@@ -1415,9 +1415,9 @@ bootstrap-sass@3.3.7:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/bootstrap-sass/-/bootstrap-sass-3.3.7.tgz#6596c7ab40f6637393323ab0bc80d064fc630498"
 
-bootstrap-talend-theme@^0.101.0:
-  version "0.101.0"
-  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.101.0.tgz#9b710a0cb1e4d28742b4da972d2bd17b9695907f"
+bootstrap-talend-theme@^0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/bootstrap-talend-theme/-/bootstrap-talend-theme-0.102.0.tgz#31146c7130b1445205abb76336a7163ba2d5ce48"
   dependencies:
     bootstrap-sass "3.3.7"
 
@@ -5479,9 +5479,9 @@ react-bootstrap@0.31.0:
     uncontrollable "^4.1.0"
     warning "^3.0.0"
 
-react-cmf@^0.101.0:
-  version "0.101.0"
-  resolved "https://registry.yarnpkg.com/react-cmf/-/react-cmf-0.101.0.tgz#751cecb5ebcb907ffe55d5d552f26cb40669dd07"
+react-cmf@^0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/react-cmf/-/react-cmf-0.102.0.tgz#ff1d62c88fa83b6b136525cecb701608e2053a47"
   dependencies:
     hoist-non-react-statics "^1.2.0"
 
@@ -5674,21 +5674,22 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-talend-components@^0.101.0:
-  version "0.101.0"
-  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.101.0.tgz#2d4a777bed00f543acf18881a035ad8f8db11b55"
+react-talend-components@^0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/react-talend-components/-/react-talend-components-0.102.0.tgz#cfc3e8b8ea5afbb0ad391c68b3733b797dd1b34f"
   dependencies:
     lodash "4.17.4"
     react-autowhatever "^7.0.0"
     react-debounce-input "^2.4.2"
     react-virtualized "^9.3.0"
 
-react-talend-forms@^0.101.0:
-  version "0.101.0"
-  resolved "https://registry.yarnpkg.com/react-talend-forms/-/react-talend-forms-0.101.0.tgz#82b8ee4b39353c2bf41f56391812727752e182b6"
+react-talend-forms@^0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/react-talend-forms/-/react-talend-forms-0.102.0.tgz#df51d65b5d75a912ce30495e7048ae0430feb386"
   dependencies:
     classnames "2.2.5"
     keycode "2.1.9"
+    prop-types "^15.5.10"
     react-autowhatever "^7.0.0"
     react-jsonschema-form "^0.42.0"
     talend-json-schema-form-core "1.0.2-alpha.2"
@@ -6498,9 +6499,9 @@ taffydb@2.6.2:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/taffydb/-/taffydb-2.6.2.tgz#7cbcb64b5a141b6a2efc2c5d2c67b4e150b2a268"
 
-talend-icons@^0.101.0:
-  version "0.101.0"
-  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.101.0.tgz#385c862ab31bc81e7a6d3e6f8953911aa16a0c98"
+talend-icons@^0.102.0:
+  version "0.102.0"
+  resolved "https://registry.yarnpkg.com/talend-icons/-/talend-icons-0.102.0.tgz#b08cdbe6c98b9a7dd2e506b749de5b779f376eaf"
 
 talend-json-schema-form-core@1.0.2-alpha.2:
   version "1.0.2-alpha.2"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fields definition could not be customized by a props

**What is the chosen solution to this problem?**
Fields can be customized by a props now.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

