### PR TITLE
doc(CMF): fix gh-pages serving context

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -11,6 +11,8 @@ To contribute on this, you need to install [Jekyll](https://jekyllrb.com/).
 jekyll serve
 ```
 
+The app is served on [http://localhost:4000/ui/](http://localhost:4000/ui/) 
+
 For more advanced commands, see the official [documentation](https://jekyllrb.com/docs/usage/)
 
 ### Add a post

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -28,7 +28,7 @@ sections: [
 
 # Keep as an empty string if served up at the root. If served up at a specific
 # path (e.g. on GitHub pages) leave off the trailing slash, e.g. /my-project
-baseurl: ''
+baseurl: '/ui'
 
 # Dates are not included in permalinks
 permalink: none


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The doc is broken.
I don't know why we have this change, but we lost the context (`/ui/`) in the generated links.

**What is the chosen solution to this problem?**
Changed configuration to add context in the site url

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

