### PR TITLE
chore(SidePanel): make side panel's width ajusted to its content

### DIFF
--- a/packages/components/src/ActionList/ActionList.scss
+++ b/packages/components/src/ActionList/ActionList.scss
@@ -4,7 +4,6 @@
 ////
 
 $tc-action-list-item-width: 200px !default;
-$tc-action-list-item-labels-width: 135px !default;
 $tc-action-list-item-icons-size: 20px !default;
 $tc-action-list-item-border-size: 2px !default;
 
@@ -24,7 +23,6 @@ $tc-action-list-item-border-size: 2px !default;
 
 				> span {
 					margin-left: $padding-normal;
-					width: $tc-action-list-item-labels-width;
 					vertical-align: middle;
 					text-overflow: ellipsis;
 					overflow: hidden;

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -27,8 +27,8 @@ $toggle-button-padding: $padding-small - 1;
 
 	&,
 	> ul {
-      	min-width: $tc-side-panel-minwidth;
-      	transition: 0.2s min-width ease-out, 0.2s width ease-out;
+		min-width: $tc-side-panel-minwidth;
+		transition: 0.2s min-width ease-out, 0.2s width ease-out;
 	}
 
 	:global(.tc-svg-icon) {

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -28,7 +28,7 @@ $toggle-button-padding: $padding-small - 1;
 	&,
 	> ul {
 		min-width: $tc-side-panel-minwidth;
-		transition: 0.2s min-width ease-out, 0.2s width ease-out;
+		transition: 0.2s min-width ease-out;
 	}
 
 	:global(.tc-svg-icon) {

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -9,11 +9,10 @@ $list-item-color: $white !default;
 $list-item-reverse-color: $brand-primary !default;
 $toggle-button-opacity: 0.75;
 $tc-side-panel-large-padding: 25px !default;
-$tc-side-panel-width: 200px !default;
-$tc-side-panel-large-width: 250px !default;
+$tc-side-panel-minwidth: 200px !default;
+$tc-side-panel-large-minwidth: 250px !default;
 $tc-side-panel-docked-width: 50px !default;
 $tc-side-panel-labels-width: 135px !default;
-$tc-side-panel-large-labels-width: 165px !default;
 $tc-side-panel-large-docked-width: 70px !default;
 $tc-side-panel-icons-size: 20px !default;
 $tc-side-panel-border-size: 2px !default;
@@ -21,15 +20,15 @@ $tc-side-panel-large-toggle-padding: 4px !default;
 $toggle-button-padding: $padding-small - 1;
 
 .tc-side-panel {
-	display: flex;
+	display: inline-flex;
 	flex-direction: column;
 	overflow-x: hidden;
 	background: $list-item-reverse-color;
 
 	&,
 	> ul {
-		width: $tc-side-panel-width;
-		transition: 0.2s width ease-out;
+      	min-width: $tc-side-panel-minwidth;
+      	transition: 0.2s min-width ease-out, 0.2s width ease-out;
 	}
 
 	:global(.tc-svg-icon) {
@@ -83,6 +82,7 @@ $toggle-button-padding: $padding-small - 1;
 	&.docked {
 		&,
 		> ul {
+			min-width: $tc-side-panel-docked-width;
 			width: $tc-side-panel-docked-width;
 		}
 
@@ -110,7 +110,7 @@ $toggle-button-padding: $padding-small - 1;
 	&.large {
 		&,
 		> ul {
-			width: $tc-side-panel-large-width;
+			min-width: $tc-side-panel-large-minwidth;
 		}
 
 		.toggle-btn {
@@ -125,10 +125,6 @@ $toggle-button-padding: $padding-small - 1;
 			.btn.btn-link {
 				padding: $padding-normal $tc-side-panel-large-padding;
 
-				> span {
-					width: $tc-side-panel-large-labels-width;
-				}
-
 				.tc-svg-icon + span {
 					margin-left: $tc-side-panel-large-padding;
 				}
@@ -139,6 +135,7 @@ $toggle-button-padding: $padding-small - 1;
 			&,
 			> ul,
 			:global(.tc-action-list-item) {
+				min-width: $tc-side-panel-large-docked-width;
 				width: $tc-side-panel-large-docked-width;
 			}
 		}

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -19,18 +19,18 @@ const icons = {
 
 const actions = [
 	{
-		label: 'Preparations',
+		label: 'Preparations de chimistes',
 		icon: 'talend-dataprep',
 		onClick: action('Preparations clicked'),
 		active: true,
 	},
 	{
-		label: 'Datasets',
+		label: 'Datasets pour les cons',
 		icon: 'talend-download',
 		onClick: action('Datasets clicked'),
 	},
 	{
-		label: 'Favorites',
+		label: 'Favorites des boulets',
 		icon: 'talend-star',
 		onClick: action('Favorites clicked'),
 	},
@@ -38,18 +38,18 @@ const actions = [
 
 const actionsLinks = [
 	{
-		label: 'Preparations',
+		label: 'Preparations de malade pour les chimistes',
 		icon: 'talend-dataprep',
 		href: '/preparations',
 		active: true,
 	},
 	{
-		label: 'Datasets',
+		label: 'Datasets assez court :)',
 		icon: 'talend-download',
 		href: '/datasets',
 	},
 	{
-		label: 'Favorites',
+		label: 'Favorites my faroris long',
 		icon: 'talend-star',
 		href: '/favorites',
 	},
@@ -58,17 +58,17 @@ const actionsLinks = [
 const items = [
 	{
 		key: 'preparations',
-		label: 'Preparations',
+		label: 'Preparations assez longue quand meme',
 		icon: 'talend-dataprep',
 	},
 	{
 		key: 'datasets',
-		label: 'Datasets',
+		label: 'Datasets data set assez long',
 		icon: 'talend-download',
 	},
 	{
 		key: 'favorites',
-		label: 'Favorites',
+		label: 'Favorites mon favoris le plus long',
 		icon: 'talend-star',
 	},
 ];

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -19,18 +19,18 @@ const icons = {
 
 const actions = [
 	{
-		label: 'Preparations de chimistes',
+		label: 'Preparations',
 		icon: 'talend-dataprep',
 		onClick: action('Preparations clicked'),
 		active: true,
 	},
 	{
-		label: 'Datasets pour les cons',
+		label: 'Datasets',
 		icon: 'talend-download',
 		onClick: action('Datasets clicked'),
 	},
 	{
-		label: 'Favorites des boulets',
+		label: 'Favorites',
 		icon: 'talend-star',
 		onClick: action('Favorites clicked'),
 	},
@@ -38,18 +38,18 @@ const actions = [
 
 const actionsLinks = [
 	{
-		label: 'Preparations de malade pour les chimistes',
+		label: 'Preparations',
 		icon: 'talend-dataprep',
 		href: '/preparations',
 		active: true,
 	},
 	{
-		label: 'Datasets assez court :)',
+		label: 'Datasets',
 		icon: 'talend-download',
 		href: '/datasets',
 	},
 	{
-		label: 'Favorites my faroris long',
+		label: 'Favorites',
 		icon: 'talend-star',
 		href: '/favorites',
 	},
@@ -58,17 +58,17 @@ const actionsLinks = [
 const items = [
 	{
 		key: 'preparations',
-		label: 'Preparations assez longue quand meme',
+		label: 'Preparations',
 		icon: 'talend-dataprep',
 	},
 	{
 		key: 'datasets',
-		label: 'Datasets data set assez long',
+		label: 'Datasets',
 		icon: 'talend-download',
 	},
 	{
 		key: 'favorites',
-		label: 'Favorites mon favoris le plus long',
+		label: 'Favorites',
 		icon: 'talend-star',
 	},
 ];


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The side panel has a fix size for the moment. This causes readability issue when the labels are too long (ellipsis).
![image](https://user-images.githubusercontent.com/14272767/39533763-30f0784e-4e30-11e8-9135-9179cf671585.png)

**What is the chosen solution to this problem?**
Make the side panel width ajusted to its content.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
