### PR TITLE
fix(cmf): sagaRouter import

### DIFF
--- a/packages/cmf/__tests__/sagaRouter/router.test.js
+++ b/packages/cmf/__tests__/sagaRouter/router.test.js
@@ -1,8 +1,16 @@
 import { spawn, take, cancel } from 'redux-saga/effects';
 import { createMockTask } from 'redux-saga/utils';
-import routerSaga from '../../src/sagaRouter/router';
+import sagaRouter from '../../src/sagaRouter/router';
+import { sagaRouter as sagaRouterFromRoot } from '../../src';
 
-describe('routerSaga RouteChange', () => {
+describe('sagaRouter import', () => {
+	it('shouldBe defined', () => {
+		expect(sagaRouter).toBeDefined();
+		expect(sagaRouter).toBe(sagaRouterFromRoot);
+	});
+});
+
+describe('sagaRouter RouteChange', () => {
 	it('start the configured saga if route equals current location', () => {
 		const mockHistory = {
 			getCurrentLocation() {
@@ -16,7 +24,7 @@ describe('routerSaga RouteChange', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(mockHistory, routes);
+		const gen = sagaRouter(mockHistory, routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute'], {})
@@ -36,7 +44,7 @@ describe('routerSaga RouteChange', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(mockHistory, routes);
+		const gen = sagaRouter(mockHistory, routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute'], {})
@@ -66,7 +74,7 @@ describe('routerSaga RouteChange', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(getMockedHistory(), routes);
+		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute'], {})
@@ -100,7 +108,7 @@ describe('routerSaga RouteChange', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(getMockedHistory(), routes);
+		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute'], {})
@@ -136,7 +144,7 @@ describe('routerSaga RouteChange', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(getMockedHistory(), routes);
+		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/toCancelFirst'], {})
@@ -154,7 +162,7 @@ describe('routerSaga RouteChange', () => {
 			},
 		};
 
-		const anotherGen = routerSaga(getMockedHistory(), alternateRoutes);
+		const anotherGen = sagaRouter(getMockedHistory(), alternateRoutes);
 		expect(anotherGen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(anotherGen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(alternateRoutes['/toCancelFirst'], {})
@@ -165,7 +173,7 @@ describe('routerSaga RouteChange', () => {
 	});
 });
 
-describe('routerSaga route and route params', () => {
+describe('sagaRouter route and route params', () => {
 	it('route params should be given to target saga as object', () => {
 		function getMockedHistory() {
 			let count = 0;
@@ -188,7 +196,7 @@ describe('routerSaga route and route params', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(getMockedHistory(), routes);
+		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute/:id'], { id: 'anId' })
@@ -218,7 +226,7 @@ describe('routerSaga route and route params', () => {
 				yield take('SOMETHING');
 			},
 		};
-		const gen = routerSaga(getMockedHistory(), routes);
+		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
 			spawn(routes['/matchingroute/:id'], { id: 'anId' })

--- a/packages/cmf/src/sagaRouter/index.js
+++ b/packages/cmf/src/sagaRouter/index.js
@@ -1,7 +1,3 @@
-import { all, fork } from 'redux-saga/effects';
-import { browserHistory as history } from 'react-router';
-import routerSaga from './router';
+import sagaRouter from './router';
 
-export default function* initSagaRouter(routes) {
-	yield all([fork(routerSaga, history, routes)]);
-}
+export default sagaRouter;

--- a/packages/cmf/src/sagaRouter/router.js
+++ b/packages/cmf/src/sagaRouter/router.js
@@ -39,10 +39,10 @@ function parseSagaState(routeFragments, sagas, currentLocation, index) {
 	};
 }
 
-export default function* routerSaga(history, routes) {
+export default function* sagaRouter(history, routes) {
 	const sagas = {};
 	const routeFragments = Object.keys(routes);
-	while (true) {
+	while (true) {  // eslint-disable-line no-constant-condition
 		yield take('@@router/LOCATION_CHANGE');
 		const shouldStart = [];
 		const currentLocation = history.getCurrentLocation();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

You can't import sagaRouter from cmf, but only the initSagaRouter exposed as `sagaRouter`...
sometimes in the code it's used as routerSaga. (naming !)

**What is the chosen solution to this problem?**

expose sagaRouter as it is.
rename routerSaga to sagaRouter every where.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

