### PR TITLE
feat(cmf/sagaRouter): add isExact param

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.141.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.142.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
@@ -17,8 +17,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   50:4  warning  Unexpected console statement  no-console
 
 /home/travis/build/Talend/ui/packages/cmf/src/sagaRouter/router.js
-  153:54  error  There should be no spaces inside this paren  space-in-parens
-  166:51  error  There should be no spaces inside this paren  space-in-parens
+  149:2   warning  Unexpected constant condition                no-constant-condition
+  154:54  error    There should be no spaces inside this paren  space-in-parens
+  167:51  error    There should be no spaces inside this paren  space-in-parens
 
-✖ 6 problems (2 errors, 4 warnings)
+✖ 7 problems (2 errors, 5 warnings)
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.141.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.142.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.141.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.142.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.141.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.142.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.141.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.142.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.141.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.142.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.141.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.142.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/sagas.eslint.txt
+++ b/output/sagas.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-sagas@0.141.0 lint:es /home/travis/build/Talend/ui/packages/sagas
+> @talend/react-sagas@0.142.0 lint:es /home/travis/build/Talend/ui/packages/sagas
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.141.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.142.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/cmf/__tests__/sagaRouter/router.test.js
+++ b/packages/cmf/__tests__/sagaRouter/router.test.js
@@ -20,14 +20,16 @@ describe('sagaRouter RouteChange', () => {
 			},
 		};
 		const routes = {
-			'/matchingroute': function* matchingSaga() {
-				yield take('SOMETHING');
+			'/matchingroute': function* matchingSaga(notUsed, isExact) {
+				if (isExact) {
+					yield take('SOMETHING');
+				}
 			},
 		};
 		const gen = sagaRouter(mockHistory, routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute'], {})
+			spawn(routes['/matchingroute'], {}, true)
 		);
 	});
 
@@ -40,14 +42,17 @@ describe('sagaRouter RouteChange', () => {
 			},
 		};
 		const routes = {
-			'/matchingroute': function* matchingSaga() {
+			'/matchingroute': function* matchingSaga(notused, isExact) {
+				if (isExact) {
+					yield take({ type: 'NOT_DISPATCHED' });
+				}
 				yield take('SOMETHING');
 			},
 		};
 		const gen = sagaRouter(mockHistory, routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute'], {})
+			spawn(routes['/matchingroute'], {}, false)
 		);
 	});
 
