### PR TITLE
feat(UIForms): add columns common title

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.js
@@ -10,11 +10,11 @@ export default function Columns(props) {
 
 	return (
 		<div className={classNames('tf-columns', theme['tf-columns'])}>
-			{schema.title && (<legend>{schema.title}</legend>)}
+			{schema.title && <legend>{schema.title}</legend>}
 			<div className={classNames('tf-columns-items', theme.items)}>
-				{schema.items.map(
-					(colSchema, index) => (<Widget {...restProps} key={index} schema={colSchema} />)
-				)}
+				{schema.items.map((colSchema, index) => (
+					<Widget {...restProps} key={index} schema={colSchema} />
+				))}
 			</div>
 		</div>
 	);

--- a/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.js
@@ -10,9 +10,12 @@ export default function Columns(props) {
 
 	return (
 		<div className={classNames('tf-columns', theme['tf-columns'])}>
-			{schema.items.map(
-				(colSchema, index) => (<Widget {...restProps} key={index} schema={colSchema} />)
-			)}
+			{schema.title && (<legend>{schema.title}</legend>)}
+			<div className={classNames('tf-columns-items', theme.items)}>
+				{schema.items.map(
+					(colSchema, index) => (<Widget {...restProps} key={index} schema={colSchema} />)
+				)}
+			</div>
 		</div>
 	);
 }

--- a/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/Columns/Columns.component.test.js
@@ -49,6 +49,7 @@ describe('Columns widget', () => {
 		const schema = {
 			widget: 'columns',
 			items: columns,
+			title: 'My awesome columns',
 		};
 
 		// when

--- a/packages/forms/src/UIForm/fieldsets/Columns/Columns.scss
+++ b/packages/forms/src/UIForm/fieldsets/Columns/Columns.scss
@@ -1,13 +1,15 @@
 .tf-columns {
-	display: flex;
-	flex-wrap: wrap;
-	margin-left: -$padding-normal;
-	margin-top: -$padding-normal;
+	.items {
+		display: flex;
+		flex-wrap: wrap;
+		margin-left: -$padding-normal;
+		margin-top: -$padding-normal;
 
-	> * {
-		flex: 1;
-		margin-left: $padding-normal;
-		margin-top: $padding-normal;
-		min-width: 30rem;
+		> * {
+			flex: 1;
+			margin-left: $padding-normal;
+			margin-top: $padding-normal;
+			min-width: 30rem;
+		}
 	}
 }

--- a/packages/forms/src/UIForm/fieldsets/Columns/README.md
+++ b/packages/forms/src/UIForm/fieldsets/Columns/README.md
@@ -38,11 +38,13 @@ This widget allows you to columns containing widgets/fields.
 |---|---|
 | widget | `columns` |
 | items | An array of field/fieldset definitions |
+| title | A title to set on top of the row of columns |
 
 ```json
 [
   {
     "widget": "columns",
+    "title": "My awesome columns",
     "items": [
       {
         "widget": "fieldset",

--- a/packages/forms/src/UIForm/fieldsets/Columns/__snapshots__/Columns.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Columns/__snapshots__/Columns.component.test.js.snap
@@ -4,69 +4,76 @@ exports[`Columns widget should render columns 1`] = `
 <div
   className="tf-columns"
 >
-  <Widget
-    schema={
-      Object {
-        "items": Array [
-          Object {
-            "description": "Hint: this is the last name",
-            "key": Array [
-              "lastname",
-            ],
-            "ngModelOptions": Object {},
-            "schema": Object {
-              "type": "string",
+  <legend>
+    My awesome columns
+  </legend>
+  <div
+    className="tf-columns-items"
+  >
+    <Widget
+      schema={
+        Object {
+          "items": Array [
+            Object {
+              "description": "Hint: this is the last name",
+              "key": Array [
+                "lastname",
+              ],
+              "ngModelOptions": Object {},
+              "schema": Object {
+                "type": "string",
+              },
+              "title": "Last Name (with description)",
+              "type": "text",
             },
-            "title": "Last Name (with description)",
-            "type": "text",
-          },
-          Object {
-            "key": Array [
-              "firstname",
-            ],
-            "ngModelOptions": Object {},
-            "placeholder": "Enter your firstname here",
-            "required": true,
-            "schema": Object {
-              "type": "string",
+            Object {
+              "key": Array [
+                "firstname",
+              ],
+              "ngModelOptions": Object {},
+              "placeholder": "Enter your firstname here",
+              "required": true,
+              "schema": Object {
+                "type": "string",
+              },
+              "title": "First Name (with placeholder)",
+              "type": "text",
             },
-            "title": "First Name (with placeholder)",
-            "type": "text",
-          },
-          Object {
-            "key": Array [
-              "age",
-            ],
-            "ngModelOptions": Object {},
-            "schema": Object {
+            Object {
+              "key": Array [
+                "age",
+              ],
+              "ngModelOptions": Object {},
+              "schema": Object {
+                "type": "number",
+              },
+              "title": "Age",
               "type": "number",
             },
-            "title": "Age",
-            "type": "number",
+          ],
+          "title": "User Fieldset",
+          "widget": "fieldset",
+        }
+      }
+      widgets={Object {}}
+    />
+    <Widget
+      schema={
+        Object {
+          "description": "This one is a column composed by a single input",
+          "key": Array [
+            "singleInput",
+          ],
+          "ngModelOptions": Object {},
+          "schema": Object {
+            "type": "string",
           },
-        ],
-        "title": "User Fieldset",
-        "widget": "fieldset",
+          "title": "singleInput",
+          "type": "text",
+        }
       }
-    }
-    widgets={Object {}}
-  />
-  <Widget
-    schema={
-      Object {
-        "description": "This one is a column composed by a single input",
-        "key": Array [
-          "singleInput",
-        ],
-        "ngModelOptions": Object {},
-        "schema": Object {
-          "type": "string",
-        },
-        "title": "singleInput",
-        "type": "text",
-      }
-    }
-    widgets={Object {}}
-  />
+      widgets={Object {}}
+    />
+  </div>
 </div>
 `;

--- a/packages/forms/stories-core/json/fieldsets/core-columns.json
+++ b/packages/forms/stories-core/json/fieldsets/core-columns.json
@@ -41,6 +41,7 @@
   "uiSchema": [
     {
       "widget": "columns",
+      "title": "My awesome columns",
       "items": [
         {
           "widget": "fieldset",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
*WARNING: this fix is only on UIForms, not the current forms*

Columns is only a box manager, but when we want a common title on top of a row of columns, the only solution is to set the title on the first columns.  
But doing that makes the columns inputs not aligned anymore.

**What is the chosen solution to this problem?**
Columns widget now accepts and displays a title, like any other "fieldset" widget.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

