### PR TITLE
feat(components/sidepanel): accept custom action ids

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -2,6 +2,13 @@ Before 1.0, the stack do NOT follow semver version in releases.
 
 This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
 
+## v0.125.0
+* Component: SidePanel
+* PR: [feat(components/sidepanel): accept custom action ids](https://github.com/Talend/ui/pull/846)
+* Changes :
+
+Before this, action ids were ignored. Now, if an id is provided per action, it will be used instead of the label ; so it could break some QA tests.
+
 ## v0.121.0
 * Component: SidePanel
 * PR: [feat(SidePanel): i18n](https://github.com/Talend/ui/pull/818)

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -10,7 +10,6 @@ import Action from '../Actions/Action';
 
 import theme from './SidePanel.scss';
 
-
 /**
  * return the formatted action id
  * if there is no action id, it is generated from the action label
@@ -19,7 +18,12 @@ import theme from './SidePanel.scss';
  * @return {string}        	formatted id
  */
 function getActionId(id, action) {
-	const actionId = action.id || action.label.toLowerCase().split(' ').join('-');
+	const actionId =
+		action.id ||
+		action.label
+			.toLowerCase()
+			.split(' ')
+			.join('-');
 	return id && `${id}-nav-${actionId}`;
 }
 

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -10,6 +10,19 @@ import Action from '../Actions/Action';
 
 import theme from './SidePanel.scss';
 
+
+/**
+ * return the formatted action id
+ * if there is no action id, it is generated from the action label
+ * @param  {string} id		sidepanel id
+ * @param  {string} action 	current action
+ * @return {string}        	formatted id
+ */
+function getActionId(id, action) {
+	const actionId = action.id || action.label.toLowerCase().split(' ').join('-');
+	return id && `${id}-nav-${actionId}`;
+}
+
 /**
  * This component aims to display links as a menu.
  * @param {object} props react props
@@ -65,12 +78,6 @@ function SidePanel({ id, selected, onSelect, actions, docked, onToggleDock, t, r
 					const a11y = {};
 					const extra = {};
 					const isSelected = isActionSelected(action);
-					const actionId =
-						action.id ||
-						action.label
-							.toLowerCase()
-							.split(' ')
-							.join('-');
 
 					if (isSelected) {
 						a11y['aria-current'] = true;
@@ -89,7 +96,7 @@ function SidePanel({ id, selected, onSelect, actions, docked, onToggleDock, t, r
 						action,
 						{
 							active: undefined, // active scope is only the list item
-							id: id && `${id}-nav-${actionId}`,
+							id: getActionId(id, action),
 							bsStyle: 'link',
 							role: 'link',
 							className: classNames(theme.link, action.className),

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -62,12 +62,19 @@ function SidePanel({ id, selected, onSelect, actions, docked, onToggleDock, t, r
 					/>
 				</li>
 				{actions.map(action => {
-					const isSelected = isActionSelected(action);
 					const a11y = {};
+					const extra = {};
+					const isSelected = isActionSelected(action);
+					const actionId =
+						action.id ||
+						action.label
+							.toLowerCase()
+							.split(' ')
+							.join('-');
+
 					if (isSelected) {
 						a11y['aria-current'] = true;
 					}
-					const extra = {};
 					if (onSelect) {
 						extra.onClick = event => {
 							onSelect(event, action);
@@ -76,18 +83,19 @@ function SidePanel({ id, selected, onSelect, actions, docked, onToggleDock, t, r
 							}
 						};
 					}
-					const actionProps = Object.assign({}, action, {
-						active: undefined, // active scope is only the list item
-						id:
-							id &&
-							`${id}-nav-${action.label
-								.toLowerCase()
-								.split(' ')
-								.join('-')}`,
-						bsStyle: 'link',
-						role: 'link',
-						className: classNames(theme.link, action.className),
-					}, extra);
+
+					const actionProps = Object.assign(
+						{},
+						action,
+						{
+							active: undefined, // active scope is only the list item
+							id: id && `${id}-nav-${actionId}`,
+							bsStyle: 'link',
+							role: 'link',
+							className: classNames(theme.link, action.className),
+						},
+						extra,
+					);
 					return (
 						<li
 							title={action.label}
@@ -113,6 +121,7 @@ SidePanel.defaultProps = {
 
 if (process.env.NODE_ENV !== 'production') {
 	const actionPropType = PropTypes.shape({
+		id: PropTypes.string,
 		active: PropTypes.bool,
 		icon: PropTypes.string,
 		key: PropTypes.string,

--- a/packages/components/src/SidePanel/SidePanel.test.js
+++ b/packages/components/src/SidePanel/SidePanel.test.js
@@ -67,4 +67,18 @@ describe('SidePanel', () => {
 		expect(onDatasetsClick).toBeCalled();
 		expect(onFavoritesClick).not.toBeCalled();
 	});
+
+	it('should accept custom action ids', () => {
+		const actions = [
+			{ label: 'Preparations', id: 'preparation-custom-id' },
+			{ label: 'Datasets', id: 'datasets-custom-id' },
+			{ label: 'Favorites', id: 'favs-custom-id' },
+		];
+		const sidePanel = <SidePanel id="test" actions={actions} />;
+		const wrapper = mount(sidePanel);
+
+		expect(wrapper.find('#test-nav-preparation-custom-id').text()).toEqual('Preparations');
+		expect(wrapper.find('#test-nav-datasets-custom-id').text()).toEqual('Datasets');
+		expect(wrapper.find('#test-nav-favs-custom-id').text()).toEqual('Favorites');
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Actions ids are base on the action's label. It cause problems with i18n (for example TDP onboarding uses theses IDs to target elements).

**What is the chosen solution to this problem?**

Actions can have a new `id` property.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

Before this, action ids were ignored. Now, if an id is provided per action, it will be used instead of the label ; so it could break some QA tests.

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

