### PR TITLE
fix(component/filterbar): always display placeholder

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -7,9 +7,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.test.js
   4:10  error  'ActionSplitDropdown' is defined but never used  no-unused-vars
 
-/home/travis/build/Talend/ui/packages/containers/src/index.js
-  45:2  error  'AppHeaderBar' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   12:90  error  'notifications' is missing in props validation  react/prop-types
 
@@ -22,5 +19,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
   3:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -169,7 +169,7 @@ class FilterBar extends React.Component {
 						onFocus={this.onFocus}
 						onFilter={this.onFilter}
 						onToggle={this.props.onToggle}
-						placeholder={this.state.focus ? '' : this.props.placeholder}
+						placeholder={this.props.placeholder}
 						value={this.state.value}
 						dockable={this.props.dockable}
 					/>

--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -42,7 +42,6 @@ export {
 	ActionDropdown,
 	Actions,
 	ActionSplitDropdown,
-	AppHeaderBar,
 	Breadcrumbs,
 	CircularProgress,
 	ConfirmDialog,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The search placeholder was only display when the input is not focused : 
![image](https://user-images.githubusercontent.com/14272767/34049817-11f26814-e1b9-11e7-8ce1-1c157b9bc2d3.png)

**What is the chosen solution to this problem?**
Always display the placeholder.
**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

