### PR TITLE
feat(containers/Actions): gets items by an expression or other actions

### DIFF
--- a/packages/cmf/src/mock/settings.js
+++ b/packages/cmf/src/mock/settings.js
@@ -41,6 +41,22 @@ const settings = {
 				args: ['/myarticle'],
 			},
 		},
+		'menu:article:items': {
+			id: 'menu:article:items',
+			name: 'My article',
+			icon: 'icon-article',
+			payload: {
+				type: '@@router/CALL_HISTORY_METHOD',
+				method: 'push',
+				args: ['/myarticle'],
+			},
+			items: ['menu:demo', 'menu:actionCreator'],
+		},
+		'menu:items': {
+			id: 'menu:items',
+			name: 'my items',
+			itemsExpression: 'getItems',
+		},
 		'menu:demo': {
 			id: 'menu',
 			name: 'Menu',
@@ -118,9 +134,7 @@ const settings = {
 		path: '/',
 		component: 'App',
 		indexRoute: { component: 'SortableListWithSideMenu', view: 'homepage' },
-		childRoutes: [
-			{ path: 'myarticle', component: 'SortableListWithSideMenu', view: 'homepage' },
-		],
+		childRoutes: [{ path: 'myarticle', component: 'SortableListWithSideMenu', view: 'homepage' }],
 	},
 };
 export default settings;

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -37,16 +37,49 @@ function confirmDialog(event, data) {
 	};
 }
 
+function chooceItem1() {
+	return {
+		type: 'CHOOSE_ITEM1',
+	};
+}
+
+function chooceItem2() {
+	return {
+		type: 'CHOOSE_ITEM2',
+	};
+}
+
 const registerActionCreator = api.action.registerActionCreator;
 registerActionCreator('object:view', objectView);
 registerActionCreator('cancel:hide:dialog', hideDialog);
 registerActionCreator('confirm:dialog', confirmDialog);
+registerActionCreator('item1:action', chooceItem1);
+registerActionCreator('item2:action', chooceItem2);
 
 const isTrueExpressionAction = action('isTrueExpression');
 api.expression.register('isTrueExpression', (context, first) => {
 	isTrueExpressionAction(context, first);
 	return !!first;
 });