@@ -77,7 +82,7 @@ describe('sagaRouter RouteChange', () => {
 		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute'], {})
+			spawn(routes['/matchingroute'], {}, true)
 		);
 		expect(gen.next(mockTask).value).toEqual(take('@@router/LOCATION_CHANGE'));
 		// since the saga should be kept running the router to be able to handle a new route change
@@ -111,7 +116,7 @@ describe('sagaRouter RouteChange', () => {
 		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute'], {})
+			spawn(routes['/matchingroute'], {}, true)
 		);
 		expect(gen.next(mockTask).value).toEqual(take('@@router/LOCATION_CHANGE'));
 		const expectedCancelYield = cancel(mockTask);
@@ -147,7 +152,7 @@ describe('sagaRouter RouteChange', () => {
 		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/toCancelFirst'], {})
+			spawn(routes['/toCancelFirst'], {}, true)
 		);
 		expect(gen.next(mockTask).value).toEqual(take('@@router/LOCATION_CHANGE'));
 		const expectedCancelYield = cancel(mockTask);
@@ -165,7 +170,7 @@ describe('sagaRouter RouteChange', () => {
 		const anotherGen = sagaRouter(getMockedHistory(), alternateRoutes);
 		expect(anotherGen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(anotherGen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(alternateRoutes['/toCancelFirst'], {})
+			spawn(alternateRoutes['/toCancelFirst'], {}, true)
 		);
 		expect(anotherGen.next(mockTask).value).toEqual(take('@@router/LOCATION_CHANGE'));
 		const anotherExpectedCancelYield = cancel(mockTask);
@@ -199,7 +204,7 @@ describe('sagaRouter route and route params', () => {
 		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute/:id'], { id: 'anId' })
+			spawn(routes['/matchingroute/:id'], { id: 'anId' }, true)
 		);
 	});
 
@@ -229,11 +234,11 @@ describe('sagaRouter route and route params', () => {
 		const gen = sagaRouter(getMockedHistory(), routes);
 		expect(gen.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(
-			spawn(routes['/matchingroute/:id'], { id: 'anId' })
+			spawn(routes['/matchingroute/:id'], { id: 'anId' }, true)
 		);
 		expect(gen.next(mockTask).value).toEqual(take('@@router/LOCATION_CHANGE'));
 		const expectedCancelYield = cancel(mockTask);
 		expect(gen.next({ type: '@@router/LOCATION_CHANGE' }).value).toEqual(expectedCancelYield);
-		expect(gen.next().value).toEqual(spawn(routes['/matchingroute/:id'], { id: 'anotherId' }));
+		expect(gen.next().value).toEqual(spawn(routes['/matchingroute/:id'], { id: 'anotherId' }, true));
 	});
 });

--- a/packages/cmf/src/sagaRouter/index.md
+++ b/packages/cmf/src/sagaRouter/index.md
@@ -46,3 +46,27 @@ const routes = {
 // router saga is forked and given router history, and route configuration
 yield fork(routerSaga, history, routes);
 ```
+
+### Match exact route
+
+```javascript
+import { sagaRouter } from '@talend/react-cmf';
+import { browserHistory as history } from 'react-router';
+
+const CANCEL_ACTION = 'CANCEL_ACTION';
+// route configuration, a url fragment match with a generator
+const routes = {
+  "/datasets/add": function* addDataset(notUsed, isExact) {
+    if (!isExact) {
+      return;
+    }
+    yield take(CANCEL_ACTION);
+    yield put({
+      type: REDIRECT_CONNECTION_ADD_DATASET_CANCEL,
+      cmf: {
+        routerReplace: `/connections/${datastoreId}/edit`
+      }
+    });
+  },
+};
+```

--- a/packages/cmf/src/sagaRouter/router.js
+++ b/packages/cmf/src/sagaRouter/router.js
@@ -163,10 +163,10 @@ export default function* sagaRouter(history, routes) {
 			}
 			index += 1;
 		}
-		for (let index = 0; index < shouldStart.length; ) {
+		for (let index = 0; index < shouldStart.length;) {
 			const { routeFragment, match } = shouldStart[index];
 			sagas[routeFragment] = {
-				saga: yield spawn(routes[routeFragment], match.params),
+				saga: yield spawn(routes[routeFragment], match.params, match.isExact),
 				match,
 			};
 			index += 1;

--- a/packages/cmf/src/sagaRouter/router.js
+++ b/packages/cmf/src/sagaRouter/router.js
@@ -146,7 +146,8 @@ function parseSagaState(routeFragment, sagas, currentLocation) {
 export default function* sagaRouter(history, routes) {
 	const sagas = {};
 	const routeFragments = Object.keys(routes);
-	while (true) {  // eslint-disable-line no-constant-condition
+	while (true) {
+		// eslint-disable-line no-constant-condition
 		yield take('@@router/LOCATION_CHANGE');
 		const shouldStart = [];
 		const currentLocation = history.getCurrentLocation();
@@ -163,7 +164,7 @@ export default function* sagaRouter(history, routes) {
 			}
 			index += 1;
 		}
-		for (let index = 0; index < shouldStart.length;) {
+		for (let index = 0; index < shouldStart.length; ) {
 			const { routeFragment, match } = shouldStart[index];
 			sagas[routeFragment] = {
 				saga: yield spawn(routes[routeFragment], match.params, match.isExact),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If you defined a router saga on `/resources` and `/resources/:id`, and then when you access `/resources/:id`, saga of /resources will be triggered too.

No way to know if you are on one or the children route.

**What is the chosen solution to this problem?**

add ìsExact` param

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

