### PR TITLE
chore: revert babel-eslint version to fix it

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -2,19 +2,8 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/cmf/src/cmfConnect.js
-  234:11  error  'displayName' is not defined     no-undef
-  235:11  error  'propTypes' is not defined       no-undef
-  239:11  error  'contextTypes' is not defined    no-undef
-  246:11  error  'setStateAction' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/cmf/src/componentState.js
   87:3  warning  Unexpected console statement  no-console
-
-/home/travis/build/Talend/ui/packages/cmf/src/Dispatcher.js
-  39:9  error  'displayName' is not defined   no-undef
-  40:9  error  'propTypes' is not defined     no-undef
-  47:9  error  'contextTypes' is not defined  no-undef
 
 /home/travis/build/Talend/ui/packages/cmf/src/Inject.component.js
   23:2  warning  Unexpected console statement  no-console
@@ -27,5 +16,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/sagas/collection.js
   10:1  error  Prefer default export  import/prefer-default-export
 
-✖ 13 problems (10 errors, 3 warnings)
+✖ 6 problems (3 errors, 3 warnings)
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -6,11 +6,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
 
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionFile/ActionFile.component.js
-  65:9  error  'displayName' is not defined   no-undef
-  67:9  error  'propTypes' is not defined     no-undef
-  85:9  error  'defaultProps' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/__snapshots__/config.js
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
@@ -26,26 +21,11 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
 
-/home/travis/build/Talend/ui/packages/components/src/Slider/Slider.component.js
-  132:9  error  'displayName' is not defined  no-undef
-  134:9  error  'propTypes' is not defined    no-undef
-
-/home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/InputTitleSubHeader/InlineFormSubHeader.component.js
-  11:9  error  'propTypes' is not defined     no-undef
-  19:9  error  'defaultProps' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
-  24:9  error  'displayName' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
-  62:9  error  'propTypes' is not defined     no-undef
-  85:9  error  'defaultProps' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
   47:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 21 problems (20 errors, 1 warning)
+✖ 11 problems (10 errors, 1 warning)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,76 +2,14 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/ConfirmDialog/ConfirmDialog.container.js
-  15:9  error  'displayName' is not defined   no-undef
-  16:9  error  'propTypes' is not defined     no-undef
-  19:9  error  'contextTypes' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/DeleteResource/DeleteResource.container.js
-  17:9  error  'displayName' is not defined   no-undef
-  18:9  error  'propTypes' is not defined     no-undef
-  28:9  error  'contextTypes' is not defined  no-undef
-  32:9  error  'defaultProps' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/FilterBar/FilterBar.container.js
-  19:9  error  'displayName' is not defined   no-undef
-  21:9  error  'contextTypes' is not defined  no-undef
-  26:9  error  'propTypes' is not defined     no-undef
-  34:9  error  'defaultProps' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/Form/Form.container.js
-  17:9  error  'displayName' is not defined  no-undef
-  18:9  error  'propTypes' is not defined    no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/List/List.container.js
-  40:9  error  'displayName' is not defined   no-undef
-  41:9  error  'propTypes' is not defined     no-undef
-  70:9  error  'defaultProps' is not defined  no-undef
-  74:9  error  'contextTypes' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:80  error  'notifications' is missing in props validation  react/prop-types
-
-/home/travis/build/Talend/ui/packages/containers/src/ObjectViewer/ObjectViewer.container.js
-  61:9  error  'displayName' is not defined  no-undef
-  62:9  error  'propTypes' is not defined    no-undef
 
 /home/travis/build/Talend/ui/packages/containers/src/register.js
   6:1  error  Prefer default export  import/prefer-default-export
 
-/home/travis/build/Talend/ui/packages/containers/src/SelectObject/SelectObject.container.js
-   92:9  error  'displayName' is not defined   no-undef
-   93:9  error  'propTypes' is not defined     no-undef
-  102:9  error  'defaultProps' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/ShortcutManager/ShortcutManager.container.js
-  14:9  error  'displayName' is not defined   no-undef
-  15:9  error  'propTypes' is not defined     no-undef
-  19:9  error  'contextTypes' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
   3:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
