### PR TITLE
feat(forms): Collapse previous array items on add

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-cmf@0.103.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.104.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.103.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.104.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.103.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.104.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-containers@0.103.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.104.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,17 +5,17 @@
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
 /home/travis/build/Talend/ui/packages/forms/src/fields/ArrayField.js
-  564:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  572:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  573:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  576:3  error  Prop type `array` is forbidden   react/forbid-prop-types
-  582:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  595:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  602:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  629:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  630:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  650:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  651:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  560:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  568:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  569:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  572:3  error  Prop type `array` is forbidden   react/forbid-prop-types
+  578:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  591:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  598:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  625:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  626:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  646:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  647:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/fields/BooleanField.js
   72:3  error  Prop type `object` is forbidden  react/forbid-prop-types

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,21 +1,21 @@
 
-> react-talend-forms@0.103.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.104.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
 /home/travis/build/Talend/ui/packages/forms/src/fields/ArrayField.js
-  560:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  568:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  569:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  572:3  error  Prop type `array` is forbidden   react/forbid-prop-types
-  578:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  591:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  598:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  625:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  626:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  646:3  error  Prop type `object` is forbidden  react/forbid-prop-types
-  647:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  564:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  572:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  573:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  576:3  error  Prop type `array` is forbidden   react/forbid-prop-types
+  582:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  595:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  602:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  629:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  630:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  650:3  error  Prop type `object` is forbidden  react/forbid-prop-types
+  651:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
 /home/travis/build/Talend/ui/packages/forms/src/fields/BooleanField.js
   72:3  error  Prop type `object` is forbidden  react/forbid-prop-types

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> react-talend-forms@0.103.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.104.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> talend-log@0.103.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.104.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> bootstrap-talend-theme@0.103.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.104.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/forms/src/fields/ArrayField.js
+++ b/packages/forms/src/fields/ArrayField.js
@@ -198,11 +198,7 @@ class ArrayField extends Component {
 		if (isFixedItems(schema) && allowAdditionalItems(schema)) {
 			itemSchema = schema.additionalItems;
 		}
-		formData.map((item) => {
-			const i = item || {};
-			i.isClosed = true;
-			return i;
-		});
+		formData.forEach(item => Object.assign(item, { isClosed: true }));
 		this.props.onChange([
 			...formData,
 			getDefaultFormState(itemSchema, undefined, definitions),

--- a/packages/forms/src/fields/ArrayField.js
+++ b/packages/forms/src/fields/ArrayField.js
@@ -150,7 +150,6 @@ function DefaultNormalArrayFieldTemplate(props) {
 					description={props.schema.description}
 				/>
 			) : null}
-
 			<div
 				className="row array-item-list"
 				key={`array-item-list-${props.idSchema.$id}`}
@@ -199,6 +198,11 @@ class ArrayField extends Component {
 		if (isFixedItems(schema) && allowAdditionalItems(schema)) {
 			itemSchema = schema.additionalItems;
 		}
+		formData.map((item) => {
+			const i = item || {};
+			i.isClosed = true;
+			return i;
+		});
 		this.props.onChange([
 			...formData,
 			getDefaultFormState(itemSchema, undefined, definitions),

--- a/packages/forms/src/templates/ArrayFieldTemplate.js
+++ b/packages/forms/src/templates/ArrayFieldTemplate.js
@@ -57,16 +57,13 @@ if (process.env.NODE_ENV !== 'production') {
 
 function ArrayFieldTemplate(props) {
 	const { items, canAdd, onAddClick, minItems, maxItems } = props;
+	const addBtnClass = classNames(theme.addBtn, 'btn', 'btn-info');
 	return (
 		<div className={theme.ArrayFieldTemplate}>
 			<IconsProvider />
-			{items &&
-				items.map(element =>
-					<FieldTemplate element={element} cantDelete={items.length <= minItems} />
-				)}
 			{canAdd &&
 				<button
-					className="btn btn-info"
+					className={addBtnClass}
 					type="button"
 					name="btn-new-element"
 					disabled={items.length >= maxItems}
@@ -74,6 +71,10 @@ function ArrayFieldTemplate(props) {
 				>
 					{`NEW ${props.type}`}
 				</button>}
+			{items &&
+				items.map(element =>
+					<FieldTemplate element={element} cantDelete={items.length <= minItems} />
+				)}
 		</div>
 	);
 }

--- a/packages/forms/src/templates/ArrayFieldTemplate.scss
+++ b/packages/forms/src/templates/ArrayFieldTemplate.scss
@@ -1,6 +1,11 @@
 $tf-filterwidget-shadow-color: $shadow !default;
 
 .ArrayFieldTemplate {
+
+	.addBtn {
+		margin-bottom: 30px;
+	}
+
 	.arrayElement {
 		display: flex;
 		background: $wild-sand;

--- a/packages/forms/src/templates/ArrayFieldTemplate.scss
+++ b/packages/forms/src/templates/ArrayFieldTemplate.scss
@@ -1,7 +1,6 @@
 $tf-filterwidget-shadow-color: $shadow !default;
 
 .ArrayFieldTemplate {
-
 	.addBtn {
 		margin-bottom: 30px;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Adding elements to an array forces the user to scroll to fill the newly added item.

**What is the chosen solution to this problem?**
Collapse all previous items when adding a new one.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR