### PR TITLE
fix(UIForm): resetting form structure if it didn't change

### DIFF
--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -22,9 +22,11 @@ export default class UIForm extends React.Component {
 	 * @param nextProps
 	 */
 	componentWillReceiveProps(nextProps) {
-		this.setState({
-			...nextProps.data,
-		});
+		if (nextProps.data !== this.props.data) {
+			this.setState({
+				...nextProps.data,
+			});
+		}
 	}
 
 	/**

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -38,7 +38,7 @@ describe('UIForm container', () => {
 			expect(wrapper.state()).not.toBe(previousState);
 		});
 
-		it('should not update state if form data structure didn\'t change', () => {
+		it("should not update state if form data structure didn't change", () => {
 			// given
 			const wrapper = shallow(<UIForm data={data} {...props} />);
 

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -22,6 +22,38 @@ describe('UIForm container', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	describe('#componentWillReceiveProps', () => {
+		it('should update state if form data structure changed', () => {
+			// given
+			const wrapper = shallow(<UIForm data={data} {...props} />);
+
+			const previousState = wrapper.state();
+
+			// when
+			wrapper.setProps({
+				data: Object.assign({}, data),
+			});
+
+			// then
+			expect(wrapper.state()).not.toBe(previousState);
+		});
+
+		it('should not update state if form data structure didn\'t change', () => {
+			// given
+			const wrapper = shallow(<UIForm data={data} {...props} />);
+
+			const previousState = wrapper.state();
+
+			// when
+			wrapper.setProps({
+				whateverOtherThanData: 'something',
+			});
+
+			// then
+			expect(wrapper.state()).toBe(previousState);
+		});
+	});
+
 	describe('#onChange', () => {
 		it('should update state properties', () => {
 			// given


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Prevents component's state resetting (form data included), when any other property have changed.

**What is the chosen solution to this problem?**
Resetting only if the props related to the structure have changed.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
