### PR TITLE
chore(html-webpack-plugin): webpack 4 compatibility

### DIFF
--- a/packages/html-webpack-plugin/index.js
+++ b/packages/html-webpack-plugin/index.js
@@ -7,7 +7,7 @@ function TalendHTMLOptimize(options) {
 TalendHTMLOptimize.prototype.apply = function myapply(compiler) {
 	const options = this.options || {};
 	compiler.plugin('compilation', compilation => {
-		compilation.plugin('html-webpack-plugin-alter-asset-tags', (data, cb) => {
+		compilation.plugin('html-webpack-plugin-alter-asset-tags', data => {
 			if (options.bodyBefore) {
 				data.body = options.bodyBefore.concat(data.body);
 			}
@@ -37,7 +37,7 @@ TalendHTMLOptimize.prototype.apply = function myapply(compiler) {
 					innerHTML: AppLoader.getLoaderStyle(options.appLoaderIcon),
 				});
 			}
-			cb(null, data);
+			return data;
 		});
 	});
 };

--- a/packages/html-webpack-plugin/index.test.js
+++ b/packages/html-webpack-plugin/index.test.js
@@ -46,27 +46,27 @@ describe('@talend/html-webpack-plugin', () => {
 	});
 	it('should not modify data when no option is provided', () => {
 		refresh();
-		pluginExecFn(DATA, pluginExecCallback);
-		expect(pluginExecCallback).toHaveBeenCalledWith(null, DATA);
+		const result = pluginExecFn(DATA, pluginExecCallback);
+		expect(result).toEqual(DATA);
 	});
 	it('should add data before content based on bodyBefore option', () => {
 		const item = { foo: 'bar' };
 		refresh({ bodyBefore: [item] });
-		pluginExecFn(DATA, pluginExecCallback);
-		expect(pluginExecCallback.mock.calls[0][1].body[0]).toBe(item);
+		const result = pluginExecFn(DATA, pluginExecCallback);
+		expect(result.body[0]).toBe(item);
 	});
 	it('should modify <link> media with loadCSSAsync option', () => {
 		refresh({ loadCSSAsync: true });
-		pluginExecFn(DATA, pluginExecCallback);
-		expect(pluginExecCallback.mock.calls[0][1].head[0].attributes).toMatchObject({
+		const result = pluginExecFn(DATA, pluginExecCallback);
+		expect(result.head[0].attributes).toMatchObject({
 			media: 'none',
 			onload: 'if(media!=\'all\')media=\'all\'',
 		});
 	});
 	it('should add TALEND_APP_INFO global var with versions option', () => {
 		refresh({ versions: { '@talend/my-app': '1.2.3' } });
-		pluginExecFn(DATA, pluginExecCallback);
-		expect(pluginExecCallback.mock.calls[0][1].body[0]).toMatchObject({
+		const result = pluginExecFn(DATA, pluginExecCallback);
+		expect(result.body[0]).toMatchObject({
 			tagName: 'script',
 			innerHTML: 'TALEND_APP_INFO={"@talend/my-app":"1.2.3"}',
 		});
@@ -74,8 +74,8 @@ describe('@talend/html-webpack-plugin', () => {
 	it('should inline style in head with appLoaderIcon option', () => {
 		const options = { appLoaderIcon: "url('data:image/svg+xml;base64,PHN2...')" };
 		refresh(options);
-		pluginExecFn(DATA, pluginExecCallback);
-		expect(pluginExecCallback.mock.calls[0][1].head[0].innerHTML).toBe(
+		const result = pluginExecFn(DATA, pluginExecCallback);
+		expect(result.head[0].innerHTML).toBe(
 			AppLoader.getLoaderStyle(options.appLoaderIcon)
 		);
 	});

--- a/packages/html-webpack-plugin/package.json
+++ b/packages/html-webpack-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/html-webpack-plugin",
-  "version": "0.0.3",
+  "version": "1.0.0",
   "description": "@talend/html-webpack-plugin library.",
   "license": "Apache-2.0",
   "author": "Talend Frontend <frontend@talend.com>",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
_Short explanation_
The talend addon to html-webpack-plugin is not compatible with webpack 4.

_Long explanation_
The api has changed, the `compilation.plugin()` doesn't provide a callback to the compilation function anymore. The official html-webpack-plugin wrap the hook call in a Promise waiting a required result.

**What is the chosen solution to this problem?**
Removed the on longer existing callback, replaced it with a simple `return` that will be used in the official `html-webpack-plugin` promise.

This is a breaking change, next release (not related with common Talend/ui packages) will be a 1.0.0

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
