### PR TITLE
fix(forms): apply border styling for form input fields in focus

### DIFF
--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -12,11 +12,11 @@ src/theme/_dropdowns.scss
 src/theme/_forms.scss
    29:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
    64:7   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  115:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  131:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  362:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  375:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  465:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  116:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  132:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  363:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  376:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  467:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_tables.scss
   21:2   warning  Vendor prefixes should not be used  no-vendor-prefixes

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -12,11 +12,14 @@ src/theme/_dropdowns.scss
 src/theme/_forms.scss
    29:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
    64:7   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  116:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  132:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  363:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  376:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  467:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+   81:3   error    Mixins should come before declarations                   mixins-before-declarations
+  115:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  118:3   error    Mixins should come before declarations                   mixins-before-declarations
+  130:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  361:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  374:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  380:3   error    Mixins should come before declarations                   mixins-before-declarations
+  463:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_tables.scss
   21:2   warning  Vendor prefixes should not be used  no-vendor-prefixes
@@ -24,5 +27,5 @@ src/theme/_tables.scss
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 13 problems (10 errors, 3 warnings)
+✖ 16 problems (13 errors, 3 warnings)
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -12,13 +12,10 @@ src/theme/_dropdowns.scss
 src/theme/_forms.scss
    29:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
    64:7   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-   81:3   error    Mixins should come before declarations                   mixins-before-declarations
   115:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  118:3   error    Mixins should come before declarations                   mixins-before-declarations
   130:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
   361:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
   374:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  380:3   error    Mixins should come before declarations                   mixins-before-declarations
   463:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_tables.scss
