### PR TITLE
fix(components/Sidepanel): dock icon don't rotate anymore

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.143.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.145.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.143.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.145.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.143.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.145.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.143.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.145.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.143.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.145.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.143.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.145.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.143.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.145.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/sagas.eslint.txt
+++ b/output/sagas.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-sagas@0.143.0 lint:es /home/travis/build/Talend/ui/packages/sagas
+> @talend/react-sagas@0.145.0 lint:es /home/travis/build/Talend/ui/packages/sagas
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.143.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.145.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -151,17 +151,14 @@ $toggle-button-padding: $padding-small - 1;
 			:global(.btn.btn-link) {
 				padding: $padding-normal;
 			}
-
-			.toggle-btn {
-				:global(.tc-svg-icon) {
-					transform: rotate(-180deg);
-				}
-			}
 		}
 
 		.toggle-btn {
 			:global(.btn.btn-link) {
 				padding: $padding-small;
+				:global(.tc-svg-icon) {
+					transform: rotate(-180deg);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dock icon is not rotated when sidepanel is docked
<img width="57" alt="capture d ecran 2018-01-17 a 11 26 51" src="https://user-images.githubusercontent.com/2909671/35037962-62c753f6-fb79-11e7-8932-14d5ec5171fd.png">

**What is the chosen solution to this problem?**
rotate it !
<img width="55" alt="capture d ecran 2018-01-17 a 11 27 00" src="https://user-images.githubusercontent.com/2909671/35037986-7a06e1b2-fb79-11e7-8849-b3fedb41f367.png">

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

