### PR TITLE
chore: remove React.PropTypes in test or component

### DIFF
--- a/packages/cmf/__tests__/cmfConnect.test.js
+++ b/packages/cmf/__tests__/cmfConnect.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { fromJS, Map } from 'immutable';
 import { shallow, mount } from 'enzyme';
 import expression from '../src/expression';
@@ -240,7 +241,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected />, {
 				context: mock.context(),
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 
@@ -359,7 +360,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 
@@ -387,7 +388,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 
@@ -414,7 +415,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected keepComponentState />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 
@@ -441,7 +442,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected keepComponentState={false} />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 
@@ -471,7 +472,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnected {...iProps} />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 			const props = wrapper.find(TestComponent).props();
@@ -507,7 +508,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnectedButton onClickDispatch={onClickDispatch} />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 			const props = wrapper.find(Button).props();
@@ -533,7 +534,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnectedButton onClickActionCreator={onClickActionCreator} />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 			const props = wrapper.find(Button).props();
@@ -569,7 +570,7 @@ describe('cmfConnect', () => {
 			const wrapper = mount(<CMFConnectedButton onClickActionCreator={onClickActionCreator} />, {
 				context,
 				childContextTypes: {
-					registry: React.PropTypes.object,
+					registry: PropTypes.object,
 				},
 			});
 			const props = wrapper.find(Button).props();
@@ -595,7 +596,7 @@ describe('cmfConnect', () => {
 				{
 					context,
 					childContextTypes: {
-						registry: React.PropTypes.object,
+						registry: PropTypes.object,
 					},
 				},
 			);
@@ -641,7 +642,7 @@ describe('cmfConnect', () => {
 				{
 					context,
 					childContextTypes: {
-						registry: React.PropTypes.object,
+						registry: PropTypes.object,
 					},
 				},
 			);

--- a/packages/components/__mocks__/react-addons-css-transition-group.js
+++ b/packages/components/__mocks__/react-addons-css-transition-group.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 
 function ReactCSSTransitionGroup({children, ...props}) {
 	return (
@@ -8,7 +9,7 @@ function ReactCSSTransitionGroup({children, ...props}) {
 	);
 }
 ReactCSSTransitionGroup.propTypes = {
-	children: React.PropTypes.arrayOf(React.PropTypes.element),
+	children: PropTypes.arrayOf(PropTypes.element),
 };
 
 export default ReactCSSTransitionGroup;

--- a/packages/forms/stories/index.js
+++ b/packages/forms/stories/index.js
@@ -395,7 +395,7 @@ const UnknownWidget = props => {
 };
 
 UnknownWidget.propTypes = {
-	value: React.PropTypes.string,
+	value: PropTypes.string,
 };
 
 decoratedStories.add('Custom widget', () => {

--- a/packages/generator/generators/react-cmf/templates/src/app/components/App.container.js
+++ b/packages/generator/generators/react-cmf/templates/src/app/components/App.container.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { IconsProvider } from '@talend/react-components';
 import { Notification } from '@talend/react-containers';
 
@@ -18,5 +19,5 @@ export default function App(props) {
 }
 
 App.propTypes = {
-	children: React.PropTypes.element,
+	children: PropTypes.element,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Direct reference in our code to React.PropTypes is baring our route to react16 migration
**What is the chosen solution to this problem?**
Remove them, should remove some warning in test and live code.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
