### PR TITLE
fix(SidePanel/theme): side panel + nav-pills style, with anchors

### DIFF
--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -85,7 +85,6 @@ function ActionList(props) {
 		<ul
 			className={classNames(
 				'nav',
-				'nav-inverse',
 				'nav-pills',
 				'nav-stacked',
 				theme['tc-action-list'],

--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -85,6 +85,7 @@ function ActionList(props) {
 		<ul
 			className={classNames(
 				'nav',
+				'nav-inverse',
 				'nav-pills',
 				'nav-stacked',
 				theme['tc-action-list'],

--- a/packages/components/src/ActionList/ActionList.scss
+++ b/packages/components/src/ActionList/ActionList.scss
@@ -3,9 +3,6 @@
 /// @group Custom widgets
 ////
 
-$list-item-hover-color: rgba($white, 0.12) !default;
-$list-item-active-color: rgba($white, 0.25) !default;
-$list-item-color: $white !default;
 $tc-action-list-item-width: 200px !default;
 $tc-action-list-item-labels-width: 135px !default;
 $tc-action-list-item-icons-size: 20px !default;
@@ -13,8 +10,6 @@ $tc-action-list-item-border-size: 2px !default;
 
 .tc-action-list {
 	.tc-action-list-item {
-		color: $list-item-color;
-
 		:global {
 			.tc-svg-icon {
 				width: $tc-action-list-item-icons-size;
@@ -24,8 +19,6 @@ $tc-action-list-item-border-size: 2px !default;
 
 			.btn.btn-link {
 				padding: $padding-normal;
-				font-size: $font-size-small;
-				text-align: left;
 				text-overflow: inherit;
 				text-transform: uppercase;
 
@@ -38,23 +31,6 @@ $tc-action-list-item-border-size: 2px !default;
 					transition: 0.1s opacity ease-out;
 				}
 			}
-		}
-
-		&:hover,
-		&.active {
-			color: $list-item-color;
-
-			:global(.tc-svg-icon) {
-				color: $list-item-color;
-			}
-		}
-
-		&:hover {
-			background-color: $list-item-hover-color;
-		}
-
-		&.active {
-			background-color: $list-item-active-color;
 		}
 	}
 }

--- a/packages/components/src/ActionList/__snapshots__/ActionList.snapshot.test.js.snap
+++ b/packages/components/src/ActionList/__snapshots__/ActionList.snapshot.test.js.snap
@@ -95,7 +95,7 @@ exports[`Storyshots ActionList default 1`] = `
     }
   >
     <ul
-      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list"
+      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -371,7 +371,7 @@ exports[`Storyshots ActionList single 1`] = `
     }
   >
     <ul
-      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list"
+      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item active theme-active"
@@ -535,7 +535,7 @@ exports[`Storyshots ActionList with custom class names 1`] = `
       }
     >
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list custom-container-classname"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list custom-container-classname"
       >
         <li
           className="theme-tc-action-list-item tc-action-list-item custom-item-classname"

--- a/packages/components/src/ActionList/__snapshots__/ActionList.snapshot.test.js.snap
+++ b/packages/components/src/ActionList/__snapshots__/ActionList.snapshot.test.js.snap
@@ -90,13 +90,12 @@ exports[`Storyshots ActionList default 1`] = `
   <div
     style={
       Object {
-        "background": "#236192",
         "display": "inline-table",
       }
     }
   >
     <ul
-      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list"
+      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -367,13 +366,12 @@ exports[`Storyshots ActionList single 1`] = `
   <div
     style={
       Object {
-        "background": "#236192",
         "display": "inline-table",
       }
     }
   >
     <ul
-      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list"
+      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item active theme-active"
@@ -532,13 +530,12 @@ exports[`Storyshots ActionList with custom class names 1`] = `
     <div
       style={
         Object {
-          "background": "#236192",
           "display": "inline-table",
         }
       }
     >
       <ul
-        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list custom-container-classname"
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list custom-container-classname"
       >
         <li
           className="theme-tc-action-list-item tc-action-list-item custom-item-classname"

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -53,11 +53,9 @@ function SidePanel({
 		reverse,
 		[theme.reverse]: reverse,
 	});
-	const listCSS = classNames(
-		theme['tc-side-panel-list'],
-		'tc-side-panel-list',
-		{ 'nav-inverse': !reverse },
-	);
+	const listCSS = classNames(theme['tc-side-panel-list'], 'tc-side-panel-list', {
+		'nav-inverse': !reverse,
+	});
 
 	const expandLabel = t('SIDEPANEL_EXPAND', { defaultValue: 'Expand' });
 	const collapseTitle = t('SIDEPANEL_COLLAPSE', { defaultValue: 'Collapse' });

--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -53,7 +53,11 @@ function SidePanel({
 		reverse,
 		[theme.reverse]: reverse,
 	});
-	const listCSS = classNames(theme['tc-side-panel-list'], 'tc-side-panel-list');
+	const listCSS = classNames(
+		theme['tc-side-panel-list'],
+		'tc-side-panel-list',
+		{ 'nav-inverse': !reverse },
+	);
 
 	const expandLabel = t('SIDEPANEL_EXPAND', { defaultValue: 'Expand' });
 	const collapseTitle = t('SIDEPANEL_COLLAPSE', { defaultValue: 'Collapse' });

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -165,7 +165,7 @@ exports[`Storyshots SidePanel default 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
       >
         <li
           aria-current={true}
@@ -425,7 +425,7 @@ exports[`Storyshots SidePanel docked 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
       >
         <li
           aria-current={true}
@@ -682,7 +682,7 @@ exports[`Storyshots SidePanel large docked 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
       >
         <li
           aria-current={true}
@@ -931,7 +931,7 @@ exports[`Storyshots SidePanel large reverse 1`] = `
       </button>
     </div>
     <ul
-      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -1188,7 +1188,7 @@ exports[`Storyshots SidePanel links 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
       >
         <li
           aria-current={true}
@@ -1421,7 +1421,7 @@ exports[`Storyshots SidePanel not dockable 1`] = `
       role="navigation"
     >
       <ul
-        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
       >
         <li
           className="theme-tc-action-list-item tc-action-list-item"
@@ -1670,7 +1670,7 @@ exports[`Storyshots SidePanel reverse 1`] = `
       </button>
     </div>
     <ul
-      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -1928,7 +1928,7 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
             </button>
           </div>
           <ul
-            className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+            className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
           >
             <li
               className="theme-tc-action-list-item tc-action-list-item"
@@ -2540,7 +2540,7 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
             </button>
           </div>
           <ul
-            className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+            className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
           >
             <li
               className="theme-tc-action-list-item tc-action-list-item"
@@ -3154,7 +3154,7 @@ exports[`Storyshots SidePanel 🎨 [PORTAL] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -3419,7 +3419,7 @@ exports[`Storyshots SidePanel 🎨 [TDC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -3684,7 +3684,7 @@ exports[`Storyshots SidePanel 🎨 [TDP] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -3949,7 +3949,7 @@ exports[`Storyshots SidePanel 🎨 [TDS] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -4214,7 +4214,7 @@ exports[`Storyshots SidePanel 🎨 [TFD] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -4479,7 +4479,7 @@ exports[`Storyshots SidePanel 🎨 [TIC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}
@@ -4744,7 +4744,7 @@ exports[`Storyshots SidePanel 🎨 [TMC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list nav-inverse"
         >
           <li
             aria-current={true}

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -165,7 +165,7 @@ exports[`Storyshots SidePanel default 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
       >
         <li
           aria-current={true}
@@ -425,7 +425,7 @@ exports[`Storyshots SidePanel docked 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
       >
         <li
           aria-current={true}
@@ -682,7 +682,7 @@ exports[`Storyshots SidePanel large docked 1`] = `
         </button>
       </div>
       <ul
-        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
       >
         <li
           aria-current={true}
@@ -931,7 +931,7 @@ exports[`Storyshots SidePanel large reverse 1`] = `
       </button>
     </div>
     <ul
-      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -1020,6 +1020,267 @@ exports[`Storyshots SidePanel large reverse 1`] = `
       </li>
     </ul>
   </nav>
+</div>
+`;
+
+exports[`Storyshots SidePanel links 1`] = `
+<div>
+  <nav
+    style={
+      Object {
+        "bottom": 0,
+        "position": "fixed",
+        "textAlign": "center",
+        "width": "100vw",
+        "zIndex": 1,
+      }
+    }
+  >
+    <div
+      className="btn-group"
+    >
+      <button
+        className="btn"
+        onClick={[Function]}
+      >
+        en
+         
+        (default)
+      </button>
+      <button
+        className="btn"
+        onClick={[Function]}
+      >
+        fr
+         
+      </button>
+      <button
+        className="btn"
+        onClick={[Function]}
+      >
+        it
+         
+      </button>
+    </div>
+  </nav>
+  <svg
+    focusable="false"
+    style={
+      Object {
+        "display": "none",
+      }
+    }
+    xmlns="http://www.w3.org/2000/svg"
+  >
+    <symbol
+      id="talend-arrow-left"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 7H4.4l4-4L7 1.6.6 8 7 14.4 8.4 13l-4-4H15z"
+        />
+      </svg>
+    </symbol>
+    <symbol
+      id="talend-dataprep"
+    >
+      <svg
+        viewBox="0 0 32 32"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M15 6a3 3 0 1 0-3-3 3 3 0 0 0 3 3zM8 8a2 2 0 1 0-2-2 1.999 1.999 0 0 0 2 2zm16-1.6a2 2 0 1 0-2-2 1.999 1.999 0 0 0 2 2zm5.027 23.85l-8.055-14.504A3.303 3.303 0 0 0 20 14.738V11.5a1.894 1.894 0 0 0 2-1.75A1.892 1.892 0 0 0 20 8h-8a1.892 1.892 0 0 0-2 1.75 1.894 1.894 0 0 0 2 1.75v3.238a3.288 3.288 0 0 0-.972 1.008L2.971 30.25A1.08 1.08 0 0 0 4 32h24a1.08 1.08 0 0 0 1.027-1.75zM7.111 28l2.222-4h13.335l2.22 4z"
+        />
+      </svg>
+    </symbol>
+    <symbol
+      id="talend-download"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M16 11v5H0v-5h2v3h12v-3zm-2.6-4L12 5.6l-3 3V0H7v8.6l-3-3L2.6 7 8 12z"
+        />
+      </svg>
+    </symbol>
+    <symbol
+      id="talend-star"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M8 0l2.5 5 5.5.8-4 3.9.9 5.5L8 12.6l-4.9 2.6.9-5.5-4-3.9L5.5 5z"
+        />
+      </svg>
+    </symbol>
+    <symbol
+      id="talend-opener"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M3.508 7.998l5.23 5.151c.1.099.1.258 0 .356l-1.444 1.421a.258.258 0 0 1-.36 0L1.538 9.613c-.007-.006-.015-.003-.02-.009L.073 8.182a.25.25 0 0 1 0-.355l.001-.001c.002-.002.001-.006.004-.008l1.443-1.422c.003-.002.006-.001.008-.003l5.4-5.319a.258.258 0 0 1 .36 0l1.444 1.421a.25.25 0 0 1 0 .356L3.508 7.998zm12.417 5.151c.1.098.1.257 0 .355l-1.443 1.422a.258.258 0 0 1-.36 0L8.727 9.612c-.006-.005-.016-.003-.022-.008L7.263 8.182a.249.249 0 0 1 0-.356c.002-.002.002-.006.004-.009l1.443-1.42c.002-.003.006-.002.008-.005l5.4-5.319a.258.258 0 0 1 .36 0l1.443 1.422c.1.098.1.257 0 .355l-5.225 5.148 5.23 5.151z"
+        />
+      </svg>
+    </symbol>
+    <symbol
+      id="talend-world"
+    >
+      <svg
+        viewBox="0 0 16 16"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <path
+          d="M.1 9.26a8.07 8.07 0 0 1 3.718-8.077 7.965 7.965 0 0 1 8.073-.164 8.15 8.15 0 0 1 3.994 8.33 7.995 7.995 0 0 1-14.337 3.376A7.94 7.94 0 0 1 .1 9.26zm4.08-.195a1.146 1.146 0 0 0 1.78.842c.344.072.99.191.81.744a2.273 2.273 0 0 1 .226 1.782c.313.62-.065 1.737.688 2.024.868.007 1.13-.925 1.578-1.474-.197-.682 1.003-.914.457-1.68-.186-.767.678-1.228.984-1.837.189-.366.277-.618-.178-.37-.694.03-1.144-.674-1.396-1.238.482-.922.777.76 1.17.98.784-.094 1.15-.826 1.448-1.365.483-.054.743.491 1.19.462.358.321.118 1.652.697 1.409-.066-.643.476-1.58 1.08-1.482-.034.71.483.35.34-.156a6.702 6.702 0 0 0-3.133-5.338c-.55-.012-.856-.293-1.072-.11-.063.427-.17.693-.705.588-.572-.204-1.033.75-1.48.38.183-.175.399-.9-.255-.834-.773.002-1.802-.105-2.245.68-.113.453.67.72.816.887.394-.756 1.496.19.456.237a3.907 3.907 0 0 0-2.123.625c.562.34.003.556-.336.571-.089.248-.1.867.194.765.61.136 1.163-1.317 1.76-.526.163.337.696.5.364-.045-.252-.256-.403-.745.057-.312.134.199.852 1.24.713.519.102-.518.378.555.769.404.844.362-.097 1.107-.676.806-.464.056-.687.585-1.123.043-.268-.163-.008-.697-.58-.476-.809.048-1.613.153-1.992.991-.418.4-.167 1-.283 1.503zm.906-4.761c.29.598 1.485-.156.79-.75-.471-.591-.995-.09-.498.426-.002.18-.168.24-.291.324z"
+        />
+      </svg>
+    </symbol>
+  </svg>
+  <div
+    style={
+      Object {
+        "background": "#236192",
+        "display": "inline-table",
+      }
+    }
+  >
+    <nav
+      aria-expanded={true}
+      className="theme-tc-side-panel tc-side-panel"
+      id="context"
+      role="navigation"
+    >
+      <div
+        className="theme-toggle-btn tc-side-panel-toggle-btn"
+        title="Collapse"
+      >
+        <button
+          className="btn btn-link"
+          disabled={false}
+          id="context-toggle-dock"
+          onClick={[Function]}
+          onMouseDown={[Function]}
+          role={null}
+          type="button"
+        >
+          <svg
+            aria-hidden="true"
+            className="theme-tc-svg-icon tc-svg-icon"
+            focusable="false"
+            title={null}
+          >
+            <use
+              xlinkHref="#talend-opener"
+            />
+          </svg>
+          <span>
+            
+          </span>
+        </button>
+      </div>
+      <ul
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+      >
+        <li
+          aria-current={true}
+          className="theme-tc-action-list-item tc-action-list-item active theme-active"
+          role="presentation"
+          title="Preparations"
+        >
+          <a
+            className="btn btn-link"
+            href="/preparations"
+            id="context-nav-preparations"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="theme-tc-svg-icon tc-svg-icon"
+              focusable="false"
+              title={null}
+            >
+              <use
+                xlinkHref="#talend-dataprep"
+              />
+            </svg>
+            <span>
+              Preparations
+            </span>
+          </a>
+        </li>
+        <li
+          className="theme-tc-action-list-item tc-action-list-item"
+          role="presentation"
+          title="Datasets"
+        >
+          <a
+            className="btn btn-link"
+            href="/datasets"
+            id="context-nav-datasets"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="theme-tc-svg-icon tc-svg-icon"
+              focusable="false"
+              title={null}
+            >
+              <use
+                xlinkHref="#talend-download"
+              />
+            </svg>
+            <span>
+              Datasets
+            </span>
+          </a>
+        </li>
+        <li
+          className="theme-tc-action-list-item tc-action-list-item"
+          role="presentation"
+          title="Favorites"
+        >
+          <a
+            className="btn btn-link"
+            href="/favorites"
+            id="context-nav-favorites"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            onMouseDown={[Function]}
+            role={null}
+          >
+            <svg
+              aria-hidden="true"
+              className="theme-tc-svg-icon tc-svg-icon"
+              focusable="false"
+              title={null}
+            >
+              <use
+                xlinkHref="#talend-star"
+              />
+            </svg>
+            <span>
+              Favorites
+            </span>
+          </a>
+        </li>
+      </ul>
+    </nav>
+  </div>
 </div>
 `;
 
@@ -1160,7 +1421,7 @@ exports[`Storyshots SidePanel not dockable 1`] = `
       role="navigation"
     >
       <ul
-        className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+        className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
       >
         <li
           className="theme-tc-action-list-item tc-action-list-item"
@@ -1409,7 +1670,7 @@ exports[`Storyshots SidePanel reverse 1`] = `
       </button>
     </div>
     <ul
-      className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+      className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
     >
       <li
         className="theme-tc-action-list-item tc-action-list-item"
@@ -1667,7 +1928,7 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
             </button>
           </div>
           <ul
-            className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+            className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
           >
             <li
               className="theme-tc-action-list-item tc-action-list-item"
@@ -2279,7 +2540,7 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
             </button>
           </div>
           <ul
-            className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+            className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
           >
             <li
               className="theme-tc-action-list-item tc-action-list-item"
@@ -2893,7 +3154,7 @@ exports[`Storyshots SidePanel 🎨 [PORTAL] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -3158,7 +3419,7 @@ exports[`Storyshots SidePanel 🎨 [TDC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -3423,7 +3684,7 @@ exports[`Storyshots SidePanel 🎨 [TDP] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -3688,7 +3949,7 @@ exports[`Storyshots SidePanel 🎨 [TDS] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -3953,7 +4214,7 @@ exports[`Storyshots SidePanel 🎨 [TFD] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -4218,7 +4479,7 @@ exports[`Storyshots SidePanel 🎨 [TIC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}
@@ -4483,7 +4744,7 @@ exports[`Storyshots SidePanel 🎨 [TMC] SidePanel 1`] = `
           </button>
         </div>
         <ul
-          className="nav nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
+          className="nav nav-inverse nav-pills nav-stacked theme-tc-action-list tc-action-list theme-tc-side-panel-list tc-side-panel-list"
         >
           <li
             aria-current={true}

--- a/packages/components/stories/ActionList.js
+++ b/packages/components/stories/ActionList.js
@@ -63,7 +63,7 @@ stories
 		</div>
 	))
 	.addWithInfo('default', () => (
-		<div style={{ display: 'inline-table', background: '#236192' }}>
+		<div style={{ display: 'inline-table' }}>
 			<ActionList
 				id="context"
 				actions={actions}
@@ -111,7 +111,7 @@ stories
 					}`
 				}
 			</style>
-			<div style={{ display: 'inline-table', background: '#236192' }}>
+			<div style={{ display: 'inline-table' }}>
 				<ActionList
 					id="context"
 					actions={actions}
@@ -125,7 +125,7 @@ stories
 		</div>
 	))
 	.addWithInfo('single', () => (
-		<div style={{ display: 'inline-table', background: '#236192' }}>
+		<div style={{ display: 'inline-table' }}>
 			<ActionList
 				id="context"
 				actions={[actions[1]]}

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -36,6 +36,25 @@ const actions = [
 	},
 ];
 
+const actionsLinks = [
+	{
+		label: 'Preparations',
+		icon: 'talend-dataprep',
+		href: '/preparations',
+		active: true,
+	},
+	{
+		label: 'Datasets',
+		icon: 'talend-download',
+		href: '/datasets',
+	},
+	{
+		label: 'Favorites',
+		icon: 'talend-star',
+		href: '/favorites',
+	},
+];
+
 const items = [
 	{
 		key: 'preparations',
@@ -75,6 +94,16 @@ stories
 				id="context"
 				actions={actions}
 				onSelect={action('onItemSelect')}
+				onToggleDock={action('onToggleDock')}
+				tooltipPlacement="top"
+			/>
+		</div>
+	))
+	.addWithInfo('links', () => (
+		<div style={{ display: 'inline-table', background: '#236192' }}>
+			<SidePanel
+				id="context"
+				actions={actionsLinks}
 				onToggleDock={action('onToggleDock')}
 				tooltipPlacement="top"
 			/>

--- a/packages/theme/example/index.html
+++ b/packages/theme/example/index.html
@@ -1164,9 +1164,29 @@
             <br>
             <div class="bs-component">
               <ul class="nav nav-pills nav-stacked">
-                <li class="active"><button class="btn btn-link" role="link">Home</button></li>
+                <li class="active"><button class="btn btn-link" role="link">Home with buttons</button></li>
                 <li><button class="btn btn-link" role="link">Profile</button></li>
                 <li class="disabled"><button class="btn btn-link" role="link" disabled>Disabled</button></li>
+                <li class="dropdown">
+                  <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                    Dropdown <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                    <li><a href="#">Something else here</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Separated link</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
+            <br>
+            <div class="bs-component">
+              <ul class="nav nav-pills nav-stacked">
+                <li class="active"><a class="btn btn-link">Home with links</a></li>
+                <li><a class="btn btn-link">Profile</a></li>
+                <li class="disabled"><a class="btn btn-link" disabled>Disabled</a></li>
                 <li class="dropdown">
                   <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
                     Dropdown <span class="caret"></span>
@@ -1204,7 +1224,7 @@
             <br>
             <div class="bs-component">
               <ul class="nav nav-inverse nav-pills nav-stacked">
-                <li class="active"><button class="btn btn-link" role="link">Home</button></li>
+                <li class="active"><button class="btn btn-link" role="link">Home with buttons</button></li>
                 <li><button class="btn btn-link" role="link">Raw denim you probably haven't heard of them jean shorts Austin. Nesciunt tofu stumptown aliqua, retro synth master cleanse. Mustache cliche tempor, williamsburg carles vegan helvetica. Reprehenderit butcher retro keffiyeh dreamcatcher synth. Cosby sweater eu banh mi, qui irure terry richardson ex squid. Aliquip placeat salvia cillum iphone. Seitan aliquip quis cardigan american apparel, butcher voluptate nisi qui.</button></li>
                 <li class="disabled"><button class="btn btn-link" role="link" disabled="disabled">Disabled</button></li>
                 <li class="dropdown">
@@ -1221,7 +1241,28 @@
                 </li>
               </ul>
             </div>
+            <br>
+            <div class="bs-component">
+              <ul class="nav nav-pills nav-inverse nav-stacked">
+                <li class="active"><a class="btn btn-link">Home with links</a></li>
+                <li><a class="btn btn-link">Profile</a></li>
+                <li class="disabled"><a class="btn btn-link" disabled>Disabled</a></li>
+                <li class="dropdown">
+                  <button class="btn btn-link dropdown-toggle" data-toggle="dropdown">
+                    Dropdown <span class="caret"></span>
+                  </button>
+                  <ul class="dropdown-menu">
+                    <li><a href="#">Action</a></li>
+                    <li><a href="#">Another action</a></li>
+                    <li><a href="#">Something else here</a></li>
+                    <li class="divider"></li>
+                    <li><a href="#">Separated link</a></li>
+                  </ul>
+                </li>
+              </ul>
+            </div>
           </div>
+
           <div class="col-lg-4">
             <h2 id="breadcrumbs">Breadcrumbs</h2>
             <div class="bs-component">

--- a/packages/theme/src/theme/_navs.scss
+++ b/packages/theme/src/theme/_navs.scss
@@ -66,6 +66,22 @@
 			.btn.btn-link {
 				width: 100%;
 				text-align: left;
+				background-color: transparent;
+			}
+		}
+	}
+
+	&-pills.nav-inverse {
+		> li {
+			&:focus,
+			&:hover {
+				background-color: rgba($white, 0.12);
+			}
+
+			&:active,
+			&.active,
+			&.open {
+				background-color: rgba($white, 0.25);
 			}
 		}
 	}

--- a/packages/theme/src/theme/_visual-helpers.scss
+++ b/packages/theme/src/theme/_visual-helpers.scss
@@ -78,6 +78,10 @@
 		overflow: hidden;
 		background: linear-gradient(#{$gradient-angle}, $st-tropaz, $brand-primary 95%);
 
+		.nav-inverse {
+			background-color: transparent;
+		}
+
 		&:before {
 			content: '';
 			position: absolute;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When using side panel with `<a>` tags, the colors is different than with buttons.

**What is the chosen solution to this problem?**
Align the styles, within the theme.
Removed duplicate/custom style in ActionList, and use the theme.

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

