### PR TITLE
fix(allyJS): remove mock and make the tests pass

### DIFF
--- a/__mocks__/ally.js/style/_style.js
+++ b/__mocks__/ally.js/style/_style.js
@@ -1,2 +1,0 @@
-/* eslint-disable import/prefer-default-export */
-export function focusWithin() {};

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -142,8 +142,7 @@
     },
     "roots": [
       "src",
-      "__mocks__",
-      "../../__mocks__"
+      "__mocks__"
     ],
     "testRegex": "&*\\.test\\.js$",
     "moduleNameMapper": {

--- a/packages/components/src/polyfills/focus-within.js
+++ b/packages/components/src/polyfills/focus-within.js
@@ -1,3 +1,3 @@
 import { focusWithin } from 'ally.js/style/_style';
 
-focusWithin();
+setTimeout(focusWithin);

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -131,8 +131,7 @@
       "!**/__snapshots__/**"
     ],
     "roots": [
-      "src",
-      "../../__mocks__"
+      "src"
     ],
     "transform": {
       ".*": "<rootDir>/../../node_modules/babel-jest"

--- a/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.test.js
+++ b/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.test.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import mock from '@talend/react-cmf/lib/mock';
-import { ActionSplitDropdown } from '@talend/react-components';
 import Connected, {
 	mapStateToProps,
 	ContainerActionSplitDropdown,

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -126,8 +126,7 @@
       "!**/__snapshots__/**"
     ],
     "roots": [
-      "src",
-      "../../__mocks__"
+      "src"
     ],
     "transform": {
       ".*": "<rootDir>/../../node_modules/babel-jest"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we introduced ally.js to polyfill css focus-within, there was an error in test
`Uncaught TypeError: Cannot read property 'appendChild' of null`.
To fix that, we added a mock to avoid executing the polyfill.

But there will be the error in apps tests that doesn't have the mock. But needing a mock to test your app if you Talend/ui lib is not acceptable. We need another solution.

**What is the chosen solution to this problem?**
I ended up here : https://github.com/medialize/ally.js/issues/85#issuecomment-161762943
This issue explains that it is executed before the body is ready.
Still I'm not sure in our case (tests) that's the right explanation.

I decided to defer the call to the polyfill. In practice it ensure that it is executed when everything is ready, and in tests it will not be executed (or after the test), making it fail out of the tests, silently.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
