### PR TITLE
fix(containers/form): add back ArrayFieldTemplate customisation in container

### DIFF
--- a/packages/containers/src/Form/Form.container.js
+++ b/packages/containers/src/Form/Form.container.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { Map } from 'immutable';
 import { componentState } from '@talend/react-cmf';
 import ComponentForm from '@talend/react-forms';
-import ArrayFieldTemplate from '@talend/react-forms/lib/templates/ArrayFieldTemplate';
+import DefaultArrayFieldTemplate from '@talend/react-forms/lib/templates/ArrayFieldTemplate';
 import classnames from 'classnames';
 
 export const DEFAULT_STATE = new Map({});
@@ -125,6 +125,7 @@ class Form extends React.Component {
 			dirty: state.dirty,
 			pristine: !state.dirty,
 		});
+		const ArrayFieldTemplate = this.props.ArrayFieldTemplate || DefaultArrayFieldTemplate;
 		return (
 			<ComponentForm
 				ArrayFieldTemplate={ArrayFieldTemplate}

--- a/packages/containers/src/Form/Form.md
+++ b/packages/containers/src/Form/Form.md
@@ -1,0 +1,19 @@
+# FormContainer
+
+## override default ArrayFieldTemplate
+
+in same fashion as the wrapped form component
+the default ArrayFieldTemplate can be overided by a custom one
+to do this simply pass the desired ArrayFieldTemplate to the Form#ArrayFieldTemplate props.
+
+```javascript
+<Container
+	ArrayFieldTemplate="ArrayFieldTemplate"
+	formId="test-form"
+	jsonSchema={{ schema: true }}
+	uiSchema={{ uiSchema: true }}
+	actions={[]}
+	className="foo"
+	formProps={{ other: true }} // extra props
+/>
+```

--- a/packages/containers/src/Form/Form.md
+++ b/packages/containers/src/Form/Form.md
@@ -8,7 +8,7 @@ to do this simply pass the desired ArrayFieldTemplate to the Form#ArrayFieldTemp
 
 ```javascript
 <Container
-	ArrayFieldTemplate="ArrayFieldTemplate"
+	ArrayFieldTemplate={ArrayFieldTemplate}
 	formId="test-form"
 	jsonSchema={{ schema: true }}
 	uiSchema={{ uiSchema: true }}

--- a/packages/containers/src/Form/Form.test.js
+++ b/packages/containers/src/Form/Form.test.js
@@ -147,6 +147,22 @@ describe('Container(Form)', () => {
 		});
 		expect(form.uiSchema()).toBe(uiSchema);
 	});
+
+	it('use ArrayFieldTemplate given by props over default ArrayFieldTemplate', () => {
+		const wrapper = shallow(
+			<Container
+				ArrayFieldTemplate="ArrayFieldTemplate"
+				formId="test-form"
+				jsonSchema={{ schema: true }}
+				uiSchema={{ uiSchema: true }}
+				actions={[]}
+				className="foo"
+				formProps={{ other: true }} // extra props
+			/>,
+		);
+		const props = wrapper.props();
+		expect(props).toHaveProperty('ArrayFieldTemplate', 'ArrayFieldTemplate');
+	});
 });
 
 describe('Connected Form', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Overiding default ArrayFieldTemplate is no more available from the FormContainer, this was not spotted in regression testing in datastreams because the new default template was exactly the one we used.

**What is the chosen solution to this problem?**
add inside the render if a Form#ArrayFieldTemplate props is present and use it over the default ArrayFieldTemplate if available.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