+
+api.expression.register('getItems', () => [
+	{
+		id: {
+			actionCreator: 'item1:action',
+			property: 'item1',
+		},
+		label: 'label1',
+		actionCreator: 'item1:action',
+	},
+	{
+		id: {
+			actionCreator: 'item2:action',
+			property: 'item2',
+		},
+		label: 'label2',
+		actionCreator: 'item2:action',
+	},
+]);
 
 const modelHasLabelAction = action('modelHasLabel');
 api.expression.register('modelHasLabel', context => {
@@ -62,8 +95,8 @@ function loadStories() {
 		};
 		state.cmf.settings.views['HeaderBar#default'] = {
 			logo: { name: 'appheaderbar:logo', isFull: true },
-			brand: { label: 'DATA STREAMS'},
-			notification: { name: 'appheaderbar:notification'}
+			brand: { label: 'DATA STREAMS' },
+			notification: { name: 'appheaderbar:notification' },
 		};
 		const actions = state.cmf.settings.actions;
 		actions['appheaderbar:logo'] = {
@@ -125,6 +158,18 @@ function loadStories() {
 			label: 'Cancel',
 			id: 'object:hide:dialog',
 			actionCreator: 'cancel:hide:dialog',
+		};
+		actions['menu:items'] = {
+			id: 'menu:items',
+			displayMode: 'dropdown',
+			label: 'my items',
+			itemsExpression: 'getItems',
+		};
+		actions['menu:items-id'] = {
+			id: 'menu:items',
+			displayMode: 'dropdown',
+			label: 'my items',
+			items: ['menu:first', 'menu:second'],
 		};
 
 		const story = storiesOf(example);

--- a/packages/containers/examples/ExampleActions.js
+++ b/packages/containers/examples/ExampleActions.js
@@ -46,6 +46,10 @@ export default function ExampleActions() {
 			<Actions names={['menu:first', 'menu:second', 'menu:third']} />
 			<p>Using pure component props</p>
 			<Actions actions={infos} />
+			<p>Using with items defined by id</p>
+			<Actions names={['menu:items-id']} />
+			<p>Using with dynamics items by an expression</p>
+			<Actions names={['menu:items']} />
 		</div>
 	);
 }

--- a/packages/containers/src/Action/Action.component.js
+++ b/packages/containers/src/Action/Action.component.js
@@ -12,18 +12,15 @@ function Action({ name, ...rest }, context) {
 	let action;
 
 	if (name) {
-		action = Object.assign(
-			{},
-			rest,
-			actions.getProps(context, name, rest.model),
-		);
+		action = Object.assign({}, rest, actions.getProps(context, name, rest.model));
 	} else {
 		action = actions.getProps(context, rest, rest.model);
 	}
+
 	if (action.available === false) {
 		return null;
 	}
-	return (<PureAction {...action} />);
+	return <PureAction {...action} />;
 }
 
 Action.propTypes = {

--- a/packages/containers/src/Actions/Actions.component.js
+++ b/packages/containers/src/Actions/Actions.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Actions as PureActions } from '@talend/react-components';
 import actionAPI from '../actionAPI';
+import cloneDeep from 'lodash/cloneDeep';
 /**
  * @param {Object} props react props
  * @example
@@ -13,13 +14,15 @@ function Actions({ names, ...rest }, context) {
 	};
 	let actions = names ? names.map(name => actionAPI.getProps(context, name)) : null;
 
-	actions = actions.map((action) => {
-		if (action.displayMode === 'dropdown') {
-			delete action.onClick;
-		}
+	actions = actions
+		? actions.map((action) => {
+			if (action.displayMode === 'dropdown') {
+				delete action.onClick;
+			}
 
-		return action;
-	});
+			return action;
+		})
+		: null;
 
 	return <PureActions actions={actions} {...rest} onClick={onClick} />;
 }

--- a/packages/containers/src/Actions/Actions.component.js
+++ b/packages/containers/src/Actions/Actions.component.js
@@ -1,8 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { api } from '@talend/react-cmf';
 import { Actions as PureActions } from '@talend/react-components';
-
+import actionAPI from '../actionAPI';
 /**
  * @param {Object} props react props
  * @example
@@ -12,17 +11,17 @@ function Actions({ names, ...rest }, context) {
 	const onClick = (event, payload) => {
 		context.store.dispatch(payload.action.payload);
 	};
-	const actions = names ? names.map(
-		name => api.action.getActionInfo(context, name),
-	) : null;
+	let actions = names ? names.map(name => actionAPI.getProps(context, name)) : null;
 
-	return (
-		<PureActions
-			actions={actions}
-			{...rest}
-			onClick={onClick}
-		/>
-	);
+	actions = actions.map((action) => {
+		if (action.displayMode === 'dropdown') {
+			delete action.onClick;
+		}
+
+		return action;
+	});
+
+	return <PureActions actions={actions} {...rest} onClick={onClick} />;
 }
 
 Actions.propTypes = {
@@ -31,6 +30,7 @@ Actions.propTypes = {
 
 Actions.contextTypes = {
 	store: PropTypes.object,
+	registry: PropTypes.object,
 };
 
 Actions.displayName = 'CMF(Actions)';

--- a/packages/containers/src/Actions/Actions.component.js
+++ b/packages/containers/src/Actions/Actions.component.js
@@ -3,6 +3,8 @@ import React from 'react';
 import { Actions as PureActions } from '@talend/react-components';
 import actionAPI from '../actionAPI';
 import cloneDeep from 'lodash/cloneDeep';
+
+const TYPE_DROPDOWN = 'dropdown';
 /**
  * @param {Object} props react props
  * @example
@@ -12,17 +14,20 @@ function Actions({ names, ...rest }, context) {
 	const onClick = (event, payload) => {
 		context.store.dispatch(payload.action.payload);
 	};
-	let actions = names ? names.map(name => actionAPI.getProps(context, name)) : null;
 
-	actions = actions
-		? actions.map((action) => {
-			if (action.displayMode === 'dropdown') {
+	let actions = null;
+
+	if (names) {
+		actions = names.map((name) => {
+			const action = actionAPI.getProps(context, name);
+
+			if (action.displayMode === TYPE_DROPDOWN) {
 				delete action.onClick;
 			}
 
 			return action;
-		})
-		: null;
+		});
+	}
 
 	return <PureActions actions={actions} {...rest} onClick={onClick} />;
 }

--- a/packages/containers/src/Actions/Actions.component.js
+++ b/packages/containers/src/Actions/Actions.component.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Actions as PureActions } from '@talend/react-components';
 import actionAPI from '../actionAPI';
-import cloneDeep from 'lodash/cloneDeep';
 
 const TYPE_DROPDOWN = 'dropdown';
 /**

--- a/packages/containers/src/__snapshots__/actionAPI.test.js.snap
+++ b/packages/containers/src/__snapshots__/actionAPI.test.js.snap
@@ -1,0 +1,104 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`actionAPI.getActionsProps should return an action with sub elements 1`] = `
+Array [
+  Object {
+    "icon": "fa-bars",
+    "id": "menu",
+    "model": Object {
+      "model": Object {},
+    },
+    "name": "Menu",
+    "onClick": [Function],
+    "payload": Object {
+      "type": "TEST_MENU",
+    },
+  },
+  Object {
+    "icon": "icon-article",
+    "id": "menu:article:items",
+    "items": Array [
+      Object {
+        "icon": "fa-bars",
+        "id": "menu",
+        "model": undefined,
+        "name": "Menu",
+        "onClick": [Function],
+        "payload": Object {
+          "type": "TEST_MENU",
+        },
+      },
+      Object {
+        "actionCreator": "action-creator",
+        "icon": "fa-bars",
+        "id": "menu:actionCreator",
+        "model": undefined,
+        "name": "Action creator",
+        "onClick": [Function],
+        "payload": Object {
+          "type": "TEST_ACTION_CREATOR",
+        },
+      },
+    ],
+    "model": Object {
+      "model": Object {},
+    },
+    "name": "My article",
+    "onClick": [Function],
+    "payload": Object {
+      "args": Array [
+        "/myarticle",
+      ],
+      "method": "push",
+      "type": "@@router/CALL_HISTORY_METHOD",
+    },
+  },
+]
+`;
+
+exports[`actionAPI.getActionsProps should return an action with sub elements evaled before 1`] = `
+Array [
+  Object {
+    "icon": "fa-bars",
+    "id": "menu",
+    "model": Object {
+      "model": Object {},
+    },
+    "name": "Menu",
+    "onClick": [Function],
+    "payload": Object {
+      "type": "TEST_MENU",
+    },
+  },
+  Object {
+    "id": "menu:items",
+    "items": Array [
+      Object {
+        "actionCreator": "item1:action",
+        "id": Object {
+          "actionCreator": "item1:action",
+          "property": "item1",
+        },
+        "label": "label1",
+        "model": undefined,
+        "onClick": [Function],
+      },
+      Object {
+        "actionCreator": "item2:action",
+        "id": Object {
+          "actionCreator": "item2:action",
+          "property": "item2",
+        },
+        "label": "label2",
+        "model": undefined,
+        "onClick": [Function],
+      },
+    ],
+    "model": Object {
+      "model": Object {},
+    },
+    "name": "my items",
+    "onClick": [Function],
+  },
+]
+`;

--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -44,22 +44,29 @@ function getOnClick(action, context, model) {
 		onClick(event, data) {
 			if (action.actionCreator) {
 				context.store.dispatch(api.action.getActionObject(context, action.id, event, data));
+			} else {
+				context.store.dispatch(
+					Object.assign(
+						{
+							model,
+						},
+						action.payload,
+					),
+				);
 			}
-			context.store.dispatch(
-				Object.assign(
-					{
-						model,
-					},
-					action.payload,
-				),
-			);
 		},
 	};
 }
 
-function extendAction(action, context, model) {
+function buidAction(action, context, model) {
+	// prettier-ignore
 	return getItems(
-		getOnClick(evalExpressions(getActionById(action, context), context, { model }), context, model),
+		getOnClick(
+			evalExpressions(
+				getActionById(action, context),
+				context, { model }
+			),
+			context, model),
 		context,
 	);
 }
@@ -68,7 +75,7 @@ function getItems(action, context) {
 	if (action.items) {
 		return {
 			...action,
-			items: action.items.map(info => extendAction(info, context)),
+			items: action.items.map(info => buidAction(info, context)),
 		};
 	}
 	return action;
@@ -84,7 +91,7 @@ export function getActionsProps(context, ids, model) {
 		tmpIds = [ids];
 	}
 
-	const props = tmpIds.map(id => extendAction(id, context, model));
+	const props = tmpIds.map(id => buidAction(id, context, model));
 
 	if (onlyOne) {
 		return props[0];

--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -24,7 +24,54 @@ function evalExpressions(action, context, payload = {}) {
 		delete newAction.iconExpression;
 		newAction.icon = api.expression.call(action.iconExpression, context, newAction);
 	}
+	if (action.itemsExpression) {
+		delete newAction.itemsExpression;
+		newAction.items = api.expression.call(action.itemsExpression, context, newAction);
+	}
 	return newAction;
+}
+
+function getActionById(id, context) {
+	if (typeof id === 'string') {
+		return api.action.getActionInfo(context, id);
+	}
+	return id;
+}
+
+function getOnClick(action, context, model) {
+	return {
+		...action,
+		onClick(event, data) {
+			if (action.actionCreator) {
+				context.store.dispatch(api.action.getActionObject(context, action.id, event, data));
+			}
+			context.store.dispatch(
+				Object.assign(
+					{
+						model,
+					},
+					action.payload,
+				),
+			);
+		},
+	};
+}
+
+function extendAction(action, context, model) {
+	return getItems(
+		getOnClick(evalExpressions(getActionById(action, context), context, { model }), context, model),
+		context,
+	);
+}
+
+function getItems(action, context) {
+	if (action.items) {
+		return {
+			...action,
+			items: action.items.map(info => extendAction(info, context)),
+		};
+	}
+	return action;
 }
 
 export function getActionsProps(context, ids, model) {
@@ -37,34 +84,7 @@ export function getActionsProps(context, ids, model) {
 		tmpIds = [ids];
 	}
 
-	const infos = tmpIds.map(id => {
-		if (typeof id === 'string') {
-			return api.action.getActionInfo(context, id);
-		}
-		return id;
-	});
-
-	const props = infos.map(info =>
-		Object.assign(
-			{
-				onClick(event, data) {
-					if (info.actionCreator) {
-						context.store.dispatch(api.action.getActionObject(context, info.id, event, data));
-					} else {
-						context.store.dispatch(
-							Object.assign(
-								{
-									model,
-								},
-								info.payload,
-							),
-						);
-					}
-				},
-			},
-			evalExpressions(info, context, { model }),
-		),
-	);
+	const props = tmpIds.map(id => extendAction(id, context, model));
 
 	if (onlyOne) {
 		return props[0];

--- a/packages/containers/src/actionAPI.test.js
+++ b/packages/containers/src/actionAPI.test.js
@@ -83,6 +83,51 @@ describe('actionAPI.getActionsProps', () => {
 		expect(props[1].actionCreator).toBe('my');
 		expect(props[1].model).toBe(model);
 	});
+
+	it('should return an action with sub elements', () => {
+		const context = mock.context();
+		const model = { model: {} };
+		const props = action.getProps(context, ['menu:demo', 'menu:article:items'], model);
+
+		expect(props).toMatchSnapshot();
+	});
+
+	it('should return an action with sub elements evaled before', () => {
+		const getItems = () => [
+			{
+				id: {
+					actionCreator: 'item1:action',
+					property: 'item1',
+				},
+				label: 'label1',
+				actionCreator: 'item1:action',
+			},
+			{
+				id: {
+					actionCreator: 'item2:action',
+					property: 'item2',
+				},
+				label: 'label2',
+				actionCreator: 'item2:action',
+			},
+		];
+
+		const context = mock.context();
+		context.store.dispatch = jest.fn();
+		context.registry['actionCreator:action-creator'] = jest.fn();
+		context.registry = {
+			'expression:getItems': getItems,
+			'actionCreator:item1:action': jest.fn(),
+			'actionCreator:item2:action': jest.fn(),
+		};
+		const model = { model: {} };
+		context.store.dispatch = jest.fn();
+		const props = action.getProps(context, ['menu:demo', 'menu:items'], model);
+
+		expect(props).toMatchSnapshot();
+		props[1].items[0].onClick();
+		expect(context.registry['actionCreator:item1:action']).toHaveBeenCalledWith();
+	});
 });
 
 describe('actionAPI.evalExpressions', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Passing a ActionDropDown or SplitDroopDown on a Actions container don't manage the actions on the items

**What is the chosen solution to this problem?**

Fetch the items to get the action
Allow to get the items by other actions or by an expression


**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

