### PR TITLE
fix(html-webpack-plugin): change deps to peerDeps

### DIFF
--- a/packages/html-webpack-plugin/package.json
+++ b/packages/html-webpack-plugin/package.json
@@ -18,7 +18,7 @@
     "eslint-plugin-import": "1.14.0",
     "jest-cli": "20.0.3"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@talend/react-components": "^0.175.0"
   }
 }

--- a/packages/html-webpack-plugin/package.json
+++ b/packages/html-webpack-plugin/package.json
@@ -13,6 +13,7 @@
     "url": "github:Talend/ui"
   },
   "devDependencies": {
+    "@talend/react-components": "^0.175.0",
     "eslint": "3.4.0",
     "eslint-config-airbnb": "10.0.1",
     "eslint-plugin-import": "1.14.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dependencies is absolute, we still retrieve `@talend/react-components`@0.175.0

**What is the chosen solution to this problem?**
Prefer `peerDependencies` here

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
