### PR TITLE
fix(components/virtualizedlist): force button type and remove any icon

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
@@ -40,11 +40,13 @@ function CellTitleSelector(props) {
 				{...columnData}
 				{...rowData}
 				id={id && `${id}-btn`}
+				icon={undefined}
 				className={className}
 				onClick={event => onClick(event, rowData)}
 				role="link"
 				bsStyle="link"
 				label={cellData}
+				type="button"
 			/>
 		);
 	}

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleSelector.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleSelector.test.js.snap
@@ -4,10 +4,12 @@ exports[`CellTitleSelector should render the button 1`] = `
 <Action
   bsStyle="link"
   className="my-title-classname"
+  icon={undefined}
   id="my-title-btn"
   label="my value"
   onClick={[Function]}
   role="link"
+  type="button"
 />
 `;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Before #1235, we're using button instead of Action so any extra `ActionButton` props like `type` or `icon` are not take into account

**What is the chosen solution to this problem?**
Just force CellTitle to the initial rendering.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
