### PR TITLE
fix(Containers): import babel-polyfill in storybook

### DIFF
--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -1,3 +1,4 @@
+import 'babel-polyfill';
 import { action, storiesOf, configure, setAddon } from '@storybook/react';
 import cmf from 'react-storybook-cmf';
 import mock from 'react-cmf/lib/mock';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook is broken

```
VM299 preview.bundle.js:87914 Uncaught ReferenceError: regeneratorRuntime is not defined
    at Object.defineProperty.value (VM167 preview.bundle.js:87914)
    at __webpack_require__ (VM167 preview.bundle.js:677)
    at fn (VM167 preview.bundle.js:88)
    at Object.isArray (VM167 preview.bundle.js:25892)
    at __webpack_require__ (VM167 preview.bundle.js:677)
    at fn (VM167 preview.bundle.js:88)
    at Object.<anonymous> (VM167 preview.bundle.js:3548)
    at __webpack_require__ (VM167 preview.bundle.js:677)
    at fn (VM167 preview.bundle.js:88)
    at Object.__webpack_exports__.a (VM167 preview.bundle.js:85604)
```

**What is the chosen solution to this problem?**
Add babel-polyfill

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

