### PR TITLE
chore(): remove prop-types warnings

### DIFF
--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -39,7 +39,7 @@ import api from './api';
 import deprecated from './deprecated';
 import CONSTANT from './constant';
 
-import { statePropTypes, initState, getStateAccessors, getStateProps } from './componentState';
+import { initState, getStateAccessors, getStateProps } from './componentState';
 import { mapStateToViewProps } from './settings';
 
 let newState;
@@ -242,7 +242,7 @@ export default function cmfConnect({
 			static displayName = `CMF(${getComponentName(WrappedComponent)})`;
 			static propTypes = {
 				...WrappedComponent.propTypes,
-				...statePropTypes,
+				...cmfConnect.propTypes,
 			};
 			static contextTypes = {
 				store: PropTypes.object,

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -327,7 +327,7 @@ if (process.env.NODE_ENV !== 'production') {
 		help: PropTypes.shape(omit(Help.propTypes, 't')),
 		information: PropTypes.shape(omit(Information.propTypes, 't')),
 		user: PropTypes.shape(User.propTypes),
-		notification: PropTypes.shape(AppNotification.propTypes, 't'),
+		notification: PropTypes.shape(omit(AppNotification.propTypes, 't')),
 		products: PropTypes.shape({
 			items: PropTypes.array,
 			onSelect: PropTypes.func,

--- a/packages/components/src/wrap.js
+++ b/packages/components/src/wrap.js
@@ -28,6 +28,10 @@ const BLACK_LISTED_ATTR = [
 	'propTypes', // already set by HOC
 ];
 
+const COMPONENT_EXCEPTIONS = {
+	MenuItem: props => props.divider,
+};
+
 function isNotBlackListedAttr(attr) {
 	return !BLACK_LISTED_ATTR.includes(attr);
 }
@@ -36,6 +40,9 @@ export default function wrap(Component, key) {
 	const Wrapper = ({ getComponent, components, text, ...props }) => {
 		const injected = Inject.all(getComponent, components);
 		const newprops = Object.assign({}, omit(props, OMIT_PROPS));
+		if (COMPONENT_EXCEPTIONS[key] && COMPONENT_EXCEPTIONS[key](props)) {
+			return <Component {...newprops} />;
+		}
 		return (
 			<Component {...newprops}>
 				{injected('children')}

--- a/packages/containers/src/ActionFile/ActionFile.connect.js
+++ b/packages/containers/src/ActionFile/ActionFile.connect.js
@@ -54,8 +54,8 @@ ContainerActionFile.propTypes = {
 	actionCreator: PropTypes.string,
 	dispatch: PropTypes.func,
 	dispatchActionCreator: PropTypes.func,
-	model: PropTypes.Object,
-	payload: PropTypes.Object,
+	model: PropTypes.object,
+	payload: PropTypes.object,
 };
 
 export default cmfConnect({

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -1,4 +1,5 @@
 import PropTypes from 'prop-types';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import React from 'react';
 import { Map } from 'immutable';
 import { List as Component } from '@talend/react-components';
@@ -54,7 +55,7 @@ class List extends React.Component {
 			}),
 		}),
 		displayMode: PropTypes.string,
-		items: PropTypes.arrayOf(PropTypes.object).isRequired,
+		items: ImmutablePropTypes.list.isRequired,
 		...cmfConnect.propTypes,
 	};
 

--- a/packages/containers/src/state.js
+++ b/packages/containers/src/state.js
@@ -1,4 +1,4 @@
-import { componentState } from '@talend/react-cmf';
+import { componentState, cmfConnect } from '@talend/react-cmf';
 
 /* eslint-disable no-console */
 console.warn(`DEPRECATION WARNING: import state, {} from '@talend/react-containers'; is deprecated.
@@ -20,4 +20,4 @@ export const stateWillMount = props => {
 	/* eslint-enable no-console */
 	componentState.init(props);
 };
-export const statePropTypes = componentState.propTypes;
+export const statePropTypes = cmfConnect.propTypes;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Remove some prop-types warnings from the client developer console

**What is the chosen solution to this problem?**
- Use cmfConnect propTypes instead of deprecated statePropTypes. 
- Use immutable proptypes where needed
- Fix typos

**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

