### PR TITLE
fix(cmf): listen the last settings fetched to get the document title

### DIFF
--- a/packages/cmf/src/sagas/documentTitle.js
+++ b/packages/cmf/src/sagas/documentTitle.js
@@ -1,4 +1,4 @@
-import { take } from 'redux-saga/effects';
+import { take, takeLatest } from 'redux-saga/effects';
 
 import matchPath from '../sagaRouter/matchPath';
 
@@ -65,14 +65,7 @@ export function assignDocTitle(title) {
 	}
 }
 
-/**
- * A saga which listen to the REQUEST_SETTINGS_OK.
- * We use the routes of the settings to build a map [route: documentTitle].
- * We use the root path '/' to get the default document title and we assign it.
- * When the location changes @@router/LOCATION_CHANGE we update the document title.
- */
-export default function* changeDocumentTitle() {
-	const { settings } = yield take('REACT_CMF.REQUEST_SETTINGS_OK');
+export function* handleDocumentTitle({ settings }) {
 	const mapRoutes = buildMapFromRoutes(settings.routes, new Map());
 	const defaultDocTitle = mapRoutes.get('/');
 	assignDocTitle(defaultDocTitle);
@@ -82,4 +75,14 @@ export default function* changeDocumentTitle() {
 		const docTitle = getTitleFromRoutes(mapRoutes, router.payload.pathname, defaultDocTitle);
 		assignDocTitle(docTitle);
 	}
+}
+
+/**
+ * A saga which listen to the REQUEST_SETTINGS_OK.
+ * We use the routes of the settings to build a map [route: documentTitle].
+ * We use the root path '/' to get the default document title and we assign it.
+ * When the location changes @@router/LOCATION_CHANGE we update the document title.
+ */
+export default function* changeDocumentTitle() {
+	yield takeLatest('REACT_CMF.REQUEST_SETTINGS_OK', handleDocumentTitle);
 }

--- a/packages/cmf/src/sagas/documentTitle.test.js
+++ b/packages/cmf/src/sagas/documentTitle.test.js
@@ -1,0 +1,66 @@
+import { takeLatest, take } from 'redux-saga/effects';
+
+import changeDocumentTitle, { handleDocumentTitle } from './documentTitle';
+
+describe('documentTitle', () => {
+	describe('#changeDocumentTitle', () => {
+		it('should listen REACT_CMF.REQUEST_SETTINGS_OK', () => {
+			const generator = changeDocumentTitle();
+
+			expect(generator.next().value).toEqual(
+				takeLatest('REACT_CMF.REQUEST_SETTINGS_OK', handleDocumentTitle),
+			);
+		});
+	});
+
+	describe('#handleDocumentTitle', () => {
+		it('should handle the document title in order of the router path', () => {
+			const generator = handleDocumentTitle({
+				settings: {
+					routes: {
+						childRoutes: [
+							{
+								path: 'subA',
+								documentTitle: 'Sub A',
+								childRoutes: [
+									{
+										path: 'subsubA',
+										documentTitle: 'Sub A sub A',
+									},
+								],
+							},
+							{
+								path: 'subB',
+								documentTitle: 'Sub B',
+							},
+						],
+						path: '/',
+						component: 'App',
+						documentTitle: 'Root',
+					},
+				},
+			});
+
+			expect(generator.next().value).toEqual(take('@@router/LOCATION_CHANGE'));
+			expect(document.title).toBe('Root');
+
+			expect(
+				generator.next({
+					payload: {
+						pathname: '/subA/subsubA',
+					},
+				}).value,
+			).toEqual(take('@@router/LOCATION_CHANGE'));
+			expect(document.title).toBe('Sub A sub A');
+
+			expect(
+				generator.next({
+					payload: {
+						pathname: '/subA/unknow',
+					},
+				}).value,
+			).toEqual(take('@@router/LOCATION_CHANGE'));
+			expect(document.title).toBe('Root');
+		});
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With the i18n, we call the first time the default settings 'en' and whe we get the preferencedLanguages,w e call again the settings for this localse.
When the router change, he get the documentTitle from the first call to the settings and not the last.

**What is the chosen solution to this problem?**
change take by takeLatest

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
