### PR TITLE
TPSVC-4185: Fixed: [IE] Continue adding roles or groups doesn't work in user drawer in IE browser

### DIFF
--- a/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.js
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.js
@@ -94,6 +94,7 @@ class MultiSelectTagWidget extends React.Component {
 		onChange(nextValue);
 
 		this.setState({ filterText: '' });
+		this.component.querySelector('input').blur();
 	}
 
 	onRemoveTag(tagValue) {

--- a/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
@@ -35,7 +35,7 @@ $tf-typeahead-section-border-color: #e0e0e0 !default;
 			width: 100%;
 		}
 
-		&[class*="container-open"] .items-container {
+		&[class*='container-open'] .items-container {
 			display: block;
 		}
 	}

--- a/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
@@ -34,9 +34,14 @@ $tf-typeahead-section-border-color: #e0e0e0 !default;
 		> div {
 			width: 100%;
 		}
+
+		&[class*="container-open"] .items-container {
+			display: block;
+		}
 	}
 
 	.items-container {
+		display: none;
 		position: absolute;
 		width: 100%;
 		top: 100%;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Multi Select Tag Widget behaves wrong in IE.
1. Dropdown doesn't disappear on blur (styles doesn't work in IE). 
2. When you select item from dropdown blur it doen't trigger blur event.

**What is the chosen solution to this problem?**
1. Apply styles another way.
2. Force blur event inside onSelect callback.

**Please check if the PR fulfills these requirements**
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
