### PR TITLE
fix(Component): switch to dropup when it's short for dropdown

### DIFF
--- a/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
@@ -54,7 +54,7 @@ function ListTable(props) {
 	return (
 		<VirtualizedTable
 			className={`tc-list-table ${theme['tc-list-table']}`}
-			gridClassName={theme.grid}
+			gridClassName={`${theme.grid} tc-dropdown-container`}
 			headerHeight={35}
 			height={height}
 			id={id}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For dropdown in restricted divs, it's possible to have the dropdown menu cropped if it is around the bottom of the div

**What is the chosen solution to this problem?**
Make it be a dropup when it's too close from the bottom

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
