### PR TITLE
chore(component-objects): downgrade selenium version to 2.35.0

### DIFF
--- a/packages/components/e2e/component-objects/pom.xml
+++ b/packages/components/e2e/component-objects/pom.xml
@@ -11,12 +11,12 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-java</artifactId>
-            <version>3.6.0</version>
+            <version>2.35.0</version>
         </dependency>
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-support</artifactId>
-            <version>3.6.0</version>
+            <version>2.35.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Talend QA use selenium 2.35.0. With the initialisation in test-common-web module, current version, set to 3+ is problematic.

**What is the chosen solution to this problem?**
Downgrade.
Run the component-objects e2e tests on our storybook, everything is still fine.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

