### PR TITLE
fix(Typeahead): display result with right position

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-cmf@0.109.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.110.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.109.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.110.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.109.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.110.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-containers@0.109.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.110.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-forms@0.109.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.110.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> react-talend-forms@0.109.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.110.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> talend-log@0.109.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.110.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> bootstrap-talend-theme@0.109.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.110.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -14,7 +14,7 @@ $tc-typeahead-only-icon-color: #CCC !default;
 $tc-typeahead-section-header-color: #63AEBD !default;
 
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
-$tc-typeahead-items-border-radius: 4px !default;
+$tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
 
 .tc-typeahead-container {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -13,7 +13,9 @@ $tc-typeahead-icon-color: #CCC !default;
 $tc-typeahead-only-icon-color: #CCC !default;
 $tc-typeahead-section-header-color: #63AEBD !default;
 
-$tc-typeahead-items-shadow-color: rgba(0, 0, 0, 0.4) !default;
+$tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
+$tc-typeahead-items-border-radius: 4px !default;
+$tc-typeahead-items-font-size: 1.5rem !default;
 
 .tc-typeahead-container {
 	position: relative;
@@ -29,10 +31,10 @@ $tc-typeahead-items-shadow-color: rgba(0, 0, 0, 0.4) !default;
 		top: 100%;
 		max-height: 70vh;
 		min-width: $tc-typeahead-input-width;
-		font-size: 1.5rem;
+		font-size: $tc-typeahead-items-font-size;
 		background-color: $tc-typeahead-opened-items-container-background-color;
-		border-radius: 4px;
-		box-shadow: 0 1px 3px 0 $tc-typeahead-items-shadow-color;
+		border-radius: $tc-typeahead-items-border-radius;
+		box-shadow: $tc-typeahead-items-box-shadow;
 		overflow-y: auto;
 	}
 

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -22,8 +22,34 @@ $tc-typeahead-items-shadow-color: rgba(0, 0, 0, 0.4) !default;
 	align-items: flex-start;
 	width: auto;
 
+	.items-container {
+		display: none;
+		position: absolute;
+		margin-top: $padding-smaller;
+		top: 100%;
+		max-height: 70vh;
+		min-width: $tc-typeahead-input-width;
+		font-size: 1.5rem;
+		background-color: $tc-typeahead-opened-items-container-background-color;
+		border-radius: 4px;
+		box-shadow: 0 1px 3px 0 $tc-typeahead-items-shadow-color;
+		overflow-y: auto;
+	}
+
 	&.right {
 		align-items: flex-end;
+
+		.items-container {
+			right: 0;
+		}
+	}
+
+	.is-searching,
+	.no-result,
+	&.container-open .items-container {
+		display: block;
+		padding-top: 1px;
+		padding-bottom: 1px;
 	}
 }
 
@@ -42,20 +68,6 @@ $tc-typeahead-items-shadow-color: rgba(0, 0, 0, 0.4) !default;
 	}
 }
 
-.items-container {
-	display: none;
-	position: absolute;
-	margin-top: $padding-smaller;
-	top: 100%;
-	max-height: 70vh;
-	min-width: $tc-typeahead-input-width;
-	font-size: 1.5rem;
-	background-color: $tc-typeahead-opened-items-container-background-color;
-	border-radius: 4px;
-	box-shadow: 0 1px 3px 0 $tc-typeahead-items-shadow-color;
-	overflow-y: auto;
-}
-
 .is-searching,
 .no-result {
 	padding: $padding-normal;
@@ -68,15 +80,6 @@ $tc-typeahead-items-shadow-color: rgba(0, 0, 0, 0.4) !default;
 		padding: $padding-normal 0;
 	}
 }
-
-.is-searching,
-.no-result,
-.container-open .items-container {
-	display: block;
-	padding-top: 1px;
-	padding-bottom: 1px;
-}
-
 
 .is-searching {
 	display: flex;

--- a/packages/components/stories/Typeahead.js
+++ b/packages/components/stories/Typeahead.js
@@ -83,17 +83,6 @@ decoratedStories
 			<Typeahead {...props} />
 		);
 	})
-	.addWithInfo('on the right', () => {
-		const props = {
-			placeholder: 'Search...',
-			position: 'right',
-			onBlur: action('onBlur'),
-			onChange: action('onChange'),
-		};
-		return (
-			<Typeahead {...props} />
-		);
-	})
 	.addWithInfo('searching', () => {
 		const props = {
 			value: 'Lorem ipsum',
@@ -123,6 +112,19 @@ decoratedStories
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			items: [],
+		};
+		return (
+			<Typeahead {...props} />
+		);
+	})
+	.addWithInfo('on the right', () => {
+		const props = {
+			value: 'le',
+			items,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			position: 'right',
 		};
 		return (
 			<Typeahead {...props} />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With right position, the typeahead results were on the right. So sometimes, outside of the window.
#44 

![capture d ecran de 2017-09-13 16-58-09](https://user-images.githubusercontent.com/10761073/30384516-cc49f5c8-98a4-11e7-9968-1a0178e51736.png)

**What is the chosen solution to this problem?**
Fix it with css
![capture d ecran de 2017-09-13 16-58-15](https://user-images.githubusercontent.com/10761073/30384524-d3a9b7f4-98a4-11e7-9284-ee2d2dc95675.png)


**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