@@ -27,5 +24,5 @@ src/theme/_tables.scss
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 16 problems (13 errors, 3 warnings)
+✖ 13 problems (10 errors, 3 warnings)
 

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -18,7 +18,7 @@ $tf-typeahead-input-width: 135px !default;
 	padding: 0;
 
 	&:focus-within {
-		box-shadow: $form-focus-shadow;
+		border-bottom: $form-focus-border-bottom;
 	}
 
 	.typeahead {

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -12,14 +12,12 @@ $tf-typeahead-input-width: 135px !default;
 
 	border: 0;
 	border-radius: 0;
-	border-bottom: $form-border-bottom;
-	box-shadow: none;
+	@include box-shadow($form-shadow);
 	height: auto;
 	padding: 0;
 
 	&:focus-within {
-		border-bottom: $form-focus-border-bottom;
-		box-shadow: none;
+		@include box-shadow($form-focus-shadow);
 	}
 
 	.typeahead {

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -12,12 +12,12 @@ $tf-typeahead-input-width: 135px !default;
 
 	border: 0;
 	border-radius: 0;
-	@include box-shadow($form-shadow);
+	box-shadow: $form-shadow;
 	height: auto;
 	padding: 0;
 
 	&:focus-within {
-		@include box-shadow($form-focus-shadow);
+		box-shadow: $form-focus-shadow;
 	}
 
 	.typeahead {

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -19,6 +19,7 @@ $tf-typeahead-input-width: 135px !default;
 
 	&:focus-within {
 		border-bottom: $form-focus-border-bottom;
+		box-shadow: none;
 	}
 
 	.typeahead {

--- a/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
@@ -25,7 +25,7 @@ $tf-typeahead-section-border-color: #e0e0e0 !default;
 
 	border: 0;
 	border-radius: 0;
-	@include box-shadow($form-shadow);
+	box-shadow: $form-shadow;
 	padding: 0;
 
 	.typeahead {

--- a/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
@@ -25,8 +25,7 @@ $tf-typeahead-section-border-color: #e0e0e0 !default;
 
 	border: 0;
 	border-radius: 0;
-	border-bottom: $form-border-bottom;
-	box-shadow: none;
+	@include box-shadow($form-shadow);
 	padding: 0;
 
 	.typeahead {

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -4,7 +4,7 @@
 ////
 
 $form-border-bottom: solid 1px $gallery;
-$form-focus-shadow: inset 0 -2px 0 $scooter;
+$form-focus-border-bottom: solid 2px $scooter;
 
 @import 'forms.switch';
 @import 'forms.switch-nested';
@@ -82,7 +82,7 @@ form {
 		border-bottom: $form-border-bottom;
 
 		&:focus {
-			@include box-shadow($form-focus-shadow);
+			border-bottom: $form-focus-border-bottom;
 		}
 
 		&[disabled] {
@@ -383,7 +383,7 @@ form {
 		border-right: 1px solid $gallery;
 
 		&:focus {
-			@include box-shadow($form-focus-shadow);
+			border-bottom: $form-focus-border-bottom;
 		}
 	}
 }

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -83,6 +83,7 @@ form {
 
 		&:focus {
 			border-bottom: $form-focus-border-bottom;
+			box-shadow: none;
 		}
 
 		&[disabled] {
@@ -384,6 +385,7 @@ form {
 
 		&:focus {
 			border-bottom: $form-focus-border-bottom;
+            box-shadow: none;
 		}
 	}
 }

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -385,7 +385,7 @@ form {
 
 		&:focus {
 			border-bottom: $form-focus-border-bottom;
-            box-shadow: none;
+			box-shadow: none;
 		}
 	}
 }

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -78,10 +78,10 @@ form {
 		border-radius: 0;
 		font-size: $form-input-font-size;
 		font-weight: $form-base-font-weight;
-		@include box-shadow($form-shadow);
+		box-shadow: $form-shadow;
 
 		&:focus {
-			@include box-shadow($form-focus-shadow);
+			box-shadow: $form-focus-shadow;
 		}
 
 		&[disabled] {
@@ -115,7 +115,7 @@ form {
 	select.form-control {
 		border: none;
 		border-radius: 0;
-		@include box-shadow($form-shadow);
+		box-shadow: $form-shadow;
 		appearance: none;
 		padding-left: 0;
 		padding-right: 0 \9; // remove padding for < ie9 since default arrow can't be removed
@@ -377,11 +377,11 @@ form {
 		border-radius: 0;
 		font-size: $form-input-font-size;
 		font-weight: $form-base-font-weight;
-		@include box-shadow($form-shadow);
+		box-shadow: $form-shadow;
 		border-right: 1px solid $gallery;
 
 		&:focus {
-			@include box-shadow($form-focus-shadow);
+			box-shadow: $form-focus-shadow;
 		}
 	}
 }

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -3,8 +3,8 @@
 /// @group Forms
 ////
 
-$form-border-bottom: solid 1px $gallery;
-$form-focus-border-bottom: solid 2px $scooter;
+$form-shadow: inset 0 -1px 0 $gallery;
+$form-focus-shadow: inset 0 -2px 0 $scooter;
 
 @import 'forms.switch';
 @import 'forms.switch-nested';
@@ -73,22 +73,21 @@ form {
 	[type='tel'].form-control,
 	[type='search'].form-control,
 	[contenteditable].form-control {
-		box-shadow: none;
 		padding: 0;
 		border: none;
 		border-radius: 0;
 		font-size: $form-input-font-size;
 		font-weight: $form-base-font-weight;
-		border-bottom: $form-border-bottom;
+		@include box-shadow($form-shadow);
 
 		&:focus {
-			border-bottom: $form-focus-border-bottom;
-			box-shadow: none;
+			@include box-shadow($form-focus-shadow);
 		}
 
 		&[disabled] {
 			background-color: transparent;
 			border-bottom: dashed 1px $gallery;
+			box-shadow: none;
 		}
 
 		&[readonly],
@@ -114,10 +113,9 @@ form {
 	}
 
 	select.form-control {
-		box-shadow: none;
 		border: none;
 		border-radius: 0;
-		border-bottom: $form-border-bottom;
+		@include box-shadow($form-shadow);
 		appearance: none;
 		padding-left: 0;
 		padding-right: 0 \9; // remove padding for < ie9 since default arrow can't be removed
@@ -374,18 +372,16 @@ form {
 	}
 
 	textarea.form-control {
-		box-shadow: none;
 		padding: 0;
 		border: none;
 		border-radius: 0;
 		font-size: $form-input-font-size;
 		font-weight: $form-base-font-weight;
-		border-bottom: $form-border-bottom;
+		@include box-shadow($form-shadow);
 		border-right: 1px solid $gallery;
 
 		&:focus {
-			border-bottom: $form-focus-border-bottom;
-			box-shadow: none;
+			@include box-shadow($form-focus-shadow);
 		}
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Multiple borders for form input fields on focus

**What is the chosen solution to this problem?**
Apply border bottom styling for form input fields on focus

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
