### PR TITLE
feat(Scripts): set source-map to map original files, not eval

### DIFF
--- a/packages/scripts/preset/config/webpack.config.dev.js
+++ b/packages/scripts/preset/config/webpack.config.dev.js
@@ -37,5 +37,6 @@ module.exports = ({ getUserConfig }) => {
 			contentBase: path.join(process.cwd(), '/dist'),
 		},
 		plugins,
+		devtool: 'source-map',
 	};
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The source map is the default webpack 4 dev mode source map: `eval`. But we want original files.

**What is the chosen solution to this problem?**
Switch the devtool to `source-map`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
