### PR TITLE
feat(scripts): customisable app loader

### DIFF
--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -110,36 +110,9 @@ yarn add --dev talend-scripts-preset-${presetName}
 
 3. Add any preset variables in talend-scripts.json, following your preset documentation.
 
-### Preset talend configuration
+### Preset talend (default)
 
-```json
-{
-  "preset": "talend",
-  "html": {
-    "title": "Talend Data Preparation"
-  },
-  "sass": {
-    "data": {
-      "$brand-primary": "#4F93A7",
-      "$brand-primary-t7": "#00A1B3",
-      "$brand-secondary-t7": "#168AA6"
-    }
-  },
-  "webpack": {
-    "config": {
-      "development": "./webpack.config.dev.js",
-      "production": "./webpack.config.prod.js"
-    },
-    "api-url": "http://localhost:3030"
-  }
-}
-```
-
-| Preset variable | Description |
-|---|---|
-| html.title | The title to display on the browser tab. |
-| sass.data | Define a set of sass variables to customise @talend/theme. |
-| webpack.api-url | Default: `http://localhost`. The preset adds a proxy to `/api` urls. |
+Preset documentation available [here](./preset/README.md).
 
 ## Possible issues
 

--- a/packages/scripts/README.md
+++ b/packages/scripts/README.md
@@ -112,7 +112,7 @@ yarn add --dev talend-scripts-preset-${presetName}
 
 ### Preset talend (default)
 
