### PR TITLE
fix(SidePanel): non bold font on active

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -63,9 +63,6 @@ $toggle-button-padding: $padding-small - 1;
 					color: $brand-primary;
 				}
 			}
-			:global(.btn.btn-link) {
-				font-weight: bold;
-			}
 		}
 
 		.tc-side-panel-list-item:hover {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The active element on side panel is bold.
The [guideline](https://company-57688.frontify.com/document/92132#/navigation-layout/side-panel-main-menu) says the reverse

**What is the chosen solution to this problem?**
Remove the bold style.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

