### PR TITLE
feat(theme): update rio-grande color

### DIFF
--- a/packages/theme/src/theme/_colors.scss
+++ b/packages/theme/src/theme/_colors.scss
@@ -60,7 +60,7 @@ $silver: #c6c6c6;
 /// Used to valid/validated/validation elements.
 ///
 /// @type Color
-$rio-grande: #82BD41;
+$rio-grande: #82bd41;
 
 /// Secondary color.
 /// Contextual color for informational alert messages.

--- a/packages/theme/src/theme/_colors.scss
+++ b/packages/theme/src/theme/_colors.scss
@@ -60,7 +60,7 @@ $silver: #c6c6c6;
 /// Used to valid/validated/validation elements.
 ///
 /// @type Color
-$rio-grande: #c3d600;
+$rio-grande: #82BD41;
 
 /// Secondary color.
 /// Contextual color for informational alert messages.


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`$rio-grande` has changed in [guuideline](https://company-57688.frontify.com/document/92132#/design-principles/colors-in-ui) 

**What is the chosen solution to this problem?**
Update the color

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
