### PR TITLE
fix(components) : improve translation in circularProgress

### DIFF
--- a/packages/components/src/CircularProgress/CircularProgress.component.js
+++ b/packages/components/src/CircularProgress/CircularProgress.component.js
@@ -40,7 +40,10 @@ function CircularProgress({ size, light, percent, className, t }) {
 		[theme.large]: size === SIZE.large,
 	});
 
-	const percentLabel = percent && `${percent}%`;
+	const percentLabel = percent && t('CIRCULAR_PROGRESS_LOADING_PERCENT', {
+		defaultValue: '{{percent}}%',
+		percent,
+	});
 	return (
 		<svg
 			focusable="false"

--- a/packages/components/src/CircularProgress/CircularProgress.component.js
+++ b/packages/components/src/CircularProgress/CircularProgress.component.js
@@ -16,7 +16,7 @@ function getCircleStyle(percent) {
 	if (percent) {
 		return {
 			strokeDasharray: CIRCUMFERENCE,
-			strokeDashoffset: (100 - percent) / 100 * CIRCUMFERENCE,
+			strokeDashoffset: ((100 - percent) / 100) * CIRCUMFERENCE,
 		};
 	}
 	return {
@@ -40,10 +40,12 @@ function CircularProgress({ size, light, percent, className, t }) {
 		[theme.large]: size === SIZE.large,
 	});
 
-	const percentLabel = percent && t('CIRCULAR_PROGRESS_LOADING_PERCENT', {
-		defaultValue: '{{percent}}%',
-		percent,
-	});
+	const percentLabel =
+		percent &&
+		t('CIRCULAR_PROGRESS_LOADING_PERCENT', {
+			defaultValue: '{{percent}}%',
+			percent,
+		});
 	return (
 		<svg
 			focusable="false"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
currently it's not possible to have a different translation for the percent label
for exemple, we need to have a space before the %
**What is the chosen solution to this problem?**
add a new key  to make this possible

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
