### PR TITLE
fix: pass default values in option object

### DIFF
--- a/packages/components/src/ListView/Header/Header.component.js
+++ b/packages/components/src/ListView/Header/Header.component.js
@@ -45,7 +45,7 @@ export function renderActions(headerDefault = []) {
 
 function Header({ headerDefault, headerLabel, nbItemsSelected, nbItems, required, t }) {
 	function renderTitle() {
-		const computedHeaderLabel = headerLabel || t('LISTVIEW_HEADER_TITLE', 'Values');
+		const computedHeaderLabel = headerLabel || t('LISTVIEW_HEADER_TITLE', { defaultValue: 'Values' });
 		return (
 			<strong>
 				{computedHeaderLabel}

--- a/packages/components/src/ListView/Header/Header.component.js
+++ b/packages/components/src/ListView/Header/Header.component.js
@@ -45,7 +45,8 @@ export function renderActions(headerDefault = []) {
 
 function Header({ headerDefault, headerLabel, nbItemsSelected, nbItems, required, t }) {
 	function renderTitle() {
-		const computedHeaderLabel = headerLabel || t('LISTVIEW_HEADER_TITLE', { defaultValue: 'Values' });
+		const computedHeaderLabel =
+			headerLabel || t('LISTVIEW_HEADER_TITLE', { defaultValue: 'Values' });
 		return (
 			<strong>
 				{computedHeaderLabel}

--- a/packages/components/src/ListView/Header/HeaderInput.component.js
+++ b/packages/components/src/ListView/Header/HeaderInput.component.js
@@ -40,7 +40,7 @@ function getAction(action, index) {
 
 function HeaderInput({ headerInput, onInputChange, inputPlaceholder, onAddKeyDown, t }) {
 	const computedInputPlaceholder =
-		inputPlaceholder || t('LISTVIEW_HEADERINPUT_SEARCH_PLACEHOLDER', 'Search');
+		inputPlaceholder || t('LISTVIEW_HEADERINPUT_SEARCH_PLACEHOLDER', { defaultValue: 'Search' });
 
 	function onInputChangeHandler(event) {
 		onInputChange(event, {

--- a/packages/components/src/ListView/Items/Items.component.js
+++ b/packages/components/src/ListView/Items/Items.component.js
@@ -88,7 +88,7 @@ class Items extends React.PureComponent {
 						onChange={onToggleAll}
 						checked={!!toggleAllChecked}
 					/>
-					<strong>{t('LISTVIEW_ITEMS_TOGGLE_ALL', 'Toggle all')}</strong>
+					<strong>{t('LISTVIEW_ITEMS_TOGGLE_ALL', { defaultValue: 'Toggle all' })}</strong>
 				</label>
 			</div>
 		);

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -18,8 +18,8 @@ function listviewClasses() {
 }
 
 function ListView(props) {
-	const noResultLabel = props.t('LISTVIEW_NO_RESULT', 'No result found.');
-	const emptyLabel = props.t('LISTVIEW_EMPTY', 'This list is empty.');
+	const noResultLabel = props.t('LISTVIEW_NO_RESULT', { defaultValue: 'No result found.' });
+	const emptyLabel = props.t('LISTVIEW_EMPTY', { defaultValue: 'This list is empty.' });
 	const label = props.displayMode === DISPLAY_MODE_SEARCH ? noResultLabel : emptyLabel;
 	return (
 		<div className={listviewClasses()}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
i18n.t() accept an object as options, but in those components, the default value is passed as option

**What is the chosen solution to this problem?**
Pas an object `{ defaultValue }` instead

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

