### PR TITLE
fix(UIForms): MultiSelectTag suggestions update on value update

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-cmf@0.110.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> react-cmf@0.111.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.110.0 lint:es /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.111.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-components@0.110.0 lint:style /home/travis/build/Talend/ui/packages/components
+> react-talend-components@0.111.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-containers@0.110.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> react-talend-containers@0.111.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -37,9 +37,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
   8:4  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
-  222:30  error  A space is required before closing bracket  react/jsx-space-before-closing
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   23:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
@@ -63,5 +60,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   69:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
-✖ 35 problems (35 errors, 0 warnings)
+✖ 34 problems (34 errors, 0 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> react-talend-forms@0.110.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.111.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
@@ -38,7 +38,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   8:4  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
-  219:30  error  A space is required before closing bracket  react/jsx-space-before-closing
+  222:30  error  A space is required before closing bracket  react/jsx-space-before-closing
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   23:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -37,6 +37,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
   8:4  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+  219:30  error  A space is required before closing bracket  react/jsx-space-before-closing
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   23:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
@@ -60,5 +63,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:3  error  Prop type `object` is forbidden  react/forbid-prop-types
   69:3  error  Prop type `object` is forbidden  react/forbid-prop-types
 
-✖ 34 problems (34 errors, 0 warnings)
+✖ 35 problems (35 errors, 0 warnings)
 

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> react-talend-forms@0.110.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> react-talend-forms@0.111.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> talend-log@0.110.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> talend-log@0.111.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> bootstrap-talend-theme@0.110.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> bootstrap-talend-theme@0.111.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -42,6 +42,20 @@ export default class MultiSelectTag extends React.Component {
 	}
 
 	/**
+	 * On Tags value change, we update suggestions if they are displayed
+	 * @param value The tags values
+	 */
+	componentDidUpdate({ value }) {
+		if (value === this.props.value) {
+			return;
+		}
+		if (this.state.suggestions) {
+			this.updateSuggestions();
+		}
+	}
+
+
+	/**
 	 * Manage suggestion selection
 	 * @param event
 	 * @param focusedItemIndex
@@ -202,7 +216,7 @@ export default class MultiSelectTag extends React.Component {
 						value={this.state.value}
 					/>
 					<div className={theme.caret}>
-						<span className="caret" />
+						<span className="caret"/>
 					</div>
 				</div>
 			</FieldTemplate>

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -43,7 +43,7 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * On Tags value change, we update suggestions if they are displayed
-	 * @param nextProps The new props
+	 * @param { Object } nextProps The new props
 	 */
 	componentWillReceiveProps(nextProps) {
 		if (nextProps.value === this.props.value) {
@@ -56,9 +56,9 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * Manage suggestion selection
-	 * @param event
-	 * @param focusedItemIndex
-	 * @param newFocusedItemIndex
+	 * @param { object } event
+	 * @param { number } focusedItemIndex
+	 * @param { number } newFocusedItemIndex
 	 */
 	onKeyDown(event, { focusedItemIndex, newFocusedItemIndex }) {
 		switch (event.which) {
@@ -86,8 +86,8 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * Update suggestions on input value change
-	 * @param event The input change event
-	 * @param value The new input value
+	 * @param { object } event The input change event
+	 * @param { string } value The new input value
 	 */
 	onChange(event, { value }) {
 		this.updateSuggestions(value);
@@ -102,8 +102,8 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * Add a new tag
-	 * @param event The user event
-	 * @param itemIndex The selected suggestion index
+	 * @param { object } event The user event
+	 * @param { number } itemIndex The selected suggestion index
 	 */
 	onAddTag(event, { itemIndex }) {
 		const currentValue = this.state.value;
@@ -122,8 +122,8 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * Remove a tag
-	 * @param event The user event
-	 * @param itemIndex The tag index
+	 * @param { object } event The user event
+	 * @param { number } itemIndex The tag index
 	 */
 	onRemoveTag(event, itemIndex) {
 		const value = this.props.value.slice(0);
@@ -147,8 +147,8 @@ export default class MultiSelectTag extends React.Component {
 	 * Update suggestions
 	 * - remove current tags values
 	 * - filter based on input value
-	 * @param value The new input value. Undefined if we should use the current input value.
-	 * @param props The props to use. If not provided, it used this.props.
+	 * @param { string } value The new input value. If not provided, it uses the current input value.
+	 * @param { object } props The props to use. If not provided, it uses this.props.
 	 */
 	updateSuggestions(value, props) {
 		this.setState((oldState) => {

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -43,17 +43,16 @@ export default class MultiSelectTag extends React.Component {
 
 	/**
 	 * On Tags value change, we update suggestions if they are displayed
-	 * @param value The tags values
+	 * @param nextProps The new props
 	 */
-	componentDidUpdate({ value }) {
-		if (value === this.props.value) {
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.value === this.props.value) {
 			return;
 		}
 		if (this.state.suggestions) {
-			this.updateSuggestions();
+			this.updateSuggestions(undefined, nextProps);
 		}
 	}
-
 
 	/**
 	 * Manage suggestion selection
@@ -149,27 +148,31 @@ export default class MultiSelectTag extends React.Component {
 	 * - remove current tags values
 	 * - filter based on input value
 	 * @param value The new input value. Undefined if we should use the current input value.
+	 * @param props The props to use. If not provided, it used this.props.
 	 */
-	updateSuggestions(value) {
-		const currentValue = value === undefined ? this.state.value : value;
-		let suggestions = this.props.schema.titleMap
-			.map(item => item.value)
-			.filter(item => this.props.value.indexOf(item) < 0);
+	updateSuggestions(value, props) {
+		this.setState((oldState) => {
+			const currentValue = value === undefined ? oldState.value : value;
+			const currentProps = props === undefined ? this.props : props;
+			let suggestions = currentProps.schema.titleMap
+				.map(item => item.value)
+				.filter(item => currentProps.value.indexOf(item) < 0);
 
-		if (currentValue) {
-			const escapedValue = escapeRegexCharacters(currentValue.trim());
-			const regex = new RegExp(escapedValue, 'i');
-			suggestions = suggestions.filter(itemValue => regex.test(itemValue));
+			if (currentValue) {
+				const escapedValue = escapeRegexCharacters(currentValue.trim());
+				const regex = new RegExp(escapedValue, 'i');
+				suggestions = suggestions.filter(itemValue => regex.test(itemValue));
 
-			if (!suggestions.length && this.props.schema.restricted === false) {
-				suggestions.push(getNewItemText(currentValue));
+				if (!suggestions.length && currentProps.schema.restricted === false) {
+					suggestions.push(getNewItemText(currentValue));
+				}
 			}
-		}
 
-		this.setState({
-			focusedItemIndex: suggestions.length ? 0 : undefined,
-			suggestions,
-			value: currentValue,
+			return {
+				focusedItemIndex: suggestions.length ? 0 : undefined,
+				suggestions,
+				value: currentValue,
+			};
 		});
 	}
 

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -219,7 +219,7 @@ export default class MultiSelectTag extends React.Component {
 						value={this.state.value}
 					/>
 					<div className={theme.caret}>
-						<span className="caret"/>
+						<span className="caret" />
 					</div>
 				</div>
 			</FieldTemplate>

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import ReactDOM from 'react-dom';
 import { mount, shallow } from 'enzyme';
 import Typeahead from 'react-talend-components/lib/Typeahead';
 import keycode from 'keycode';
@@ -32,7 +33,7 @@ describe('MultiSelectTag field', () => {
 		expect(wrapper.node).toMatchSnapshot();
 	});
 
-	it('should update suggestion', () => {
+	it('should update suggestion on input change', () => {
 		// given
 		const wrapper = mount(<MultiSelectTag {...props} />);
 
@@ -41,6 +42,21 @@ describe('MultiSelectTag field', () => {
 
 		// then
 		expect(wrapper.find(Typeahead).props().items).toEqual(['titi']);
+	});
+
+	it('should update suggestion on props.value change', () => {
+		// given
+		const node = document.createElement('div');
+		// eslint-disable-next-line react/no-render-return-value
+		const instance = ReactDOM.render(<MultiSelectTag {...props} />, node);
+		instance.updateSuggestions();
+		expect(instance.state.suggestions).toEqual(['titi']);
+
+		// when : trigger a props update
+		ReactDOM.render(<MultiSelectTag {...props} value={['aze']} />, node);
+
+		// then
+		expect(instance.state.suggestions).toEqual(['titi', 'tutu']);
 	});
 
 	it('should suggest new item creation when widget is not restricted', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In MultiSelectTag widget, current tags should not appear in the suggestions list.

![old](https://user-images.githubusercontent.com/10761073/30430593-f6a14d96-995b-11e7-81d0-bb568c52321b.gif)

**What is the chosen solution to this problem?**
When component receive new value props, the suggestions list is updated.

![new](https://user-images.githubusercontent.com/10761073/30430598-fc9f0152-995b-11e7-9c1f-68fadeb7fce8.gif)

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

