### PR TITLE
fix(components/virtualizedlist): add tooltip on the item's title

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
@@ -46,13 +46,14 @@ function CellTitleSelector(props) {
 				role="link"
 				bsStyle="link"
 				label={cellData}
+				title={cellData}
 				type="button"
 			/>
 		);
 	}
 
 	return (
-		<span id={id} className={className}>
+		<span id={id} className={className} title={cellData}>
 			{cellData}
 		</span>
 	);

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleSelector.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleSelector.test.js.snap
@@ -9,6 +9,7 @@ exports[`CellTitleSelector should render the button 1`] = `
   label="my value"
   onClick={[Function]}
   role="link"
+  title="my value"
   type="button"
 />
 `;
@@ -31,6 +32,7 @@ exports[`CellTitleSelector should render the simple text 1`] = `
 <span
   className="my-title-classname"
   id="my-title"
+  title="my value"
 >
   my value
 </span>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

There is no tooltip on virtualizedlist's item title.

**What is the chosen solution to this problem?**

Add it.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
