### PR TITLE
doc(Forms): doc links in storybooks

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/Columns/README.md
+++ b/packages/forms/src/UIForm/fieldsets/Columns/README.md
@@ -1,4 +1,4 @@
-# Buttons
+# Columns
 
 This widget allows you to columns containing widgets/fields.
 

--- a/packages/forms/stories-core/json/fields/core-buttons.json
+++ b/packages/forms/stories-core/json/fields/core-buttons.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Button/README.md",
+  "doc": "Button/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fields/core-buttons.json
+++ b/packages/forms/stories-core/json/fields/core-buttons.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Button/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fields/core-checkbox.json
+++ b/packages/forms/stories-core/json/fields/core-checkbox.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/CheckBox/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Booleans",

--- a/packages/forms/stories-core/json/fields/core-checkbox.json
+++ b/packages/forms/stories-core/json/fields/core-checkbox.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/CheckBox/README.md",
+  "doc": "CheckBox/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Booleans",

--- a/packages/forms/stories-core/json/fields/core-datalist.json
+++ b/packages/forms/stories-core/json/fields/core-datalist.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Datalist/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Datalist",

--- a/packages/forms/stories-core/json/fields/core-datalist.json
+++ b/packages/forms/stories-core/json/fields/core-datalist.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Datalist/README.md",
+  "doc": "Datalist/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Datalist",

--- a/packages/forms/stories-core/json/fields/core-keyValue.json
+++ b/packages/forms/stories-core/json/fields/core-keyValue.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/KeyValue/README.md",
+  "doc": "KeyValue/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Key/Value",

--- a/packages/forms/stories-core/json/fields/core-keyValue.json
+++ b/packages/forms/stories-core/json/fields/core-keyValue.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/KeyValue/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Key/Value",

--- a/packages/forms/stories-core/json/fields/core-listView.json
+++ b/packages/forms/stories-core/json/fields/core-listView.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/ListView/README.md",
+  "doc": "ListView/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "ListView",

--- a/packages/forms/stories-core/json/fields/core-listView.json
+++ b/packages/forms/stories-core/json/fields/core-listView.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/ListView/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "ListView",

--- a/packages/forms/stories-core/json/fields/core-multiSelectTag.json
+++ b/packages/forms/stories-core/json/fields/core-multiSelectTag.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/MultiSelectTag/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "MultiSelectTag",

--- a/packages/forms/stories-core/json/fields/core-multiSelectTag.json
+++ b/packages/forms/stories-core/json/fields/core-multiSelectTag.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/MultiSelectTag/README.md",
+  "doc": "MultiSelectTag/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "MultiSelectTag",

--- a/packages/forms/stories-core/json/fields/core-radios-or-select.json
+++ b/packages/forms/stories-core/json/fields/core-radios-or-select.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/RadioOrSelect/README.md",
+  "doc": "RadioOrSelect/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Choice",

--- a/packages/forms/stories-core/json/fields/core-radios-or-select.json
+++ b/packages/forms/stories-core/json/fields/core-radios-or-select.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/RadioOrSelect/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Choice",

--- a/packages/forms/stories-core/json/fields/core-radios.json
+++ b/packages/forms/stories-core/json/fields/core-radios.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Radios/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Choice",

--- a/packages/forms/stories-core/json/fields/core-radios.json
+++ b/packages/forms/stories-core/json/fields/core-radios.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Radios/README.md",
+  "doc": "Radios/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Choice",

--- a/packages/forms/stories-core/json/fields/core-select.json
+++ b/packages/forms/stories-core/json/fields/core-select.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Select/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Select",

--- a/packages/forms/stories-core/json/fields/core-select.json
+++ b/packages/forms/stories-core/json/fields/core-select.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Select/README.md",
+  "doc": "Select/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Select",

--- a/packages/forms/stories-core/json/fields/core-text.json
+++ b/packages/forms/stories-core/json/fields/core-text.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Text/README.md",
+  "doc": "Text/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Text",

--- a/packages/forms/stories-core/json/fields/core-text.json
+++ b/packages/forms/stories-core/json/fields/core-text.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Text/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Text",

