### PR TITLE
fix(cmf): cmfConnect perfs

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -4,6 +4,9 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/cmf/src/cmfConnect.js
+  169:23  error  Expected parentheses around arrow function argument having a body with curly braces  arrow-parens
+
 /home/travis/build/Talend/ui/packages/cmf/src/componentState.js
   67:3  warning  Unexpected console statement  no-console
 
@@ -16,5 +19,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/sagaRouter/router.js
   45:2  warning  Unexpected constant condition  no-constant-condition
 
-✖ 4 problems (1 error, 3 warnings)
+✖ 5 problems (2 errors, 3 warnings)
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
getCollection is recreated on  each call to getStateToProps, the problem being that each time a connected component is rendered, this props ref is not equal to the one on precedent call, preventing connect to do its shallow equal performance job.

**What is the chosen solution to this problem?**
getCollection is now a single ref pointer, and state is provided to it via a module scoped value refreshed on each call to getStateToProps

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

