### PR TITLE
feat(List): add CellRenderer for showing text + icon

### DIFF
--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
@@ -13,9 +13,7 @@ function CellWithIcon(props) {
 	return (
 		<div className={styles['cell-icon-container']}>
 			<div>{props.cellData}</div>
-			<div>
-				{action && <Action {...action} hideLabel link />}
-			</div>
+			<div>{action && <Action {...action} hideLabel link />}</div>
 		</div>
 	);
 }

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
@@ -1,0 +1,34 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+
+import Action from '../../Actions/Action';
+import styles from './CellWithIcon.scss';
+
+/**
+ * Cell renderer that displays a badge
+ */
+function CellWithIcon(props) {
+	const action = props.columnData.getIcon(props.rowData);
+
+	return (
+		<div className={styles['cell-icon-container']}>
+			<div>{props.cellData}</div>
+			<div>
+				{action && <Action {...action} hideLabel link />}
+			</div>
+		</div>
+	);
+}
+
+CellWithIcon.displayName = 'VirtualizedList(CellWithIcon)';
+CellWithIcon.propTypes = {
+	// The cell value : props.rowData[props.dataKey]
+	cellData: PropTypes.string,
+	// Can be any object
+	rowData: PropTypes.object,
+	columnData: PropTypes.shape({
+		getIcon: PropTypes.func,
+	}).isRequired,
+};
+
+export default CellWithIcon;

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
@@ -1,19 +1,26 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import classnames from 'classnames';
 
 import Action from '../../Actions/Action';
 import styles from './CellWithIcon.scss';
 
 /**
- * Cell renderer that displays a badge
+ * Cell renderer that displays text + icon
  */
