### PR TITLE
fix(containers/FilterBar): use props when passed

### DIFF
--- a/packages/containers/src/FilterBar/FilterBar.container.js
+++ b/packages/containers/src/FilterBar/FilterBar.container.js
@@ -13,6 +13,8 @@ export const DEFAULT_STATE = new Immutable.Map({
 
 export const DISPLAY_NAME = 'Container(FilterBar)';
 
+const DOCKED_ATTR = 'docked';
+
 class FilterBar extends React.Component {
 	static displayName = DISPLAY_NAME;
 
@@ -67,7 +69,7 @@ class FilterBar extends React.Component {
 	render() {
 		const state = this.props.state || DEFAULT_STATE;
 		const props = Object.assign({}, omit(this.props, cmfConnect.INJECTED_PROPS), {
-			docked: this.props.docked !== undefined ? this.props.docked : state.get('docked'),
+			docked: this.props.docked != null ? this.props.docked : state.get(DOCKED_ATTR),
 			value: this.props.value ? this.props.value : state.get(QUERY_ATTR, ''),
 			onToggle: this.onToggle,
 			onFilter: this.onFilter,

--- a/packages/containers/src/FilterBar/FilterBar.container.js
+++ b/packages/containers/src/FilterBar/FilterBar.container.js
@@ -67,8 +67,8 @@ class FilterBar extends React.Component {
 	render() {
 		const state = this.props.state || DEFAULT_STATE;
 		const props = Object.assign({}, omit(this.props, cmfConnect.INJECTED_PROPS), {
-			docked: state.get('docked'),
-			value: state.get(QUERY_ATTR, ''),
+			docked: this.props.docked !== undefined ? this.props.docked : state.get('docked'),
+			value: this.props.value ? this.props.value : state.get(QUERY_ATTR, ''),
 			onToggle: this.onToggle,
 			onFilter: this.onFilter,
 		});

--- a/packages/containers/src/FilterBar/FilterBar.test.js
+++ b/packages/containers/src/FilterBar/FilterBar.test.js
@@ -16,6 +16,7 @@ describe('Filter container', () => {
 	it('should render', () => {
 		const props = {
 			docked: false,
+			value: 'a filter',
 			navbar: true,
 			dockable: true,
 			collectionToFilter: 'myCollectionToFilter',

--- a/packages/containers/src/FilterBar/__snapshots__/FilterBar.test.js.snap
+++ b/packages/containers/src/FilterBar/__snapshots__/FilterBar.test.js.snap
@@ -6,7 +6,7 @@ exports[`Filter container should render 1`] = `
   className=""
   collectionToFilter="myCollectionToFilter"
   dockable={true}
-  docked={true}
+  docked={false}
   focus={false}
   iconAlwaysVisible={false}
   navbar={true}
@@ -14,6 +14,6 @@ exports[`Filter container should render 1`] = `
   onToggle={[Function]}
   placeholder="Filter"
   t={[Function]}
-  value=""
+  value="a filter"
 />
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The filterbar container was only using its state but in some case (when used inside of List) it needs to take the props.
https://jira.talendforge.org/browse/TDS-3254, this bug is also present on other apps.

**What is the chosen solution to this problem?**
Using props attribute when they are passed.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
