### PR TITLE
fix(component/SidePanel): Use provided className property instead of ignoring it

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -81,7 +81,7 @@ function SidePanel({
 							id={id && `${id}-nav-${action.label.toLowerCase().split(' ').join('-')}`}
 							bsStyle="link"
 							role="link"
-							className={theme.link}
+							className={classNames(theme.link, action.className)}
 							onClick={(event) => {
 								if (onSelect) {
 									onSelect(event, action);

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -36,17 +36,13 @@ function SidePanel({
 	collapseTitle = 'Collapse',
 }) {
 	const dockedCSS = { [theme.docked]: docked };
-	const navCSS = classNames(
-		theme['tc-side-panel'],
-		dockedCSS,
-		'tc-side-panel',
-	);
+	const navCSS = classNames(theme['tc-side-panel'], dockedCSS, 'tc-side-panel');
 	const listCSS = classNames(
 		'nav nav-pills nav-inverse nav-stacked',
 		'tc-side-panel-list',
 		theme['action-list'],
 	);
-	const isActionSelected = (action) => {
+	const isActionSelected = action => {
 		if (selected) {
 			return action === selected;
 		}
@@ -68,33 +64,39 @@ function SidePanel({
 						label=""
 					/>
 				</li>
-				{actions.map(action => (
-					<li
-						title={action.label}
-						key={action.key || action.label}
-						className={classNames(
-							'tc-side-panel-list-item',
-							{ active: isActionSelected(action) },
-						)}
-					>
-						<Action
-							id={id && `${id}-nav-${action.label.toLowerCase().split(' ').join('-')}`}
-							bsStyle="link"
-							role="link"
-							className={classNames(theme.link, action.className)}
-							onClick={(event) => {
-								if (onSelect) {
-									onSelect(event, action);
-								}
-								if (action.onClick) {
-									action.onClick(event);
-								}
-							}}
-							label={action.label}
-							icon={action.icon}
-						/>
-					</li>
-				))}
+				{actions.map(action => {
+					const actionProps = Object.assign({}, action, {
+						id:
+							id &&
+							`${id}-nav-${action.label
+								.toLowerCase()
+								.split(' ')
+								.join('-')}`,
+						bsStyle: 'link',
+						role: 'link',
+						className: classNames(theme.link, action.className),
+						onClick: event => {
+							if (onSelect) {
+								onSelect(event, action);
+							}
+							if (action.onClick) {
+								action.onClick(event);
+							}
+						},
+					});
+
+					return (
+						<li
+							title={action.label}
+							key={action.key || action.label}
+							className={classNames('tc-side-panel-list-item', {
+								active: isActionSelected(action),
+							})}
+						>
+							<Action {...actionProps} />
+						</li>
+					);
+				})}
 			</ul>
 		</nav>
 	);

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -65,7 +65,8 @@ function SidePanel({
 					/>
 				</li>
 				{actions.map(action => {
-					const actionProps = Object.assign({}, action, {
+					const { active, ...actionModel } = { ...action };
+					const actionProps = Object.assign({}, actionModel, {
 						id:
 							id &&
 							`${id}-nav-${action.label


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Side panel does not allow to reuse provided className for actions.

**What is the chosen solution to this problem?**
Make the component action className computed from the json setting action "className" property.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

