### PR TITLE
feat(Components): add className in props for drawer.content

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -131,7 +131,10 @@ DrawerTitle.propTypes = {
 
 function DrawerContent({ children, className, ...rest }) {
 	return (
-		<div className={classnames('tc-drawer-content', theme['tc-drawer-content'], className)} {...rest}>
+		<div
+			className={classnames('tc-drawer-content', theme['tc-drawer-content'], className)}
+			{...rest}
+		>
 			{children}
 		</div>
 	);

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -129,9 +129,9 @@ DrawerTitle.propTypes = {
 	children: PropTypes.node,
 };
 
-function DrawerContent({ children, ...rest }) {
+function DrawerContent({ children, className, ...rest }) {
 	return (
-		<div className={classnames('tc-drawer-content', theme['tc-drawer-content'])} {...rest}>
+		<div className={classnames('tc-drawer-content', theme['tc-drawer-content'], className)} {...rest}>
 			{children}
 		</div>
 	);
@@ -139,6 +139,7 @@ function DrawerContent({ children, ...rest }) {
 
 DrawerContent.propTypes = {
 	children: PropTypes.node,
+	className: PropTypes.string,
 };
 
 function DrawerFooter({ children }) {

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -90,4 +90,26 @@ describe('Drawer', () => {
 			.toJSON();
 		expect(wrapper).toMatchSnapshot();
 	});
+
+	it('render drawer content without extra className', () => {
+		const wrapper = renderer
+			.create(
+				<Drawer.Content>
+					<h1>Hello world</h1>
+				</Drawer.Content>,
+			)
+			.toJSON();
+		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('render drawer content with extra className', () => {
+		const wrapper = renderer
+			.create(
+				<Drawer.Content className="extraClass">
+					<h1>Hello world</h1>
+				</Drawer.Content>,
+			)
+			.toJSON();
+		expect(wrapper).toMatchSnapshot();
+	});
 });

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -1,5 +1,25 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Drawer render drawer content with extra className 1`] = `
+<div
+  className="tc-drawer-content extraClass"
+>
+  <h1>
+    Hello world
+  </h1>
+</div>
+`;
+
+exports[`Drawer render drawer content without extra className 1`] = `
+<div
+  className="tc-drawer-content"
+>
+  <h1>
+    Hello world
+  </h1>
+</div>
+`;
+
 exports[`Drawer should not render if no children 1`] = `null`;
 
 exports[`Drawer should render 1`] = `


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For TMC, we need to have the possibility to extend the className of Drawer.Content

Currently, if we set a custom className on Drawer.Content, initial classes are deleted

**What is the chosen solution to this problem?**
Add className in Drawer.content's props

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

