### PR TITLE
fix(theme): fix filter bar styling in forms

### DIFF
--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -10,11 +10,11 @@ src/theme/_dropdowns.scss
   22:22  error  !important not allowed  no-important
 
 src/theme/_forms.scss
-  109:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  125:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  356:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  369:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  459:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  113:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  129:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  360:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  373:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  463:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_tables.scss
   21:2   warning  Vendor prefixes should not be used  no-vendor-prefixes

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -10,11 +10,13 @@ src/theme/_dropdowns.scss
   22:22  error  !important not allowed  no-important
 
 src/theme/_forms.scss
-  113:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  129:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  360:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  373:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  463:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+   29:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+   64:7   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  115:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  131:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  362:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  375:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  465:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_tables.scss
   21:2   warning  Vendor prefixes should not be used  no-vendor-prefixes
@@ -22,5 +24,5 @@ src/theme/_tables.scss
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 11 problems (8 errors, 3 warnings)
+✖ 13 problems (10 errors, 3 warnings)
 

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -30,10 +30,12 @@ form {
 		input[type='password'],
 		input[type='email'],
 		input[type='number'],
+		input[type='search'],
 		[type='text'].form-control,
 		[type='password'].form-control,
 		[type='email'].form-control,
 		[type='tel'].form-control,
+		[type='search'].form-control,
 		[contenteditable].form-control {
 			&:focus:not([readonly]) + label {
 				color: $scooter;
@@ -62,10 +64,12 @@ form {
 	input[type='password'],
 	input[type='email'],
 	input[type='number'],
+	input[type='search'],
 	[type='text'].form-control,
 	[type='password'].form-control,
 	[type='email'].form-control,
 	[type='tel'].form-control,
+	[type='search'].form-control,
 	[contenteditable].form-control {
 		box-shadow: none;
 		padding: 0;

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -26,6 +26,7 @@ form {
 
 	div:not(.has-success):not(.has-warning):not(.has-error) {
 		textarea,
+        input.form-control,
 		input[type='text'],
 		input[type='password'],
 		input[type='email'],
@@ -60,6 +61,7 @@ form {
 	}
 
 	textarea,
+    input.form-control,
 	input[type='text'],
 	input[type='password'],
 	input[type='email'],

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -26,7 +26,7 @@ form {
 
 	div:not(.has-success):not(.has-warning):not(.has-error) {
 		textarea,
-        input.form-control,
+		input.form-control,
 		input[type='text'],
 		input[type='password'],
 		input[type='email'],
@@ -61,7 +61,7 @@ form {
 	}
 
 	textarea,
-    input.form-control,
+	input.form-control,
 	input[type='text'],
 	input[type='password'],
 	input[type='email'],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Filter bar styling not applied after the recent changes made from https://jira.talendforge.org/browse/TUI-87

**What is the chosen solution to this problem?**
Applying custom styles to search fields under form-group class

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
