### PR TITLE
enhancement(component/Headerbar): small change

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -13,6 +13,14 @@ This document aims to ease the WIP migration from a version to another by provid
 * $mine-shaft : replace by $dove-gray
 * $smalt-blue : not used
 
+## v0.120.0
+
+* PR 807 [enhancement(component/Headerbar): small change]
+The brand of the header bar used `name` to be rendered as the application title.
+Using containers and cmf, `name` is used to resolve `CMFAction` from the registry.
+To be able to use name to describe the CMFAction associated to the Brand section of the header bar,
+`label` has to be used for application title rendering and `name` to resolve `CMFAction`
+
 ## v0.71.0
 
 * PR #364 [feat: onTrigger !== onChange]

--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -16,8 +16,11 @@ This document aims to ease the WIP migration from a version to another by provid
 ## v0.120.0
 
 * PR 807 [enhancement(component/Headerbar): small change]
+
 The brand of the header bar used `name` to be rendered as the application title.
+
 Using containers and cmf, `name` is used to resolve `CMFAction` from the registry.
+
 To be able to use name to describe the CMFAction associated to the Brand section of the header bar,
 `label` has to be used for application title rendering and `name` to resolve `CMFAction`
 

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -48,7 +48,7 @@ function Logo({ isFull, renderers, t, ...props }) {
 	);
 }
 
-function Brand({ name, isSeparated, renderers, ...props }) {
+function Brand({ label, isSeparated, renderers, ...props }) {
 	const className = classNames(theme['tc-header-bar-action'], {
 		[theme.separated]: isSeparated,
 	});
@@ -59,7 +59,7 @@ function Brand({ name, isSeparated, renderers, ...props }) {
 				bsStyle="link"
 				className={theme['tc-header-bar-brand']}
 				tooltipPlacement="bottom"
-				label={name}
+				label={label}
 				{...props}
 			/>
 		</li>

--- a/packages/components/src/utils/getPropsFrom.js
+++ b/packages/components/src/utils/getPropsFrom.js
@@ -4,6 +4,7 @@ const NATIVE_PROPS = [
 	'className',
 	'id',
 	'name',
+	'target',
 ];
 
 function extractComponentProps(Component, props) {

--- a/packages/components/src/utils/getPropsFrom.test.js
+++ b/packages/components/src/utils/getPropsFrom.test.js
@@ -11,6 +11,7 @@ describe('Action', () => {
 			block: false,
 			onClick,
 			href: 'www.google.de',
+			target: '_blank',
 			type: 'button',
 
 			// native props should be kept
@@ -32,6 +33,7 @@ describe('Action', () => {
 			href: 'www.google.de',
 			type: 'button',
 			className: 'my class',
+			target: '_blank',
 		});
 	});
 });

--- a/packages/components/stories/HeaderBar.js
+++ b/packages/components/stories/HeaderBar.js
@@ -86,7 +86,7 @@ const typeaheadItems = [
 const props = {
 	brand: {
 		id: 'header-brand',
-		name: 'Example App Name',
+		label: 'Example App Name',
 		onClick: action('onApplicationNameClick'),
 	},
 	logo: {

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -62,7 +62,7 @@ function loadStories() {
 		};
 		state.cmf.settings.views['HeaderBar#default'] = {
 			logo: { name: 'appheaderbar:logo', isFull: true },
-			brand: { name: 'DATA STREAMS'},
+			brand: { label: 'DATA STREAMS'},
 			notification: { name: 'appheaderbar:notification'}
 		};
 		const actions = state.cmf.settings.actions;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
HeaderBar/Brand use name property to render as label wich prevent to use CMFAction wich use name to resolve CMFAction from the registry.
Target property could not be passed down to an Action component

**What is the chosen solution to this problem?**
Add target to the whitelist.
Change headerBar Brand descriptor to label.
Name now can be used to resolve CMFAction from the registry. 

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

- [X] This PR introduces a breaking change
The brand element of the HeaderBar don't use name as label wich is conflicting with CMFAction name used for action resolution.

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

