### PR TITLE
feat(cmf): add schema to validate settings

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -14,11 +14,12 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   23:2  warning  Unexpected console statement  no-console
 
 /home/travis/build/Talend/ui/packages/cmf/src/reducers/settingsReducers.js
-  50:4  warning  Unexpected console statement  no-console
+   7:1  error    'tv4' should be listed in the project's dependencies. Run 'npm i -S tv4' to add it  import/no-extraneous-dependencies
+  74:4  warning  Unexpected console statement                                                        no-console
 
 /home/travis/build/Talend/ui/packages/cmf/src/sagaRouter/router.js
   153:54  error  There should be no spaces inside this paren  space-in-parens
   166:51  error  There should be no spaces inside this paren  space-in-parens
 
-✖ 6 problems (2 errors, 4 warnings)
+✖ 7 problems (3 errors, 4 warnings)
 

--- a/packages/cmf/src/api.js
+++ b/packages/cmf/src/api.js
@@ -29,12 +29,14 @@ import actionCreator from './actionCreator';
 import expression from './expression';
 import saga from './saga';
 import component from './component';
+import schema from './schema';
 
 export default {
 	action,
 	actions,
 	actionCreator,
 	component,
+	schema,
 	expression,
 	route,
 	registry,

--- a/packages/cmf/src/component.js
+++ b/packages/cmf/src/component.js
@@ -49,7 +49,7 @@ function register(id, component, context) {
 	}
 	if (component.schema) {
 		Object.keys(component.schema).forEach(key => {
-			schema.register(key, component.schema, context)
+			schema.register(key, component.schema, context);
 		});
 	}
 }

--- a/packages/cmf/src/component.js
+++ b/packages/cmf/src/component.js
@@ -2,6 +2,7 @@ import invariant from 'invariant';
 import action from './action';
 import expression from './expression';
 import registry from './registry';
+import schema from './schema';
 import CONST from './constant';
 
 /**
@@ -44,6 +45,11 @@ function register(id, component, context) {
 	if (component.expressions) {
 		Object.keys(component.expressions).forEach(key => {
 			expression.register(key, component.expressions[key], context);
+		});
+	}
+	if (component.schema) {
+		Object.keys(component.schema).forEach(key => {
+			schema.register(key, component.schema, context)
 		});
 	}
 }

--- a/packages/cmf/src/schema.js
+++ b/packages/cmf/src/schema.js
@@ -1,0 +1,16 @@
+import registry from './registry';
+
+const SCHEMA_PREFIX = 'Schema';
+
+function register(id, schema) {
+	registry.register(`${SCHEMA_PREFIX}:${id}`, schema);
+}
+
+function get(id, context) {
+	registry.getFromRegistry(`${SCHEMA_PREFIX}:${id}`, context);
+}
+
+export default {
+	register,
+	get,
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

settings are fetched via json.
This is pretty hard to follow and validate when props changes.
from the beginning we want a validation schema.

**What is the chosen solution to this problem?**

Add a schema registry so you can register schema for external components
Let thoses schema being auto registred if attached to the component.
Think many schema can be registred and will be taken by id.
`Container(SidePanel)#validation` will be looked up to validate the settings for `Container(SidePanel)` component.

This will be the same for the `"props"` id which is `Container(SidePanel)#default`

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

