### PR TITLE
chore(ci): Bump travis NodeJS version to latest LTS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
 addons:
   firefox: "50.0"
 node_js:
-  - '6'
+  - '8'
 before_install:
 #   Fail fast if ci is triggered by ci commit
   - export TALEND_COMMIT_MSG=$TRAVIS_COMMIT_MESSAGE


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Our continuous integration server is using the deprecated NodeJS 6 version to build and run test. 

**What is the chosen solution to this problem?**
Bump to NodeJS 8. Latest LTS version being 8.9.4 at this time.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR