### PR TITLE
fix(components): disable the overlay when inProgress

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -123,7 +123,7 @@ function ActionButton(props) {
 			{buttonContent}
 		</Button>
 	);
-	if (overlayComponent) {
+	if (!inProgress && overlayComponent) {
 		btn = (
 			// this span is here to allow the tooltip trigger to work
 			<span>

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -126,6 +126,7 @@ describe('Action', () => {
 		const wrapper = shallow(<ActionButton {...props} />);
 
 		// then
+		expect(wrapper.find('OverlayTrigger').length).toBe(0);
 		expect(wrapper.getNode()).toMatchSnapshot();
 	});
 
@@ -144,6 +145,7 @@ describe('Action', () => {
 		const wrapper = shallow(<ActionButton {...props} />);
 
 		// then
+		expect(wrapper.find('OverlayTrigger').length).toBe(1);
 		expect(wrapper.getNode()).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -110,6 +110,25 @@ describe('Action', () => {
 		expect(wrapper.type()).toBe(null);
 	});
 
+	it('should render a button without an overlay component if inProgress is true', () => {
+		function OverlayComponent() {
+			return <div>OverlayComponent</div>;
+		}
+
+		const props = {
+			...myAction,
+			inProgress: true,
+			overlayComponent: OverlayComponent,
+			overlayPlacement: 'bottom',
+		};
+
+		// when
+		const wrapper = shallow(<ActionButton {...props} />);
+
+		// then
+		expect(wrapper.getNode()).toMatchSnapshot();
+	});
+
 	it('should render a button with a overlay component', () => {
 		function OverlayComponent() {
 			return <div>OverlayComponent</div>;

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -145,6 +145,26 @@ exports[`Action should render a button with a overlay component 1`] = `
 </span>
 `;
 
+exports[`Action should render a button without an overlay component if inProgress is true 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  disabled={true}
+  onClick={null}
+  onMouseDown={null}
+  role={null}
+>
+  <CircularProgress
+    size="small"
+  />
+  <span>
+    Click me
+  </span>
+</Button>
+`;
+
 exports[`Action should render action with html property name = props.name if set 1`] = `
 <Button
   active={false}

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -56,6 +56,16 @@ storiesOf('Action', module)
 				{...mouseDownAction}
 				hideLabel
 			/>
+			<p>Action with popover</p>
+			<Action
+				id="hidelabel"
+				inProgress="true"
+				overlayComponent={OverlayComponent}
+				overlayPlacement="top"
+				tooltipPlacement="left"
+				{...mouseDownAction}
+				hideLabel
+			/>
 		</div>
 	))
 	.addWithPropsCombinations('combinations', Action, {

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -14,7 +14,7 @@ const myAction = {
 	onClick: action('You clicked me'),
 };
 
-const OverlayComponent = <div>I'm an overlay</div>;
+const OverlayComponent = <div>I am an overlay</div>;
 
 const mouseDownAction = {
 	label: 'Click me',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When we set the props InProgress with an overlay, the overlay shows

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

