### PR TITLE
fix(UIForms): create properties nested objects when mutated

### DIFF
--- a/packages/forms/src/UIForm/utils/properties.js
+++ b/packages/forms/src/UIForm/utils/properties.js
@@ -58,12 +58,12 @@ export function convertValue(type, value) {
 
 /**
  * Mutate the properties, setting the value in the path identified by key
- * @param {object} properties The original properties store
+ * @param {object | array} properties The original properties store
  * @param {array} key The key chain (array of strings) to identify the path
  * @param {any} value The value to set
  * @returns {object} The new mutated properties store.
  */
-export function mutateValue(properties, key, value) {
+export function mutateValue(properties = {}, key, value) {
 	if (!key.length) {
 		return value;
 	}

--- a/packages/forms/src/UIForm/utils/properties.test.js
+++ b/packages/forms/src/UIForm/utils/properties.test.js
@@ -124,5 +124,20 @@ describe('Properties utils', () => {
 				},
 			});
 		});
+
+		it('should add a value, creating nested objects', () => {
+			// given
+			const key = ['user', 'firstname'];
+
+			// when
+			const value = mutateValue(undefined, key, 'titi');
+
+			// then
+			expect(value).toEqual({
+				user: {
+					firstname: 'titi',
+				},
+			});
+		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When nested properties are not provided in uiSpecs, on nested input change it crashes.

**What is the chosen solution to this problem?**
Create the nested properties on mutation.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

