### PR TITLE
chore(components): remove skeleton constants from index

### DIFF
--- a/packages/components/src/PieChartButton/PieChartButton.component.js
+++ b/packages/components/src/PieChartButton/PieChartButton.component.js
@@ -334,7 +334,7 @@ function PieChartButton({
 				})}
 			>
 				<Skeleton
-					type={SKELETON_TYPES.circle}
+					type={Skeleton.SKELETON_TYPES.circle}
 					width={sizeObject.svgSize}
 					height={sizeObject.svgSize}
 					className={classnames(
@@ -342,7 +342,9 @@ function PieChartButton({
 						'tc-pie-chart-loading-circle',
 					)}
 				/>
-				{!hideLabel && <Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.small} />}
+				{!hideLabel && (
+					<Skeleton type={Skeleton.SKELETON_TYPES.text} size={Skeleton.SKELETON_SIZES.small} />
+				)}
 			</Button>
 		);
 	}

--- a/packages/components/src/Skeleton/Skeleton.component.js
+++ b/packages/components/src/Skeleton/Skeleton.component.js
@@ -4,61 +4,65 @@ import classnames from 'classnames';
 import Icon from '../Icon';
 import theme from './Skeleton.scss';
 
-export const SKELETON_TYPES = {
+const SKELETON_TYPES = {
 	icon: 'icon',
 	text: 'text',
 	button: 'button',
 	circle: 'circle',
 };
 
-export const SKELETON_SIZES = {
+const SKELETON_SIZES = {
 	xlarge: 'xlarge',
 	large: 'large',
 	medium: 'medium',
 	small: 'small',
 };
 
-function Skeleton({ type, size, width, height, name, className }) {
-	const classes = classnames(
-		theme['tc-skeleton'],
-		theme[`tc-skeleton-${type}`],
-		theme[`tc-skeleton-${type}-${size}`],
-		'tc-skeleton',
-		`tc-skeleton-${type}`,
-		`tc-skeleton-${type}-${size}`,
-		className,
-	);
+// eslint-disable-next-line react/prefer-stateless-function
+class Skeleton extends React.Component {
+	static displayName = 'Skeleton';
+	static defaultProps = {
+		type: SKELETON_TYPES.text,
+		size: SKELETON_SIZES.medium,
+	};
+	static propTypes = {
+		type: PropTypes.oneOf([
+			SKELETON_TYPES.button,
+			SKELETON_TYPES.circle,
+			SKELETON_TYPES.icon,
+			SKELETON_TYPES.text,
+		]).isRequired,
+		size: PropTypes.oneOf([
+			SKELETON_SIZES.xlarge,
+			SKELETON_SIZES.large,
+			SKELETON_SIZES.medium,
+			SKELETON_SIZES.small,
+		]),
+		width: PropTypes.number,
+		height: PropTypes.number,
+		name: PropTypes.string,
+		className: PropTypes.string,
+	};
+	static SKELETON_SIZES = SKELETON_SIZES;
+	static SKELETON_TYPES = SKELETON_TYPES;
 
-	if (type === 'icon') {
-		return <Icon className={classes} name={name} />;
+	render() {
+		const { type, size, width, height, name, className } = this.props;
+		const classes = classnames(
+			theme['tc-skeleton'],
+			theme[`tc-skeleton-${type}`],
+			theme[`tc-skeleton-${type}-${size}`],
+			'tc-skeleton',
+			`tc-skeleton-${type}`,
+			`tc-skeleton-${type}-${size}`,
+			className,
+		);
+
+		if (type === 'icon') {
+			return <Icon className={classes} name={name} />;
+		}
+		return <span style={{ width, height }} className={classes} />;
 	}
-	return <span style={{ width, height }} className={classes} />;
 }
-
-Skeleton.propTypes = {
-	type: PropTypes.oneOf([
-		SKELETON_TYPES.button,
-		SKELETON_TYPES.circle,
-		SKELETON_TYPES.icon,
-		SKELETON_TYPES.text,
-	]).isRequired,
-	size: PropTypes.oneOf([
-		SKELETON_SIZES.small,
-		SKELETON_SIZES.medium,
-		SKELETON_SIZES.large,
-		SKELETON_SIZES.xlarge,
-	]),
-	width: PropTypes.number,
-	height: PropTypes.number,
-	name: PropTypes.string,
-	className: PropTypes.string,
-};
-
-Skeleton.defaultProps = {
-	type: SKELETON_TYPES.text,
-	size: SKELETON_SIZES.medium,
-};
-
-Skeleton.displayName = 'Skeleton';
 
 export default Skeleton;

--- a/packages/components/src/Skeleton/index.js
+++ b/packages/components/src/Skeleton/index.js
@@ -1,4 +1,3 @@
-import Skeleton, { SKELETON_SIZES, SKELETON_TYPES } from './Skeleton.component';
+import Skeleton from './Skeleton.component';
 
-export { SKELETON_SIZES, SKELETON_TYPES };
 export default Skeleton;

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -103,7 +103,7 @@ import Loader from './Loader';
 import ObjectViewer from './ObjectViewer';
 import Progress from './Progress';
 import SidePanel from './SidePanel';
-import Skeleton, { SKELETON_SIZES, SKELETON_TYPES } from './Skeleton';
+import Skeleton from './Skeleton';
 import { Status } from './Status';
 import SubHeaderBar from './SubHeaderBar';
 import TabBar from './TabBar';
@@ -228,6 +228,4 @@ export {
 	Well,
 	I18N_DOMAIN_COMPONENTS,
 	CIRCULAR_PROGRESS_SIZE,
-	SKELETON_SIZES,
-	SKELETON_TYPES,
 };

--- a/packages/components/stories/Skeleton.js
+++ b/packages/components/stories/Skeleton.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import talendIcons from '@talend/icons/dist/react';
-import Skeleton, { SKELETON_SIZES, SKELETON_TYPES } from '../src/Skeleton';
+import Skeleton from '../src/Skeleton';
 import IconProvider from '../src/IconsProvider';
 
 const stories = storiesOf(Skeleton.displayName, module);
@@ -20,30 +20,39 @@ stories
 			<IconProvider defaultIcons={icons} />
 			<h4>Circles :</h4>
 			<div>small</div>
-			<Skeleton type={SKELETON_TYPES.circle} size={SKELETON_SIZES.small} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.circle} size={Skeleton.SKELETON_SIZES.small} />
 			<div>medium</div>
-			<Skeleton type={SKELETON_TYPES.circle} size={SKELETON_SIZES.medium} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.circle} size={Skeleton.SKELETON_SIZES.medium} />
 			<div>large</div>
-			<Skeleton type={SKELETON_TYPES.circle} size={SKELETON_SIZES.large} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.circle} size={Skeleton.SKELETON_SIZES.large} />
 			<div>custom size override class definition </div>
-			<Skeleton type={SKELETON_TYPES.circle} size={SKELETON_SIZES.small} width={50} height={50} />
+			<Skeleton
+				type={Skeleton.SKELETON_TYPES.circle}
+				size={Skeleton.SKELETON_SIZES.small}
+				width={50}
+				height={50}
+			/>
 
 			<h4>Texts :</h4>
 			<div>small:</div>
-			<Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.small} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.text} size={Skeleton.SKELETON_SIZES.small} />
 			<div>medium:</div>
-			<Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.medium} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.text} size={Skeleton.SKELETON_SIZES.medium} />
 			<div>large:</div>
-			<Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.large} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.text} size={Skeleton.SKELETON_SIZES.large} />
 			<div>extra-large:</div>
-			<Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.xlarge} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.text} size={Skeleton.SKELETON_SIZES.xlarge} />
 			<div>custom width:</div>
-			<Skeleton type={SKELETON_TYPES.text} size={SKELETON_SIZES.small} width={400} />
+			<Skeleton
+				type={Skeleton.SKELETON_TYPES.text}
+				size={Skeleton.SKELETON_SIZES.small}
+				width={400}
+			/>
 
 			<h4>Button: </h4>
-			<Skeleton type={SKELETON_TYPES.button} />
+			<Skeleton type={Skeleton.SKELETON_TYPES.button} />
 
 			<h4>Icons :</h4>
-			<Skeleton type={SKELETON_TYPES.icon} name="talend-locked" />
+			<Skeleton type={Skeleton.SKELETON_TYPES.icon} name="talend-locked" />
 		</div>
 	));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
removing the skeleton constants from index to get only components to import by the register

**What is the chosen solution to this problem?**
set the constants on the component by  converting the component to a class component

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

