### PR TITLE
doc(components/Dialog): fix 'show info' button in storybook

### DIFF
--- a/packages/components/.storybook/webpack.config.js
+++ b/packages/components/.storybook/webpack.config.js
@@ -16,6 +16,10 @@ module.exports = (storybookBaseConfig) => {
 		include: /node_modules\/(react-storybook-addon-props-combinations)/,
 		loader: 'babel-loader',
 	});
+	storybookConfig.module.rules.push({
+		test: /\.css$/,
+		loader: 'style-loader!css-loader',
+	});
 
 	return storybookConfig;
 };

--- a/packages/components/stories/Dialog.css
+++ b/packages/components/stories/Dialog.css
@@ -1,4 +1,3 @@
 div[role="dialog"] {
     pointer-events: none;
 }
-

--- a/packages/components/stories/Dialog.css
+++ b/packages/components/stories/Dialog.css
@@ -1,0 +1,4 @@
+div[role="dialog"] {
+    pointer-events: none;
+}
+

--- a/packages/components/stories/Dialog.css
+++ b/packages/components/stories/Dialog.css
@@ -1,3 +1,7 @@
-div[role="dialog"] {
-    pointer-events: none;
+.modal,
+.modal-backdrop {
+  pointer-events: none;
+}
+.modal-dialog {
+  pointer-events: auto;
 }

--- a/packages/components/stories/Dialog.js
+++ b/packages/components/stories/Dialog.js
@@ -3,6 +3,8 @@ import { storiesOf, action } from '@storybook/react';
 
 import { Dialog } from '../src/index';
 
+import './Dialog.css';
+
 const defaultProps = {
 	show: true,
 };


### PR DESCRIPTION
Thanks Fabien for the fix tip

**What is the problem this PR is trying to solve?**

No way to click on "show info" in the storybook of the dialog component

**What is the chosen solution to this problem?**

pointer-events: none in the css of the dialog for the story book

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->
