### PR TITLE
fix(cmf/test): mock do a deepcopy

### DIFF
--- a/packages/cmf/__tests__/action.test.js
+++ b/packages/cmf/__tests__/action.test.js
@@ -10,7 +10,8 @@ describe('CMF action', () => {
 	beforeEach(() => {
 		settings = mock.settings();
 		state = mock.state();
-		context = mock.context();
+		state.cmf.settings = settings;
+		context = mock.context(state);
 		emptyContext = mock.emptyContext();
 	});
 	it('getActionsById should return action from settings', () => {

--- a/packages/cmf/__tests__/cmfConnect.test.js
+++ b/packages/cmf/__tests__/cmfConnect.test.js
@@ -129,7 +129,7 @@ describe('cmfConnect', () => {
 			const state = mock.state();
 			const mapStateToProps = jest.fn();
 			const ownProps = { view: 'simple' };
-			const props = getStateToProps({
+			getStateToProps({
 				state,
 				ownProps,
 				mapStateToProps,
@@ -196,6 +196,10 @@ describe('cmfConnect', () => {
 
 	describe('Higher Order Component', () => {
 		const Button = ({ onClick, label }) => <button onClick={onClick}>{label}</button>;
+		Button.propTypes = {
+			onClick: PropTypes.func,
+			label: PropTypes.string,
+		};
 		const CMFConnectedButton = cmfConnect({})(Button);
 		it('should create a connected component', () => {
 			const TestComponent = jest.fn();

--- a/packages/cmf/src/mock/store.js
+++ b/packages/cmf/src/mock/store.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import cloneDeep from 'lodash/cloneDeep';
 import settings from './settings';
 import collections from './collections';
 import components from './components';
@@ -51,16 +52,31 @@ const emptyContext = {
 };
 
 function copy(obj) {
-	return Object.assign({}, obj);
+	return cloneDeep(obj);
 }
 
 const mock = {
-	context: () => copy(context),
+	context: (myState, myRegistry) => {
+		const myContext = copy(context);
+		if (myState) {
+			myContext.store.getState = () => myState;
+		}
+		if (myRegistry) {
+			myContext.registry = myRegistry;
+		}
+		return myContext;
+	},
 	emptyContext: () => copy(emptyContext),
 	notInitializedState: () => copy(notInitializedState),
 	registry: () => copy(registry),
 	state: () => copy(state),
 	settings: () => copy(settings),
-	store: () => copy(store),
+	store: myState => {
+		const myStore = copy(store);
+		if (myState) {
+			myStore.getState = () => myState;
+		}
+		return myStore;
+	},
 };
 export default mock;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The current mock provided by CMF for testing purpose doesn't do deep copy.
So if you change a value in the provided mocked state it will change the reference for other tests which is not the expected behavior

**What is the chosen solution to this problem?**

use lodash cloneDeep.
You may have tests that fails after that. It's not considered as breaking changes.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
