### PR TITLE
feat(containers/form): add generic onTrigger

### DIFF
--- a/packages/containers/src/Form/Form.container.js
+++ b/packages/containers/src/Form/Form.container.js
@@ -62,11 +62,27 @@ class Form extends React.Component {
 	onTrigger(formData, formId, propertyName, propertyValue) {
 		if (this.props.onTrigger) {
 			this.props.onTrigger(formData, formId, propertyName, propertyValue);
+		} else if (propertyName !== 'properties') {
+			this.props.dispatchActionCreator(
+				'Form#onTriggerAfter',
+				{ type: 'onTrigger', target: this, props: this.props },
+				{
+					formData,
+					formId,
+					propertyName,
+					propertyValue,
+				},
+			);
 		}
 	}
 
 	onChange(form) {
-		this.props.setState({ data: form.formData, dirty: true });
+		this.props.setState(oldState => {
+			if (oldState.state.get('formData')) {
+				return { formData: oldState.state.get('formData').mergeDeep(form.formData) };
+			}
+			return { ...form, dirty: true };
+		});
 		if (this.props.onChange) {
 			this.props.onChange(form);
 		}

--- a/packages/containers/src/Form/actions.js
+++ b/packages/containers/src/Form/actions.js
@@ -1,0 +1,28 @@
+import { api } from '@talend/react-cmf';
+
+function onTriggerAfter(event, data) {
+	const {
+		collectionId,
+		properties,
+		url,
+	} = data;
+	// const definitionName = properties['@definitionName'];
+	// const store = context.store.getState();
+	// const data = store.cmf.collections.get(collectionId);
+	return api.actions.http.post(url, properties, {
+		// transform(response) {
+		// 	const newResponse = Object.assign({}, response, {
+		// 		properties,
+		// 	});
+		// 	newResponse.properties.properties = response.properties.properties;
+		// 	return newResponse;
+		// },
+		cmf: {
+			collectionId,
+		},
+	});
+}
+
+export default {
+	'Form#onTriggerAfter': onTriggerAfter,
+};

--- a/packages/containers/src/Form/index.js
+++ b/packages/containers/src/Form/index.js
@@ -1,3 +1,6 @@
 import Form from './Form.connect';
+import actions from './actions';
+
+Form.actions = actions;
 
 export default Form;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Today we have multiple forms in our project which use tcomp. They all have their own implementation of onTrigger.

**What is the chosen solution to this problem?**

Let's provide a generic implementation, so specific form can use this one.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
