### PR TITLE
feat(datagrid): allow to customize the empty data message

### DIFF
--- a/output/cmf-webpack-plugin.eslint.txt
+++ b/output/cmf-webpack-plugin.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf-webpack-plugin@0.165.0 lint:es /home/travis/build/Talend/ui/packages/cmf-webpack-plugin
+> @talend/react-cmf-webpack-plugin@0.166.0 lint:es /home/travis/build/Talend/ui/packages/cmf-webpack-plugin
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.165.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.166.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.165.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.166.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.165.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.166.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.165.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.166.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-datagrid@0.165.0 lint:es /home/travis/build/Talend/ui/packages/datagrid
+> @talend/react-datagrid@0.166.0 lint:es /home/travis/build/Talend/ui/packages/datagrid
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.165.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.166.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.165.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.166.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.165.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.166.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/sagas.eslint.txt
+++ b/output/sagas.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-sagas@0.165.0 lint:es /home/travis/build/Talend/ui/packages/sagas
+> @talend/react-sagas@0.166.0 lint:es /home/travis/build/Talend/ui/packages/sagas
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.165.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.166.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -155,6 +155,7 @@ export default class DataGrid extends React.Component {
 			navigateToNextCell: this.handleKeyboard,
 			onViewportChanged: this.updateStyleFocusColumn,
 			onVirtualColumnsChanged: this.updateStyleFocusColumn,
+			overlayNoRowsTemplate: this.props.overlayNoRowsTemplate,
 			ref: this.setGridInstance, // use ref in AgGridReact to get the current instance
 			rowData: this.props.getRowDataFn(this.props.data),
 			rowHeight: this.props.rowHeight,

--- a/packages/datagrid/src/components/DataGrid/__snapshots__/DataGrid.test.js.snap
+++ b/packages/datagrid/src/components/DataGrid/__snapshots__/DataGrid.test.js.snap
@@ -20,6 +20,7 @@ exports[`#DataGrid should render DataGrid 1`] = `
     onGridReady={[Function]}
     onViewportChanged={[Function]}
     onVirtualColumnsChanged={[Function]}
+    overlayNoRowsTemplate={undefined}
     rowData={Array []}
     rowHeight={39}
     rowSelection="single"
@@ -121,6 +122,7 @@ exports[`#DataGrid should render DataGrid with columnsDefs and rowData 1`] = `
     onGridReady={[Function]}
     onViewportChanged={[Function]}
     onVirtualColumnsChanged={[Function]}
+    overlayNoRowsTemplate={undefined}
     rowData={
       Array [
         Object {

--- a/packages/datagrid/stories/datagrid.component.js
+++ b/packages/datagrid/stories/datagrid.component.js
@@ -31,6 +31,19 @@ storiesOf('Component Datagrid')
 			/>
 		</div>
 	))
+	.add('no row specific message', () => (
+		<div style={{ height: '100vh' }}>
+			<IconsProvider />
+			<DataGrid
+				data={[]}
+				overlayNoRowsTemplate="Custom message"
+				onFocusedCell={event => console.log(event)}
+				onFocusedColumn={event => console.log(event)}
+				onVerticalScroll={event => console.log(event)}
+				rowSelection="multiple"
+			/>
+		</div>
+	))
 	.add('loading', () => (
 		<div style={{ height: '100vh' }}>
 			<IconsProvider />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
It show every time the message from ag-grid when no data is set
**What is the chosen solution to this problem?**
Allow a way to customize it by props

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

