### PR TITLE
fix(cmf): http actionCreator now imported with actions.http

### DIFF
--- a/packages/cmf/__tests__/actions/http.test.js
+++ b/packages/cmf/__tests__/actions/http.test.js
@@ -1,10 +1,4 @@
-import http, {
-	httpRequest,
-	httpError,
-	httpResponse,
-	onError,
-	onResponse,
-} from '../../src/actions/http';
+import http from '../../src/actions/http';
 import {
 	HTTP_METHODS,
 	ACTION_TYPE_HTTP_REQUEST,
@@ -86,20 +80,20 @@ describe('actions.http', () => {
 	it('should httpRequest create action', () => {
 		url = '//foo/bar';
 		config = { method: 'GET' };
-		const action = httpRequest(url, config);
+		const action = http.onRequest(url, config);
 		expect(action.type).toBe(ACTION_TYPE_HTTP_REQUEST);
 		expect(action.url).toBe(url);
 		expect(action.config).toBe(config);
 	});
 	it('should httpError create action', () => {
 		const error = { message: 'something goes wrong' };
-		const action = httpError(error);
+		const action = http.onError(error);
 		expect(action.type).toBe(ACTION_TYPE_HTTP_ERRORS);
 		expect(action.error).toBe(error);
 	});
 	it('should httpResponse create action', () => {
 		const response = { id: '2312321323' };
-		const action = httpResponse(response);
+		const action = http.onResponse(response);
 		expect(action.type).toBe(ACTION_TYPE_HTTP_RESPONSE);
 		expect(action.data).toBe(response);
 	});
@@ -109,12 +103,12 @@ describe('actions.http', () => {
 			type: 'DONT_CARE',
 			onError: 'CALL_ME_BACK',
 		};
-		const newAction = onError(action, error);
+		const newAction = http.onActionError(action, error);
 		expect(newAction.type).toBe('CALL_ME_BACK');
 		expect(newAction.error).toBe(error);
 
 		action.onError = jest.fn();
-		onError(action, error);
+		http.onActionError(action, error);
 		expect(action.onError.mock.calls.length).toBe(1);
 		expect(action.onError.mock.calls[0][0]).toBe(error);
 	});
@@ -125,12 +119,12 @@ describe('actions.http', () => {
 			type: 'DONT_CARE',
 			onResponse: 'CALL_ME_BACK',
 		};
-		const newAction = onResponse(action, response);
+		const newAction = http.onActionResponse(action, response);
 		expect(newAction.type).toBe('CALL_ME_BACK');
 		expect(newAction.response).toBe(response);
 
 		action.onResponse = jest.fn();
-		onResponse(action, response);
+		http.onActionResponse(action, response);
 		expect(action.onResponse.mock.calls.length).toBe(1);
 		expect(action.onResponse.mock.calls[0][0]).toBe(response);
 	});

--- a/packages/cmf/src/actions/http.js
+++ b/packages/cmf/src/actions/http.js
@@ -26,7 +26,7 @@ function onRequest(url, config) {
 	};
 }
 
-function reducerError(error, action) {
+function onJSError(error, action) {
 	return {
 		type: ACTION_TYPE_HTTP_REDUCER_ERROR,
 		error,
@@ -124,7 +124,7 @@ http.head = function head(url, config) {
 
 http.onError = onError;
 http.onActionError = onActionError;
-http.onReducerError = reducerError;
+http.onJSError = onJSError;
 http.onRequest = onRequest;
 http.onResponse = onResponse;
 http.onActionResponse = onActionResponse;

--- a/packages/cmf/src/actions/http.js
+++ b/packages/cmf/src/actions/http.js
@@ -1,5 +1,3 @@
-import has from 'lodash/has';
-
 import { HTTP_METHODS } from '../middlewares/http';
 import {
 	ACTION_TYPE_HTTP_REQUEST,
@@ -13,18 +11,14 @@ export const DEFAULT_HTTP_HEADERS = {
 	'Content-Type': 'application/json',
 };
 
-export function isHTTPRequest(action) {
-	return action.type in HTTP_METHODS || has(action, 'cmf.http');
-}
-
-export function httpError(error) {
+function onError(error) {
 	return {
 		type: ACTION_TYPE_HTTP_ERRORS,
 		error,
 	};
 }
 
-export function httpRequest(url, config) {
+function onRequest(url, config) {
 	return {
 		type: ACTION_TYPE_HTTP_REQUEST,
 		url,
@@ -32,7 +26,7 @@ export function httpRequest(url, config) {
 	};
 }
 
-export function httpReducerError(error, action) {
+function reducerError(error, action) {
 	return {
 		type: ACTION_TYPE_HTTP_REDUCER_ERROR,
 		error,
@@ -40,14 +34,14 @@ export function httpReducerError(error, action) {
 	};
 }
 
-export function httpResponse(response) {
+function onResponse(response) {
 	return {
 		type: ACTION_TYPE_HTTP_RESPONSE,
 		data: response,
 	};
 }
 
-export function onResponse(action, response) {
+function onActionResponse(action, response) {
 	if (typeof action.onResponse === 'function') {
 		return action.onResponse(response);
 	}
@@ -57,7 +51,7 @@ export function onResponse(action, response) {
 	};
 }
 
-export function onError(action, error) {
+function onActionError(action, error) {
 	if (typeof action.onError === 'function') {
 		return action.onError(error);
 	}
@@ -127,3 +121,10 @@ http.head = function head(url, config) {
 		...config,
 	});
 };
+
+http.onError = onError;
+http.onActionError = onActionError;
+http.onReducerError = reducerError;
+http.onRequest = onRequest;
+http.onResponse = onResponse;
+http.onActionResponse = onActionResponse;

--- a/packages/cmf/src/middlewares/http/index.md
+++ b/packages/cmf/src/middlewares/http/index.md
@@ -138,7 +138,7 @@ import { api } from '@talend/react-cmf';
 return actions.http.get('/api/may-not-exists', {
 	onError(error) {
 		if (get(error, 'stack.status') !== 404) {
-			return api.actions.http.httpError(error);
+			return api.actions.http.onError(error);
 		}
 		return {
 			type: NOT_FOUND,

--- a/packages/cmf/src/middlewares/http/middleware.js
+++ b/packages/cmf/src/middlewares/http/middleware.js
@@ -93,7 +93,7 @@ function getOnError(dispatch, httpAction) {
 		};
 		const clone = get(error, 'stack.response.clone');
 		if (!clone) {
-			dispatch(http.onReducerError(errorObject, httpAction));
+			dispatch(http.onJSError(errorObject, httpAction));
 		} else {
 			// clone the response object else the next call to text or json
 			// triggers an exception Already use


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

documented httpError actionCreator is undefined
```javascript
return api.actions.http.httpError(error);
```

plus the name is not very understandable ...

**What is the chosen solution to this problem?**

Let's rename it to onError and same for other actions
Update the middleware accordingly

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

