### PR TITLE
fix(List): fix cellDictionary wrong proptype

### DIFF
--- a/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
+++ b/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
@@ -90,7 +90,7 @@ ListToVirtualizedList.propTypes = {
 	columns: PropTypes.arrayOf(PropTypes.object),
 	displayMode: PropTypes.oneOf(['large', 'table']),
 	defaultHeight: PropTypes.number,
-	cellDictionary: PropTypes.obj,
+	cellDictionary: PropTypes.object,
 	itemProps: PropTypes.shape({
 		isActive: PropTypes.func,
 		isSelected: PropTypes.func,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Proptypes.obj is not a valid proptype
**What is the chosen solution to this problem?**
Proptypes.object is really better
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
