### PR TITLE
fix(Component/SubHeaderBar): edition button color

### DIFF
--- a/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
@@ -80,7 +80,7 @@ $tc-input-subheader-sub-title-weight: 300 !default;
 				padding-right: $padding-small;
 
 				&:global(.btn-link) {
-					color: $gallery;
+					color: $silver;
 				}
 			}
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The SubHeaderBar edition button is not in the right color.

Current: $gallery
<img width="108" alt="capture d ecran 2018-05-16 a 15 03 15" src="https://user-images.githubusercontent.com/10761073/40118459-4d55193c-591a-11e8-9308-dec1a3d5fd33.png">

Expected: $silver
<img width="128" alt="capture d ecran 2018-05-16 a 15 03 10" src="https://user-images.githubusercontent.com/10761073/40118462-5033c658-591a-11e8-9879-a09f4c7de496.png">

**What is the chosen solution to this problem?**
Change the button color

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
