### PR TITLE
fix(cmf): persist event when using dispatchActionCreator

### DIFF
--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -46,7 +46,7 @@ let newState;
 
 function serializeEvent(event) {
 	if (event.persist) {
-		return event.persist();
+		event.persist();
 	}
 	return event;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
event.persist() return undefined, so the event is lost as it is now
https://reactjs.org/docs/events.html
**What is the chosen solution to this problem?**
persist the event, but return also return the event 

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

