### PR TITLE
fix(container): change props on filterBar to fit ActionCreator new api

### DIFF
--- a/packages/containers/src/FilterBar/FilterBar.container.js
+++ b/packages/containers/src/FilterBar/FilterBar.container.js
@@ -49,8 +49,8 @@ class FilterBar extends React.Component {
 				props: this.props,
 			});
 		}
-		if (this.props.onFilterActionCreator) {
-			this.props.dispatchActionCreator(this.props.onFilterActionCreator, event, {
+		if (this.props.onFilterAction) {
+			this.props.dispatchActionCreator(this.props.onFilterAction, event, {
 				props: this.props,
 			});
 		}
@@ -64,8 +64,8 @@ class FilterBar extends React.Component {
 			}
 			return state.set(QUERY_ATTR, '');
 		});
-		if (this.props.onToggleActionCreator) {
-			this.props.dispatchActionCreator(this.props.onToggleActionCreator);
+		if (this.props.onToggleAction) {
+			this.props.dispatchActionCreator(this.props.onToggleAction);
 		}
 		if (this.props.onToggle) {
 			this.props.onToggle(event);

--- a/packages/containers/src/FilterBar/FilterBar.container.js
+++ b/packages/containers/src/FilterBar/FilterBar.container.js
@@ -49,11 +49,6 @@ class FilterBar extends React.Component {
 				props: this.props,
 			});
 		}
-		if (this.props.onFilterAction) {
-			this.props.dispatchActionCreator(this.props.onFilterAction, event, {
-				props: this.props,
-			});
-		}
 	}
 
 	onToggle(event) {
@@ -64,9 +59,6 @@ class FilterBar extends React.Component {
 			}
 			return state.set(QUERY_ATTR, '');
 		});
-		if (this.props.onToggleAction) {
-			this.props.dispatchActionCreator(this.props.onToggleAction);
-		}
 		if (this.props.onToggle) {
 			this.props.onToggle(event);
 		}

--- a/packages/containers/src/FilterBar/FilterBar.test.js
+++ b/packages/containers/src/FilterBar/FilterBar.test.js
@@ -49,23 +49,6 @@ describe('Filter container', () => {
 			},
 		});
 	});
-	it('should call onFilterActionCreator when onFilter event trigger', () => {
-		const props = {
-			setState: jest.fn(),
-			dispatchActionCreator: jest.fn(),
-			onFilterAction: jest.fn(),
-		};
-		const event = {};
-		const query = 'foo';
-		const wrapper = shallow(<Container {...props} />);
-		wrapper.simulate('filter', event, query);
-		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onFilterAction, event, {
-			props: {
-				dockable: true,
-				...props,
-			},
-		});
-	});
 	it('should call onBlur when onBlur event trigger', () => {
 		const onBlur = jest.fn();
 		const event = {};
@@ -96,17 +79,6 @@ describe('Filter container', () => {
 		expect(props.setState).toHaveBeenCalled();
 		expect(prevState.state).not.toBe(state);
 		expect(prevState.state.get('docked')).toBe(true);
-	});
-	it('should call onToggleActionCreator when onToggle event trigger', () => {
-		const props = {
-			onToggleAction: jest.fn(),
-			dispatchActionCreator: jest.fn(),
-			setState: jest.fn(),
-			state: Map({ docked: false }),
-		};
-		const wrapper = shallow(<Container {...props} />);
-		wrapper.simulate('toggle');
-		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onToggleAction);
 	});
 	it('should call onToggle when onToggle event trigger', () => {
 		const props = {

--- a/packages/containers/src/FilterBar/FilterBar.test.js
+++ b/packages/containers/src/FilterBar/FilterBar.test.js
@@ -53,13 +53,13 @@ describe('Filter container', () => {
 		const props = {
 			setState: jest.fn(),
 			dispatchActionCreator: jest.fn(),
-			onFilterActionCreator: jest.fn(),
+			onFilterAction: jest.fn(),
 		};
 		const event = {};
 		const query = 'foo';
 		const wrapper = shallow(<Container {...props} />);
 		wrapper.simulate('filter', event, query);
-		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onFilterActionCreator, event, {
+		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onFilterAction, event, {
 			props: {
 				dockable: true,
 				...props,
@@ -99,16 +99,16 @@ describe('Filter container', () => {
 	});
 	it('should call onToggleActionCreator when onToggle event trigger', () => {
 		const props = {
-			onToggleActionCreator: jest.fn(),
+			onToggleAction: jest.fn(),
 			dispatchActionCreator: jest.fn(),
 			setState: jest.fn(),
 			state: Map({ docked: false }),
 		};
 		const wrapper = shallow(<Container {...props} />);
 		wrapper.simulate('toggle');
-		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onToggleActionCreator);
+		expect(props.dispatchActionCreator).toHaveBeenCalledWith(props.onToggleAction);
 	});
-	it('should call onToggleActionCreator when onToggle event trigger', () => {
+	it('should call onToggle when onToggle event trigger', () => {
 		const props = {
 			onToggle: jest.fn(),
 			setState: jest.fn(),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some code on the filterBar container use a props name ***ActionCreator, with this PR -> #1097, this code to dispatch some specific value with the action creator is not working anymore

**What is the chosen solution to this problem?**
Rename the param to avoid trigger cmf manipulation of props

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

Breaking change on the filterBar container API 

Breaking change on the Slider container API
onFilterActionCreator override onFilterAction if defined
onToggleActionCreator override onToggleAction if defined

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