-function CellWithIcon(props) {
-	const action = props.columnData.getIcon(props.rowData);
+function CellWithIcon({
+	columnData,
+	rowData,
+	cellData,
+}) {
+	const action = columnData.getIcon(rowData);
 
 	return (
-		<div className={styles['cell-icon-container']}>
-			<div>{props.cellData}</div>
-			<div>{action && <Action {...action} hideLabel link />}</div>
+		<div className={classnames('cell-icon-container', styles['cell-icon-container'])}>
+			<div>{cellData}</div>
+			<div>
+				{action && <Action {...action} hideLabel link />}
+			</div>
 		</div>
 	);
 }
@@ -25,7 +32,7 @@ CellWithIcon.propTypes = {
 	// Can be any object
 	rowData: PropTypes.object,
 	columnData: PropTypes.shape({
-		getIcon: PropTypes.func,
+		getIcon: PropTypes.func.isRequired,
 	}).isRequired,
 };
 

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.component.js
@@ -8,19 +8,13 @@ import styles from './CellWithIcon.scss';
 /**
  * Cell renderer that displays text + icon
  */
-function CellWithIcon({
-	columnData,
-	rowData,
-	cellData,
-}) {
+function CellWithIcon({ columnData, rowData, cellData }) {
 	const action = columnData.getIcon(rowData);
 
 	return (
 		<div className={classnames('cell-icon-container', styles['cell-icon-container'])}>
 			<div>{cellData}</div>
-			<div>
-				{action && <Action {...action} hideLabel link />}
-			</div>
+			<div>{action && <Action {...action} hideLabel link />}</div>
 		</div>
 	);
 }

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.scss
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.scss
@@ -1,0 +1,4 @@
+.cell-icon-container {
+	display: flex;
+	align-items: center;
+}

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.test.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.test.js
@@ -14,7 +14,7 @@ describe('CellWithIcon', () => {
 			}),
 		};
 
-		const wrapper = shallow(<CellWithIcon cellData={"Test label"} columnData={columnData} />);
+		const wrapper = shallow(<CellWithIcon cellData={'Test label'} columnData={columnData} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -26,7 +26,7 @@ describe('CellWithIcon', () => {
 			getIcon: () => undefined,
 		};
 
-		const wrapper = shallow(<CellWithIcon cellData={"Test label 2"} columnData={columnData} />);
+		const wrapper = shallow(<CellWithIcon cellData={'Test label 2'} columnData={columnData} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.test.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CellWithIcon from './CellWithIcon.component';
+
+describe('CellWithIcon', () => {
+	it('should render with icon', () => {
+		// when
+		const columnData = {
+			getIcon: () => ({
+				label: 'test',
+				icon: 'talend-star',
+				onClick: jest.fn(),
+			}),
+		};
+
+		const wrapper = shallow(<CellWithIcon cellData={"Test label"} columnData={columnData} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render without icon', () => {
+		// when
+		const columnData = {
+			getIcon: () => undefined,
+		};
+
+		const wrapper = shallow(<CellWithIcon cellData={"Test label 2"} columnData={columnData} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/VirtualizedList/CellTextIcon/__snapshots__/CellWithIcon.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTextIcon/__snapshots__/CellWithIcon.test.js.snap
@@ -1,0 +1,31 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellWithIcon should render with icon 1`] = `
+<div
+  className={undefined}
+>
+  <div>
+    Test label
+  </div>
+  <div>
+    <Action
+      hideLabel={true}
+      icon="talend-star"
+      label="test"
+      link={true}
+      onClick={[Function]}
+    />
+  </div>
+</div>
+`;
+
+exports[`CellWithIcon should render without icon 1`] = `
+<div
+  className={undefined}
+>
+  <div>
+    Test label 2
+  </div>
+  <div />
+</div>
+`;

--- a/packages/components/src/VirtualizedList/CellTextIcon/__snapshots__/CellWithIcon.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTextIcon/__snapshots__/CellWithIcon.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CellWithIcon should render with icon 1`] = `
 <div
-  className={undefined}
+  className="cell-icon-container"
 >
   <div>
     Test label
@@ -21,7 +21,7 @@ exports[`CellWithIcon should render with icon 1`] = `
 
 exports[`CellWithIcon should render without icon 1`] = `
 <div
-  className={undefined}
+  className="cell-icon-container"
 >
   <div>
     Test label 2

--- a/packages/components/src/VirtualizedList/CellTextIcon/index.js
+++ b/packages/components/src/VirtualizedList/CellTextIcon/index.js
@@ -1,0 +1,7 @@
+import CellWithIcon from './CellWithIcon.component';
+
+export const cellType = 'texticon';
+
+export default {
+	cellRenderer: CellWithIcon,
+};

--- a/packages/components/src/VirtualizedList/utils/dictionary.js
+++ b/packages/components/src/VirtualizedList/utils/dictionary.js
@@ -4,12 +4,14 @@ import CellActionsRenderer, { cellType as cellActionsType } from '../CellActions
 import CellCheckboxRenderer, { cellType as cellCheckboxType } from '../CellCheckbox';
 import CellTitleRenderer, { cellType as cellTitleType } from '../CellTitle';
 import CellBadgeRenderer, { cellType as cellBadgeType } from '../CellBadge';
+import CellTextIconRenderer, { cellType as cellTextType } from '../CellTextIcon';
 /** Cell renderers dictionary */
 export const cellDictionary = {
 	[cellActionsType]: CellActionsRenderer,
 	[cellCheckboxType]: CellCheckboxRenderer,
 	[cellTitleType]: CellTitleRenderer,
 	[cellBadgeType]: CellBadgeRenderer,
+	[cellTextType]: CellTextIconRenderer,
 };
 
 /** Row renderers dictionary */

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -29,6 +29,7 @@ const icons = {
 	'talend-table': talendIcons['talend-table'],
 	'talend-tiles': talendIcons['talend-tiles'],
 	'talend-trash': talendIcons['talend-trash'],
+	'talend-warning': talendIcons['talend-warning'],
 };
 
 const selected = [
@@ -274,6 +275,68 @@ storiesOf('List', module)
 			<List {...props} />
 		</div>
 	))
+	.add('Table icons', () => {
+		const customProps = { ...props };
+
+		const okIcon = {
+			label: 'OK!',
+			icon: 'talend-star',
+			onClick: () => {},
+		};
+
+		const warningIcon = {
+			label: 'Oh no!',
+			icon: 'talend-warning',
+			onClick: () => {},
+		};
+
+		const getIcon = item => {
+			switch (item.cat) {
+				case 'fluffy' : return okIcon;
+				case 'fat' : return warningIcon;
+				default: return null;
+			}
+		};
+
+		customProps.list.columns = [
+			{ key: 'id', label: 'Id' },
+			{ key: 'name', label: 'Name' },
+			{ key: 'status', label: 'Status', type: 'texticon', data: { getIcon } },
+			{ key: 'cat', label: 'Cat' },
+		];
+
+		customProps.list.items = [
+			{
+				id: 0,
+				name: 'Title 1',
+				status: 'ok',
+				cat: 'fluffy',
+			},
+			{
+				id: 1,
+				name: 'Title 2',
+				status: 'warning',
+				cat: 'fat',
+			},
+			{
+				id: 2,
+				name: 'Title 3',
+				status: 'random',
+				cat: 'regular',
+			},
+		];
+
+		return (
+			<div style={{ height: '60vh' }} className="virtualized-list">
+				<h1>List</h1>
+				<p>
+					Display the list in table mode.<br />
+					This is the default mode.
+				</p>
+				<List {...customProps} />
+			</div>
+		);
+	})
 	.add('Large display', () => (
 		<div style={{ height: '60vh' }} className="virtualized-list">
 			<h1>List</h1>
@@ -508,7 +571,7 @@ storiesOf('List', module)
 			<div style={{ height: '60vh' }} className="virtualized-list">
 				<h1>List</h1>
 				<p>
-					Display the list with hidden header labels.<br/>
+					Display the list with hidden header labels.<br />
 					<pre>
 						const props = &#123;...&#125;;<br />
 						props.list.columns[0].hideHeader = true;<br />
@@ -519,23 +582,19 @@ storiesOf('List', module)
 			</div>
 		);
 	})
-	.add('Custom classnames', () => {
-		return (
-			<div style={{ height: '60vh' }} className="virtualized-list virtualized-list-customized-row">
-				<h1>List</h1>
-				<p>Display the list with hidden header labels.</p>
+	.add('Custom classnames', () => (
+		<div style={{ height: '60vh' }} className="virtualized-list virtualized-list-customized-row">
+			<h1>List</h1>
+			<p>Display the list with hidden header labels.</p>
+			<List {...props} />
+		</div>
+		))
+	.add('Inline parent', () => (
+		<div className="virtualized-list">
+			<h1>List</h1>
+			{/* Do not reproduce!*/}
+			<span>
 				<List {...props} />
-			</div>
-		);
-	})
-	.add('Inline parent', () => {
-		return (
-			<div className="virtualized-list">
-				<h1>List</h1>
-				{/*Do not reproduce!*/}
-				<span>
-					<List {...props} />
-				</span>
-			</div>
-		);
-	});
+			</span>
+		</div>
+		));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We need to show icon right after the text in table cell like on the picture:

https://jira.talendforge.org/secure/attachment/132019/132019_screenshot-1.png

**What is the chosen solution to this problem?**

Custom Cell renderer

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

