### PR TITLE
fix(components/layout): fix stories with lists

### DIFF
--- a/packages/components/src/VirtualizedList/PropTypes.js
+++ b/packages/components/src/VirtualizedList/PropTypes.js
@@ -19,7 +19,7 @@ export default {
 	/** Function : (collectionItem) => Boolean
 	 *  This is called to determine if the element is selected.
 	 *  Note that this is not used/displayed if the selectionToggle props is not passed */
-	isSelected: PropTypes.func,
+	isSelected: PropTypes.func.isRequired,
 	// Show spinner during loading
 	inProgress: PropTypes.bool,
 	// The row click

--- a/packages/components/stories/Layout.js
+++ b/packages/components/stories/Layout.js
@@ -94,6 +94,7 @@ const listProps = {
 			onSelect: action('onSelect'),
 			onToggle: action('onToggle'),
 			onToggleAll: action('onToggleAll'),
+			isSelected: () => false,
 		},
 	},
 	toolbar: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Following stories are broken in the storybook :

- `TwoColumns with big Table list`
- `TwoColumns with big Large list`


**What is the chosen solution to this problem?**

Add `isRequired` on `isSelected` list prop.
Add `isSelected` method in stories. 

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

