### PR TITLE
chores(ci): use the ci to prettify modified files

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -34,11 +34,6 @@ rules:
     - 2
     -
       include: false
-  empty-line-between-blocks:
-    - 1
-    -
-      include: true
-      allow-single-line-rulesets: false
   extends-before-declarations: 2
   extends-before-mixins: 2
   final-newline:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_install:
   - .travis/before_install.sh
 before_script:
   - sh -e /etc/init.d/xvfb start
-  - yarn global add sassdoc http-server surge
+  - yarn global add sassdoc http-server surge prettier
 script:
   - yarn test:cov
 after_success:
@@ -29,6 +29,7 @@ after_success:
   - .travis/after_success_demo.sh
   - .travis/after_success_coverage.sh
   - .travis/after_success_deploy.sh
+  - .travis/after_success_prettier.sh
   - .travis/after_success_lint.sh
   - .travis/after_success_screenshots.sh
   - .travis/after_success_git.sh

--- a/.travis/after_success_git.sh
+++ b/.travis/after_success_git.sh
@@ -24,6 +24,10 @@ if [ -n "$GH_TOKEN" ]; then
 		git -c user.name="travis" -c user.email="travis" commit -m "test(ci): update code style outputs"
 		echo "✓ Commit updated lint output to $TRAVIS_PULL_REQUEST_BRANCH"
 
+		find packages/*/src -name "*.scss" -o -name "*.js" | xargs git add
+		git -c user.name="travis" -c user.email="travis" commit -m "test(ci): prettier"
+		echo "✓ Commit prettified files to $TRAVIS_PULL_REQUEST_BRANCH"
+
 		git push -q https://build-travis-ci:$GH_TOKEN@github.com/Talend/ui $TRAVIS_PULL_REQUEST_BRANCH
 		echo "✓ Push to $TRAVIS_PULL_REQUEST_BRANCH"
 	fi

--- a/.travis/after_success_prettier.sh
+++ b/.travis/after_success_prettier.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+#!/bin/bash
+
+modified_files=($(git diff --name-only HEAD $(git merge-base HEAD master)))
+
+for i in ${modified_files[@]}; do
+	if [[ $i == *.js || $i == *.scss ]]; then
+		prettier --config .prettierrc ${i} --write
+	fi
+done

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -9,8 +9,5 @@ src/Actions/ActionFile/ActionFile.scss
 src/VirtualizedList/NoRows/NoRows.scss
   6:17  warning  No unit allowed for values of 0  zero-unit
 
-src/VirtualizedList/RowSelection/RowSelection.scss
-  12:1  warning  Space expected between blocks  empty-line-between-blocks
-
-✖ 3 problems (1 error, 2 warnings)
+✖ 2 problems (1 error, 1 warning)
 

--- a/packages/components/.sass-lint.yml
+++ b/packages/components/.sass-lint.yml
@@ -34,11 +34,6 @@ rules:
     - 2
     -
       include: false
-  empty-line-between-blocks:
-    - 1
-    -
-      include: true
-      allow-single-line-rulesets: false
   extends-before-declarations: 2
   extends-before-mixins: 2
   final-newline:

--- a/packages/forms/.sass-lint.yml
+++ b/packages/forms/.sass-lint.yml
@@ -34,11 +34,6 @@ rules:
     - 2
     -
       include: false
-  empty-line-between-blocks:
-    - 1
-    -
-      include: true
-      allow-single-line-rulesets: false
   extends-before-declarations: 2
   extends-before-mixins: 2
   final-newline:

--- a/packages/theme/.sass-lint.yml
+++ b/packages/theme/.sass-lint.yml
@@ -34,11 +34,6 @@ rules:
     - 2
     -
       include: false
-  empty-line-between-blocks:
-    - 1
-    -
-      include: true
-      allow-single-line-rulesets: false
   extends-before-declarations: 2
   extends-before-mixins: 2
   final-newline:


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The CI doesn't prettify modified files.

**What is the chosen solution to this problem?**

The CI prettify files, then push a new `test(ci): prettier` commit.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

