### PR TITLE
fix(components): app loader spinner styling

### DIFF
--- a/packages/components/src/AppLoader/constant.js
+++ b/packages/components/src/AppLoader/constant.js
@@ -1,4 +1,8 @@
-const LOADER_STYLE = `html {
+const LOADER_STYLE = `* {
+	box-sizing: border-box;
+}
+
+html {
 	font-size: 10px;
 	text-size-adjust: 100%;
 	-ms-text-size-adjust: 100%;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The appLoader spinner animation is broken during the application launch

**What is the chosen solution to this problem?**
Override default "box-sizing: content-box;" and set to "box-sizing: border-box;" for all the elements while the bootstrap.css is loading (Refer screenshots below)

http://1321.talend.surge.sh/components/?selectedKind=AppLoader&selectedStory=default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
