### PR TITLE
chore(ActionDropdown): adding margin between svg and text

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -65,6 +65,7 @@ function renderMutableMenuItem(item, index, getComponent) {
 			eventKey={item}
 			onClick={wrapOnClick(item)}
 			title={item.title || item.label}
+			className={classNames(theme['tc-dropdown-item'], 'tc-dropdown-item')}
 		>
 			{item.icon && <Icon name={item.icon} />}
 			{!item.hideLabel && item.label}

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
@@ -5,3 +5,9 @@
 		text-decoration: none;
 	}
 }
+
+.tc-dropdown-item {
+	a svg {
+		margin: 0 $padding-smaller;
+	}
+}

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -200,6 +200,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                 >
                   <MenuItem
                     bsClass="dropdown"
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     disabled={false}
                     divider={false}
                     eventKey={
@@ -219,7 +220,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                     title="document 1"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                     >
                       <SafeAnchor
@@ -264,6 +265,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                   </MenuItem>
                   <MenuItem
                     bsClass="dropdown"
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     disabled={false}
                     divider={false}
                     eventKey={
@@ -281,7 +283,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                     title="document 2"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                     >
                       <SafeAnchor
@@ -340,6 +342,7 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
 >
   <MenuItem
     bsClass="dropdown"
+    className="theme-tc-dropdown-item tc-dropdown-item"
     disabled={false}
     divider={false}
     eventKey={
@@ -362,6 +365,7 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
   </MenuItem>
   <MenuItem
     bsClass="dropdown"
+    className="theme-tc-dropdown-item tc-dropdown-item"
     disabled={false}
     divider={false}
     eventKey={
@@ -405,6 +409,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
 >
   <MenuItem
     bsClass="dropdown"
+    className="theme-tc-dropdown-item tc-dropdown-item"
     disabled={false}
     divider={false}
     eventKey={
@@ -428,6 +433,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
   </MenuItem>
   <MenuItem
     bsClass="dropdown"
+    className="theme-tc-dropdown-item tc-dropdown-item"
     disabled={false}
     divider={false}
     eventKey={
@@ -471,6 +477,7 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
   >
     <MenuItem
       bsClass="dropdown"
+      className="theme-tc-dropdown-item tc-dropdown-item"
       disabled={false}
       divider={false}
       eventKey={
@@ -493,6 +500,7 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
     </MenuItem>
     <MenuItem
       bsClass="dropdown"
+      className="theme-tc-dropdown-item tc-dropdown-item"
       disabled={false}
       divider={false}
       eventKey={
@@ -534,6 +542,7 @@ exports[`ActionDropdown should render icon-only items with item hideLabel props 
     >
       <MenuItem
         bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item"
         disabled={false}
         divider={false}
         eventKey={
@@ -555,7 +564,7 @@ exports[`ActionDropdown should render icon-only items with item hideLabel props 
         title="document 1"
       >
         <li
-          className=""
+          className="theme-tc-dropdown-item tc-dropdown-item"
           role="presentation"
         >
           <SafeAnchor
@@ -601,6 +610,7 @@ exports[`ActionDropdown should render icon-only items with item hideLabel props 
       </MenuItem>
       <MenuItem
         bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item"
         disabled={false}
         divider={false}
         eventKey={
@@ -620,7 +630,7 @@ exports[`ActionDropdown should render icon-only items with item hideLabel props 
         title="document 2"
       >
         <li
-          className=""
+          className="theme-tc-dropdown-item tc-dropdown-item"
           role="presentation"
         >
           <SafeAnchor
@@ -794,6 +804,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
                 >
                   <MenuItem
                     bsClass="dropdown"
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     disabled={false}
                     divider={false}
                     eventKey={
@@ -813,7 +824,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
                     title="document 1"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                     >
                       <SafeAnchor
@@ -858,6 +869,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
                   </MenuItem>
                   <MenuItem
                     bsClass="dropdown"
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     disabled={false}
                     divider={false}
                     eventKey={
@@ -875,7 +887,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
                     title="document 2"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                     >
                       <SafeAnchor

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
@@ -44,6 +44,7 @@ exports[`getMenuItem should return a MenuItem with divider 1`] = `
 exports[`getMenuItem should return a MenuItem with icon and label 1`] = `
 <MenuItem
   bsClass="dropdown"
+  className="theme-tc-dropdown-item tc-dropdown-item"
   data-feature="action.feature"
   disabled={false}
   divider={false}
@@ -70,6 +71,7 @@ exports[`getMenuItem should return a MenuItem with icon and label 1`] = `
 exports[`getMenuItem should return a MenuItem with label 1`] = `
 <MenuItem
   bsClass="dropdown"
+  className="theme-tc-dropdown-item tc-dropdown-item"
   data-feature="action.feature"
   disabled={false}
   divider={false}

--- a/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
+++ b/packages/components/src/Enumeration/Header/__snapshots__/header.snapshot.test.js.snap
@@ -127,7 +127,7 @@ exports[`Header should render header with one dropdown and two items 1`] = `
         role="menu"
       >
         <li
-          className=""
+          className="theme-tc-dropdown-item tc-dropdown-item"
           role="presentation"
           style={undefined}
         >
@@ -145,7 +145,7 @@ exports[`Header should render header with one dropdown and two items 1`] = `
           </a>
         </li>
         <li
-          className=""
+          className="theme-tc-dropdown-item tc-dropdown-item"
           role="presentation"
           style={undefined}
         >

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -702,7 +702,7 @@ exports[`Storyshots HeaderBar default 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -731,7 +731,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -760,7 +760,7 @@ exports[`Storyshots HeaderBar default 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -909,7 +909,7 @@ exports[`Storyshots HeaderBar default 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -1333,7 +1333,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -1362,7 +1362,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -1391,7 +1391,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -1588,7 +1588,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -2012,7 +2012,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2041,7 +2041,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2070,7 +2070,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2152,7 +2152,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -2288,7 +2288,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -2712,7 +2712,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2741,7 +2741,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2770,7 +2770,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -2919,7 +2919,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -3343,7 +3343,7 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -3372,7 +3372,7 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -3401,7 +3401,7 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -3550,7 +3550,7 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -3974,7 +3974,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4003,7 +4003,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4032,7 +4032,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4207,7 +4207,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -4631,7 +4631,7 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4660,7 +4660,7 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4689,7 +4689,7 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -4866,7 +4866,7 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -5290,7 +5290,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -5319,7 +5319,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -5348,7 +5348,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -5517,7 +5517,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -5941,7 +5941,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -5970,7 +5970,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -5999,7 +5999,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -6501,7 +6501,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -6925,7 +6925,7 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -6954,7 +6954,7 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -6983,7 +6983,7 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -7160,7 +7160,7 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -7682,7 +7682,7 @@ exports[`Storyshots HeaderBar without products 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -8106,7 +8106,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
               role="menu"
             >
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -8135,7 +8135,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -8164,7 +8164,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
                 </a>
               </li>
               <li
-                className=""
+                className="theme-tc-dropdown-item tc-dropdown-item"
                 role="presentation"
                 style={undefined}
               >
@@ -8307,7 +8307,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
             role="menu"
           >
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -8330,7 +8330,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
               style={undefined}
             />
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -8348,7 +8348,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
               </a>
             </li>
             <li
-              className=""
+              className="theme-tc-dropdown-item tc-dropdown-item"
               role="presentation"
               style={undefined}
             >
@@ -8769,7 +8769,7 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -8798,7 +8798,7 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -8827,7 +8827,7 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -8976,7 +8976,7 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -9412,7 +9412,7 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -9441,7 +9441,7 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -9470,7 +9470,7 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -9619,7 +9619,7 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -10055,7 +10055,7 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10084,7 +10084,7 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10113,7 +10113,7 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10262,7 +10262,7 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -10698,7 +10698,7 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10727,7 +10727,7 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10756,7 +10756,7 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -10905,7 +10905,7 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -11341,7 +11341,7 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -11370,7 +11370,7 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -11399,7 +11399,7 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -11548,7 +11548,7 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -11984,7 +11984,7 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12013,7 +12013,7 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12042,7 +12042,7 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12191,7 +12191,7 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >
@@ -12627,7 +12627,7 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
                     role="menu"
                   >
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12656,7 +12656,7 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12685,7 +12685,7 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
                       </a>
                     </li>
                     <li
-                      className=""
+                      className="theme-tc-dropdown-item tc-dropdown-item"
                       role="presentation"
                       style={undefined}
                     >
@@ -12834,7 +12834,7 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
                   role="menu"
                 >
                   <li
-                    className=""
+                    className="theme-tc-dropdown-item tc-dropdown-item"
                     role="presentation"
                     style={undefined}
                   >


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
issue with action dropdown item displaying svg + text : 
![image](https://user-images.githubusercontent.com/14272767/40661344-c73239ae-6353-11e8-8d20-90877435659a.png)


**What is the chosen solution to this problem?**
Adding margin to svg:
![image](https://user-images.githubusercontent.com/14272767/40661374-e03d6644-6353-11e8-83de-0190bdb26984.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
