### PR TITLE
feat(forms): update styles of error msg

### DIFF
--- a/packages/forms/stories/index.js
+++ b/packages/forms/stories/index.js
@@ -496,3 +496,44 @@ decoratedStories.add('Form Children', () => {
 		</Form>
 	);
 });
+
+
+decoratedStories.add('Form with live validation', () => {
+	const schema = {
+		jsonSchema: {
+			title: 'Form with live validation',
+			type: 'object',
+			properties: {
+				name: {
+					title: 'Name',
+					type: 'string',
+					required: true,
+					minLength: 3,
+				},
+				email: {
+					title: 'Email',
+					type: 'string',
+					pattern: '^\\S+@\\S+$',
+					minLength: 5,
+				},
+			},
+		},
+		uiSchema: {
+			email: {
+				'ui:help': 'List of errors will be displayed, if email is empty',
+			},
+		},
+		properties: {
+			name: 'Rey',
+			email: 'lastJedi@sw.com',
+		},
+	};
+	return (
+		<Form
+			liveValidate
+			data={schema}
+			showErrorList={false}
+			onSubmit={action('SUBMIT')}
+		/>
+	);
+});

--- a/packages/forms/stories/index.js
+++ b/packages/forms/stories/index.js
@@ -515,12 +515,13 @@ decoratedStories.add('Form with live validation', () => {
 					type: 'string',
 					pattern: '^\\S+@\\S+$',
 					minLength: 5,
+					required: true,
 				},
 			},
 		},
 		uiSchema: {
 			email: {
-				'ui:help': 'List of errors will be displayed, if email is empty',
+				'ui:help': 'Please enter a valid email address, e.g. user@email.com',
 			},
 		},
 		properties: {

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -301,6 +301,7 @@ form {
 
 		.error-detail {
 			padding-left: 0;
+			
 			.text-danger {
 				list-style-type: none;
 				font-size: $font-size-small;

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -298,6 +298,14 @@ form {
 			@include box-shadow(inset 0 -2px 0 $brand-danger);
 			border-bottom: none;
 		}
+
+		.error-detail {
+			padding-left: 0;
+			.text-danger {
+				list-style-type: none;
+				font-size: $font-size-small;
+			}
+		}
 	}
 
 	.has-success {

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -288,6 +288,9 @@ form {
 	}
 
 	.has-error {
+		font-size: $font-size-small;
+		color: $chestnut-rose;
+
 		input:not([type=checkbox]),
 		.form-control,
 		input.form-control[readonly],
@@ -301,10 +304,9 @@ form {
 
 		.error-detail {
 			padding-left: 0;
-			
+
 			.text-danger {
 				list-style-type: none;
-				font-size: $font-size-small;
 			}
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
 Removing of the bullet points, and left align the text displayed. 
If more than one error message needs to be displayed, this will be done as today, on a separate line/ under each other.
Changes connected to:
     -  http://guidelines.talend.com/document/92132#/ui-controls/input-field
     -  https://jira.talendforge.org/browse/TPSVC-3545

**What is the chosen solution to this problem?**
Styling adjustment

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

