### PR TITLE
chore(containers): remove Form from default export

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -2,6 +2,21 @@ Before 1.0, the stack do NOT follow semver version in releases.
 
 This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
 
+## v0.151.0
+* Container: Form
+* PR: https://github.com/Talend/ui/pull/1031
+* Changes: With Form container in default export, we must have form as dependency on the project that import containers. Remove Form from default export and import it à la lodash when you need it.
+
+Before
+```javascript
+import { Form } from '@talend/react-containers'
+```
+After
+```javascript
+import Form from '@talend/react-containers/lib/Form'
+```
+
+
 ## 0.150.0
 * Component: Typeahead
 * PR: [chore: upgrade react-autowhatever](https://github.com/Talend/ui/pull/1022)
@@ -46,7 +61,7 @@ function renderItemsContainer({ children, containerProps }) {
     );
 }
 ```
- 
+
 ## v0.143.0
 * Component: CollapsiblePanel
 * PR: [feat(components/collapsiblepanel): style update](https://github.com/Talend/ui/pull/961)

--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -19,7 +19,6 @@ import Actions from './Actions';
 import ActionSplitDropdown from './ActionSplitDropdown';
 import ConfirmDialog from './ConfirmDialog';
 import FilterBar from './FilterBar';
-import Form from './Form';
 import HeaderBar from './HeaderBar';
 import HomeListView from './HomeListView';
 import List from './List';
@@ -48,7 +47,6 @@ export {
 	Drawer,
 	DeleteResource,
 	FilterBar,
-	Form,
 	HeaderBar,
 	HomeListView,
 	Icon,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With Form container in default export, we must have form as dependency on the project that import containers
**What is the chosen solution to this problem?**
Remove Form from default export and import it _à la_ lodash when you need it

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

