### PR TITLE
fix(containers/List): pass `inProgress` from List container to List component

### DIFF
--- a/packages/containers/examples/ExampleList.js
+++ b/packages/containers/examples/ExampleList.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { IconsProvider } from '@talend/react-components';
 import Immutable from 'immutable';
 import { I18nextProvider } from 'react-i18next';
+import { cloneDeep } from 'lodash';
 
 import { List } from '../src';
 import i18n from './config/i18n';
@@ -92,6 +93,18 @@ const ExampleList = {
 			</div>
 		</div>
 	),
+	'in progress': () => {
+		const props2 = cloneDeep(props);
+		props2.list.inProgress = true;
+		return (
+				<div>
+					<IconsProvider />
+					<div className="list-container">
+						<List {...props2} items={items} />
+					</div>
+				</div>
+		)
+	},
 	'no toolbar': () => (
 		<div>
 			<IconsProvider />

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -106,6 +106,7 @@ class List extends React.Component {
 					isDescending: !state.sortAsc,
 					onChange: this.onSelectSortBy,
 				},
+				inProgress: get(this.props, 'list.inProgress', false),
 			},
 			virtualized: this.props.virtualized,
 			renderers: this.props.renderers,

--- a/packages/containers/src/List/__snapshots__/List.test.js.snap
+++ b/packages/containers/src/List/__snapshots__/List.test.js.snap
@@ -138,6 +138,7 @@ Object {
       },
     ],
     "id": "list",
+    "inProgress": false,
     "items": Array [
       Object {
         "actions": Array [],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`list.inProgress: true` is not working with List container.
**What is the chosen solution to this problem?**
pass `inProgress` from List container to List component.
**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

