### PR TITLE
fix(components/list): actions display mode

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -1,4 +1,5 @@
 @import '../colors';
+
 $tc-list-title-actions-color: $brand-primary-dark !default;
 
 .main-title-actions-group {
@@ -23,6 +24,22 @@ $tc-list-title-actions-color: $brand-primary-dark !default;
 
 		:global(.btn-link) {
 			color: $tc-list-title-actions-color;
+		}
+	}
+
+	// Specific case for Win7/IE11 which it cannot compute width with float
+	:global(.btn-group) {
+		:global(> .btn-group) {
+			float: none;
+		}
+
+		&,
+		&-vertical {
+			display: inline-block;
+
+			:global(> .btn) {
+				float: none;
+			}
 		}
 	}
 }

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -1,5 +1,4 @@
 @import '../colors';
-
 $tc-list-title-actions-color: $brand-primary-dark !default;
 
 .main-title-actions-group {
@@ -24,22 +23,6 @@ $tc-list-title-actions-color: $brand-primary-dark !default;
 
 		:global(.btn-link) {
 			color: $tc-list-title-actions-color;
-		}
-	}
-
-	// Specific case for Win7/IE11 which it cannot compute width with float
-	:global(.btn-group) {
-		:global(> .btn-group) {
-			float: none;
-		}
-
-		&,
-		&-vertical {
-			display: inline-block;
-
-			:global(> .btn) {
-				float: none;
-			}
 		}
 	}
 }

--- a/packages/components/src/VirtualizedList/VirtualizedList.scss
+++ b/packages/components/src/VirtualizedList/VirtualizedList.scss
@@ -1,3 +1,25 @@
+:global(.tc-list) {
+	&-item {
+		// Specific case for Win7/IE11 which it cannot compute width with float
+		:global(.btn-group) {
+			white-space: nowrap;
+
+			:global(> .btn-group) {
+				float: none;
+			}
+
+			&,
+			&-vertical {
+				display: inline-block;
+
+				:global(> .btn) {
+					float: none;
+				}
+			}
+		}
+	}
+}
+
 .tc-list-progress {
 	width: 100%;
 	display: flex;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
WIN7/IE11 cannot compute width
![before](https://user-images.githubusercontent.com/18534166/34519354-d948afd0-f083-11e7-913b-25927742a1ee.png)

**What is the chosen solution to this problem?**
Change display mode
![after](https://user-images.githubusercontent.com/18534166/34519358-df778264-f083-11e7-9d16-7053c52a440b.png)

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

