### PR TITLE
feat(cmf): auto use view from component name and id

### DIFF
--- a/packages/cmf/__tests__/cmfConnect.test.js
+++ b/packages/cmf/__tests__/cmfConnect.test.js
@@ -79,6 +79,38 @@ describe('cmfConnect', () => {
 			});
 			expect(props.sidemenu.actions.length).toBe(2);
 		});
+
+		it('should inject view settings using displayName and componentId', () => {
+			const state = mock.state();
+			state.cmf.components = fromJS({});
+			state.cmf.settings.views['TestComponent:default'] = { foo: 'from-displayName' };
+			state.cmf.settings.views['TestComponent:props-id'] = { foo: 'from-props-componentId' };
+			state.cmf.settings.views['TestComponent:connect-id'] = { foo: 'from-connect-componentId' };
+			let props = getStateToProps({
+				componentId: 'connect-id',
+				ownProps: {},
+				state,
+				WrappedComponent: { displayName: 'TestComponent' },
+			});
+			expect(props.foo).toBe('from-connect-componentId');
+
+			props = getStateToProps({
+				ownProps: { componentId: 'props-id' },
+				state,
+				WrappedComponent: { displayName: 'TestComponent' },
+			});
+			expect(props.foo).toBe('from-props-componentId');
+
+			props = getStateToProps({
+				ownProps: {},
+				state,
+				WrappedComponent: { displayName: 'TestComponent' },
+			});
+			expect(props.foo).toBe('from-displayName');
+			delete state.cmf.settings.views['TestComponent:default'];
+			delete state.cmf.settings.views['TestComponent:props-id'];
+			delete state.cmf.settings.views['TestComponent:connect-id'];
+		});
 	});
 
 	describe('#getDispatchToProps', () => {

--- a/packages/cmf/__tests__/settings.test.js
+++ b/packages/cmf/__tests__/settings.test.js
@@ -31,6 +31,21 @@ describe('mapStateToViewProps', () => {
 		};
 		expect(shouldThrow).toThrow(new Error('CMF/Settings: Reference \'myref\' not found'));
 	});
+
+	it('should apply default views from displayName if no view are passed', () => {
+		const state = mock.state();
+		state.cmf.settings.views.MyComponent = { foo: 'bar' };
+		const props = mapStateToViewProps(state, { views: undefined }, 'MyComponent');
+		expect(props.foo).toBe('bar');
+	});
+
+	it('should apply default views from displayName and componentId if no view are passed', () => {
+		const state = mock.state();
+		state.cmf.settings.views.MyComponent = { foo: 'bar' };
+		state.cmf.settings.views['MyComponent:my-component-id'] = { foo: 'baz' };
+		const props = mapStateToViewProps(state, { view: undefined }, 'MyComponent', 'my-component-id');
+		expect(props.foo).toBe('baz');
+	});
 });
 
 describe('attachRef', () => {

--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -51,7 +51,12 @@ export function getStateToProps({
 
 	cmfProps.getCollection = getCollection;
 
-	const viewProps = mapStateToViewProps(state, ownProps);
+	const viewProps = mapStateToViewProps(
+		state,
+		ownProps,
+		getComponentName(WrappedComponent),
+		getComponentId(componentId, ownProps),
+	);
 
 	let userProps = {};
 	if (mapStateToProps) {

--- a/packages/cmf/src/settings.js
+++ b/packages/cmf/src/settings.js
@@ -77,12 +77,18 @@ export function attachRefs(state, props) {
  * @param  {Object} ownProps   the props passed to the component. may have a view attribute
  * @return {Object}           React props for the component injected from the settings
  */
-export function mapStateToViewProps(state, ownProps) {
+export function mapStateToViewProps(state, ownProps, componentName, componentId) {
 	let viewProps = {};
-	if (ownProps.view) {
+	let viewId = ownProps.view;
+	if (!ownProps.view && componentName && !componentId) {
+		viewId = componentName;
+	} else if (!ownProps.view && componentName && componentId) {
+		viewId = `${componentName}:${componentId}`;
+	}
+	if (viewId && state.cmf.settings.views[viewId]) {
 		viewProps = Object.assign(
 			{},
-			state.cmf.settings.views[ownProps.view],
+			state.cmf.settings.views[viewId],
 		);
 		viewProps = attachRefs(state, viewProps);
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Currently when we want to configure component we apply the view props to it so we can add settings and voila.
but when the component is called by a library you have to add the view to the call so you can add your own configuration.

**What is the chosen solution to this problem?**

Now if you cmfConnect a component 'MyComponent' it will get the view 'MyComponent:default' if you do not provide any view props to it.
If it's connected with a componentId, default will be replace by this one.
If a props componentId is passed to the component it also will be used.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

