### PR TITLE
fix(VirtualizedList): no rows i18n default value

### DIFF
--- a/packages/components/src/VirtualizedList/ListGrid/__snapshots__/ListGrid.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListGrid/__snapshots__/ListGrid.test.js.snap
@@ -103,7 +103,9 @@ exports[`ListGrid should render no-rows component 1`] = `
             aria-live="polite"
             className="no-result"
             role="status"
-          />
+          >
+            No result found
+          </span>
         </NoRows>
       </div>
     </Grid>

--- a/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
@@ -171,7 +171,9 @@ exports[`ListGrid should render no-rows component 1`] = `
               aria-live="polite"
               className="no-result"
               role="status"
-            />
+            >
+              No result found
+            </span>
           </NoRows>
         </div>
       </Grid>

--- a/packages/components/src/VirtualizedList/NoRows/NoRows.component.js
+++ b/packages/components/src/VirtualizedList/NoRows/NoRows.component.js
@@ -9,7 +9,7 @@ import theme from './NoRows.scss';
 function NoRows({ t }) {
 	return (
 		<span className={classNames(theme['no-result'], 'no-result')} role="status" aria-live="polite">
-			{t('VIRTUALIZEDLIST_NO_RESULT', 'No result found')}
+			{t('VIRTUALIZEDLIST_NO_RESULT', { defaultValue: 'No result found' })}
 		</span>
 	);
 }

--- a/packages/components/src/VirtualizedList/NoRows/__snapshots__/NoRows.test.js.snap
+++ b/packages/components/src/VirtualizedList/NoRows/__snapshots__/NoRows.test.js.snap
@@ -5,5 +5,7 @@ exports[`NoRows should show no result 1`] = `
   aria-live="polite"
   className="no-result"
   role="status"
-/>
+>
+  No result found
+</span>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
NoRows component use a translated label, but default value is not passed correctly.
i18n.t() accept an object as options, but in this component, the default value is passed as option

**What is the chosen solution to this problem?**
Pas an object `{ defaultValue }` instead

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

