### PR TITLE
fix(forms/listview): update state when receive props

### DIFF
--- a/output/cmf-webpack-plugin.eslint.txt
+++ b/output/cmf-webpack-plugin.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf-webpack-plugin@0.174.0 lint:es /home/travis/build/Talend/ui/packages/cmf-webpack-plugin
+> @talend/react-cmf-webpack-plugin@0.175.0 lint:es /home/travis/build/Talend/ui/packages/cmf-webpack-plugin
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-cmf@0.174.0 lint:es /home/travis/build/Talend/ui/packages/cmf
+> @talend/react-cmf@0.175.0 lint:es /home/travis/build/Talend/ui/packages/cmf
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.174.0 lint:es /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.175.0 lint:es /home/travis/build/Talend/ui/packages/components
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-components@0.174.0 lint:style /home/travis/build/Talend/ui/packages/components
+> @talend/react-components@0.175.0 lint:style /home/travis/build/Talend/ui/packages/components
 > sass-lint -v -q
 
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-containers@0.174.0 lint:es /home/travis/build/Talend/ui/packages/containers
+> @talend/react-containers@0.175.0 lint:es /home/travis/build/Talend/ui/packages/containers
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-datagrid@0.174.0 lint:es /home/travis/build/Talend/ui/packages/datagrid
+> @talend/react-datagrid@0.175.0 lint:es /home/travis/build/Talend/ui/packages/datagrid
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -25,9 +25,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
   59:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
 
