### PR TITLE
chore: Prettier deals with hex-notation rule

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -53,9 +53,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'uppercase'
+    - 0
   id-name-format:
     - 2
     -

--- a/packages/components/.sass-lint.yml
+++ b/packages/components/.sass-lint.yml
@@ -53,9 +53,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'lowercase'
+    - 0
   id-name-format:
     - 2
     -

--- a/packages/forms/.sass-lint.yml
+++ b/packages/forms/.sass-lint.yml
@@ -53,9 +53,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'uppercase'
+    - 0
   id-name-format:
     - 2
     -

--- a/packages/sagas/.sass-lint.yml
+++ b/packages/sagas/.sass-lint.yml
@@ -58,9 +58,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'uppercase'
+    - 0
   id-name-format:
     - 2
     -

--- a/packages/theme/.sass-lint.yml
+++ b/packages/theme/.sass-lint.yml
@@ -53,9 +53,7 @@ rules:
     -
       style: 'short'
   hex-notation:
-    - 1
-    -
-      style: 'uppercase'
+    - 0
   id-name-format:
     - 2
     -


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
sass-lint waits for uppercase hex notation
Prettier changes colors for lowercase hex notation

**What is the chosen solution to this problem?**
Disable the sass-lint rule et let Prettier doing the trick

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

Related to https://github.com/Talend/tools/pull/64

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

