### PR TITLE
feat(components): add skeleton on action button

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -5,6 +5,7 @@ import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
 
 import TooltipTrigger from '../../TooltipTrigger';
 import CircularProgress from '../../CircularProgress';
+import Skeleton from '../../Skeleton';
 import Icon from '../../Icon';
 import getPropsFrom from '../../utils/getPropsFrom';
 import theme from './ActionButton.scss';
@@ -12,9 +13,22 @@ import theme from './ActionButton.scss';
 const LEFT = 'left';
 const RIGHT = 'right';
 
-function getIcon({ icon, iconTransform, inProgress }) {
+function getIcon({ icon, iconTransform, inProgress, loading }) {
 	if (inProgress) {
 		return <CircularProgress size="small" key="icon" />;
+	}
+
+	if (loading) {
+		return (
+			<Skeleton
+				size="small"
+				type="circle"
+				className={classNames(
+					theme['tc-action-button-skeleton-circle'],
+					'tc-action-button-skeleton-circle',
+				)}
+			/>
+		);
 	}
 
 	if (icon) {
@@ -29,15 +43,19 @@ getIcon.propTypes = {
 	inProgress: PropTypes.bool,
 };
 
-function getLabel({ hideLabel, label }) {
+function getLabel({ hideLabel, label, loading }) {
 	if (hideLabel) {
 		return null;
+	}
+	if (loading) {
+		return <Skeleton type="text" size="medium" />;
 	}
 	return <span key="label">{label}</span>;
 }
 
 getLabel.propTypes = {
 	label: PropTypes.string,
+	loading: PropTypes.bool,
 	hideLabel: PropTypes.bool,
 };
 
@@ -74,6 +92,7 @@ function ActionButton(props) {
 		disabled,
 		hideLabel,
 		label,
+		loading,
 		link,
 		model,
 		onMouseDown = noOp,
@@ -91,7 +110,13 @@ function ActionButton(props) {
 		return null;
 	}
 
+	if (loading && !link) {
+		return <Skeleton type="button" />;
+	}
+
 	const buttonProps = getPropsFrom(Button, rest);
+	const buttonContent = getContent(props);
+	const btnIsDisabled = inProgress || disabled;
 	const style = link ? 'link' : bsStyle;
 	let rClick = null;
 	let rMouseDown = null;
@@ -110,9 +135,6 @@ function ActionButton(props) {
 				model,
 			});
 	}
-
-	const buttonContent = getContent(props);
-	const btnIsDisabled = inProgress || disabled;
 
 	if (btnIsDisabled) {
 		buttonProps.className = classNames(buttonProps.className, theme['btn-disabled']);
@@ -164,6 +186,7 @@ ActionButton.propTypes = {
 	hideLabel: PropTypes.bool,
 	iconPosition: PropTypes.oneOf([LEFT, RIGHT]),
 	label: PropTypes.string.isRequired,
+	loading: PropTypes.bool,
 	link: PropTypes.bool,
 	model: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 	name: PropTypes.string,
@@ -180,6 +203,7 @@ ActionButton.defaultProps = {
 	bsStyle: 'default',
 	tooltipPlacement: 'top',
 	inProgress: false,
+	loading: false,
 	disabled: false,
 };
 

--- a/packages/components/src/Actions/ActionButton/ActionButton.scss
+++ b/packages/components/src/Actions/ActionButton/ActionButton.scss
@@ -1,3 +1,8 @@
 .btn-disabled {
 	pointer-events: none;
 }
+
+.tc-action-button-skeleton-circle {
+	margin-left: $padding-smaller;
+	margin-right: $padding-small;
+}

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -25,7 +25,7 @@ describe('Action', () => {
 
 	it('should render a button with loading state', () => {
 		// when
-		const wrapper = shallow(<ActionButton {...myAction} loading />);
+		const wrapper = shallow(<ActionButton loading />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -33,7 +33,7 @@ describe('Action', () => {
 
 	it('should render a link button with loading state', () => {
 		// when
-		const wrapper = shallow(<ActionButton {...myAction} link loading />);
+		const wrapper = shallow(<ActionButton link loading />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -23,6 +23,22 @@ describe('Action', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render a button with loading state', () => {
+		// when
+		const wrapper = shallow(<ActionButton {...myAction} loading />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render a link button with loading state', () => {
+		// when
+		const wrapper = shallow(<ActionButton {...myAction} link loading />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	it('should click on the button trigger the onclick props', () => {
 		// given
 		const wrapper = shallow(<ActionButton extra="extra" {...myAction} />);

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -145,6 +145,13 @@ exports[`Action should render a button with a overlay component 1`] = `
 </span>
 `;
 
+exports[`Action should render a button with loading state 1`] = `
+<Skeleton
+  size="medium"
+  type="button"
+/>
+`;
+
 exports[`Action should render a button without an overlay component if inProgress is true 1`] = `
 <Button
   active={false}
@@ -163,6 +170,29 @@ exports[`Action should render a button without an overlay component if inProgres
   <span>
     Click me
   </span>
+</Button>
+`;
+
+exports[`Action should render a link button with loading state 1`] = `
+<Button
+  active={false}
+  block={false}
+  bsClass="btn"
+  bsStyle="link"
+  disabled={false}
+  onClick={[Function]}
+  onMouseDown={[Function]}
+  role="link"
+>
+  <Skeleton
+    className="theme-tc-action-button-skeleton-circle tc-action-button-skeleton-circle"
+    size="small"
+    type="circle"
+  />
+  <Skeleton
+    size="medium"
+    type="text"
+  />
 </Button>
 `;
 

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -5186,6 +5186,7 @@ exports[`List should render 1`] = `
                           icon="talend-search"
                           inProgress={false}
                           label="Toggle filter"
+                          loading={false}
                           onClick={[Function]}
                           tooltipPlacement="top"
                         >
@@ -10437,6 +10438,7 @@ exports[`List should render id if provided 1`] = `
                           id="context-filter"
                           inProgress={false}
                           label="Toggle filter"
+                          loading={false}
                           onClick={[Function]}
                           tooltipPlacement="top"
                         >

--- a/packages/components/src/Skeleton/Skeleton.scss
+++ b/packages/components/src/Skeleton/Skeleton.scss
@@ -7,7 +7,7 @@ $tc-skeleton-circle-medium-size: 20px !default;
 $tc-skeleton-circle-large-size: 24px !default;
 $tc-skeleton-text-height: 14px !default;
 $tc-skeleton-text-width-small: 30px !default;
-$tc-skeleton-text-width-medium: 100px !default;
+$tc-skeleton-text-width-medium: 60px !default;
 $tc-skeleton-text-width-large: 130px !default;
 $tc-skeleton-text-width-extra-large: 160px !default;
 $tc-skeleton-button-height: 35px !default;

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -39,11 +39,11 @@ storiesOf('Action', module)
 			<p>In progress</p>
 			<Action id="inprogress" {...myAction} inProgress />
 			<p>loading</p>
-			<Action id="loading" {...myAction} loading />
+			<Action id="loading" loading />
 			<p>Icon button</p>
 			<Action id="icon" {...myAction} link />
 			<p>Loading Icon button</p>
-			<Action id="icon" {...myAction} link loading />
+			<Action id="icon" link loading />
 			<p>Disabled</p>
 			<Action id="disabled" {...myAction} disabled />
 			<p>Reverse display</p>

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -38,6 +38,12 @@ storiesOf('Action', module)
 			<Action id="hidelabel" {...myAction} hideLabel />
 			<p>In progress</p>
 			<Action id="inprogress" {...myAction} inProgress />
+			<p>loading</p>
+			<Action id="loading" {...myAction} loading />
+			<p>Icon button</p>
+			<Action id="icon" {...myAction} link />
+			<p>Loading Icon button</p>
+			<Action id="icon" {...myAction} link loading />
 			<p>Disabled</p>
 			<Action id="disabled" {...myAction} disabled />
 			<p>Reverse display</p>

--- a/packages/containers/src/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/containers/src/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -6,6 +6,7 @@ exports[`CMF(Container(ActionButton)) should inject a component overlay 1`] = `
   bsStyle="default"
   disabled={false}
   inProgress={false}
+  loading={false}
   onClick={[Function]}
   overlayComponent={
     <Inject
@@ -25,6 +26,7 @@ exports[`CMF(Container(ActionButton)) should render 1`] = `
   disabled={false}
   extra="foo"
   inProgress={false}
+  loading={false}
   onClick={[Function]}
   tooltipPlacement="top"
 />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an inProgress state but loading state is not dev for action button
**What is the chosen solution to this problem?**
Implement it
**Please check if the PR fulfills these requirements**
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- **Original Template** -->
<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

