### PR TITLE
chore(cmf): refactor actionCreator api

### DIFF
--- a/packages/cmf/__tests__/action.test.js
+++ b/packages/cmf/__tests__/action.test.js
@@ -32,21 +32,7 @@ describe('CMF action', () => {
 		expect(Array.isArray(actions)).toBe(true);
 		expect(actions.length === 0).toBe(true);
 	});
-	it('getActionCreatorFunction should return a function', () => {
-		const id = 'myactioncreator';
 
-		function creator() {}
-		context.registry = {};
-		context.registry[`actionCreator:${id}`] = creator;
-		const actionCreator = actionAPI.getActionCreatorFunction(context, id);
-		expect(typeof actionCreator).toBe('function');
-	});
-	it('getActionCreatorFunction should throw an error', () => {
-		const id = 'myactioncreator';
-		context.registry = {};
-		const test = () => actionAPI.getActionCreatorFunction(context, id);
-		expect(test).toThrowError(`actionCreator not found in the registry: ${id}`);
-	});
 	it('getActionInfo should return an object', () => {
 		const id = 'menu:article';
 		const action = actionAPI.getActionInfo(context, id);
@@ -92,9 +78,12 @@ describe('CMF action', () => {
 		};
 		context.registry = {};
 		context.registry['actionCreator:myActionCreator'] = function creator() {
-			return Object.assign({
-				data: true,
-			}, settings.actions.myaction);
+			return Object.assign(
+				{
+					data: true,
+				},
+				settings.actions.myaction,
+			);
 		};
 		const id = 'myaction';
 		const action = actionAPI.getActionObject(context, id);

--- a/packages/cmf/__tests__/actionCreator.test.js
+++ b/packages/cmf/__tests__/actionCreator.test.js
@@ -1,0 +1,26 @@
+import mock from '../src/mock';
+import actionCreatorAPI from '../src/actionCreator';
+
+describe('CMF action', () => {
+	let context;
+
+	beforeEach(() => {
+		context = mock.context();
+	});
+
+	it('get should return a function', () => {
+		const id = 'myactioncreator';
+
+		function creator() {}
+		context.registry = {};
+		context.registry[`actionCreator:${id}`] = creator;
+		const actionCreator = actionCreatorAPI.get(context, id);
+		expect(typeof actionCreator).toBe('function');
+	});
+	it('get should throw an error', () => {
+		const id = 'myactioncreator';
+		context.registry = {};
+		const test = () => actionCreatorAPI.get(context, id);
+		expect(test).toThrowError(`actionCreator not found in the registry: ${id}`);
+	});
+});

--- a/packages/cmf/src/action.js
+++ b/packages/cmf/src/action.js
@@ -1,6 +1,6 @@
 import get from 'lodash/get';
-import registry from './registry';
-import CONST from './constant';
+import deprecated from './deprecated';
+import actionCreatorAPI from './actionCreator';
 
 /**
  * This module provide low level api to register and handle action in a CMF App.
@@ -28,20 +28,6 @@ function getActionsById(context) {
 function getContentTypeActions(context, contentType, category) {
 	const state = context.store.getState();
 	return get(state, `cmf.settings.contentTypes[${contentType}.actions[${category}]`, []);
-}
-
-/**
- * return a function from the registry
- * @param  {object} context
- * @param  {string} id the id of the action creator
- * @return {function}
- */
-function getActionCreatorFunction(context, id) {
-	const creator = context.registry[`${CONST.REGISTRY_ACTION_CREATOR_PREFIX}:${id}`];
-	if (!creator) {
-		throw new Error(`actionCreator not found in the registry: ${id}`);
-	}
-	return creator;
 }
 
 /**
@@ -74,7 +60,7 @@ function getActionObject(context, action, event, data) {
 		actionInfo = action;
 	}
 	if (actionInfo.actionCreator) {
-		const actionCreator = getActionCreatorFunction(context, actionInfo.actionCreator);
+		const actionCreator = actionCreatorAPI.get(context, actionInfo.actionCreator);
 		return actionCreator(event, data, {
 			getState: context.store.getState,
 			router: context.router,
@@ -119,18 +105,15 @@ function mapDispatchToProps(dispatch, props) {
 	return Object.assign({}, props, resolvedActions);
 }
 
-/**
- * register your action creator. The action creator is a function with
- * the following arguments:
- * - event which trigger this action
- * - data attached to the action (could contains anything)
- * - context of the current react app (could contains registry, getState, ...)
- * @param  {String} id
- * @param  {Function} actionCreator (event, data, context)
- */
-function registerActionCreator(id, actionCreator, context) {
-	registry.addToRegistry(`${CONST.REGISTRY_ACTION_CREATOR_PREFIX}:${id}`, actionCreator, context);
-}
+const registerActionCreator = deprecated(
+	(id, actionCreator, context) => actionCreatorAPI.register(id, actionCreator, context),
+	'stop use api.action.registerActionCreator. please use api.actionCreator.register',
+);
+
+const getActionCreatorFunction = deprecated(
+	(context, id) => actionCreatorAPI.get(context, id),
+	'stop use api.action.getActionCreatorFunction. please use api.actionCreator.get',
+);
 
 export default {
 	getActionsById,

--- a/packages/cmf/src/actionCreator.js
+++ b/packages/cmf/src/actionCreator.js
@@ -1,0 +1,46 @@
+import registry from './registry';
+import CONST from './constant';
+
+/**
+ * return a function from the registry
+ * @param  {object} context
+ * @param  {string} id the id of the action creator
+ * @return {function}
+ */
+function get(context, id) {
+	const creator = context.registry[`${CONST.REGISTRY_ACTION_CREATOR_PREFIX}:${id}`];
+	if (!creator) {
+		throw new Error(`actionCreator not found in the registry: ${id}`);
+	}
+	return creator;
+}
+
+/**
+ * register your action creator. The action creator is a function with
+ * the following arguments:
+ * - event which trigger this action
+ * - data attached to the action (could contains anything)
+ * - context of the current react app (could contains registry, getState, ...)
+ * @param  {String} id
+ * @param  {Function} actionCreator (event, data, context)
+ */
+function register(id, actionCreator, context) {
+	registry.addToRegistry(`${CONST.REGISTRY_ACTION_CREATOR_PREFIX}:${id}`, actionCreator, context);
+}
+
+/**
+ * This function allow to register an object with some action creators
+ * @param {object} actionCreators map of action creators
+ * @param {object} context optional context to get the registry
+ */
+function registerMany(actionCreators, context) {
+	Object.keys(actionCreators).forEach(key => {
+		register(key, actionCreators[key], context);
+	});
+}
+
+export default {
+	get,
+	register,
+	registerMany,
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, we use action api to register / get the actionCreator.
But actions is not the same concept as actioncreator
**What is the chosen solution to this problem?**
Create an action creator api

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

