### PR TITLE
fix(components/breadcrumbs): remove title case

### DIFF
--- a/packages/components/src/Breadcrumbs/Breadcrumbs.scss
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.scss
@@ -15,7 +15,8 @@
 				box-shadow: none;
 			}
 
-			> button > span, > span {
+			> button > span,
+			> span {
 				text-transform: none;
 			}
 		}

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.scss
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.scss
@@ -14,6 +14,10 @@
 				border: none;
 				box-shadow: none;
 			}
+
+			> button > span, > span {
+				text-transform: none;
+			}
 		}
 	}
 }

--- a/packages/components/stories/Breadcrumbs.js
+++ b/packages/components/stories/Breadcrumbs.js
@@ -17,6 +17,7 @@ storiesOf('Breadcrumbs', module)
 			{ text: 'Text A', title: 'Text title A', onClick: action('Text A clicked') },
 			{ text: 'Text B', title: 'Text title B', onClick: action('Text B clicked') },
 			{ text: 'Text C', title: 'Text title C', onClick: action('Text C clicked') },
+			{ text: 'lower case', title: 'lower case', onClick: action('lower case clicked') },
 		];
 		return (
 			<div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Breadcrumbs first letter is always in uppercase.

**What is the chosen solution to this problem?**

Override this unwanted CSS rule.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
