### PR TITLE
fix(TFD-3270): Center InputTitleSubHeader icon in Edge

### DIFF
--- a/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
@@ -114,6 +114,7 @@ $tc-input-subheader-size-small: 1rem !default;
 				padding: 0;
 				margin-left: $padding-large;
 				justify-content: center;
+				align-items: center;
 
 				> svg {
 					width: $tc-input-subheader-size-medium;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In Edge the icon in InputTitleSubHeader is not centered (preview at: SubHeaderBar -> with all)

![input-icons](https://user-images.githubusercontent.com/36537247/38034991-abbc2800-32a3-11e8-9aaf-ac510eeaf065.png)

**What is the chosen solution to this problem?**
Center it with `align-items: center`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
