### PR TITLE
fix(cmf/merge): destination is optional again

### DIFF
--- a/packages/cmf/scripts/cmf-settings.merge.js
+++ b/packages/cmf/scripts/cmf-settings.merge.js
@@ -48,7 +48,7 @@ function merge(options, errorCallback) {
 	const cmfconfig = options.cmfConfig || importAndValidate(cmfconfigPath, onError);
 	const sources = dev ? cmfconfig.settings['sources-dev'] : cmfconfig.settings.sources;
 	let destination = cmfconfig.settings.destination;
-	if (!path.isAbsolute(destination)) {
+	if (destination && !path.isAbsolute(destination)) {
 		destination = path.join(process.cwd(), cmfconfig.settings.destination);
 	}
 	let settings;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
PR #1345 introduced a breaking change. If the cmf.json destination is not provided, it breaks :/

**What is the chosen solution to this problem?**
Set back the destination optionnal

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
