### PR TITLE
fix(icons): fixing svg#g#fill-rules value for AWS-kinesis

### DIFF
--- a/packages/components/src/IconsProvider/__snapshots__/IconsProvider.test.js.snap
+++ b/packages/components/src/IconsProvider/__snapshots__/IconsProvider.test.js.snap
@@ -172,7 +172,7 @@ exports[`IconsProvider should render default talend-icons 1`] = `
         <g
           className="ti-kinesis-brand-lighter-color"
           fill="#86A6BF"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M1.364 11.516l6.634 2.204 6.793-2.204L8.01 9.883zm-.001-2.418l6.639.681 6.789-.681-6.789-.366zm12.683-1.032h-3.545V5.11l3.545-.928z"
@@ -187,7 +187,7 @@ exports[`IconsProvider should render default talend-icons 1`] = `
         <g
           className="ti-kinesis-brand-plain-color"
           fill="#5D88AA"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M8.002 13.719v2.28l6.79-3.144v-1.34zm0-3.963v2.281l6.79-1.597V9.099zm6.045-1.689h.747V4.485l-.747-.304zm-1.544 0h.902V4.949l-.902-.31zm-.93 0h-1.057V2.784l1.057.464zM8.002 0v8.068h1.34V.774z"
@@ -196,7 +196,7 @@ exports[`IconsProvider should render default talend-icons 1`] = `
         <g
           className="ti-kinesis-brand-darker-color"
           fill="#46667F"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M1.362 12.855L8.002 16v-2.282l-6.64-2.203zm0-2.415l6.64 1.597V9.756l-6.64-.657z"
@@ -2956,7 +2956,7 @@ exports[`IconsProvider should render default talend-icons and custom icons defin
         <g
           className="ti-kinesis-brand-lighter-color"
           fill="#86A6BF"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M1.364 11.516l6.634 2.204 6.793-2.204L8.01 9.883zm-.001-2.418l6.639.681 6.789-.681-6.789-.366zm12.683-1.032h-3.545V5.11l3.545-.928z"
@@ -2971,7 +2971,7 @@ exports[`IconsProvider should render default talend-icons and custom icons defin
         <g
           className="ti-kinesis-brand-plain-color"
           fill="#5D88AA"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M8.002 13.719v2.28l6.79-3.144v-1.34zm0-3.963v2.281l6.79-1.597V9.099zm6.045-1.689h.747V4.485l-.747-.304zm-1.544 0h.902V4.949l-.902-.31zm-.93 0h-1.057V2.784l1.057.464zM8.002 0v8.068h1.34V.774z"
@@ -2980,7 +2980,7 @@ exports[`IconsProvider should render default talend-icons and custom icons defin
         <g
           className="ti-kinesis-brand-darker-color"
           fill="#46667F"
-          fillRule="none-zero"
+          fillRule="nonzero"
         >
           <path
             d="M1.362 12.855L8.002 16v-2.282l-6.64-2.203zm0-2.415l6.64 1.597V9.756l-6.64-.657z"

--- a/packages/icons/src/svg/AWS-kinesis.svg
+++ b/packages/icons/src/svg/AWS-kinesis.svg
@@ -1,14 +1,14 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16">
   <g fill="none">
-    <g fill="#86A6BF" fill-rule="none-zero" class="ti-kinesis-brand-lighter-color">
+    <g fill="#86A6BF" fill-rule="nonzero" class="ti-kinesis-brand-lighter-color">
       <path d="M1.364 11.516l6.634 2.204 6.793-2.204L8.01 9.883zm-.001-2.418l6.639.681 6.789-.681-6.789-.366zm12.683-1.032h-3.545V5.11l3.545-.928z"/>
       <path d="M10.516 8.069H3.877v-3.43l6.639-1.855z"/>
       <path d="M12.496 8.068H8.951l.008-2.493 3.545-.929zM8.002 0L1.364 3.403v4.666h6.638z"/>
     </g>
-    <g fill="#5D88AA" fill-rule="none-zero" class="ti-kinesis-brand-plain-color">
+    <g fill="#5D88AA" fill-rule="nonzero" class="ti-kinesis-brand-plain-color">
       <path d="M8.002 13.719v2.28l6.79-3.144v-1.34zm0-3.963v2.281l6.79-1.597V9.099zm6.045-1.689h.747V4.485l-.747-.304zm-1.544 0h.902V4.949l-.902-.31zm-.93 0h-1.057V2.784l1.057.464zM8.002 0v8.068h1.34V.774z"/>
     </g>
-    <g fill="#46667F" fill-rule="none-zero" class="ti-kinesis-brand-darker-color">
+    <g fill="#46667F" fill-rule="nonzero" class="ti-kinesis-brand-darker-color">
       <path d="M1.362 12.855L8.002 16v-2.282l-6.64-2.203zm0-2.415l6.64 1.597V9.756l-6.64-.657z"/>
     </g>
   </g>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

CSS errors when parsing the svg.

**What is the chosen solution to this problem?**

Fix the value set for the fill-rule attribute

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

