### PR TITLE
chore(Proptypes): Removes isRequired from Icon onClick prop

### DIFF
--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -101,7 +101,7 @@ Icon.propTypes = {
 	name: PropTypes.string.isRequired,
 	title: PropTypes.string,
 	transform: PropTypes.oneOf(TRANSFORMS),
-	onClick: PropTypes.func.isRequired,
+	onClick: PropTypes.func,
 };
 
 export default Icon;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
onClick isn't really required on all Icons. But the proptypes says so. That creates a ton of proptypes warnings.

**What is the chosen solution to this problem?**
Remove the isRequired from the Icon onClick prop.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR