### PR TITLE
fix(cmf): mergeProps in cmfConnect

### DIFF
--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -160,9 +160,9 @@ export function getMergeProps({
 		);
 	}
 	return {
-		...api.expression.mergeProps(stateProps),
 		...api.expression.mergeProps(dispatchProps),
 		...api.expression.mergeProps(ownProps),
+		...api.expression.mergeProps(stateProps),
 	};
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Container List stories are broken on surge

https://github.com/reactjs/react-redux/blob/master/docs/api.md#connectmapstatetoprops-mapdispatchtoprops-mergeprops-options

the mergeProps from cmfConnect doesn't respect the default order

**What is the chosen solution to this problem?**
It seems the items passed to List component are wrapped with immutable instead of the mutables ones.
Solution : change the way the props are injected to have the good items

make it respect the order:
ownProps, dispatchProps, stateProps

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

