### PR TITLE
feat(Containers/DeleteResource): add support without react-router

### DIFF
--- a/packages/containers/src/DeleteResource/DeleteResource.connect.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.connect.js
@@ -1,12 +1,17 @@
 import { cmfConnect } from '@talend/react-cmf';
 import Immutable from 'immutable';
+import get from 'lodash/get';
 import Container from './DeleteResource.container';
 
 export function mapStateToProps(state, ownProps) {
 	if (ownProps.resourceType) {
+		let resourceId = ownProps.resourceId;
+		if (!resourceId) {
+			resourceId = get(ownProps, 'routeParams.id');
+		}
 		const resource = state.cmf.collections
 			.get(ownProps.resourceType, new Immutable.Map())
-			.find(currentResource => currentResource.get('id') === ownProps.routeParams.id);
+			.find(currentResource => currentResource.get('id') === resourceId);
 		return {
 			resource,
 		};

--- a/packages/containers/src/DeleteResource/DeleteResource.test.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.test.js
@@ -1,10 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { store } from '@talend/react-cmf/lib/mock';
+import mock, { store } from '@talend/react-cmf/lib/mock';
 import Immutable from 'immutable';
 
 import { DeleteResource } from './DeleteResource.container';
-import Connected from './DeleteResource.connect';
+import Connected, { mapStateToProps } from './DeleteResource.connect';
 
 const state = store.state();
 const settings = {
@@ -25,6 +25,11 @@ const settings = {
 state.cmf = {
 	settings,
 };
+state.cmf.collections = new Immutable.Map({
+	foo: new Immutable.List([
+		new Immutable.Map({ id: '123' }),
+	]),
+});
 
 const context = {
 	store: {
@@ -66,5 +71,20 @@ describe('Connected DeleteResource', () => {
 	it('should connect TestGenerator', () => {
 		expect(Connected.displayName).toBe('Connect(CMF(Translate(Container(DeleteResource))))');
 		expect(Connected.WrappedComponent).toBe(DeleteResource);
+	});
+	describe('mapStateToProps', () => {
+		it('should return empty object if no resourceType', () => {
+			expect(mapStateToProps({}, {})).toEqual({});
+		});
+		it('should return the props.resource corresponding to resourceId', () => {
+			expect(mapStateToProps(state, { resourceType: 'foo', resourceId: '123' }).resource).toBe(
+				state.cmf.collections.get('foo').get(0)
+			);
+		});
+		it('should return the props.resource corresponding to routeParams.id', () => {
+			expect(mapStateToProps(state, { resourceType: 'foo', routeParams: { id: '123' } }).resource).toBe(
+				state.cmf.collections.get('foo').get(0)
+			);
+		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

This component depends on react-router and cmf sagaRouter.

**What is the chosen solution to this problem?**

Let's make it work without both and use just expression and saga

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