-Preset documentation available [here](./preset/README.md).
+Preset documentation is available [here](./preset/README.md).
 
 ## Possible issues
 

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -5,6 +5,7 @@
     "talend-scripts": "./index.js"
   },
   "dependencies": {
+    "@talend/html-webpack-plugin": "1.0.0",
     "autoprefixer": "^7.1.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
@@ -50,6 +51,10 @@
     "whatwg-fetch": "2.0.3",
     "which": "^1.3.0",
     "yargs-parser": "^9.0.2"
+  },
+  "peerDependencies": {
+    "@talend/bootstrap-theme": ">=0.150.0",
+    "@talend/react-components": ">=0.170.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/scripts/preset/README.md
+++ b/packages/scripts/preset/README.md
@@ -11,7 +11,7 @@ This preset allows some customisation through specific entry points. The configu
   "preset": "talend",
   "html": {
     "title": "Talend Data Preparation",
-    "otherOptions": "Option value passed to html-webpack-plugin"
+    "other-options": "Option value passed to html-webpack-plugin"
   },
   "sass": {
     "data": {
@@ -35,7 +35,7 @@ This preset allows some customisation through specific entry points. The configu
 |---|---|
 | html | `html-webpack-plugin` template and options customisation. |
 | sass | `sass-loader` custom data. |
-| webpack | `webpack` and `devServer customisation. |
+| webpack | `webpack` and `devServer` customisation. |
 
 ## HTML
 
@@ -44,7 +44,7 @@ This preset allows some customisation through specific entry points. The configu
   "preset": "talend",
   "html": {
     "title": "Talend Data Preparation",
-    "otherOptions": "Option value passed to html-webpack-plugin"
+    "other-options": "Option value passed to html-webpack-plugin"
   }
 }
 ```
@@ -52,6 +52,14 @@ This preset allows some customisation through specific entry points. The configu
 All those options are passed as `html-webpack-plugin` options. It goes in pair with your index.html template.  
 By default, your html template is located in `src/app/index.html`, which can be overridden with the preset html configuration.
 
+```json
+{
+  "preset": "talend",
+  "html": {
+    "template": "my-template-path"
+  }
+}
+```
 
 ## App loader
 

--- a/packages/scripts/preset/README.md
+++ b/packages/scripts/preset/README.md
@@ -2,7 +2,7 @@
 
 This is a preset for @talend/scripts. It holds most of Talend projects tools configuration.
 
-This preset allows some customisation through specific entry points. The configuration is done via `Talend/scripts` configuration file.
+This preset allows some customisation through specific entry points. The configuration is done via `Talend/scripts` configuration file `talend-scripts.json`.
 
 ## Configuration overview
 

--- a/packages/scripts/preset/README.md
+++ b/packages/scripts/preset/README.md
@@ -1,0 +1,120 @@
+# Preset Talend
+
+This is a preset for @talend/scripts. It holds most of Talend projects tools configuration.
+
+This preset allows some customisation through specific entry points. The configuration is done via `Talend/scripts` configuration file.
+
+## Configuration overview
+
+```json
+{
+  "preset": "talend",
+  "html": {
+    "title": "Talend Data Preparation",
+    "otherOptions": "Option value passed to html-webpack-plugin"
+  },
+  "sass": {
+    "data": {
+      "$brand-primary": "#4F93A7",
+      "$brand-primary-t7": "#00A1B3",
+      "$brand-secondary-t7": "#168AA6"
+    },
+    "theme": "tdp"
+  },
+  "webpack": {
+    "config": {
+      "development": "./webpack.config.dev.js",
+      "production": "./webpack.config.prod.js"
+    },
+    "api-url": "http://localhost:3030"
+  }
+}
+```
+
+| Preset variable | Description |
+|---|---|
+| html | `html-webpack-plugin` template and options customisation. |
+| sass | `sass-loader` custom data. |
+| webpack | `webpack` and `devServer customisation. |
+
+## HTML
+
+```json
+{
+  "preset": "talend",
+  "html": {
+    "title": "Talend Data Preparation",
+    "otherOptions": "Option value passed to html-webpack-plugin"
+  }
+}
+```
+
+All those options are passed as `html-webpack-plugin` options. It goes in pair with your index.html template.  
+By default, your html template is located in `src/app/index.html`, which can be overridden with the preset html configuration.
+
+
+## App loader
+
+By default, a static app loader is available to be displayed during your webapp download. The loader contains the Talend logo.
+
+To use it, you have the `html-webpack-plugin` option named `appLoader`.
+
+```html
+<html>
+    <body>
+        <div id="app">
+            <%= htmlWebpackPlugin.options.appLoader %>
+        </div>
+    </body>
+</html>
+```
+
+To change the logo, you can customise the `appLoaderIcon` variable in configuration.
+
+```json
+{
+  "preset": "talend",
+  "html": {
+    "appLoaderIcon": "url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDov+"
+  }
+}
+```
+
+## Sass
+
+You can pass all sass variables you need. Those will be loaded before any sass file.
+
+```json
+{
+  "preset": "talend",
+  "sass": {
+    "data": {
+      "$brand-primary": "red"
+    }
+  }
+}
+```
+
+In case you want to load one of T7+ @talend/bootstrap-theme variation, you can pass the variation name.
+
+```json
+{
+  "preset": "talend",
+  "sass": {
+    "theme": "tdp"
+  }
+}
+```
+
+## Webapck
+
+By default, a devServer proxy is in place, mapping all `/api` urls to `http://localhost`. You can change it to adapt to your backend api url.
+
+```json
+{
+  "preset": "talend",
+  "webpack": {
+    "api-url": "http://localhost:3000"
+  }
+}
+```

--- a/packages/scripts/preset/config/webpack.config.js
+++ b/packages/scripts/preset/config/webpack.config.js
@@ -3,18 +3,26 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
+const TalendHTML = require('@talend/html-webpack-plugin');
+const AppLoader = require('@talend/react-components/lib/AppLoader/constant').default;
+const DEFAULT_APP_LOADER_ICON = 'url(data:image/svg+xml;base64,PHN2ZyB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHZpZXdCb3g9IjAgMCAxNiAxNiI+DQoJPHBhdGggZD0iTTkuNjk0IDE0LjY1MmExLjA3NiAxLjA3NiAwIDAgMS0uNzE1LjQyMSAxLjA4NiAxLjA4NiAwIDEgMS0uMTQ4LTIuMTU4Yy4yMzUgMCAuNDYyLjA3NS42NTIuMjIuMjMuMTczLjM4LjQyNy40Mi43MTRhMS4wNyAxLjA3IDAgMCAxLS4yMDkuODAzTTIuMTUgMi42MjdBMS4wODQgMS4wODQgMCAxIDEgLjQxOCAxLjMyMiAxLjA4NCAxLjA4NCAwIDAgMSAyLjE1IDIuNjI3bTExLjM4MyAyLjQ5MWEyLjQ2IDIuNDYgMCAwIDAtMS40ODIuNDk0TDguOTQgMS43OThhLjU5LjU5IDAgMSAwLS4xNTYuMTI1bDMuMTExIDMuODE2YTIuNDg2IDIuNDg2IDAgMCAwLS41NTcuNzE4bC04Ljg0LTQuMDYyYy4wNjUtLjE5LjA4Ni0uMzk0LjA1Ny0uNTk5QTEuMjc0IDEuMjc0IDAgMCAwIDIuMDU4Ljk1YTEuMjc4IDEuMjc4IDAgMCAwLS45NTItLjI0NyAxLjI4NiAxLjI4NiAwIDAgMCAuMzU2IDIuNTQ0IDEuMjc5IDEuMjc5IDAgMCAwIC45NTYtLjY2OGw4LjgzOCA0LjA2Yy0uMTEuMjY0LS4xNzYuNTUtLjE4Ny44NUgzLjU2M2EuNzg4Ljc4OCAwIDAgMC0uMzEtLjUzMy43OTkuNzk5IDAgMCAwLTEuMTEzLjE1NS43ODYuNzg2IDAgMCAwIC4xNTYgMS4xMDUuNzk5Ljc5OSAwIDAgMCAxLjI2Ny0uNTI3aDcuNTA2Yy4wMTQuMzIzLjA4OC42My4yMTUuOTFsLTEuOTAzLjk0MWEuNTkyLjU5MiAwIDEgMCAuMDg5LjE3OWwxLjkwNC0uOTRjLjE2Mi4yOTIuMzgyLjU0OC42NDUuNzUzbC0yLjQ3MyAzLjQwNGExLjI4IDEuMjggMCAwIDAtMS43NDIuMjkxIDEuMjg4IDEuMjg4IDAgMCAwIC4yNTMgMS44IDEuMjggMS4yOCAwIDAgMCAuOTUyLjI0NmMuMzQtLjA0OC42NC0uMjI1Ljg0Ny0uNDk5LjIwNy0uMjc0LjI5NC0uNjEyLjI0Ni0uOTUyYTEuMjc2IDEuMjc2IDAgMCAwLS4zOTktLjc2M2wyLjQ3OS0zLjQxYTIuNDY4IDIuNDY4IDAgMSAwIDEuMzUyLTQuNTMiLz4NCjwvc3ZnPg0K)';
+
 const babelrc = require('./.babelrc.json');
 
 function getSassData(getUserConfig) {
-	const sassData = '@import \'~@talend/bootstrap-theme/src/theme/guidelines\';';
-	const userSassData = getUserConfig(['sass', 'data']);
-	if (userSassData) {
-		const adaptedUserSassData = Object.keys(userSassData)
-			.map(key => (`${key}: ${userSassData[key]};`))
-			.join('\n');
-		return `${adaptedUserSassData}\n${sassData}`;
+	let sassData = ['@import \'~@talend/bootstrap-theme/src/theme/guidelines\';'];
+
+	const userSassData = getUserConfig('sass');
+	if (userSassData && userSassData.data) {
+		sassData = Object.keys(userSassData.data)
+			.map(key => (`${key}: ${userSassData.data[key]};`))
+			.concat(sassData);
 	}
-	return sassData;
+	if (userSassData && userSassData.theme) {
+		sassData.push(`@import '~@talend/bootstrap-theme/src/theme/variations/${userSassData.theme}';`);
+	}
+
+	return sassData.join('\n');
 }
 
 function getCommonStyleLoaders(enableModules) {
@@ -94,7 +102,12 @@ module.exports = ({ getUserConfig }) => {
 			new HtmlWebpackPlugin({
 				filename: './index.html',
 				template: `${process.cwd()}/src/app/index.html`,
-				title: getUserConfig(['html', 'title']),
+				appLoader: AppLoader.APP_LOADER,
+				...getUserConfig('html'),
+			}),
+			new TalendHTML({
+				loadCSSAsync: true,
+				appLoaderIcon: getUserConfig(['html', 'appLoaderIcon'], DEFAULT_APP_LOADER_ICON),
 			}),
 			new CopyWebpackPlugin([
 				{ from: 'src/assets' },


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Talend/script does not manage static app loader. To add it we have to :
- provide a custom webpack conf to insert the Talend html plugin with the right icon
- provide a custom webpack conf to pass the html logo from @talend/react-components

**What is the chosen solution to this problem?**

_**Waiting for #1335 to be merged and released**_

Now Talend/scripts depends on Talend html plugin
- it sets a default talend logo as loader icon
- it exposes an `appLoader` var in html template

Bonus
- Preset documentation has been improved.
- preset now accepts any html options and pass them to `html-webpack-plugin`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
