### PR TITLE
fix(Storybook): common css file loader config

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -57,6 +57,19 @@ module.exports = storybookBaseConfig => {
 					},
 				},
 			],
+		},
+		{
+			test: /\.css$/,
+			use: [
+				'style-loader',
+				'css-loader',
+				{
+					loader: 'postcss-loader',
+					options: {
+						plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
+					},
+				},
+			],
 		}
 	);
 

--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -2,6 +2,7 @@ const SASS_DATA = "@import '~@talend/bootstrap-theme/src/theme/guidelines';";
 const autoprefixer = require.main.require('autoprefixer');
 const path = require('path');
 const webpack = require.main.require('webpack');
+const autoPrefixerPlugin = autoprefixer({ browsers: ['last 2 versions'] })
 
 module.exports = storybookBaseConfig => {
 	// remove Uglification plugin to improve build time in CI
@@ -27,7 +28,7 @@ module.exports = storybookBaseConfig => {
 				{
 					loader: 'postcss-loader',
 					options: {
-						plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
+						plugins: [autoPrefixerPlugin],
 					},
 				},
 				{
@@ -47,7 +48,7 @@ module.exports = storybookBaseConfig => {
 				{
 					loader: 'postcss-loader',
 					options: {
-						plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
+						plugins: [autoPrefixerPlugin],
 					},
 				},
 				{
@@ -66,7 +67,7 @@ module.exports = storybookBaseConfig => {
 				{
 					loader: 'postcss-loader',
 					options: {
-						plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
+						plugins: [autoPrefixerPlugin],
 					},
 				},
 			],

--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.135.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.136.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.135.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.136.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.135.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.136.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.135.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.136.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.135.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.136.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.135.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.136.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.135.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.136.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/sagas.eslint.txt
+++ b/output/sagas.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-sagas@0.135.0 lint:es /home/travis/build/Talend/ui/packages/sagas
+> @talend/react-sagas@0.136.0 lint:es /home/travis/build/Talend/ui/packages/sagas
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.135.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.136.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/.storybook/webpack.config.js
+++ b/packages/components/.storybook/webpack.config.js
@@ -5,7 +5,6 @@
 // IMPORTANT
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
-const autoprefixer = require.main.require('autoprefixer');
 const commonConfiguration = require('../../../.storybook/webpack.config');
 
 module.exports = storybookBaseConfig => {
@@ -15,19 +14,6 @@ module.exports = storybookBaseConfig => {
 		test: /\.js?$/,
 		include: /node_modules\/(react-storybook-addon-props-combinations)/,
 		loader: 'babel-loader',
-	});
-	storybookConfig.module.rules.push({
-		test: /\.css$/,
-		use: [
-			'style-loader',
-			'css-loader',
-			{
-				loader: 'postcss-loader',
-				options: {
-					plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
-				},
-			},
-		],
 	});
 
 	return storybookConfig;

--- a/packages/containers/.storybook/webpack.config.js
+++ b/packages/containers/.storybook/webpack.config.js
@@ -6,7 +6,6 @@
 // When you add this file, we won't add the default configurations which is similar
 // to "React Create App". This only has babel loader to load JavaScript.
 const path = require('path');
-const autoprefixer = require.main.require('autoprefixer');
 const commonConfiguration = require('../../../.storybook/webpack.config');
 
 module.exports = storybookBaseConfig => {
@@ -17,20 +16,6 @@ module.exports = storybookBaseConfig => {
 			'react-cmf': path.join(__dirname, '../node_modules/@talend/react-cmf'),
 		},
 	};
-
-	storybookConfig.module.rules.push({
-		test: /\.css$/,
-		use: [
-			'style-loader',
-			'css-loader',
-			{
-				loader: 'postcss-loader',
-				options: {
-					plugins: [autoprefixer({ browsers: ['last 2 versions'] })],
-				},
-			},
-		],
-	});
 
 	return storybookConfig;
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook is broken because forms depends on components that import a css (not scss) file.
Forms storybook webpack config does not how to load that.

**What is the chosen solution to this problem?**
Set css loader config in common webpack config

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

