### PR TITLE
fix(components/SidePanel): smooth docked transition

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -24,12 +24,12 @@ $toggle-button-padding: $padding-small - 1;
 .tc-side-panel {
 	display: flex;
 	flex-direction: column;
-	transition: 0.2s width ease-out;
 	overflow-x: hidden;
 
 	&,
 	> ul {
 		width: $tc-side-panel-width;
+		transition: 0.2s width ease-out;
 	}
 
 	:global(.btn.btn-link) {
@@ -45,6 +45,7 @@ $toggle-button-padding: $padding-small - 1;
 			vertical-align: middle;
 			text-overflow: ellipsis;
 			overflow: hidden;
+			transition: 0.1s opacity ease-out;
 		}
 	}
 
@@ -122,9 +123,11 @@ $toggle-button-padding: $padding-small - 1;
 			width: $tc-side-panel-docked-width;
 		}
 
-		.nav-pills {
-			:global(.btn.btn-link) {
-				padding: $padding-normal;
+		:global(.btn.btn-link) {
+			padding: $padding-normal;
+
+			> span {
+				opacity: 0;
 			}
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No animation when side panel becomes docked

**What is the chosen solution to this problem?**
Add smooth animation while switching between these two states

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

