### PR TITLE
chore(datagrid): optim on componentDidUpdate

### DIFF
--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -53,6 +53,30 @@ function getAvroRenderer(avroRenderer) {
 	};
 }
 
+/**
+ * this function return information about how many row of each type are loaded
+ * @param {array} rowData the data of the datagrid
+ */
+export function getRowDataInfos(rowData) {
+	let notLoaded = 0;
+	let loading = 0;
+	let loaded = 0;
+	rowData.forEach(item => {
+		if (item.loading === false && Object.keys(item).length === 2) {
+			notLoaded += 1;
+		} else if (item.loading === true) {
+			loading += 1;
+		} else {
+			loaded += 1;
+		}
+	});
+	return {
+		loaded,
+		loading,
+		notLoaded,
+	};
+}
+
 export default class DataGrid extends React.Component {
 	static defaultProps = {
 		cellRenderer: 'DefaultCellRenderer',
@@ -88,8 +112,15 @@ export default class DataGrid extends React.Component {
 		this.onKeyDownHeaderColumn = this.onKeyDownHeaderColumn.bind(this);
 	}
 
-	componentDidUpdate() {
-		if (this.gridAPI) {
+	componentDidUpdate(prevProps) {
+		const prevInfos = getRowDataInfos(prevProps.rowData);
+		const currentInfos = getRowDataInfos(this.props.rowData);
+		if (
+			this.gridAPI &&
+			(prevInfos.loaded !== currentInfos.loaded ||
+				prevInfos.loading !== currentInfos.loading ||
+				prevInfos.notLoaded !== currentInfos.notLoaded)
+		) {
 			this.gridAPI.redrawRows();
 		}
 	}

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -58,23 +58,26 @@ function getAvroRenderer(avroRenderer) {
  * @param {array} rowData the data of the datagrid
  */
 export function getRowDataInfos(rowData) {
-	let notLoaded = 0;
-	let loading = 0;
-	let loaded = 0;
-	rowData.forEach(item => {
-		if (item.loading === false && Object.keys(item).length === 2) {
-			notLoaded += 1;
-		} else if (item.loading === true) {
-			loading += 1;
-		} else {
-			loaded += 1;
-		}
-	});
-	return {
-		loaded,
-		loading,
-		notLoaded,
-	};
+	return rowData.reduce(
+		(acc, item) => {
+			if (item.loading === false && Object.keys(item).length === 2) {
+				// eslint-disable-next-line no-param-reassign
+				acc.notLoaded += 1;
+			} else if (item.loading === true) {
+				// eslint-disable-next-line no-param-reassign
+				acc.loading += 1;
+			} else {
+				// eslint-disable-next-line no-param-reassign
+				acc.loaded += 1;
+			}
+			return acc;
+		},
+		{
+			loaded: 0,
+			loading: 0,
+			notLoaded: 0,
+		},
+	);
 }
 
 export default class DataGrid extends React.Component {

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -9,6 +9,7 @@ import DataGrid, {
 	injectedCellRenderer,
 	injectedHeaderRenderer,
 	AG_GRID,
+	getRowDataInfos,
 } from './DataGrid.component';
 
 function PinHeaderRenderer() {}
@@ -709,5 +710,48 @@ describe('#injectedHeaderRenderer', () => {
 		const wrapper = shallow(<InjectedComponent id="injectedComponent" />);
 
 		expect(wrapper.find('DefaultHeaderRenderer').length).toBe(1);
+	});
+});
+
+describe('getRowDataInfos', () => {
+	it('should return the metadata of the rowdata', () => {
+		// given
+		const rowData = [
+			{
+				loading: false,
+				'indexes.index': 0,
+			},
+			{
+				loading: false,
+				'indexes.index': 1,
+			},
+			{
+				loading: true,
+				'indexes.index': 2,
+			},
+			{
+				loading: false,
+				'indexes.index': 3,
+				'data.text': 'hello',
+			},
+			{
+				loading: false,
+				'indexes.index': 4,
+				'data.text': 'hello',
+			},
+			{
+				loading: false,
+				'indexes.index': 5,
+				'data.text': 'hello',
+			},
+		];
+		// when
+		const result = getRowDataInfos(rowData);
+		// then
+		expect(result).toEqual({
+			notLoaded: 2,
+			loading: 1,
+			loaded: 3,
+		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the component did update we refresh the raw in case the component has new rowdata for different states
**What is the chosen solution to this problem?**
Count if the row data contains different number of loading / loaded / not loaded row to redraw the cells

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