-/home/travis/build/Talend/ui/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
-  77:3  warning  Unexpected console statement  no-console
-  88:4  warning  Unexpected console statement  no-console
-
-✖ 11 problems (9 errors, 2 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-forms@0.174.0 lint:es /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.175.0 lint:es /home/travis/build/Talend/ui/packages/forms
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
@@ -25,5 +25,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
   59:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
 
-✖ 9 problems (9 errors, 0 warnings)
+/home/travis/build/Talend/ui/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
+  77:3  warning  Unexpected console statement  no-console
+  88:4  warning  Unexpected console statement  no-console
+
+✖ 11 problems (9 errors, 2 warnings)
 

--- a/output/forms.sasslint.txt
+++ b/output/forms.sasslint.txt
@@ -1,4 +1,4 @@
 
-> @talend/react-forms@0.174.0 lint:style /home/travis/build/Talend/ui/packages/forms
+> @talend/react-forms@0.175.0 lint:style /home/travis/build/Talend/ui/packages/forms
 > sass-lint -v -q
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/log@0.174.0 lint:es /home/travis/build/Talend/ui/packages/logging
+> @talend/log@0.175.0 lint:es /home/travis/build/Talend/ui/packages/logging
 > eslint --config ../../.eslintrc --ext .js src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/sagas.eslint.txt
+++ b/output/sagas.eslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/react-sagas@0.174.0 lint:es /home/travis/build/Talend/ui/packages/sagas
+> @talend/react-sagas@0.175.0 lint:es /home/travis/build/Talend/ui/packages/sagas
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,5 +1,5 @@
 
-> @talend/bootstrap-theme@0.174.0 lint:style /home/travis/build/Talend/ui/packages/theme
+> @talend/bootstrap-theme@0.175.0 lint:style /home/travis/build/Talend/ui/packages/theme
 > sass-lint -q -v
 
 

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
@@ -74,7 +74,6 @@ class ListViewWidget extends React.Component {
 	}
 
 	componentWillReceiveProps(nextProps) {
-		console.log(nextProps);
 		const options = this.props.options || {};
 		const nextOptions = nextProps.options || {};
 		const items = nextOptions.enumOptions.map((option, index) => ({
@@ -85,7 +84,6 @@ class ListViewWidget extends React.Component {
 			onChange: onItemChange.bind(this),
 		}));
 		if (options.enumOptions !== nextOptions.enumOptions) {
-			console.log('new items', items);
 			this.setState({ items, displayedItems: items });
 		}
 	}

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
@@ -73,6 +73,23 @@ class ListViewWidget extends React.Component {
 		};
 	}
 
+	componentWillReceiveProps(nextProps) {
+		console.log(nextProps);
+		const options = this.props.options || {};
+		const nextOptions = nextProps.options || {};
+		const items = nextOptions.enumOptions.map((option, index) => ({
+			index,
+			checked: nextProps.value.indexOf(option.value) !== -1,
+			label: option.label,
+			value: option.value,
+			onChange: onItemChange.bind(this),
+		}));
+		if (options.enumOptions !== nextOptions.enumOptions) {
+			console.log('new items', items);
+			this.setState({ items, displayedItems: items });
+		}
+	}
+
 	setFormData() {
 		this.props.onChange(
 			this.state.items.filter(item => item.checked).map(itemChecked => itemChecked.value),

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
@@ -76,14 +76,14 @@ class ListViewWidget extends React.Component {
 	componentWillReceiveProps(nextProps) {
 		const options = this.props.options || {};
 		const nextOptions = nextProps.options || {};
-		const items = nextOptions.enumOptions.map((option, index) => ({
-			index,
-			checked: nextProps.value.indexOf(option.value) !== -1,
-			label: option.label,
-			value: option.value,
-			onChange: onItemChange.bind(this),
-		}));
 		if (options.enumOptions !== nextOptions.enumOptions) {
+			const items = nextOptions.enumOptions.map((option, index) => ({
+				index,
+				checked: nextProps.value.indexOf(option.value) !== -1,
+				label: option.label,
+				value: option.value,
+				onChange: onItemChange.bind(this),
+			}));
 			this.setState({ items, displayedItems: items });
 		}
 	}

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.js
@@ -19,6 +19,16 @@ const DISPLAY_MODE_DEFAULT = 'DISPLAY_MODE_DEFAULT';
 const DISPLAY_MODE_SEARCH = 'DISPLAY_MODE_SEARCH';
 const DEFAULT_ITEM_HEIGHT = 33;
 
+function getItems(options, value, instance) {
+	return options.enumOptions.map((option, index) => ({
+		index,
+		checked: value.indexOf(option.value) !== -1,
+		label: option.label,
+		value: option.value,
+		onChange: onItemChange.bind(instance),
+	}));
+}
+
 class ListViewWidget extends React.Component {
 	constructor(props) {
 		super(props);
@@ -47,13 +57,7 @@ class ListViewWidget extends React.Component {
 			defaultDisplayMode = props.schema.displayMode;
 		}
 
-		const items = options.enumOptions.map((option, index) => ({
-			index,
-			checked: value.indexOf(option.value) !== -1,
-			label: option.label,
-			value: option.value,
-			onChange: onItemChange.bind(this),
-		}));
+		const items = getItems(options, value, this);
 
 		this.state = {
 			displayMode: defaultDisplayMode,
@@ -77,13 +81,7 @@ class ListViewWidget extends React.Component {
 		const options = this.props.options || {};
 		const nextOptions = nextProps.options || {};
 		if (options.enumOptions !== nextOptions.enumOptions) {
-			const items = nextOptions.enumOptions.map((option, index) => ({
-				index,
-				checked: nextProps.value.indexOf(option.value) !== -1,
-				label: option.label,
-				value: option.value,
-				onChange: onItemChange.bind(this),
-			}));
+			const items = getItems(nextOptions, nextProps.value, this);
 			this.setState({ items, displayedItems: items });
 		}
 	}

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.test.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.test.js
@@ -58,9 +58,7 @@ describe('ListViewWidget', () => {
 		const values = ['A', 'B', 'C', 'D'];
 		const nextValues = ['E', 'F', 'G', 'H'];
 		let wrapper = mount(
-			<ListViewWidget.WrappedComponent
-				{...generateProps(values, values.slice(0, 2))}
-			/>,
+			<ListViewWidget.WrappedComponent {...generateProps(values, values.slice(0, 2))} />,
 		);
 		const items = wrapper.state('items');
 		expect(wrapper.state('items').length).toEqual(4);

--- a/packages/forms/src/widgets/ListViewWidget/ListViewWidget.test.js
+++ b/packages/forms/src/widgets/ListViewWidget/ListViewWidget.test.js
@@ -54,6 +54,27 @@ function simulateSearch(wrapper, value) {
 }
 
 describe('ListViewWidget', () => {
+	it('should detect props change to update state.items', () => {
+		const values = ['A', 'B', 'C', 'D'];
+		const nextValues = ['E', 'F', 'G', 'H'];
+		let wrapper = mount(
+			<ListViewWidget.WrappedComponent
+				{...generateProps(values, values.slice(0, 2))}
+			/>,
+		);
+		const items = wrapper.state('items');
+		expect(wrapper.state('items').length).toEqual(4);
+		expect(wrapper.state('items')[0].label).toEqual('A');
+
+		// when
+		wrapper = wrapper.setProps(generateProps(nextValues, nextValues.slice(0, 2)));
+		// then
+
+		expect(items).not.toEqual(wrapper.state('items'));
+		expect(wrapper.state('items').length).toEqual(4);
+		expect(wrapper.state('items')[0].label).toEqual('E');
+	});
+
 	describe('toggleAll', () => {
 		it('should check every items', () => {
 			// given


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The ListView widget build a state.items from props.options
but when props.options changed nothing happens

**What is the chosen solution to this problem?**

use willReceveiProps deprecated hook to update the state

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
