### PR TITLE
fix(cmf/onEventSetState): toggle call setState

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,7 +3,6 @@
   "parser": "babel-eslint",
   "rules": {
     "arrow-parens": [2, "as-needed"],
-    "import/no-extraneous-dependencies": ["error", {"devDependencies": ["**/*.test.js", "**/*.spec.js"]}],
     "indent": ["error", "tab", { "SwitchCase": 1 }],
     "new-cap": [
         2,

--- a/packages/cmf/__tests__/onEvent.test.js
+++ b/packages/cmf/__tests__/onEvent.test.js
@@ -52,7 +52,7 @@ describe('onEvent', () => {
 			config.docked = 'toggle';
 			handler(...args);
 			const callback = instance.props.setState.mock.calls[0][0];
-			callback(instance.props);
+			callback({ state: instance.props.state });
 			expect(instance.props.setState.mock.calls[1][0]).toEqual({ docked: true });
 		});
 	});

--- a/packages/cmf/src/onEvent.js
+++ b/packages/cmf/src/onEvent.js
@@ -61,7 +61,7 @@ function getOnEventSetStateHandler(instance, config, currentHandler) {
 				}
 			} else if (value === 'toggle') {
 				// because toggle need to read the state we dispatch it with a function
-				instance.props.setState(props => props.setState({ [key]: !props.state.get(key) }));
+				instance.props.setState(props => instance.props.setState({ [key]: !props.state.get(key) }));
 			} else {
 				// eslint-disable-next-line no-param-reassign
 				acc[key] = value;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If you use onClickSetState with 'toggle' feature you will have the following message:
`call function setState is undefined`

This is due to the fact the given props only contains the state not setState.

**What is the chosen solution to this problem?**

let's use instance.setState

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
