### PR TITLE
fix(HeaderBar): fixed position of header bar item separator

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -39,6 +39,7 @@ $background-color-on-hover: shade($brand-primary, 30);
 		.tc-header-bar-action {
 			height: 100%;
 			list-style: none;
+			white-space: nowrap;
 
 			&:not(:last-child).separated:after {
 				content: '|';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If screen width is small, then item separator '|' move to the next line, which causes problem with headerbar height.

**What is the chosen solution to this problem?**

fix style

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
