### PR TITLE
enhancement(cmf/view settings): memoize the setting retrieval

### DIFF
--- a/packages/cmf/__tests__/__snapshots__/cmfConnect.test.js.snap
+++ b/packages/cmf/__tests__/__snapshots__/cmfConnect.test.js.snap
@@ -5,6 +5,7 @@ Object {
   "deleteState": [Function],
   "dispatch": [Function],
   "dispatchActionCreator": [Function],
+  "foo": "from-displayName",
   "getCollection": [Function],
   "initState": [Function],
   "setState": [Function],

--- a/packages/cmf/__tests__/settings.test.js
+++ b/packages/cmf/__tests__/settings.test.js
@@ -1,5 +1,6 @@
 import {
 	mapStateToViewProps,
+	nonMemoizedMapStateToViewProps,
 	attachRef,
 } from '../src/settings';
 import mock from '../src/mock';
@@ -27,7 +28,7 @@ describe('mapStateToViewProps', () => {
 		};
 		state.cmf.settings.ref = {};
 		const shouldThrow = () => {
-			mapStateToViewProps(state, { view: 'homepage' });
+			nonMemoizedMapStateToViewProps(state, { view: 'homepage' });
 		};
 		expect(shouldThrow).toThrow(new Error('CMF/Settings: Reference \'myref\' not found'));
 	});

--- a/packages/cmf/src/settings.js
+++ b/packages/cmf/src/settings.js
@@ -32,6 +32,21 @@ export function attachRefs(state, props) {
 	return attachedProps;
 }
 
+export function nonMemoizedMapStateToViewProps(state, ownProps, componentName, componentId) {
+	let viewProps = {};
+	let viewId = ownProps.view;
+	if (!ownProps.view && componentName && !componentId) {
+		viewId = componentName;
+	} else if (!ownProps.view && componentName && componentId) {
+		viewId = `${componentName}:${componentId}`;
+	}
+	if (viewId && state.cmf.settings.views[viewId]) {
+		viewProps = Object.assign({}, state.cmf.settings.views[viewId]);
+		viewProps = attachRefs(state, viewProps);
+	}
+	return viewProps;
+}
+
 /**
  * return props for a given view with reference and override support
  * this function is memoized and the map key is computed using
@@ -74,26 +89,11 @@ export function attachRefs(state, props) {
  * @param  {Object} ownProps   the props passed to the component. may have a view attribute
  * @return {Object}           React props for the component injected from the settings
  */
-export const mapStateToViewProps = memoize((
-	state,
-	ownProps,
-	componentName,
-	componentId,
-) => {
-	let viewProps = {};
-	let viewId = ownProps.view;
-	if (!ownProps.view && componentName && !componentId) {
-		viewId = componentName;
-	} else if (!ownProps.view && componentName && componentId) {
-		viewId = `${componentName}:${componentId}`;
-	}
-	if (viewId && state.cmf.settings.views[viewId]) {
-		viewProps = Object.assign({}, state.cmf.settings.views[viewId]);
-		viewProps = attachRefs(state, viewProps);
-	}
-	return viewProps;
-},
-(state, ownProps, componentName, componentId) => `${ownProps.view}-${componentName}-${componentId}`);
+export const mapStateToViewProps = memoize(
+	nonMemoizedMapStateToViewProps,
+	(state, ownProps, componentName, componentId) =>
+		`${ownProps.view}-${componentName}-${componentId}`,
+);
 
 export default {
 	attachRef,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On each container render, setting are fetched from the store then cloned to avoid store reference mutation.
Problem this prevent cmfConnect shallow testing of computed props to prevent children render if props haven't changed.

**What is the chosen solution to this problem?**
Memoize settings retrieved by this function with a cache storage on key composed of (viewName, component name, component id)

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

