### PR TITLE
fix(component/containers): add missing displayName

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -4,7 +4,7 @@ This document aims to ease the WIP migration from a version to another by provid
 
 ## v0.142.0
 * Container: HeaderBar
-* PR
+* PR [fix(component/containers): add number of missings displayName ](https://github.com/Talend/ui/pull/985)
 * Change
 
 Display name of this component was `HeaderBar` now `Container(HeaderBar)`

--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -2,6 +2,14 @@ Before 1.0, the stack do NOT follow semver version in releases.
 
 This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
 
+## v0.142.0
+* Container: HeaderBar
+* PR
+* Change
+
+Display name of this component was `HeaderBar` now `Container(HeaderBar)`
+Change made for consistency, and also because `HeaderBar` is already in use inside the component repository.
+
 ## v0.141.0
 * Container: DeleteResource
 * PR [fix(container/deleteResource): change so keyboard shortcut can be supported ](https://github.com/Talend/ui/pull/958)

--- a/packages/components/src/Actions/Actions.component.js
+++ b/packages/components/src/Actions/Actions.component.js
@@ -82,6 +82,8 @@ function Actions(props) {
 	);
 }
 
+Actions.displayName = 'Actions';
+
 Actions.propTypes = {
 	actions: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.shape(Action.propTypes)])),
 	className: PropTypes.string,

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -101,6 +101,8 @@ function Breadcrumbs(props) {
 	);
 }
 
