### PR TITLE
fix(Form): Change uiSchema propType to avoid type conflicts

### DIFF
--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -184,7 +184,7 @@ class Form extends React.Component {
 
 export const DataPropTypes = PropTypes.shape({
 	jsonSchema: PropTypes.object.isRequired,
-	uiSchema: PropTypes.object,
+	uiSchema: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 	properties: PropTypes.oneOfType([PropTypes.object, PropTypes.string]),
 });
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
As we have an hybrid Form system, with the UIForm there are some propTypes validations errors, in some cases an object type is required and in some others an array.
Ref:
https://github.com/Talend/ui/blob/a65c99585e4c5b5debfc1ad92fd21b080a2b1a1e/packages/forms/src/UIForm/UIForm.container.js#L86

**What is the chosen solution to this problem?**
I changed the uiSchema propType validation to match an object or array type.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
