### PR TITLE
chore: exclude jsfc from lerna publish

### DIFF
--- a/packages/jsfc/package.json
+++ b/packages/jsfc/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.1",
   "description": "JSON-Schema and JSON-UI-Schema utilities for form generation.",
   "main": "dist/module.js",
+  "private": true,
   "scripts": {
     "prepublish": "babel -d dist ./src/ && rimraf dist/**/*.spec.js",
     "build": "webpack",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
JSFC fork has been integrated to Talend/ui, but it should have its own lifecycle.

**What is the chosen solution to this problem?**
Set `"private": true` in jsfc package.json to be excluded from lerna publish 

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

