### PR TITLE
fix(VirtualizedList) titleProps get overwrite when column type is specified

### DIFF
--- a/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
+++ b/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
@@ -49,17 +49,17 @@ function ListToVirtualizedList(props) {
 					label: column.label,
 					dataKey: column.key,
 				};
-				if (titleProps && column.key === titleProps.key) {
-					Object.assign(cProps, CellTitle, {
-						columnData: titleProps,
-					});
-				}
 				if (supposedActions[column.key]) {
 					Object.assign(cProps, CellActions);
 				}
 				if (column.type && cellDictionary[column.type]) {
 					Object.assign(cProps, cellDictionary[column.type], {
 						columnData: column.data,
+					});
+				}
+				if (titleProps && column.key === titleProps.key) {
+					Object.assign(cProps, CellTitle, {
+						columnData: titleProps,
 					});
 				}
 				return <VirtualizedList.Content key={index} {...cProps} />;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
there's a problem when column config is
```
{
  key: 'name',
  label: 'Name',
  type: 'title'
}
```
column is rendered not clickable because titleProps gets overwrite when resolve cell renderer type.
and it's set as
**What is the chosen solution to this problem?**
change the order of code snippet, assign `titleProps` to columnData after resolving renderer type
**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