-/home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.container.js
-  17:9  error  'displayName' is not defined   no-undef
-  18:9  error  'propTypes' is not defined     no-undef
-  21:9  error  'contextTypes' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/Slider/Slider.container.js
-  16:9  error  'displayName' is not defined   no-undef
-  18:9  error  'contextTypes' is not defined  no-undef
-  23:9  error  'propTypes' is not defined     no-undef
-  29:9  error  'defaultProps' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.container.js
-  14:9  error  'displayName' is not defined   no-undef
-  16:9  error  'propTypes' is not defined     no-undef
-  31:9  error  'contextTypes' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/containers/src/TreeView/TreeView.container.js
-  66:9  error  'displayName' is not defined   no-undef
-  67:9  error  'propTypes' is not defined     no-undef
-  78:9  error  'defaultProps' is not defined  no-undef
-
-✖ 41 problems (41 errors, 0 warnings)
+✖ 3 problems (3 errors, 0 warnings)
 

--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -1,10 +1,3 @@
 > eslint --config ../../.eslintrc src
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
-
-/home/travis/build/Talend/ui/packages/datagrid/src/components/DataGrid/DataGrid.component.js
-  57:9  error  'defaultProps' is not defined  no-undef
-  75:9  error  'propTypes' is not defined     no-undef
-
-✖ 2 problems (2 errors, 0 warnings)
-

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -2,17 +2,8 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/forms/src/fields/ArrayField.js
-  160:9  error  'defaultProps' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/forms/src/fields/CollapsibleFieldset.js
-  10:10  error  'defaultProps' is not defined                                                        no-undef
-  26:3   error  'onPropertyChange' is not defined                                                    no-undef
-  82:8   error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
-
-/home/travis/build/Talend/ui/packages/forms/src/fields/ObjectField.js
-  52:9  error  'defaultProps' is not defined      no-undef
-  63:2  error  'onPropertyChange' is not defined  no-undef
+  82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/forms/src/Form.test.js
   10:36  error  Absolute imports should come before relative imports  import/imports-first
@@ -26,25 +17,11 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   24:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
-  20:9  error  'displayName' is not defined  no-undef
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.container.js
-  9:9  error  'displayName' is not defined  no-undef
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/templates.js
   1:8  error  Using exported name 'DefaultArrayTemplate' as identifier for default export  import/no-named-as-default
-
-/home/travis/build/Talend/ui/packages/forms/src/widgets/CodeWidget/CodeWidget.component.js
-  26:10  error  'displayName' is not defined  no-undef
 
 /home/travis/build/Talend/ui/packages/forms/src/widgets/ColumnsWidget/ColumnsWidget.js
   59:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
 
