### PR TITLE
feat(Enumeration): show checkboxes on selected items

### DIFF
--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -70,6 +70,7 @@ Enumeration.propTypes = {
 	inputPlaceholder: PropTypes.string,
 	inputValue: PropTypes.string,
 	label: PropTypes.string,
+	showCheckboxes: PropTypes.bool,
 	...ItemEditPropTypes,
 };
 
@@ -95,13 +96,16 @@ EmptyListPlaceholder.propTypes = {
 	displayMode: Enumeration.propTypes.displayMode,
 };
 
-function ItemsEnumeration({ items, itemsProp, searchCriteria, currentEdit, displayMode }) {
+function ItemsEnumeration({
+		items, itemsProp, searchCriteria, currentEdit, displayMode, showCheckboxes,
+	}) {
 	if (items.length > 0) {
 		return (<Items
 			items={items}
 			itemsProp={itemsProp}
 			currentEdit={currentEdit}
 			searchCriteria={searchCriteria}
+			showCheckboxes={showCheckboxes}
 		/>);
 	}
 	return (<EmptyListPlaceholder displayMode={displayMode} />);
@@ -111,6 +115,7 @@ ItemsEnumeration.propTypes = {
 	items: Enumeration.propTypes.items,
 	itemsProp: Enumeration.propTypes.itemsProp,
 	searchCriteria: Enumeration.propTypes.searchCriteria,
+	showCheckboxes: Enumeration.propTypes.showCheckboxes,
 	...ItemEditPropTypes,
 };
 

--- a/packages/components/src/Enumeration/Enumeration.snapshot.test.js
+++ b/packages/components/src/Enumeration/Enumeration.snapshot.test.js
@@ -468,6 +468,89 @@ describe('Enumeration', () => {
 		expect(wrapper).toMatchSnapshot();
 	});
 
+	it('should render with header in selected state with trash icon, and two items in selected mode with checkboxes', () => {
+		const props = {
+			showCheckboxes: true,
+			displayMode: 'DISPLAY_MODE_SELECTED',
+			currentEdit: {
+				validate: {
+					disabled: false,
+				},
+			},
+			headerDefault: [{
+				label: 'Add item',
+				icon: 'talend-plus',
+				id: 'add',
+				onClick: jest.fn(), // no click callback
+			}],
+			headerInput: [{
+				disabled: false,
+				label: 'Validate',
+				icon: 'talend-check',
+				id: 'validate',
+				onClick: jest.fn(), // no click callback
+			}, {
+				label: 'Abort',
+				icon: 'talend-cross',
+				id: 'abort',
+				onClick: jest.fn(), // no click callback
+			}],
+			headerSelected: [{
+				label: 'Selected value',
+				id: 'select',
+				onClick: jest.fn(), // no click callback
+			}],
+			items: Array(3).fill('').map((item, index) => ({
+				values: [`Lorem ipsum dolor sit amet ${index}`],
+			})),
+			itemsProp: {
+				key: 'values',
+				onSubmitItem: jest.fn(), // no click callback
+				onAbortItem: jest.fn(), // no click callback
+				getItemHeight: () => 42,
+				actionsDefault: [{
+					disabled: false,
+					label: 'Edit',
+					icon: 'talend-pencil',
+					id: 'edit',
+					onClick: jest.fn(), // no click callback
+				}, {
+					label: 'Delete',
+					icon: 'talend-trash',
+					id: 'delete',
+					onClick: jest.fn(), // no click callback
+				}],
+				actionsEdit: [{
+					disabled: false,
+					label: 'Validate',
+					icon: 'talend-check',
+					id: 'validate',
+					onClick: jest.fn(), // no click callback
+				}],
+			},
+			onAddChange: jest.fn(), // no click callback
+			onAddKeyDown: jest.fn(), // no click callback
+		};
+		props.items[0].isSelected = true;
+		props.items[1].isSelected = true;
+
+		function createNodeMock(element) {
+			if (element.type === 'input') {
+				return {};
+			}
+			return null;
+		}
+
+		const rendererOptions = { createNodeMock };
+
+		// when
+		const wrapper = renderer.create(
+			<Enumeration {...props} />,
+			rendererOptions
+		).toJSON();
+		expect(wrapper).toMatchSnapshot();
+	});
+
 	it('should render with header in default state with custom label', () => {
 		const props = {
 			displayMode: 'DISPLAY_MODE_DEFAULT',

--- a/packages/components/src/Enumeration/Items/Item/Item.component.js
+++ b/packages/components/src/Enumeration/Items/Item/Item.component.js
@@ -1,8 +1,10 @@
 import React from 'react';
 import classNames from 'classnames';
+import { Button } from 'react-bootstrap';
 import { removeDuplicates, allIndexOf } from './utils';
 import Action from '../../../Actions/Action';
 import theme from './Item.scss';
+import { Checkbox } from '../../../Toggle';
 import ItemPropTypes from './Item.propTypes';
 
 function itemClasses(isSelected) {
@@ -29,7 +31,7 @@ function itemDefaultActionsClasses() {
 	});
 }
 
-function Item({ id, item, searchCriteria }) {
+function Item({ id, item, searchCriteria, showCheckboxes }) {
 	const {
 		key,
 		actions,
@@ -96,13 +98,20 @@ function Item({ id, item, searchCriteria }) {
 				</button>
 			);
 		}
-		return (<Action
-			key={item.index}
-			label={item[key].join(',')}
-			onClick={event => onSelectItem(item, event)}
-			className={itemLabelClasses()}
-			tooltip
-		/>);
+
+		return (
+			<Button
+				className={itemLabelClasses()}
+				onClick={event => onSelectItem(item, event)}
+				key={item.index}
+			>
+				{ showCheckboxes && <Checkbox
+					className={classNames(theme['tc-enumeration-checkbox'], 'tc-enumeration-checkbox')}
+					checked={item.isSelected}
+				/> }
+				<span>{item[key].join(',')}</span>
+			</Button>
+		);
 	}
 
 	return (

--- a/packages/components/src/Enumeration/Items/Item/Item.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.scss
@@ -9,6 +9,9 @@ $tc-item-padding-top-bottom: 7px !default;
 $tc-enumeration-input-margin: 10px;
 $tc-enumeration-item-font-size: 14px;
 $tc-enumeration-item-error-padding: 0 $padding-normal;
+$selected-item-color: #fafafa;
+$item-checkbox-margin: 5px;
+$item-checkbox-size: 20px;
 
 .tc-enumeration-item {
 	display: flex;
@@ -96,8 +99,17 @@ $tc-enumeration-item-error-padding: 0 $padding-normal;
 	}
 }
 
+.tc-enumeration-checkbox {
+	display: inline-block;
+	margin: 0 $item-checkbox-margin $item-checkbox-margin 0;
+	height: $item-checkbox-size;
+	width: $item-checkbox-size;
+	vertical-align: middle;
+	pointer-events: none;
+}
+
 .selected-item {
-	background-color: #D9EEFF;
+	background-color: $selected-item-color;
 }
 
 .tc-enumeration-item:hover {

--- a/packages/components/src/Enumeration/Items/Item/__snapshots__/item.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/Item/__snapshots__/item.snapshot.test.js.snap
@@ -9,10 +9,6 @@ exports[`Item should display a selected item 1`] = `
     className="undefined tc-enumeration-item-label btn btn-default"
     disabled={false}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseOver={[Function]}
-    role={null}
     type="button"
   >
     <span>
@@ -34,10 +30,6 @@ exports[`Item should display value with three buttons 1`] = `
     className="undefined tc-enumeration-item-label btn btn-default"
     disabled={false}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseOver={[Function]}
-    role={null}
     type="button"
   >
     <span>

--- a/packages/components/src/Enumeration/Items/Items.component.js
+++ b/packages/components/src/Enumeration/Items/Items.component.js
@@ -86,6 +86,7 @@ class Items extends React.PureComponent {
 					item={itemWithIndex}
 					itemProps={itemPropDefault}
 					searchCriteria={this.props.searchCriteria}
+					showCheckboxes={this.props.showCheckboxes}
 				/>
 			);
 		}

--- a/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Items/__snapshots__/items.snapshot.test.js.snap
@@ -113,10 +113,6 @@ exports[`Items should display one item in edit mode and the other in default 1`]
               className="undefined tc-enumeration-item-label btn btn-default"
               disabled={false}
               onClick={[Function]}
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onMouseOver={[Function]}
-              role={null}
               type="button"
             >
               <span>
@@ -191,10 +187,6 @@ exports[`Items should display one item in edit mode and the other in default 1`]
               className="undefined tc-enumeration-item-label btn btn-default"
               disabled={false}
               onClick={[Function]}
-              onFocus={[Function]}
-              onMouseDown={[Function]}
-              onMouseOver={[Function]}
-              role={null}
               type="button"
             >
               <span>

--- a/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
@@ -166,10 +166,6 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -244,10 +240,6 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -322,10 +314,6 @@ exports[`Enumeration should render with header in add state and list in default 
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -556,10 +544,6 @@ exports[`Enumeration should render with header in default state and first item i
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -634,10 +618,6 @@ exports[`Enumeration should render with header in default state and first item i
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -798,10 +778,6 @@ exports[`Enumeration should render with header in default state with custom labe
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -876,10 +852,6 @@ exports[`Enumeration should render with header in default state with custom labe
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -954,10 +926,6 @@ exports[`Enumeration should render with header in default state with custom labe
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1118,10 +1086,6 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1196,10 +1160,6 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1274,10 +1234,6 @@ exports[`Enumeration should render with header in default state, list in default
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1760,10 +1716,6 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1838,10 +1790,6 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>
@@ -1916,10 +1864,6 @@ exports[`Enumeration should render with header in selected state with trash icon
                 className="undefined tc-enumeration-item-label btn btn-default"
                 disabled={false}
                 onClick={[Function]}
-                onFocus={[Function]}
-                onMouseDown={[Function]}
-                onMouseOver={[Function]}
-                role={null}
                 type="button"
               >
                 <span>

--- a/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/__snapshots__/Enumeration.snapshot.test.js.snap
@@ -1925,6 +1925,352 @@ exports[`Enumeration should render with header in selected state with trash icon
 </div>
 `;
 
+exports[`Enumeration should render with header in selected state with trash icon, and two items in selected mode with checkboxes 1`] = `
+<div
+  className="undefined tc-enumeration"
+>
+  <header
+    className="undefined tc-enumeration-header"
+  >
+    <span>
+      2 selected values
+    </span>
+    <button
+      className="btn btn-link"
+      disabled={false}
+      onClick={[Function]}
+      onFocus={[Function]}
+      onMouseDown={[Function]}
+      onMouseOver={[Function]}
+      role="link"
+      type="button"
+    />
+  </header>
+  <ul
+    className="undefined tc-enumeration-items"
+    onScroll={[Function]}
+  >
+    <div
+      id="autoSizer"
+    >
+      <div
+        aria-label="grid"
+        className="ReactVirtualized__Grid ReactVirtualized__List undefined"
+        id={undefined}
+        onScroll={[Function]}
+        role="grid"
+        style={
+          Object {
+            "WebkitOverflowScrolling": "touch",
+            "boxSizing": "border-box",
+            "direction": "ltr",
+            "height": 30,
+            "overflowX": "hidden",
+            "overflowY": "auto",
+            "position": "relative",
+            "width": 30,
+            "willChange": "transform",
+          }
+        }
+        tabIndex={0}
+      >
+        <div
+          className="ReactVirtualized__Grid__innerScrollContainer"
+          style={
+            Object {
+              "height": 126,
+              "maxHeight": 126,
+              "maxWidth": 30,
+              "overflow": "hidden",
+              "pointerEvents": "",
+              "position": "relative",
+              "width": "auto",
+            }
+          }
+        >
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 0,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="undefined tc-enumeration-item selected-item"
+              id="0-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <div
+                  className="checkbox tc-toggle tc-enumeration-checkbox"
+                >
+                  <label
+                    htmlFor={undefined}
+                  >
+                    <input
+                      autoFocus={undefined}
+                      checked={true}
+                      disabled={undefined}
+                      id={undefined}
+                      onBlur={undefined}
+                      onChange={undefined}
+                      type="checkbox"
+                    />
+                    <span />
+                  </label>
+                </div>
+                <span>
+                  Lorem ipsum dolor sit amet 0
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 42,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="undefined tc-enumeration-item selected-item"
+              id="1-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <div
+                  className="checkbox tc-toggle tc-enumeration-checkbox"
+                >
+                  <label
+                    htmlFor={undefined}
+                  >
+                    <input
+                      autoFocus={undefined}
+                      checked={true}
+                      disabled={undefined}
+                      id={undefined}
+                      onBlur={undefined}
+                      onChange={undefined}
+                      type="checkbox"
+                    />
+                    <span />
+                  </label>
+                </div>
+                <span>
+                  Lorem ipsum dolor sit amet 1
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+          <div
+            className="undefined tc-item-container"
+            style={
+              Object {
+                "height": 42,
+                "left": 0,
+                "position": "absolute",
+                "top": 84,
+                "width": "100%",
+              }
+            }
+          >
+            <li
+              className="tc-enumeration-item"
+              id="2-item"
+            >
+              <button
+                className="undefined tc-enumeration-item-label btn btn-default"
+                disabled={false}
+                onClick={[Function]}
+                type="button"
+              >
+                <div
+                  className="checkbox tc-toggle tc-enumeration-checkbox"
+                >
+                  <label
+                    htmlFor={undefined}
+                  >
+                    <input
+                      autoFocus={undefined}
+                      checked={undefined}
+                      disabled={undefined}
+                      id={undefined}
+                      onBlur={undefined}
+                      onChange={undefined}
+                      type="checkbox"
+                    />
+                    <span />
+                  </label>
+                </div>
+                <span>
+                  Lorem ipsum dolor sit amet 2
+                </span>
+              </button>
+              <div
+                className="undefined tc-enumeration-item-actions"
+              >
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-pencil"
+                    />
+                  </svg>
+                </button>
+                <button
+                  className="btn btn-link"
+                  disabled={false}
+                  onClick={[Function]}
+                  onFocus={[Function]}
+                  onMouseDown={[Function]}
+                  onMouseOver={[Function]}
+                  role="link"
+                  type="button"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="tc-svg-icon"
+                    focusable="false"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-trash"
+                    />
+                  </svg>
+                </button>
+              </div>
+            </li>
+          </div>
+        </div>
+      </div>
+    </div>
+  </ul>
+</div>
+`;
+
 exports[`Enumeration should render with header without items 1`] = `
 <div
   className="undefined tc-enumeration"

--- a/packages/components/src/ListView/Items/Item/Item.scss
+++ b/packages/components/src/ListView/Items/Item/Item.scss
@@ -1,6 +1,6 @@
 $tc-listview-item-height: 3.3rem !default;
 
-:global(.checkbox) {
+:global(.tc-listview .checkbox) {
 	margin-left: 5px;
 }
 

--- a/packages/components/stories/Enumeration.js
+++ b/packages/components/stories/Enumeration.js
@@ -153,6 +153,11 @@ selectedValuesProps.items = Array(50).fill('').map((item, index) => ({
 	isSelected: index % 2 === 0,
 }));
 
+const selectedValuesCheckboxesProps = {
+	...selectedValuesProps,
+	showCheckboxes: true,
+};
+
 const headerErrorProps = {
 	...props,
 	displayMode: 'DISPLAY_MODE_ADD',
@@ -254,6 +259,17 @@ storiesOf('Enumeration', module)
 			<Enumeration
 				{...selectedValuesProps}
 			/>
+		</div>
+	))
+	.addWithInfo('selected values with checkboxes', () => (
+		<div>
+			<p>By default :</p>
+			<IconsProvider />
+			<form>
+				<Enumeration
+					{...selectedValuesCheckboxesProps}
+				/>
+			</form>
 		</div>
 	))
 	.addWithInfo('with header error', () => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We need to show checkboxes on the in Enumeration component in TMC. 
https://jira.talendforge.org/browse/TMC-11033
Also in this PR i updated selected item background color. 

As we agreed with UX designer, checkboxes styles will be updated later in other PR. 

**What is the chosen solution to this problem?**

New property 'showCheckboxes' , that you should pass to enumeration component to see checkboxes.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