+Breadcrumbs.displayName = 'Breadcrumbs';
+
 Breadcrumbs.propTypes = {
 	id: PropTypes.string,
 	items: PropTypes.arrayOf(

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -28,16 +28,13 @@ function Breadcrumbs(props) {
 	const nbItems = items.length;
 	const maxItemsToDisplay = props.maxItems || DEFAULT_MAX_ITEMS;
 	const maxItemsReached = nbItems > maxItemsToDisplay;
-	const ellipsisIndex = (nbItems - 1) - maxItemsToDisplay;
-	const hiddenItems = items.slice(0, ellipsisIndex + 1)
-		.map((hiddenItem, index) => (
-			{
-				id: `${props.id}-item-${index}`,
-				label: hiddenItem.text,
-				title: hiddenItem.title,
-				onClick: event => hiddenItem.onClick(event, hiddenItem),
-			}),
-		);
+	const ellipsisIndex = nbItems - 1 - maxItemsToDisplay;
+	const hiddenItems = items.slice(0, ellipsisIndex + 1).map((hiddenItem, index) => ({
+		id: `${props.id}-item-${index}`,
+		label: hiddenItem.text,
+		title: hiddenItem.title,
+		onClick: event => hiddenItem.onClick(event, hiddenItem),
+	}));
 	/**
 	 * Render breadcrumb item
 	 * @param item Plain object representative of breadcrumb item
@@ -49,12 +46,13 @@ function Breadcrumbs(props) {
 			return null;
 		}
 		const { text, title, onClick } = item;
-		const isActive = index === (nbItems - 1);
+		const isActive = index === nbItems - 1;
 		const id = `${props.id}-item-${index}`;
-		const separator = index < props.items.length - 1 &&
-			(<li className="separator" key={`${index}-separator`}>
+		const separator = index < props.items.length - 1 && (
+			<li className="separator" key={`${index}-separator`}>
 				<Icon name="talend-chevron-left" transform="rotate-180" />
-			</li>);
+			</li>
+		);
 
 		/**
 		 * Wrapper for onClick in order to return item
@@ -67,7 +65,7 @@ function Breadcrumbs(props) {
 		}
 
 		if (maxItemsReached && index === ellipsisIndex) {
-			return [(
+			return [
 				<li className={classNames(theme.dots)} key={index} aria-hidden="true">
 					<ActionDropdown
 						id={`${props.id}-ellipsis`}
@@ -76,22 +74,22 @@ function Breadcrumbs(props) {
 						link
 						noCaret
 					/>
-				</li>
-			), separator];
+				</li>,
+				separator,
+			];
 		}
-		return [(
+		return [
 			<li className={isActive ? 'active' : ''} key={index}>
-				{(!isActive && onClick) ?
-					<Button
-						id={id}
-						bsStyle="link"
-						role="link"
-						title={title}
-						onClick={wrappedOnClick}
-					>{text}</Button> : <span id={id}>{text}</span>
-				}
-			</li>
-		), separator];
+				{!isActive && onClick ? (
+					<Button id={id} bsStyle="link" role="link" title={title} onClick={wrappedOnClick}>
+						{text}
+					</Button>
+				) : (
+					<span id={id}>{text}</span>
+				)}
+			</li>,
+			separator,
+		];
 	}
 
 	return (

--- a/packages/components/src/CircularProgress/CircularProgress.component.js
+++ b/packages/components/src/CircularProgress/CircularProgress.component.js
@@ -18,7 +18,7 @@ function getCircleStyle(percent) {
 	if (percent) {
 		return {
 			strokeDasharray: CIRCUMFERENCE,
-			strokeDashoffset: ((100 - percent) / 100) * CIRCUMFERENCE,
+			strokeDashoffset: (100 - percent) / 100 * CIRCUMFERENCE,
 		};
 	}
 	return {
@@ -33,24 +33,17 @@ function getCircleStyle(percent) {
  <CircularProgress size="large" />
  */
 function CircularProgress({ size, light, percent }) {
-	const classes = classNames(
-		theme.loader,
-		{
-			[theme.loaderlight]: light,
-			[theme.animate]: !percent,
-			[theme.fixed]: percent,
-			[theme.small]: size === SIZE.small,
-			[theme.default]: size === SIZE.default,
-			[theme.large]: size === SIZE.large,
-		},
-	);
+	const classes = classNames(theme.loader, {
+		[theme.loaderlight]: light,
+		[theme.animate]: !percent,
+		[theme.fixed]: percent,
+		[theme.small]: size === SIZE.small,
+		[theme.default]: size === SIZE.default,
+		[theme.large]: size === SIZE.large,
+	});
 
 	return (
-		<svg
-			focusable="false"
-			className={classes}
-			viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}
-		>
+		<svg focusable="false" className={classes} viewBox={`0 0 ${DIAMETER} ${DIAMETER}`}>
 			<circle
 				className={theme.path}
 				r={RADIUS}

--- a/packages/components/src/CircularProgress/CircularProgress.component.js
+++ b/packages/components/src/CircularProgress/CircularProgress.component.js
@@ -63,6 +63,8 @@ function CircularProgress({ size, light, percent }) {
 	);
 }
 
+CircularProgress.displayName = 'CircularProgress';
+
 CircularProgress.propTypes = {
 	size: PropTypes.oneOf([SIZE.small, SIZE.default, SIZE.large]),
 	light: PropTypes.bool,

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
@@ -47,18 +47,11 @@ function renderHeaderItem({ displayMode, className, ...headerItem }, key) {
 	switch (displayMode) {
 		case TYPE_STATUS: {
 			const { actions, ...restStatus } = headerItem;
-			const adaptActions = actions.map(
-				action => ({
-					...action,
-					onClick: getActionHandler(action.onClick, headerItem),
-				})
-			);
-			return (<Status
-				key={key}
-				actions={adaptActions}
-				{...restStatus}
-				className={css[className]}
-			/>);
+			const adaptActions = actions.map(action => ({
+				...action,
+				onClick: getActionHandler(action.onClick, headerItem),
+			}));
+			return <Status key={key} actions={adaptActions} {...restStatus} className={css[className]} />;
 		}
 		case TYPE_ACTION: {
 			const { onClick, ...restAction } = headerItem;
@@ -68,13 +61,16 @@ function renderHeaderItem({ displayMode, className, ...headerItem }, key) {
 					onClick={getActionHandler(onClick, headerItem)}
 					className={css[className]}
 					{...restAction}
-				/>);
+				/>
+			);
 		}
 		case TYPE_BADGE: {
 			const { label, tooltipPlacement, ...rest } = headerItem;
 			return (
 				<TooltipTrigger key={key} label={label} tooltipPlacement={tooltipPlacement}>
-					<Label {...rest} className={css[className]}>{label}</Label>
+					<Label {...rest} className={css[className]}>
+						{label}
+					</Label>
 				</TooltipTrigger>
 			);
 		}
@@ -92,11 +88,13 @@ renderHeaderItem.propTypes = PropTypes.oneOfType([
 	PropTypes.shape(statusPropTypes),
 	PropTypes.shape(actionPropTypes),
 	PropTypes.shape(simplePropTypes),
-	PropTypes.arrayOf(PropTypes.oneOfType([
-		PropTypes.shape(statusPropTypes),
-		PropTypes.shape(actionPropTypes),
-		PropTypes.shape(simplePropTypes),
-	])),
+	PropTypes.arrayOf(
+		PropTypes.oneOfType([
+			PropTypes.shape(statusPropTypes),
+			PropTypes.shape(actionPropTypes),
+			PropTypes.shape(simplePropTypes),
+		]),
+	),
 ]);
 
 function renderHeader(header, content, onSelect, onToggle) {
@@ -105,17 +103,15 @@ function renderHeader(header, content, onSelect, onToggle) {
 		if (Array.isArray(headerItem)) {
 			const elements = headerItem.map(renderHeaderItem);
 			return (
-				<div
-					key={index}
-					className={classNames(css.group, css[headerColumnClass])}
-				>{elements}</div>
+				<div key={index} className={classNames(css.group, css[headerColumnClass])}>
+					{elements}
+				</div>
 			);
 		}
 		return (
-			<div
-				key={index}
-				className={classNames(css[headerItem.className], css[headerColumnClass])}
-			>{renderHeaderItem(headerItem)}</div>
+			<div key={index} className={classNames(css[headerItem.className], css[headerColumnClass])}>
+				{renderHeaderItem(headerItem)}
+			</div>
 		);
 	});
 
@@ -128,15 +124,10 @@ function renderHeader(header, content, onSelect, onToggle) {
 				key={1}
 				onClick={onSelect}
 			>
-				<div className={classNames(css['panel-title'], 'panel-title')}>
-					{headerItems}
-				</div>
+				<div className={classNames(css['panel-title'], 'panel-title')}>{headerItems}</div>
 			</Button>
 		) : (
-			<div
-				className={classNames(css['panel-title'], 'panel-title')}
-				key={1}
-			>
+			<div className={classNames(css['panel-title'], 'panel-title')} key={1}>
 				{headerItems}
 			</div>
 		),
@@ -150,10 +141,7 @@ function renderHeader(header, content, onSelect, onToggle) {
 				key={2}
 				onClick={onToggle}
 			>
-				<Icon
-					key={header.length}
-					name="talend-caret-down"
-				/>
+				<Icon key={header.length} name="talend-caret-down" />
 			</Button>
 		);
 		wrappedHeader.push(defaultCaret);
@@ -162,19 +150,18 @@ function renderHeader(header, content, onSelect, onToggle) {
 }
 
 function getKeyValueContent(content) {
-	return (<dl>
-		{content.map(
-			(item, index) => (
+	return (
+		<dl>
+			{content.map((item, index) => (
 				<div key={index} className={css.content}>
 					<dt className={css.label}>
 						<Label>{item.label}</Label>
 					</dt>
-					<dd className={css.description}>
-						{item.description}
-					</dd>
-				</div>)
-		)}
-	</dl>);
+					<dd className={css.description}>{item.description}</dd>
+				</div>
+			))}
+		</dl>
+	);
 }
 
 function getTextualContent(content) {
@@ -184,11 +171,7 @@ function getTextualContent(content) {
 				{content.head.map((item, index) => {
 					const { label, tooltipPlacement, className } = item;
 					return (
-						<TooltipTrigger
-							key={index}
-							label={label}
-							tooltipPlacement={tooltipPlacement}
-						>
+						<TooltipTrigger key={index} label={label} tooltipPlacement={tooltipPlacement}>
 							<span className={className}>{label}</span>
 						</TooltipTrigger>
 					);
@@ -219,16 +202,13 @@ function getTextualContent(content) {
  */
 function CollapsiblePanel({ header, content, onSelect, onToggle, selected, expanded, theme }) {
 	const headerItems = renderHeader(header, content, onSelect, onToggle);
-	const className = classNames(
-		'panel panel-default',
-		css['tc-collapsible-panel'],
-		{
-			[css['default-panel']]: !theme,
-			[css[theme]]: !!theme,
-			[css.selected]: selected,
-			selected,
-			[css.open]: expanded,
-		});
+	const className = classNames('panel panel-default', css['tc-collapsible-panel'], {
+		[css['default-panel']]: !theme,
+		[css[theme]]: !!theme,
+		[css.selected]: selected,
+		selected,
+		[css.open]: expanded,
+	});
 
 	let children = null;
 	if (content) {
@@ -236,13 +216,8 @@ function CollapsiblePanel({ header, content, onSelect, onToggle, selected, expan
 	}
 	return (
 		<div className={className}>
-			<div className={classNames(css['panel-heading'], 'panel-heading')}>
-				{headerItems}
-			</div>
-			<Panel
-				collapsible={!!content}
-				expanded={expanded}
-			>
+			<div className={classNames(css['panel-heading'], 'panel-heading')}>{headerItems}</div>
+			<Panel collapsible={!!content} expanded={expanded}>
 				{children}
 			</Panel>
 		</div>
@@ -259,10 +234,12 @@ CollapsiblePanel.propTypes = {
 	selected: PropTypes.bool,
 	theme: PropTypes.string,
 	content: PropTypes.oneOfType([
-		PropTypes.arrayOf(PropTypes.shape({
-			label: PropTypes.string,
-			description: PropTypes.string,
-		})),
+		PropTypes.arrayOf(
+			PropTypes.shape({
+				label: PropTypes.string,
+				description: PropTypes.string,
+			}),
+		),
 		PropTypes.shape({
 			head: PropTypes.arrayOf(PropTypes.shape(simplePropTypes)),
 			description: PropTypes.string,

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
@@ -249,6 +249,8 @@ function CollapsiblePanel({ header, content, onSelect, onToggle, selected, expan
 	);
 }
 
+CollapsiblePanel.displayName = 'CollapsiblePanel';
+
 CollapsiblePanel.propTypes = {
 	header: PropTypes.arrayOf(renderHeaderItem.propTypes).isRequired,
 	onSelect: PropTypes.func,

--- a/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
@@ -55,15 +55,13 @@ function ConfirmDialog({
 				bodyOverflow && theme['modal-body-overflow'],
 			)}
 		>
-			{header
-				? <Modal.Header closeButton={false}>
+			{header ? (
+				<Modal.Header closeButton={false}>
 					<Modal.Title>{header}</Modal.Title>
 				</Modal.Header>
-				: null}
+			) : null}
 			{progressValue ? <ProgressBar now={progressValue} /> : null}
-			<Modal.Body>
-				{children}
-			</Modal.Body>
+			<Modal.Body>{children}</Modal.Body>
 			<Modal.Footer>
 				<Action {...cancelAction} />
 				<div className={theme['tc-confirm-actions']}>

--- a/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
@@ -75,6 +75,8 @@ function ConfirmDialog({
 	);
 }
 
+ConfirmDialog.displayName = 'ConfirmDialog';
+
 ConfirmDialog.propTypes = {
 	header: PropTypes.string,
 	size: PropTypes.oneOf(['small', 'large']),

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -30,6 +30,8 @@ function Dialog(props) {
 	);
 }
 
+Dialog.displayName = 'Dialog';
+
 Dialog.propTypes = {
 	header: PropTypes.string,
 	size: PropTypes.oneOf(['small', 'large']),

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -12,15 +12,13 @@ import Action from '../Actions/Action';
 function Dialog(props) {
 	const modalProps = { bsSize: props.size, show: props.show, ...props.bsDialogProps };
 	return (
-		<Modal {...modalProps} >
+		<Modal {...modalProps}>
 			{props.header && (
 				<Modal.Header closeButton>
 					<Modal.Title>{props.header}</Modal.Title>
 				</Modal.Header>
 			)}
-			<Modal.Body>
-				{props.children}
-			</Modal.Body>
+			<Modal.Body>{props.children}</Modal.Body>
 			{props.action && (
 				<Modal.Footer>
 					<Action {...props.action} />

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -213,6 +213,8 @@ function Drawer({
 	);
 }
 
+Drawer.displayName = 'Drawer';
+
 Drawer.propTypes = {
 	stacked: PropTypes.bool,
 	title: PropTypes.string,

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -33,6 +33,8 @@ function Emphasis(props) {
 	return <span>{emphasiseAll(props.text, props.value)}</span>;
 }
 
+Emphasis.displayName = 'Emphasis';
+
 Emphasis.propTypes = {
 	value: PropTypes.string,
 	text: PropTypes.string,

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -23,7 +23,11 @@ function emphasiseAll(text, value) {
 		.filter(isNotEmpty)
 		.map((part, index) => {
 			if (part.toUpperCase() === value.toUpperCase()) {
-				return <em key={index} className={theme.highlight}>{part}</em>;
+				return (
+					<em key={index} className={theme.highlight}>
+						{part}
+					</em>
+				);
 			}
 			return part;
 		});

--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -3,10 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { translate } from 'react-i18next';
 
-import {
-	getDefaultTranslate,
-	DEFAULT_I18N,
-} from '../translate';
+import { getDefaultTranslate, DEFAULT_I18N } from '../translate';
 import headerPropTypes from './Header/Header.propTypes';
 import ItemEditPropTypes from './Items/Item/ItemEdit.propTypes';
 import Action from '../Actions/Action';
@@ -16,7 +13,6 @@ import HeaderSelected from './Header/HeaderSelected.component';
 import Items from './Items/Items.component';
 import theme from './Enumeration.scss';
 import I18N_DOMAIN_COMPONENTS from '../constants';
-
 
 const DISPLAY_MODE_DEFAULT = 'DISPLAY_MODE_DEFAULT';
 const DISPLAY_MODE_ADD = 'DISPLAY_MODE_ADD';
@@ -56,16 +52,15 @@ Enumeration.propTypes = {
 	headerDefault: PropTypes.arrayOf(PropTypes.shape(headerPropTypes)).isRequired,
 	headerInput: PropTypes.arrayOf(PropTypes.shape(headerPropTypes)),
 	headerSelected: PropTypes.arrayOf(PropTypes.shape(headerPropTypes)),
-	items: PropTypes.arrayOf(PropTypes.shape({
-		values: PropTypes.arrayOf(PropTypes.string),
-	})).isRequired,
+	items: PropTypes.arrayOf(
+		PropTypes.shape({
+			values: PropTypes.arrayOf(PropTypes.string),
+		}),
+	).isRequired,
 	searchCriteria: PropTypes.string,
 	itemsProp: PropTypes.shape({
 		key: PropTypes.string,
-		getItemHeight: PropTypes.oneOfType([
-			PropTypes.func,
-			PropTypes.number,
-		]),
+		getItemHeight: PropTypes.oneOfType([PropTypes.func, PropTypes.number]),
 		onSubmitItem: PropTypes.func,
 		onChangeItem: PropTypes.func,
 		onSelectItem: PropTypes.func,
@@ -92,12 +87,13 @@ function hintClasses() {
 }
 
 function EmptyListPlaceholder({ displayMode, t }) {
-	return (<p className={hintClasses()}>
-		{ displayMode === DISPLAY_MODE_DEFAULT ?
-				t('ENUMERATION_EMPTY_LIST', { defaultValue: 'The list is empty' }) :
-				t('ENUMERATION_EMPTY_PLACEHOLDER_SEARCH', { defaultValue: 'No results' })
-		}
-	</p>);
+	return (
+		<p className={hintClasses()}>
+			{displayMode === DISPLAY_MODE_DEFAULT
+				? t('ENUMERATION_EMPTY_LIST', { defaultValue: 'The list is empty' })
+				: t('ENUMERATION_EMPTY_PLACEHOLDER_SEARCH', { defaultValue: 'No results' })}
+		</p>
+	);
 }
 
 EmptyListPlaceholder.propTypes = {
@@ -107,15 +103,17 @@ EmptyListPlaceholder.propTypes = {
 
 function ItemsEnumeration(props) {
 	if (props.items.length > 0) {
-		return (<Items
-			items={props.items}
-			itemsProp={props.itemsProp}
-			currentEdit={props.currentEdit}
-			searchCriteria={props.searchCriteria}
-			showCheckboxes={props.showCheckboxes}
-		/>);
+		return (
+			<Items
+				items={props.items}
+				itemsProp={props.itemsProp}
+				currentEdit={props.currentEdit}
+				searchCriteria={props.searchCriteria}
+				showCheckboxes={props.showCheckboxes}
+			/>
+		);
 	}
-	return (<EmptyListPlaceholder displayMode={props.displayMode} t={props.t} />);
+	return <EmptyListPlaceholder displayMode={props.displayMode} t={props.t} />;
 }
 
 ItemsEnumeration.propTypes = {
@@ -128,10 +126,20 @@ ItemsEnumeration.propTypes = {
 };
 
 function HeaderEnumeration({
-		displayMode, headerError, onInputChange, onAddKeyDown,
-		headerInput, headerDefault, headerSelected, items, required,
-		inputValue, inputRef, label, t,
-	}) {
+	displayMode,
+	headerError,
+	onInputChange,
+	onAddKeyDown,
+	headerInput,
+	headerDefault,
+	headerSelected,
+	items,
+	required,
+	inputValue,
+	inputRef,
+	label,
+	t,
+}) {
 	switch (displayMode) {
 		case DISPLAY_MODE_SEARCH: {
 			const propsInput = {
@@ -144,17 +152,16 @@ function HeaderEnumeration({
 			};
 			return <HeaderInput {...propsInput} />;
 		}
-		case DISPLAY_MODE_ADD : {
-			const propsInput =
-				{
-					headerInput,
-					onInputChange,
-					onAddKeyDown,
-					headerError,
-					inputRef,
-					value: inputValue,
-					inputPlaceholder: t('ENUMERATION_NEW_ENTRY', { defaultValue: 'New entry' }),
-				};
+		case DISPLAY_MODE_ADD: {
+			const propsInput = {
+				headerInput,
+				onInputChange,
+				onAddKeyDown,
+				headerError,
+				inputRef,
+				value: inputValue,
+				inputPlaceholder: t('ENUMERATION_NEW_ENTRY', { defaultValue: 'New entry' }),
+			};
 			return <HeaderInput {...propsInput} />;
 		}
 		case DISPLAY_MODE_DEFAULT: {

--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -40,6 +40,8 @@ function Enumeration(props) {
 	);
 }
 
+Enumeration.displayName = 'Enumeration';
+
 Enumeration.propTypes = {
 	displayMode: PropTypes.oneOf([
 		DISPLAY_MODE_DEFAULT,

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -237,6 +237,7 @@ HeaderBar.Search = Search;
 HeaderBar.Help = Help;
 HeaderBar.User = User;
 HeaderBar.Products = Products;
+HeaderBar.getDisplayName = 'Headerbar';
 
 if (process.env.NODE_ENV !== 'production') {
 	Logo.propTypes = {

--- a/packages/components/src/HttpError/HttpError.component.js
+++ b/packages/components/src/HttpError/HttpError.component.js
@@ -7,25 +7,14 @@ import css from './HttpError.scss';
 const className = 'http-error';
 
 function getScopedClassName(scopedClassName = className) {
-	return [
-		css[scopedClassName],
-		scopedClassName,
-	];
+	return [css[scopedClassName], scopedClassName];
 }
 
 function HttpError(props) {
-	const {
-		status,
-		title,
-		message,
-		style,
-	} = props;
+	const { status, title, message, style } = props;
 
 	return (
-		<div
-			className={classNames(getScopedClassName())}
-			data-status={status}
-		>
+		<div className={classNames(getScopedClassName())} data-status={status}>
 			<div
 				className={classNames(getScopedClassName(`${className}-content`), `${className}-${status}`)}
 				style={style}
@@ -43,7 +32,7 @@ HttpError.propTypes = {
 	status: PropTypes.number.isRequired,
 	title: PropTypes.string.isRequired,
 	message: PropTypes.string.isRequired,
-	style: PropTypes.object,  // eslint-disable-line react/forbid-prop-types
+	style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 };
 
 export default HttpError;

--- a/packages/components/src/HttpError/HttpError.component.js
+++ b/packages/components/src/HttpError/HttpError.component.js
@@ -37,6 +37,8 @@ function HttpError(props) {
 	);
 }
 
+HttpError.displayName = 'HttpError';
+
 HttpError.propTypes = {
 	status: PropTypes.number.isRequired,
 	title: PropTypes.string.isRequired,

--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -83,6 +83,8 @@ function Icon({ className, name, title, transform, onClick }) {
 	invariant(true, 'no name provided');
 }
 
+Icon.displayName = 'Icon';
+
 Icon.propTypes = {
 	className: PropTypes.string,
 	name: PropTypes.string.isRequired,

--- a/packages/components/src/IconsProvider/IconsProvider.component.js
+++ b/packages/components/src/IconsProvider/IconsProvider.component.js
@@ -12,11 +12,7 @@ import talendIcons from '@talend/icons/dist/react';
 <IconsProvider />
  */
 function IconsProvider({ defaultIcons, icons }) {
-	const iconset = Object.assign(
-		{},
-		defaultIcons,
-		icons,
-	);
+	const iconset = Object.assign({}, defaultIcons, icons);
 	const ids = Object.keys(iconset);
 	const style = { display: 'none' };
 	return (

--- a/packages/components/src/IconsProvider/IconsProvider.component.js
+++ b/packages/components/src/IconsProvider/IconsProvider.component.js
@@ -30,6 +30,8 @@ function IconsProvider({ defaultIcons, icons }) {
 	);
 }
 
+IconsProvider.displayName = 'IconsProvider';
+
 IconsProvider.propTypes = {
 	defaultIcons: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 	icons: PropTypes.object, // eslint-disable-line react/forbid-prop-types

--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -107,4 +107,6 @@ Inject.getAll = function injectGetAll(getComponent, config) {
 	return components;
 };
 
+Inject.displayName = 'Inject';
+
 export { Inject as default, NotFoundComponent };

--- a/packages/components/src/JSONSchemaRenderer/JSONSchemaRenderer.component.js
+++ b/packages/components/src/JSONSchemaRenderer/JSONSchemaRenderer.component.js
@@ -263,6 +263,8 @@ function JSONSchemaRenderer({ schema, className, ...props }) {
 	);
 }
 
+JSONSchemaRenderer.displayName = 'JSONSchemaRenderer';
+
 JSONSchemaRenderer.propTypes = {
 	schema: PropTypes.shape({ ...SchemaProptypes }),
 	className: PropTypes.string,

--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -56,6 +56,8 @@ function Layout({ header, subHeader, footer, mode, drawers, tabs, children, ...r
 	);
 }
 
+Layout.displayName = 'Layout';
+
 Layout.propTypes = {
 	header: PropTypes.element,
 	footer: PropTypes.element,

--- a/packages/components/src/Layout/OneColumn/OneColumn.component.js
+++ b/packages/components/src/Layout/OneColumn/OneColumn.component.js
@@ -34,6 +34,8 @@ function OneColumn({ drawers, children, tabs, ...props }) {
 	);
 }
 
+OneColumn.displayName = 'OneColumn';
+
 OneColumn.propTypes = {
 	children: PropTypes.node,
 	drawers: PropTypes.arrayOf(PropTypes.node),

--- a/packages/components/src/Layout/OneColumn/OneColumn.component.js
+++ b/packages/components/src/Layout/OneColumn/OneColumn.component.js
@@ -12,10 +12,7 @@ import WithDrawer from '../../WithDrawer';
 <OneColumn name="Hello world"></OneColumn>
  */
 function OneColumn({ drawers, children, tabs, ...props }) {
-	const container = classnames(
-		'tc-layout-one-column',
-		theme.main,
-	);
+	const container = classnames('tc-layout-one-column', theme.main);
 	const style = {
 		overflow: 'auto',
 		height: '100%',
@@ -26,9 +23,7 @@ function OneColumn({ drawers, children, tabs, ...props }) {
 		<div className={container} {...props}>
 			<WithDrawer drawers={drawers}>
 				{tabs && <TabBar {...tabs} />}
-				<div style={style}>
-					{children}
-				</div>
+				<div style={style}>{children}</div>
 			</WithDrawer>
 		</div>
 	);

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
@@ -46,6 +46,8 @@ function TwoColumns({ one, drawers, children, tabs, ...props }) {
 	);
 }
 
+TwoColumns.displayName = 'TwoColumns';
+
 TwoColumns.propTypes = {
 	one: PropTypes.element,
 	children: PropTypes.node,

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
@@ -12,18 +12,9 @@ import theme from './TwoColumns.scss';
 <TwoColumns name="Hello world"></TwoColumns>
  */
 function TwoColumns({ one, drawers, children, tabs, ...props }) {
-	const containerCSS = classnames(
-		'tc-layout-two-columns',
-		theme.container,
-	);
-	const sidemenuCSS = classnames(
-		'tc-layout-two-columns-left',
-		theme.sidemenu,
-	);
-	const mainCSS = classnames(
-		'tc-layout-two-columns-main',
-		theme.main,
-	);
+	const containerCSS = classnames('tc-layout-two-columns', theme.container);
+	const sidemenuCSS = classnames('tc-layout-two-columns-left', theme.sidemenu);
+	const mainCSS = classnames('tc-layout-two-columns-main', theme.main);
 	const style = {
 		overflow: 'auto',
 		height: '100%',
@@ -37,9 +28,7 @@ function TwoColumns({ one, drawers, children, tabs, ...props }) {
 			<div className={mainCSS}>
 				<WithDrawer drawers={drawers}>
 					{tabs && <TabBar {...tabs} />}
-					<div style={style}>
-						{children}
-					</div>
+					<div style={style}>{children}</div>
 				</WithDrawer>
 			</div>
 		</div>

--- a/packages/components/src/List/List.component.js
+++ b/packages/components/src/List/List.component.js
@@ -119,6 +119,8 @@ function List({ displayMode, id, list, toolbar, defaultHeight, renderers, rowHei
 	);
 }
 
+List.displayName = 'List';
+
 List.propTypes = {
 	...ListToolbar.propTypes,
 	renderers: PropTypes.object,

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -33,6 +33,8 @@ function ListView(props) {
 	);
 }
 
+ListView.displayName = 'ListView';
+
 ListView.propTypes = {
 	items: PropTypes.arrayOf(PropTypes.object),
 	t: PropTypes.func,

--- a/packages/components/src/Loader/Loader.component.js
+++ b/packages/components/src/Loader/Loader.component.js
@@ -16,6 +16,8 @@ function Loader({ id, className }) {
 	);
 }
 
+Loader.displayName = 'Loader';
+
 Loader.propTypes = {
 	id: PropTypes.string,
 	className: PropTypes.string,

--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -227,6 +227,8 @@ TimerBar.propTypes = {
 	autoLeaveError: PropTypes.bool,
 };
 
+Notification.displayName = 'Notification';
+
 Notification.propTypes = {
 	notification: PropTypes.shape(notificationShape).isRequired,
 	leaveFn: PropTypes.func.isRequired,
@@ -236,6 +238,8 @@ Notification.propTypes = {
 	onMouseOut: PropTypes.func,
 	onClick: PropTypes.func,
 };
+
+NotificationsContainer.displayName = 'NotificationsContainer';
 
 NotificationsContainer.propTypes = {
 	enterTimeout: PropTypes.number,

--- a/packages/components/src/ObjectViewer/ObjectViewer.component.js
+++ b/packages/components/src/ObjectViewer/ObjectViewer.component.js
@@ -31,6 +31,8 @@ export default function ObjectViewer({ displayMode, ...props }) {
 	}
 }
 
+ObjectViewer.displayName = 'ObjectViewer';
+
 ObjectViewer.propTypes = {
 	displayMode: PropTypes.oneOf(Object.keys(DISPLAY_MODES).map(key => DISPLAY_MODES[key])),
 	tupleLabel: PropTypes.string,

--- a/packages/components/src/Progress/Progress.component.js
+++ b/packages/components/src/Progress/Progress.component.js
@@ -20,18 +20,15 @@ function Progress({ id, percent, tooltip, infinite, contained }) {
 	const normalizedPercent = infinite ? 100 : normalize(percent);
 	const style = { width: `${normalizedPercent}%` };
 
-	const rootClassNames = classNames(
-		theme.progress,
-		{
-			[theme.hidden]: normalizedPercent === 0,
-			[theme.fixed]: !contained,
-			[theme.infinite]: infinite,
-		}
-	);
+	const rootClassNames = classNames(theme.progress, {
+		[theme.hidden]: normalizedPercent === 0,
+		[theme.fixed]: !contained,
+		[theme.infinite]: infinite,
+	});
 
 	let progress = (
 		<div style={style} className={theme['progress-percent']}>
-			{ infinite && <div className={theme['infinite-indicator']} /> }
+			{infinite && <div className={theme['infinite-indicator']} />}
 		</div>
 	);
 
@@ -43,7 +40,11 @@ function Progress({ id, percent, tooltip, infinite, contained }) {
 		);
 	}
 
-	return <div id={id} className={rootClassNames}>{progress}</div>;
+	return (
+		<div id={id} className={rootClassNames}>
+			{progress}
+		</div>
+	);
 }
 
 Progress.displayName = 'Progress';

--- a/packages/components/src/Progress/Progress.component.js
+++ b/packages/components/src/Progress/Progress.component.js
@@ -46,6 +46,8 @@ function Progress({ id, percent, tooltip, infinite, contained }) {
 	return <div id={id} className={rootClassNames}>{progress}</div>;
 }
 
+Progress.displayName = 'Progress';
+
 Progress.propTypes = {
 	id: PropTypes.string,
 	percent: PropTypes.number,

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -160,6 +160,8 @@ function SidePanel({
 	);
 }
 
+SidePanel.displayName = 'SidePanel';
+
 SidePanel.defaultProps = {
 	actions: [],
 	reverse: false,

--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -129,6 +129,8 @@ function getHandle(captionsFormat) {
 
 // eslint-disable-next-line react/prefer-stateless-function
 class Slider extends React.Component {
+	static displayName = 'Slider';
+
 	static propTypes = {
 		id: PropTypes.string,
 		value: PropTypes.number,

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -89,6 +89,8 @@ function Status(props) {
 	);
 }
 
+Status.displayName = 'Status';
+
 Status.propTypes = {
 	status: PropTypes.oneOf([
 		STATUS.IN_PROGRESS,

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -59,17 +59,11 @@ function renderIcon(status, icon, progress) {
 		}
 		return <CircularProgress size={'small'} percent={progress} />;
 	}
-	return (icon && <Icon name={icon} />);
+	return icon && <Icon name={icon} />;
 }
 
 function Status(props) {
-	const {
-		status,
-		label,
-		icon,
-		actions,
-		progress,
-	} = props;
+	const { status, label, icon, actions, progress } = props;
 
 	const rootClassnames = classNames(
 		css['tc-status'],
@@ -79,7 +73,7 @@ function Status(props) {
 	);
 
 	return (
-		<div role="status" className={rootClassnames} >
+		<div role="status" className={rootClassnames}>
 			{renderIcon(status, icon, progress)}
 			<span className={classNames(css['tc-status-label'], 'tc-status-label')}>{label}</span>
 			<span className={classNames(css['tc-status-actions'], 'tc-status-actions')}>
@@ -92,12 +86,7 @@ function Status(props) {
 Status.displayName = 'Status';
 
 Status.propTypes = {
-	status: PropTypes.oneOf([
-		STATUS.IN_PROGRESS,
-		STATUS.SUCCESSFUL,
-		STATUS.FAILED,
-		STATUS.CANCELED,
-	]),
+	status: PropTypes.oneOf([STATUS.IN_PROGRESS, STATUS.SUCCESSFUL, STATUS.FAILED, STATUS.CANCELED]),
 	label: PropTypes.string.isRequired,
 	icon: PropTypes.string,
 	actions: Actions.propTypes.actions,

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
@@ -90,6 +90,8 @@ function SubHeaderBar({ t, onGoBack, componentsCenter, componentsRight, classNam
 	);
 }
 
+SubHeaderBar.displayName = 'SubHeaderBar';
+
 SubHeaderBar.propTypes = {
 	onGoBack: PropTypes.func.isRequired,
 	componentsCenter: PropTypes.array,

--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -38,6 +38,8 @@ function TabBar({ items, onSelect, selected, className }) {
 	);
 }
 
+TabBar.displayName = 'TabBar';
+
 TabBar.propTypes = {
 	items: PropTypes.arrayOf(
 		PropTypes.shape({

--- a/packages/components/src/Toggle/Toggle.component.js
+++ b/packages/components/src/Toggle/Toggle.component.js
@@ -36,6 +36,8 @@ function Toggle({ id, onChange, onBlur, label, checked, autoFocus, disabled, cla
 	);
 }
 
+Toggle.displayName = 'Toggle';
+
 Toggle.defaultProps = {
 	disabled: false,
 	checked: false,

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -25,6 +25,8 @@ const props = {
  */
 class TooltipTrigger extends React.Component {
 
+	static displayName = 'TooltipTrigger';
+
 	constructor(props) {
 		super(props);
 		this.onMouseOver = this.onMouseOver.bind(this);

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { cloneElement } from 'react';
-import {
-	OverlayTrigger,
-	Tooltip,
-} from 'react-bootstrap';
+import { OverlayTrigger, Tooltip } from 'react-bootstrap';
 import uuid from 'uuid';
 import classNames from 'classnames';
 import theme from './TooltipTrigger.scss';
@@ -24,7 +21,6 @@ const props = {
 </TooltipTrigger>
  */
 class TooltipTrigger extends React.Component {
-
 	static displayName = 'TooltipTrigger';
 
 	constructor(props) {
@@ -54,27 +50,23 @@ class TooltipTrigger extends React.Component {
 		if (!this.state.hovered) {
 			const child = React.Children.only(this.props.children);
 			const childProps = child.props;
-			const triggerProps = Object.assign({
-				onMouseOver: this.onMouseOver,
-				onFocus: this.onMouseOver,
-			}, childProps);
+			const triggerProps = Object.assign(
+				{
+					onMouseOver: this.onMouseOver,
+					onFocus: this.onMouseOver,
+				},
+				childProps,
+			);
 			return cloneElement(child, triggerProps);
 		}
 		const tooltip = (
-			<Tooltip
-				className={getTooltipClass()}
-				id={this.state.id}
-			>
+			<Tooltip className={getTooltipClass()} id={this.state.id}>
 				{this.props.label}
 			</Tooltip>
 		);
 		// TODO jmfrancois : render the Tooltip in a provider so use context for that.
 		return (
-			<OverlayTrigger
-				placement={this.props.tooltipPlacement}
-				overlay={tooltip}
-				delayShow={400}
-			>
+			<OverlayTrigger placement={this.props.tooltipPlacement} overlay={tooltip} delayShow={400}>
 				{this.props.children}
 			</OverlayTrigger>
 		);

--- a/packages/components/src/TreeView/TreeView.component.js
+++ b/packages/components/src/TreeView/TreeView.component.js
@@ -105,6 +105,8 @@ function TreeView({
 	);
 }
 
+TreeView.displayName = 'TreeView';
+
 TreeView.propTypes = {
 	id: PropTypes.string,
 	headerText: PropTypes.string,

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -105,6 +105,8 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 	);
 }
 
+Typeahead.displayName = 'Typeahead';
+
 Typeahead.defaultProps = {
 	autoFocus: true,
 	disabled: false,

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -34,9 +34,9 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 		);
 	}
 
-	const sectionProps = rest.multiSection ?
-		{ getSectionItems: section => section.suggestions, renderSectionTitle } :
-		null;
+	const sectionProps = rest.multiSection
+		? { getSectionItems: section => section.suggestions, renderSectionTitle }
+		: null;
 
 	const themeProps = {
 		theme: {
@@ -51,7 +51,7 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 			...rest.theme,
 			container: classNames(
 				theme['tc-typeahead-container'],
-				(position === 'right') && theme.right,
+				position === 'right' && theme.right,
 				rest.theme && rest.theme.container,
 				rest.className,
 			),
@@ -83,7 +83,7 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 			rest.items,
 			rest.noResultText,
 			rest.searching,
-			rest.searchingText
+			rest.searchingText,
 		),
 		renderItemData: { value: rest.value },
 	};
@@ -100,9 +100,7 @@ function Typeahead({ onToggle, icon, position, ...rest }) {
 		},
 	};
 
-	return (
-		<Autowhatever {...autowhateverProps} />
-	);
+	return <Autowhatever {...autowhateverProps} />;
 }
 
 Typeahead.displayName = 'Typeahead';
@@ -169,7 +167,7 @@ Typeahead.propTypes = {
 					}),
 				),
 			}),
-		])
+		]),
 	),
 };
 

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -46,6 +46,8 @@ function WithDrawer({ drawers, children }) {
 	);
 }
 
+WithDrawer.displayName = 'WithDrawer';
+
 WithDrawer.propTypes = {
 	drawers: PropTypes.arrayOf(PropTypes.element),
 	children: PropTypes.node,

--- a/packages/containers/src/HeaderBar/HeaderBar.component.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.component.js
@@ -15,4 +15,6 @@ function HeaderBar(props) {
 	return <PureHeaderBar renderers={getRenderers(renderers)} {...props} />;
 }
 
+HeaderBar.displayName = 'Container(HeaderBar)';
+
 export default cmfConnect({})(HeaderBar);

--- a/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
+++ b/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
@@ -72,7 +72,7 @@ exports[`Component HomeListView should render with object props 1`] = `
     ]
   }
   header={
-    <Connect(CMF(HeaderBar))
+    <Connect(CMF(Container(HeaderBar)))
       app="hello app"
     />
   }

--- a/packages/containers/src/Redirect/Redirect.container.js
+++ b/packages/containers/src/Redirect/Redirect.container.js
@@ -32,4 +32,6 @@ RedirectContainer.contextTypes = {
 	store: PropTypes.object.isRequired,
 };
 
+RedirectContainer.displayName = 'RedirectContainer';
+
 export default cmfConnect({})(RedirectContainer);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For some container CMF is not able to auto injects props configuration because component didn't have display name, so this failled in production environnement.

**What is the chosen solution to this problem?**
Add `displayName` to container who missed them.
Took time to add more display names to components.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

