### PR TITLE
doc(container): fix surge

### DIFF
--- a/packages/cmf/src/mock/store.js
+++ b/packages/cmf/src/mock/store.js
@@ -17,6 +17,7 @@ const notInitializedState = {
 			contentTypes: {},
 			actions: {},
 			views: {},
+			props: {},
 		},
 	},
 };

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -196,10 +196,13 @@ function loadStories() {
 				]),
 			}),
 		);
-		state.cmf.settings.views.appheaderbar = {
+		if (!state.cmf.settings.props) {
+			state.cmf.settings.props = state.cmf.settings.views;
+		}
+		state.cmf.settings.props.appheaderbar = {
 			app: 'Hello Test',
 		};
-		state.cmf.settings.views['HeaderBar#default'] = {
+		state.cmf.settings.props['HeaderBar#default'] = {
 			logo: { name: 'appheaderbar:logo', isFull: true },
 			brand: { label: 'DATA STREAMS' },
 			notification: { name: 'appheaderbar:notification' },


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

surge/containers is broken claiming 
`TypeError: Cannot set property 'appheaderbar' of undefined`

**What is the chosen solution to this problem?**

it works

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