--- a/packages/forms/stories-core/json/fields/core-toggle.json
+++ b/packages/forms/stories-core/json/fields/core-toggle.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Toggle/README.md",
+  "doc": "Toggle/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Booleans",

--- a/packages/forms/stories-core/json/fields/core-toggle.json
+++ b/packages/forms/stories-core/json/fields/core-toggle.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fields/Toggle/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Booleans",

--- a/packages/forms/stories-core/json/fieldsets/core-arrays.json
+++ b/packages/forms/stories-core/json/fieldsets/core-arrays.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Array/README.md",
+  "doc": "Array/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-arrays.json
+++ b/packages/forms/stories-core/json/fieldsets/core-arrays.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Array/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/README.md",
+  "doc": "CollapsibleFieldset/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-columns.json
+++ b/packages/forms/stories-core/json/fieldsets/core-columns.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Columns/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-columns.json
+++ b/packages/forms/stories-core/json/fieldsets/core-columns.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Columns/README.md",
+  "doc": "Columns/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-fieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-fieldset.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Fieldset/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-fieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-fieldset.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Fieldset/README.md",
+  "doc": "Fieldset/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-tabs.json
+++ b/packages/forms/stories-core/json/fieldsets/core-tabs.json
@@ -1,4 +1,5 @@
 {
+  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Tabs/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/json/fieldsets/core-tabs.json
+++ b/packages/forms/stories-core/json/fieldsets/core-tabs.json
@@ -1,5 +1,5 @@
 {
-  "doc": "https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/fieldsets/Tabs/README.md",
+  "doc": "Tabs/README.md",
   "jsonSchema": {
     "type": "object",
     "title": "Comment",

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -52,7 +52,7 @@ function createStory(category, sampleFilenames, filename) {
 			return (
 				<section>
 					<IconsProvider />
-					{doc && <a href={doc} target="_blank" rel="noopener noreferrer">Documentation</a>}
+					{doc && <a href={`https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/${category}/${doc}`} target="_blank" rel="noopener noreferrer">Documentation</a>}
 
 					<Tabs id={'store-tabs'}>
 						<Tab

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -48,9 +48,11 @@ function createStory(category, sampleFilenames, filename) {
 		category,
 		name,
 		story() {
+			const { doc, ...data } = object(name, sampleFilenames(filename));
 			return (
 				<section>
 					<IconsProvider />
+					{doc && <a href={doc} target="_blank" rel="noopener noreferrer">Documentation</a>}
 
 					<Tabs id={'store-tabs'}>
 						<Tab
@@ -60,7 +62,7 @@ function createStory(category, sampleFilenames, filename) {
 						>
 							<UIForm
 								{...createCommonProps('state')}
-								data={object(name, sampleFilenames(filename))}
+								data={data}
 							/>
 						</Tab>
 						<Tab
@@ -70,7 +72,7 @@ function createStory(category, sampleFilenames, filename) {
 						>
 							<ConnectedUIForm
 								{...createCommonProps('redux')}
-								data={object(name, sampleFilenames(filename))}
+								data={data}
 							/>
 						</Tab>
 					</Tabs>
@@ -82,14 +84,14 @@ function createStory(category, sampleFilenames, filename) {
 
 conceptsFilenames
 	.keys()
-	.forEach((filename) => { stories.push(createStory('concepts', conceptsFilenames, filename)); });
+	.forEach(filename => { stories.push(createStory('concepts', conceptsFilenames, filename)); });
 
 fieldsetsFilenames
 	.keys()
-	.forEach((filename) => { stories.push(createStory('fieldsets', fieldsetsFilenames, filename)); });
+	.forEach(filename => { stories.push(createStory('fieldsets', fieldsetsFilenames, filename)); });
 
 fieldsFilenames
 	.keys()
-	.forEach((filename) => { stories.push(createStory('fields', fieldsFilenames, filename)); });
+	.forEach(filename => { stories.push(createStory('fields', fieldsFilenames, filename)); });
 
 export default stories;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
It's hard for someone that hasn't seen the code to find the documentation of fields/fieldsets in UIForms.

**What is the chosen solution to this problem?**
Add a link in corresponding storybooks

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

