### PR TITLE
feat(scripts): insert licence banner in bundles

### DIFF
--- a/packages/scripts/preset/config/licence.js
+++ b/packages/scripts/preset/config/licence.js
@@ -1,0 +1,16 @@
+const LICENSE_BANNER = `
+    ===========================================================================
+    
+     Copyright (C) 2006-${new Date().getFullYear()} Talend Inc. - www.talend.com
+    
+     This source code is available under agreement available at
+     https://github.com/Talend/data-prep/blob/master/LICENSE
+    
+     You should have received a copy of the agreement
+     along with this program; if not, write to Talend SA
+     9 rue Pages 92150 Suresnes, France
+    
+    ===========================================================================
+`;
+
+module.exports = LICENSE_BANNER;

--- a/packages/scripts/preset/config/licence.js
+++ b/packages/scripts/preset/config/licence.js
@@ -4,7 +4,7 @@ const LICENSE_BANNER = `
      Copyright (C) 2006-${new Date().getFullYear()} Talend Inc. - www.talend.com
     
      This source code is available under agreement available at
-     https://github.com/Talend/data-prep/blob/master/LICENSE
+     https://github.com/Talend/tools/blob/master/LICENSE
     
      You should have received a copy of the agreement
      along with this program; if not, write to Talend SA

--- a/packages/scripts/preset/config/webpack.config.js
+++ b/packages/scripts/preset/config/webpack.config.js
@@ -2,8 +2,10 @@ const autoprefixer = require('autoprefixer');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const webpack = require('webpack');
 
 const babelrc = require('./.babelrc.json');
+const LICENSE_BANNER = require('./licence');
 
 function getSassData(getUserConfig) {
 	const sassData = '@import \'~@talend/bootstrap-theme/src/theme/guidelines\';';
@@ -99,6 +101,9 @@ module.exports = ({ getUserConfig }) => {
 			new CopyWebpackPlugin([
 				{ from: 'src/assets' },
 			]),
+			new webpack.BannerPlugin({
+				banner: LICENSE_BANNER,
+			}),
 		],
 	};
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Bundles generated by Talend/scripts don't insert Talend licence.

**What is the chosen solution to this problem?**
Use webpack banner plugin to insert it.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
