### PR TITLE
fix(webapp): add displayName on SidePanel

### DIFF
--- a/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
+++ b/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
@@ -78,7 +78,7 @@ exports[`Component HomeListView should render with object props 1`] = `
   }
   mode="TwoColumns"
   one={
-    <Connect(CMF(SidePanel))
+    <Connect(CMF(Container(SidePanel)))
       actionIds={
         Array [
           "menu:demo",

--- a/packages/containers/src/SidePanel/SidePanel.container.js
+++ b/packages/containers/src/SidePanel/SidePanel.container.js
@@ -36,6 +36,7 @@ export function getActions(actionIds, context) {
  * @param {object} props react props
  */
 class SidePanel extends React.Component {
+	static displayName = 'Container(SidePanel)';
 	static propTypes = {
 		actionIds: PropTypes.arrayOf(
 			PropTypes.oneOfType([


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
add a displayname by default on sidepanel. without it, with minification process, the sidepanel entry is something like "t" or another letter. this is not very convenient to get to store it in local storage
**What is the chosen solution to this problem?**
add a displayname

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

