### PR TITLE
fix(components/sidepanel): accept empty ids

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -27,8 +27,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   5:33  error  Unexpected parentheses around single function argument  arrow-parens
 
 /home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
-  3:1   error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
-  9:42  error  Unexpected parentheses around single function argument                              arrow-parens
+  3:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
-✖ 12 problems (11 errors, 1 warning)
+✖ 11 problems (10 errors, 1 warning)
 

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -18,13 +18,16 @@ import theme from './SidePanel.scss';
  * @return {string}        	formatted id
  */
 function getActionId(id, action) {
-	const actionId =
-		action.id ||
-		action.label
-			.toLowerCase()
-			.split(' ')
-			.join('-');
-	return id && `${id}-nav-${actionId}`;
+	if (action.id || action.label) {
+		const actionId =
+			action.id ||
+			action.label
+				.toLowerCase()
+				.split(' ')
+				.join('-');
+		return id && `${id}-nav-${actionId}`;
+	}
+	return undefined;
 }
 
 /**

--- a/packages/components/src/SidePanel/SidePanel.test.js
+++ b/packages/components/src/SidePanel/SidePanel.test.js
@@ -81,4 +81,13 @@ describe('SidePanel', () => {
 		expect(wrapper.find('#test-nav-datasets-custom-id').text()).toEqual('Datasets');
 		expect(wrapper.find('#test-nav-favs-custom-id').text()).toEqual('Favorites');
 	});
+
+	it('should work even if there is no id, label, or action id', () => {
+		const actions = [{}, {}, {}];
+		const sidePanel = <SidePanel actions={actions} />;
+
+		expect(() => {
+			mount(sidePanel);
+		}).not.toThrow();
+	});
 });

--- a/packages/containers/examples/index.js
+++ b/packages/containers/examples/index.js
@@ -13,7 +13,6 @@ import NotificationExample from './ExampleNotification';
 import ObjectViewerExample from './ExampleObjectViewer';
 import SidePanelExample from './ExampleSidePanel';
 import TreeViewExample from './ExampleTreeView';
-import DeleteResource from './ExampleDeleteResource';
 
 
 export default {
@@ -32,5 +31,4 @@ export default {
 	ObjectViewerExample,
 	SidePanelExample,
 	TreeViewExample,
-	DeleteResource,
 };

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -6,15 +6,18 @@ import Container, { DEFAULT_STATE } from './SidePanel.container';
 export function mapStateToProps(state, ownProps) {
 	const props = {};
 	if (ownProps.actionIds) {
-		props.actions = ownProps.actionIds.map((id) => {
+		props.actions = ownProps.actionIds.map(id => {
 			const action = { actionId: id };
-			const info = api.action.getActionInfo({
-				registry: api.registry.getRegistry(),
-				store: {
-					getState: () => state,
+			const info = api.action.getActionInfo(
+				{
+					registry: api.registry.getRegistry(),
+					store: {
+						getState: () => state,
+					},
 				},
-			}, id);
-			action.label = info.label
+				id,
+			);
+			action.label = info.label;
 			action.id = info.id;
 			let route = get(info, 'payload.cmf.routerReplace');
 			if (!route) {
@@ -43,9 +46,11 @@ export function mergeProps(stateProps, dispatchProps, ownProps) {
 	return props;
 }
 
-export default withRouter(cmfConnect({
-	defaultState: DEFAULT_STATE,
-	keepComponentState: true,
-	mapStateToProps,
-	mergeProps,
-})(Container));
+export default withRouter(
+	cmfConnect({
+		defaultState: DEFAULT_STATE,
+		keepComponentState: true,
+		mapStateToProps,
+		mergeProps,
+	})(Container),
+);

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -14,6 +14,8 @@ export function mapStateToProps(state, ownProps) {
 					getState: () => state,
 				},
 			}, id);
+			action.label = info.label
+			action.id = info.id;
 			let route = get(info, 'payload.cmf.routerReplace');
 			if (!route) {
 				route = get(info, 'payload.cmf.routerPush');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

![image](https://user-images.githubusercontent.com/26482371/32937304-3a684b6c-cb78-11e7-9629-6f156c27f97e.png)


**What is the chosen solution to this problem?**

Add a check on `action.id` and `action.label` in the component
Add action.id and action.label in SidePanel mapStateToProps so the component has it.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

