### PR TITLE
fix(components/HeaderBar): remove caret shadow

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -114,13 +114,16 @@ $background-color-on-hover: shade($brand-primary, 30);
 		height: 100%;
 
 		:global(.caret) {
-			border-top-color: $white;
-			border-right-color: $white;
-			box-shadow: none;
+			box-shadow: 2px -2px 0 $white;
+			border: none;
 			margin-left: $padding-small;
+			margin-bottom: $padding-smaller;
 		}
 
 		&:global(.open) {
+			:global(.caret) {
+				margin-top: $padding-small;
+			}
 			:global(.btn):global(.btn-link) {
 				background-color: $background-color-on-hover;
 			}

--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -116,7 +116,7 @@ $background-color-on-hover: shade($brand-primary, 30);
 		:global(.caret) {
 			border-top-color: $white;
 			border-right-color: $white;
-			box-shadow: 1px -1px 0 $white;
+			box-shadow: none;
 			margin-left: $padding-small;
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The HeaderBar dropdown carets have
* white borders (1px)
* white box-shadow (1px)

But browser renders them with a demarkation just under the border, making it appear like a double caret.

<img width="175" alt="capture d ecran 2018-04-08 a 16 35 27" src="https://user-images.githubusercontent.com/10761073/38468810-52de4eec-3b4b-11e8-9d1c-ad6af04526b2.png">

**What is the chosen solution to this problem?**
Remove box-shadow.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
