### PR TITLE
fix(forms): datalistWidget not setting value when receiving new value props

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -47,11 +47,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   78:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   79:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
-/home/travis/build/Talend/ui/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
-  120:38  error  Missing space before opening brace  space-before-blocks
-  121:3   error  Expected space(s) after "if"        keyword-spacing
-  121:43  error  Missing space before opening brace  space-before-blocks
-
 /home/travis/build/Talend/ui/packages/forms/src/widgets/KeyValueWidget/KeyValueWidget.js
   72:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   73:3  error  Prop type `object` is forbidden  react/forbid-prop-types
@@ -65,5 +60,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   69:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
-✖ 37 problems (37 errors, 0 warnings)
+✖ 34 problems (34 errors, 0 warnings)
 

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
@@ -117,8 +117,8 @@ class DatalistWidget extends React.Component {
 		};
 	}
 
-	componentWillReceiveProps(nextProps){
-		if(nextProps.value !== this.props.value){
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.value !== this.props.value) {
 			this.setValue(nextProps.value);
 		}
 	}
@@ -151,24 +151,24 @@ class DatalistWidget extends React.Component {
 
 	onKeyDown(event, { focusedItemIndex, newFocusedItemIndex }) {
 		switch (event.which) {
-		case keycode.codes.esc:
-			this.resetValue();
-			event.preventDefault();
-			break;
-		case keycode.codes.enter:
-			// could be null in case of no match
-			if (focusedItemIndex != null) {
-				this.selectItem(focusedItemIndex);
-			}
-			event.preventDefault();
-			break;
-		case keycode.codes.up:
-		case keycode.codes.down:
-			event.preventDefault();
-			this.focusOnItem(newFocusedItemIndex);
-			break;
-		default:
-			break;
+			case keycode.codes.esc:
+				this.resetValue();
+				event.preventDefault();
+				break;
+			case keycode.codes.enter:
+				// could be null in case of no match
+				if (focusedItemIndex != null) {
+					this.selectItem(focusedItemIndex);
+				}
+				event.preventDefault();
+				break;
+			case keycode.codes.up:
+			case keycode.codes.down:
+				event.preventDefault();
+				this.focusOnItem(newFocusedItemIndex);
+				break;
+			default:
+				break;
 		}
 	}
 

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
@@ -151,24 +151,24 @@ class DatalistWidget extends React.Component {
 
 	onKeyDown(event, { focusedItemIndex, newFocusedItemIndex }) {
 		switch (event.which) {
-			case keycode.codes.esc:
-				this.resetValue();
-				event.preventDefault();
-				break;
-			case keycode.codes.enter:
-				// could be null in case of no match
-				if (focusedItemIndex != null) {
-					this.selectItem(focusedItemIndex);
-				}
-				event.preventDefault();
-				break;
-			case keycode.codes.up:
-			case keycode.codes.down:
-				event.preventDefault();
-				this.focusOnItem(newFocusedItemIndex);
-				break;
-			default:
-				break;
+		case keycode.codes.esc:
+			this.resetValue();
+			event.preventDefault();
+			break;
+		case keycode.codes.enter:
+			// could be null in case of no match
+			if (focusedItemIndex != null) {
+				this.selectItem(focusedItemIndex);
+			}
+			event.preventDefault();
+			break;
+		case keycode.codes.up:
+		case keycode.codes.down:
+			event.preventDefault();
+			this.focusOnItem(newFocusedItemIndex);
+			break;
+		default:
+			break;
 		}
 	}
 

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
@@ -117,6 +117,12 @@ class DatalistWidget extends React.Component {
 		};
 	}
 
+	componentWillReceiveProps(nextProps){
+		if(nextProps.value !== this.props.value){
+			this.setValue(nextProps.value);
+		}
+	}
+
 	onBlur(event) {
 		if (dontBlur) {
 			return;

--- a/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
+++ b/packages/forms/src/widgets/DatalistWidget/DatalistWidget.test.js
@@ -169,6 +169,23 @@ describe('DatalistWidget', () => {
 		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 
+	it('should set value when receiving a new value from props', () => {
+		const onChange = jest.fn();
+		const wrapper = mount(
+			<DatalistWidget
+				id="myWidget"
+				required
+				schema={schema}
+				onChange={onChange}
+			/>
+		);
+
+		wrapper.setProps({ value: 'new' });
+
+		// then
+		expect(wrapper.state('value')).toEqual('new');
+	});
+
 	it('should not change the value if it is the same', () => {
 		// given
 		const onChange = jest.fn();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When receiving a new value by props, the widget kept rendering what it had stored in state.
State was not updated with new value when receiving value on props


**What is the chosen solution to this problem?**
Set value in state on componentWillReceiveProps lifecycle hook

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

