### PR TITLE
fix(components/typeahead): use a flag for the display mode

### DIFF
--- a/BREAKING_CHANGES_LOG.md
+++ b/BREAKING_CHANGES_LOG.md
@@ -2,6 +2,24 @@ Before 1.0, the stack do NOT follow semver version in releases.
 
 This document aims to ease the WIP migration from a version to another by providing intels about what to do to migrate.
 
+
+## v0.159.0
+* Typeahead: new flag to manage the display mode
+
+Before
+```jsx
+<Typeahead onToggle={func} />
+```
+
+After
+```jsx
+<Typeahead onToggle={func} docked={bool} />
+```
+
+- `docked === true && onToggle !== undefined` : the toggle button is displayed
+- `docked !== true || onToggle === undefined` : the typeahead input is displayed
+
+
 ## v0.157.0
 * cmf: route onLeave/onEnter
 * PR: [feat(cmf): route onEnter/onLeave with dispatch](https://github.com/Talend/ui/pull/1082)
@@ -15,7 +33,8 @@ function onLeave(nextState, replace) { }
 
 After
 ```javascript
-function onEnter(router, dispatch) { const { nextState, replace } = router; }
+function onEnter(router, dispatch)
+ { const { nextState, replace } = router; }
 function onLeave(router, dispatch) { }
 ```
 

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -19,8 +19,8 @@ import { Action } from '../Actions';
  *
  * <Typeahead {...props} />
  */
-function Typeahead({ onToggle, icon, position, ...rest }) {
-	if (onToggle) {
+function Typeahead({ onToggle, icon, position, docked, ...rest }) {
+	if (docked === true && onToggle) {
 		return (
 			<Action
 				onClick={onToggle}
@@ -122,6 +122,7 @@ Typeahead.defaultProps = {
 	readOnly: false,
 	searching: false,
 	searchingText: 'Searching for matches…',
+	docked: false,
 };
 
 Typeahead.propTypes = {
@@ -135,6 +136,7 @@ Typeahead.propTypes = {
 
 	// toggle button
 	onToggle: PropTypes.func,
+	docked: PropTypes.bool,
 	icon: PropTypes.shape({
 		name: PropTypes.string,
 		title: PropTypes.string,

--- a/packages/components/src/Typeahead/Typeahead.snapshot.test.js
+++ b/packages/components/src/Typeahead/Typeahead.snapshot.test.js
@@ -46,6 +46,7 @@ describe('Typeahead', () => {
 			const props = {
 				id: 'my-search',
 				onToggle: jest.fn(),
+				docked: true,
 				icon: {
 					name: 'fa fa-search',
 					title: 'Toggle search bar',

--- a/packages/components/src/Typeahead/Typeahead.test.js
+++ b/packages/components/src/Typeahead/Typeahead.test.js
@@ -46,11 +46,44 @@ describe('Typeahead', () => {
 		}];
 
 	describe('toggle button', () => {
+		it('should be hidden if docked property is not true', () => {
+			// given
+			const props = {
+				...initialProps,
+				onToggle: jest.fn(),
+				docked: false,
+			};
+			const typeahead = <Typeahead {...props} />;
+
+			// when
+			const typeaheadInstance = mount(typeahead);
+
+			// then
+			expect(typeaheadInstance.find('Action').length).toBe(0);
+		});
+
+		it('should be shown if docked property is true', () => {
+			// given
+			const props = {
+				...initialProps,
+				onToggle: jest.fn(),
+				docked: true,
+			};
+			const typeahead = <Typeahead {...props} />;
+
+			// when
+			const typeaheadInstance = mount(typeahead);
+
+			// then
+			expect(typeaheadInstance.find('Action').length).toBe(1);
+		});
+
 		it('should call onToggle', () => {
 			// given
 			const props = {
 				...initialProps,
 				onToggle: jest.fn(),
+				docked: true,
 			};
 			const typeahead = <Typeahead {...props} />;
 

--- a/packages/components/stories/HeaderBar.js
+++ b/packages/components/stories/HeaderBar.js
@@ -113,6 +113,7 @@ const props = {
 		},
 		id: 'header-search',
 		onToggle: action('onSearchClick'),
+		docked: true,
 	},
 	help: {
 		id: 'header-help',

--- a/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -15,6 +15,7 @@ exports[`Datalist component should render typeahead 1`] = `
     <Typeahead
       autoFocus={true}
       disabled={false}
+      docked={false}
       focusedItemIndex={undefined}
       id="my-datalist"
       items={null}

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
@@ -23,6 +23,7 @@ exports[`MultiSelectTag field should render MultiSelectTag 1`] = `
     <Typeahead
       autoFocus={true}
       disabled={false}
+      docked={false}
       focusedItemIndex={undefined}
       id="my-select-tag"
       items={null}

--- a/packages/forms/src/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -25,6 +25,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget 1`] = `
     <Typeahead
       autoFocus={false}
       disabled={false}
+      docked={false}
       focusedItemIndex={undefined}
       focusedSectionIndex={undefined}
       id={42}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The only way to display the typeahead input when using the toggle functionnality is to delete the `onToggle` property, which is obviously a bad thing.

**What is the chosen solution to this problem?**

Add a `docked` property.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

