### PR TITLE
feat(scripts): run eslint as pre-loader in dev mode

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -26,6 +26,7 @@
     "enzyme-to-json": "^3.0.0",
     "eslint": "^3.6.1",
     "eslint-config-airbnb": "^11.1.0",
+    "eslint-loader": "^2.0.0",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.3.0",

--- a/packages/scripts/preset/config/webpack.config.dev.js
+++ b/packages/scripts/preset/config/webpack.config.dev.js
@@ -1,7 +1,18 @@
+const path = require('path');
+
 module.exports = ({ getUserConfig }) => ({
 	mode: 'development',
 	output: {
 		path: `${process.cwd()}/build`,
+	},
+	module: {
+		rules: [{
+			test:	/.*\.js$/,
+			enforce: 'pre',
+			loader: 'eslint-loader',
+			exclude: /node_modules/,
+			options: { configFile: path.resolve(__dirname, '.eslintrc') },
+		}],
 	},
 	watchOptions: {
 		aggregateTimeout: 300,
@@ -16,6 +27,7 @@ module.exports = ({ getUserConfig }) => ({
 				secure: false,
 			},
 		},
+		stats: 'errors-only',
 		historyApiFallback: true,
 	},
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Linter is not integrated as webpack build

**What is the chosen solution to this problem?**
Webpack runs the linter as pre-loader, outputing the linter errors on each compilation.
This is only in dev mode and does not block the compilation.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
