### PR TITLE
chores(version.js): update package name and doc

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.115.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.116.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.115.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.116.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.115.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.116.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.115.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.116.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.115.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.116.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.115.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.116.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.115.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.116.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.115.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.116.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/version.js
+++ b/version.js
@@ -9,10 +9,16 @@ program
 	.version('0.0.1')
 	.option('-d, --debug', 'display more info')
 	.option('-q, --quiet', 'display nothing')
-	.option('-p, --path [value]', 'path of the package.json to update')
-	.option('-s, --stack [value]', 'stack version used in combination with -p')
-	.option('-f, --force')
-	.parse(process.argv);
+	.option('-p, --path [value]', '[required] path of the package.json to update >node version.js --path=../yourapp/package.json')
+	.option('-s, --stack [value]', '[optional] stack version to use, by default the last published one')
+	.option('-f, --force');
+
+program.on('--help', function(){
+	console.log('Don\'t forget to use yarn after the package json update');
+	console.log('so you lockfile is updated !');
+})
+
+	program.parse(process.argv);
 
 const REACT_VERSION = '^15.6.1';
 const JEST_VERSION = '20.0.3';
@@ -141,13 +147,14 @@ if (program.path) {
 		console.log(`use stack version ${stack_version}`);
 	}
 	const STACK_VERSION = {
-		'bootstrap-talend-theme': stack_version,
-		'react-cmf': stack_version,
-		'react-talend-components': stack_version,
-		'react-talend-containers': stack_version,
-		'react-talend-forms': stack_version,
-		'talend-icons': stack_version,
-		'talend-log': stack_version,
+		'@talend/bootstrap-theme': stack_version,
+		'@talend/react-cmf': stack_version,
+		'@talend/react-cmf-cqrs': stack_version,
+		'@talend/react-components': stack_version,
+		'@talend/react-containers': stack_version,
+		'@talend/react-forms': stack_version,
+		'@talend/icons': stack_version,
+		'@talend/log': stack_version,
 	};
 	Object.assign(
 		VERSIONS,

--- a/version.js
+++ b/version.js
@@ -9,11 +9,15 @@ program
 	.version('0.0.1')
 	.option('-d, --debug', 'display more info')
 	.option('-q, --quiet', 'display nothing')
-	.option('-p, --path [value]', '[required] path of the package.json to update >node version.js --path=../yourapp/package.json')
+	.option('-p, --path [value]', '[optional] path of the package.json to update by default local package')
 	.option('-s, --stack [value]', '[optional] stack version to use, by default the last published one')
 	.option('-f, --force');
 
 program.on('--help', function(){
+	console.log('To update your project dependencies : ')
+	console.log('>node version.js --path ../yourapp/package.json');
+	console.log('To update your project dependencies to a specif stack version :')
+	console.log('>node version.js --path ../yourapp/package.json --stack=0.114.0')
 	console.log('Don\'t forget to use yarn after the package json update');
 	console.log('so you lockfile is updated !');
 })


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the stack part of the script was targeting the old talend package naming


**What is the chosen solution to this problem?**
upgraded talend package names

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

