### PR TITLE
fix(sagas): Export pending constants

### DIFF
--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -56,6 +56,7 @@
     "redux-saga": "0.15.4"
   },
   "devDependencies": {
+    "babel": "^6.23.0",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -56,7 +56,6 @@
     "redux-saga": "0.15.4"
   },
   "devDependencies": {
-    "babel": "^6.23.0",
     "babel-cli": "6.24.1",
     "babel-core": "6.24.1",
     "babel-eslint": "7.2.3",

--- a/packages/sagas/src/index.js
+++ b/packages/sagas/src/index.js
@@ -1,3 +1,5 @@
 import pendingMaybeNeeded from './pending';
+import { SHOW_PENDING, PENDING_COLLECTION_NAME } from './constants';
 
+export { SHOW_PENDING, PENDING_COLLECTION_NAME };
 export default pendingMaybeNeeded;

--- a/packages/sagas/yarn.lock
+++ b/packages/sagas/yarn.lock
@@ -2,9 +2,9 @@
 # yarn lockfile v1
 
 
-"@talend/react-cmf@^0.118.0":
-  version "0.118.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-0.118.0.tgz#0d7d7c2d916fa8c2aaaa9648db1fadeb5112d1cf"
+"@talend/react-cmf@^0.120.0":
+  version "0.120.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-0.120.0.tgz#c6529ce32cd2cf5d706275bcbb717507dd85d5fe"
   dependencies:
     babel-polyfill "6.26.0"
     hoist-non-react-statics "^1.2.0"
@@ -814,6 +814,10 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     esutils "^2.0.2"
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
+
+babel@^6.23.0:
+  version "6.23.0"
+  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
 
 babylon@^6.11.0, babylon@^6.17.0, babylon@^6.18.0:
   version "6.18.0"

--- a/packages/sagas/yarn.lock
+++ b/packages/sagas/yarn.lock
@@ -815,10 +815,6 @@ babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.23.0, babel-types@^6.24
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
-babel@^6.23.0:
-  version "6.23.0"
-  resolved "https://registry.yarnpkg.com/babel/-/babel-6.23.0.tgz#d0d1e7d803e974765beea3232d4e153c0efb90f4"
-
 babylon@^6.11.0, babylon@^6.17.0, babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Pending constants were not exported.
**What is the chosen solution to this problem?**
Change that forgetting

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