-/home/travis/build/Talend/ui/packages/forms/src/widgets/DatalistWidget/DatalistWidget.js
-  82:9  error  'itemContainerStyle' is not defined  no-undef
-  83:9  error  'noResultStyle' is not defined       no-undef
-  84:9  error  'emptyStyle' is not defined          no-undef
-
-✖ 20 problems (20 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
 

--- a/output/logging.eslint.txt
+++ b/output/logging.eslint.txt
@@ -3,7 +3,6 @@
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
 /home/travis/build/Talend/ui/packages/logging/src/angular/angular-logger.js
-   8:2   error    'isInitialized' is not defined             no-undef
   12:4   warning  Unexpected console statement               no-console
   16:4   warning  Unexpected console statement               no-console
   21:4   warning  Unexpected console statement               no-console
@@ -18,5 +17,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   30:3  warning  Unexpected console statement  no-console
   36:3  warning  Unexpected console statement  no-console
 
-✖ 10 problems (3 errors, 7 warnings)
+✖ 9 problems (2 errors, 7 warnings)
 

--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -38,7 +38,7 @@
     "@talend/react-cmf": "^0.187.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/cmf-webpack-plugin/package.json
+++ b/packages/cmf-webpack-plugin/package.json
@@ -39,7 +39,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-polyfill": "6.26.0",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -43,7 +43,7 @@
     "ajv": "^6.2.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,7 @@
     "autoprefixer": "^7.1.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -46,7 +46,7 @@
     "@talend/react-forms": "^0.187.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -42,7 +42,7 @@
     "@talend/react-components": "^0.187.1",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -56,7 +56,7 @@
     "autoprefixer": "^7.1.4",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/packages/generator/generators/react-cmf/templates/package.json
+++ b/packages/generator/generators/react-cmf/templates/package.json
@@ -25,12 +25,12 @@
     "@talend/scripts": "0.2.1"
   },
   "dependencies": {
-    "@talend/bootstrap-theme": "0.185.0",
-    "@talend/icons": "0.185.0",
-    "@talend/react-cmf": "0.185.0",
-    "@talend/react-components": "0.185.0",
-    "@talend/react-containers": "0.185.0",
-    "@talend/react-forms": "0.185.0",
+    "@talend/bootstrap-theme": "0.187.1",
+    "@talend/icons": "0.187.1",
+    "@talend/react-cmf": "0.187.1",
+    "@talend/react-components": "0.187.1",
+    "@talend/react-containers": "0.187.1",
+    "@talend/react-forms": "0.187.1",
     "bootstrap-sass": "3.3.7",
     "bson-objectid": "1.1.5",
     "classnames": "2.2.5",

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -43,7 +43,7 @@
   },
   "devDependencies": {
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-preset-env": "^1.6.0",
     "babel-register": "^6.14.0",
     "coveralls": "^2.11.12",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -37,7 +37,7 @@
   "devDependencies": {
     "autoprefixer": "^7.1.4",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-plugin-transform-class-properties": "^6.24.1",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",
     "babel-preset-env": "^1.6.0",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -42,7 +42,7 @@
     "angular-mocks": "^1.5.9",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-object-rest-spread": "^6.26.0",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -59,7 +59,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.0",
-    "babel-eslint": "^8.0.2",
+    "babel-eslint": "8.0.2",
     "babel-jest": "20.0.3",
     "babel-loader": "^7.1.2",
     "babel-plugin-transform-class-properties": "^6.24.1",

--- a/version.js
+++ b/version.js
@@ -124,7 +124,7 @@ const VERSIONS = Object.assign({}, ADDONS, {
 	autoprefixer: '^7.1.4',
 	'babel-cli': '^6.26.0',
 	'babel-core': '^6.26.0',
-	'babel-eslint': '^8.0.2',
+	'babel-eslint': '8.0.2',
 	'babel-jest': JEST_VERSION,
 	'babel-plugin-transform-class-properties': '^6.24.1',
 	'babel-plugin-transform-export-extensions': '^6.22.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,80 +2,84 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
+"@babel/code-frame@7.0.0-beta.49", "@babel/code-frame@^7.0.0-beta.31":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.49.tgz#becd805482734440c9d137e46d77340e64d7f51b"
   dependencies:
-    "@babel/highlight" "7.0.0-beta.44"
+    "@babel/highlight" "7.0.0-beta.49"
 
-"@babel/generator@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
+"@babel/generator@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.49.tgz#e9cffda913996accec793bbc25ab91bc19d0bf7a"
   dependencies:
-    "@babel/types" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.49"
     jsesc "^2.5.1"
-    lodash "^4.2.0"
+    lodash "^4.17.5"
     source-map "^0.5.0"
     trim-right "^1.0.1"
 
-"@babel/helper-function-name@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
+"@babel/helper-function-name@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.49.tgz#a25c1119b9f035278670126e0225c03041c8de32"
   dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.44"
-    "@babel/template" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
+    "@babel/helper-get-function-arity" "7.0.0-beta.49"
+    "@babel/template" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.49"
 
-"@babel/helper-get-function-arity@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
+"@babel/helper-get-function-arity@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.49.tgz#cf5023f32d2ad92d087374939cec0951bcb51441"
   dependencies:
-    "@babel/types" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.49"
 
-"@babel/helper-split-export-declaration@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
+"@babel/helper-split-export-declaration@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.49.tgz#40d78eda0968d011b1c52866e5746cfb23e57548"
   dependencies:
-    "@babel/types" "7.0.0-beta.44"
+    "@babel/types" "7.0.0-beta.49"
 
-"@babel/highlight@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
+"@babel/highlight@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.49.tgz#96bdc6b43e13482012ba6691b1018492d39622cc"
   dependencies:
     chalk "^2.0.0"
     esutils "^2.0.2"
     js-tokens "^3.0.0"
 
-"@babel/template@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    lodash "^4.2.0"
+"@babel/parser@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.0.0-beta.49.tgz#944d0c5ba2812bb159edbd226743afd265179bdc"
 
-"@babel/traverse@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
+"@babel/template@7.0.0-beta.49":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.49.tgz#e38abe8217cb9793f461a5306d7ad745d83e1d27"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/generator" "7.0.0-beta.44"
-    "@babel/helper-function-name" "7.0.0-beta.44"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
+    "@babel/code-frame" "7.0.0-beta.49"
+    "@babel/parser" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.49"
+    lodash "^4.17.5"
+
+"@babel/traverse@^7.0.0-beta.31":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.49.tgz#4f2a73682a18334ed6625d100a8d27319f7c2d68"
+  dependencies:
+    "@babel/code-frame" "7.0.0-beta.49"
+    "@babel/generator" "7.0.0-beta.49"
+    "@babel/helper-function-name" "7.0.0-beta.49"
+    "@babel/helper-split-export-declaration" "7.0.0-beta.49"
+    "@babel/parser" "7.0.0-beta.49"
+    "@babel/types" "7.0.0-beta.49"
     debug "^3.1.0"
     globals "^11.1.0"
     invariant "^2.2.0"
-    lodash "^4.2.0"
+    lodash "^4.17.5"
 
-"@babel/types@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
+"@babel/types@7.0.0-beta.49", "@babel/types@^7.0.0-beta.31":
+  version "7.0.0-beta.49"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.49.tgz#b7e3b1c3f4d4cfe11bdf8c89f1efd5e1617b87a6"
   dependencies:
     esutils "^2.0.2"
-    lodash "^4.2.0"
+    lodash "^4.17.5"
     to-fast-properties "^2.0.0"
 
 "@kadira/react-storybook-addon-info@^3.3.0":
@@ -908,16 +912,14 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-eslint@^8.0.2:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.3.tgz#1a2e6681cc9bc4473c32899e59915e19cd6733cf"
+babel-eslint@8.0.2:
+  version "8.0.2"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.2.tgz#e44fb9a037d749486071d52d65312f5c20aa7530"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/traverse" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    eslint-scope "~3.7.1"
-    eslint-visitor-keys "^1.0.0"
+    "@babel/code-frame" "^7.0.0-beta.31"
+    "@babel/traverse" "^7.0.0-beta.31"
+    "@babel/types" "^7.0.0-beta.31"
+    babylon "^7.0.0-beta.31"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.1"
@@ -1874,13 +1876,13 @@ babylon@7.0.0-beta.19:
   version "7.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
 
-babylon@7.0.0-beta.44:
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
-
 babylon@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-6.18.0.tgz#af2f3b88fa6f5c1e4c634d1a0f8eac4f55b395e3"
+
+babylon@^7.0.0-beta.31:
+  version "7.0.0-beta.47"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.47.tgz#6d1fa44f0abec41ab7c780481e62fd9aafbdea80"
 
 babylon@~5.8.3:
   version "5.8.38"
@@ -4336,17 +4338,6 @@ eslint-plugin-react@^6.3.0:
     has "^1.0.1"
     jsx-ast-utils "^1.3.4"
     object.assign "^4.0.4"
-
-eslint-scope@~3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^2.7.0:
   version "2.13.1"
@@ -7757,6 +7748,10 @@ lodash@^3.10.1, lodash@^3.2.0, lodash@^3.3.1, lodash@^3.5.0:
 lodash@^4.0.1, lodash@^4.11.1, lodash@^4.13.1, lodash@^4.14.0, lodash@^4.15.0, lodash@^4.17.0, lodash@^4.17.2, lodash@^4.17.3, lodash@^4.2.0, lodash@^4.6.1, lodash@~4.17.4:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
+
+lodash@^4.17.5:
+  version "4.17.10"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.10.tgz#1b7793cf7259ea38fb3661d4d38b3260af8ae4e7"
 
 log-driver@1.2.5:
   version "1.2.5"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
babel-eslint version has changed to use a wildcard `^8.0.2`.
But that introduce extra dependencies that interact with the eslint rules. That makes some valid patterns output a lint error.

**What is the chosen solution to this problem?**
Revert the version to the fixed one.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
