### PR TITLE
fix(html-webpack-plugin): change media for async loading

### DIFF
--- a/packages/html-webpack-plugin/index.js
+++ b/packages/html-webpack-plugin/index.js
@@ -18,7 +18,7 @@ TalendHTMLOptimize.prototype.apply = function myapply(compiler) {
 					}
 					const media = head.attributes.media || 'all';
 					head.attributes.media = 'none';
-					head.attributes.onload = `media='${media}'`;
+					head.attributes.onload = `if(media!='${media}')media='${media}'`;
 					return head;
 				});
 			}

--- a/packages/html-webpack-plugin/index.test.js
+++ b/packages/html-webpack-plugin/index.test.js
@@ -55,12 +55,12 @@ describe('@talend/html-webpack-plugin', () => {
 		pluginExecFn(DATA, pluginExecCallback);
 		expect(pluginExecCallback.mock.calls[0][1].body[0]).toBe(item);
 	});
-	it('hould modify <link> media with loadCSSAsync option', () => {
+	it('should modify <link> media with loadCSSAsync option', () => {
 		refresh({ loadCSSAsync: true });
 		pluginExecFn(DATA, pluginExecCallback);
 		expect(pluginExecCallback.mock.calls[0][1].head[0].attributes).toMatchObject({
 			media: 'none',
-			onload: 'media=\'all\'',
+			onload: 'if(media!=\'all\')media=\'all\'',
 		});
 	});
 	it('should add TALEND_APP_INFO global var with versions option', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`If` statement is missing

**What is the chosen solution to this problem?**
According to https://keithclark.co.uk/articles/loading-css-without-blocking-render/
Add `if` statement while `onload` is triggered

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
