### PR TITLE
fix: broken forms storybook

### DIFF
--- a/packages/forms/stories-core/index.js
+++ b/packages/forms/stories-core/index.js
@@ -33,9 +33,14 @@ a11y(ReactDOM);
 const forStoryDecorator = story => (
 	<I18nextProvider i18n={i18n}>
 	<Provider store={store}>
-		<button onClick={() => i18n.changeLanguage('fr')}>fr</button>
-		<button onClick={() => i18n.changeLanguage('it')}>it</button>
 		<div className="container-fluid">
+			<nav style={{ position: 'fixed', bottom: 0, width: '100vw', textAlign: 'center', zIndex: 1 }}>
+				<div className="btn-group">
+					<button className="btn" onClick={() => i18n.changeLanguage('en')}>Default (en)</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('fr')}>fr</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('it')}>it</button>
+				</div>
+			</nav>
 			<div
 				className="col-md-offset-1 col-md-10"
 				style={{ marginTop: '20px', marginBottom: '20px' }}

--- a/packages/forms/stories/index.js
+++ b/packages/forms/stories/index.js
@@ -24,9 +24,14 @@ const decoratedStories = storiesOf('Form', module)
 .addDecorator(story =>
 	<I18nextProvider i18n={i18n}>
 		<section>
-			<button onClick={() => i18n.changeLanguage('fr')}>fr</button>
-			<button onClick={() => i18n.changeLanguage('it')}>it</button>
-			<IconsProvider/>
+			<nav style={{ position: 'fixed', bottom: 0, width: '100vw', textAlign: 'center', zIndex: 1 }}>
+				<div className="btn-group">
+					<button className="btn" onClick={() => i18n.changeLanguage('en')}>Default (en)</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('fr')}>fr</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('it')}>it</button>
+				</div>
+			</nav>
+			<IconsProvider />
 			<div className="container-fluid">
 				<div
 					className="col-md-offset-1 col-md-10"
@@ -45,18 +50,18 @@ const capitalizeFirstLetter = string => string.charAt(0).toUpperCase() + string.
 const sampleFilenames = require.context('./json', true, /.(js|json)$/);
 const sampleFilenameRegex = /^.\/(.*).js/;
 
-sampleFilenames.keys().forEach((filename) => {
+sampleFilenames.keys().forEach(filename => {
 	const sampleNameMatches = filename.match(sampleFilenameRegex);
 	const sampleName = sampleNameMatches[sampleNameMatches.length - 1];
 	const capitalizedSampleName = capitalizeFirstLetter(sampleName);
 	decoratedStories.add(capitalizedSampleName, () =>
-			<Form
-				autocomplete="off"
-				data={object(capitalizedSampleName, sampleFilenames(filename))}
-				onChange={action('Change')}
-				onBlur={action('Blur')}
-				onSubmit={action('Submit')}
-			/>
+		<Form
+			autocomplete="off"
+			data={object(capitalizedSampleName, sampleFilenames(filename))}
+			onChange={action('Change')}
+			onBlur={action('Blur')}
+			onSubmit={action('Submit')}
+		/>
 	);
 });
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UIForms storybooks are broken because of i18n buttons that makes redux provider children to be multiple children, but it expects an only child.

**What is the chosen solution to this problem?**
Move the buttons.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

