### PR TITLE
feat(container/ObjectViewer): add tupleName support on container

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.113.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.113.1 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.113.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.113.1 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.113.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.113.1 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.113.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.113.1 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.113.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.113.1 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config .eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.113.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.113.1 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.113.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.113.1 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config .eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.113.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.113.1 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/containers/examples/ExampleObjectViewer.js
+++ b/packages/containers/examples/ExampleObjectViewer.js
@@ -2,8 +2,6 @@ import React from 'react';
 import { IconsProvider } from '@talend/react-components';
 import { ObjectViewer } from '../src';
 
-const veryLongDatasetLabel =
-	"Dataset of something that I cant't imagine; Dataset of something that I cant't imagine; Dataset of something that I cant't imagine";
 const veryLongCafeName = "Betty's Cafe witha  veryyyyyyy veryyyyyyyyyy looong name";
 const data = [
 	{
@@ -178,8 +176,7 @@ const data = [
 	},
 ];
 
-let selectedJsonpath = "$[0]['name']";
-const kTrue = true;
+const selectedJsonpath = "$[0]['name']";
 
 const ExampleObjectViewer = {
 	default: () => (
@@ -197,7 +194,13 @@ const ExampleObjectViewer = {
 	'JsonLike with types': () => (
 		<div>
 			<IconsProvider />
-			<ObjectViewer data={data} showType={kTrue} />
+			<ObjectViewer data={data} showType />
+		</div>
+	),
+	'JsonLike with tuple name': () => (
+		<div>
+			<IconsProvider />
+			<ObjectViewer data={data} showType tupleLabel="Record" />
 		</div>
 	),
 	'list default': () => (

--- a/packages/containers/src/ObjectViewer/ObjectViewer.container.js
+++ b/packages/containers/src/ObjectViewer/ObjectViewer.container.js
@@ -99,10 +99,7 @@ class ObjectViewer extends React.Component {
 		// We need for that a better JSONPath support.
 		return (
 			<Component
-				data={this.props.data}
-				displayMode={this.props.displayMode}
-				showType={this.props.showType}
-				onSubmit={this.props.onSubmit}
+				{...this.props}
 				onChange={this.props.onSubmit ? this.onChange : undefined}
 				onSelect={this.onSelect}
 				onEdit={this.onEdit}
@@ -110,7 +107,6 @@ class ObjectViewer extends React.Component {
 				selectedJsonpath={state.selectedJsonpath}
 				opened={state.opened}
 				edited={state.edited}
-				{...this.props}
 			/>
 		);
 	}

--- a/packages/containers/src/ObjectViewer/ObjectViewer.container.js
+++ b/packages/containers/src/ObjectViewer/ObjectViewer.container.js
@@ -110,6 +110,7 @@ class ObjectViewer extends React.Component {
 				selectedJsonpath={state.selectedJsonpath}
 				opened={state.opened}
 				edited={state.edited}
+				{...this.props}
 			/>
 		);
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Not all props given to the objectViewerContainer are passed down to the ObjectViewer object

**What is the chosen solution to this problem?**
props are given back to the ObjectViewer component

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

