### PR TITLE
chore: downgrade react-jsonschema-form to not use ajv

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -41,7 +41,7 @@
     "lodash": "4.17.4",
     "prop-types": "15.5.10",
     "react-autowhatever": "10.1.0",
-    "react-jsonschema-form": "1.0.0",
+    "react-jsonschema-form": "0.51.0",
     "tv4": "^1.3.0"
   },
   "devDependencies": {

--- a/packages/forms/src/__snapshots__/Form.test.js.snap
+++ b/packages/forms/src/__snapshots__/Form.test.js.snap
@@ -72,13 +72,11 @@ exports[`<Form/> actions should render form with custom css 1`] = `
             
           </option>
           <option
-            disabled={undefined}
             value="dev"
           >
             dev
           </option>
           <option
-            disabled={undefined}
             value="pm"
           >
             pm

--- a/packages/forms/src/fields/ArrayField.js
+++ b/packages/forms/src/fields/ArrayField.js
@@ -298,15 +298,14 @@ class ArrayField extends Component {
 			minItems: schema.minItems || 0,
 			maxItems: schema.maxItems || 999,
 			items: formData.map((item, index) => {
-				const itemSchema = retrieveSchema(schema.items, definitions, item);
 				const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
 				const itemIdPrefix = `${idSchema.$id}_${index}`;
-				const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions, item);
+				const itemIdSchema = toIdSchema(itemsSchema, itemIdPrefix, definitions);
 				return this.renderArrayFieldItem({
 					index,
 					canMoveUp: index > 0,
 					canMoveDown: index < formData.length - 1,
-					itemSchema,
+					itemSchema: itemsSchema,
 					itemIdSchema,
 					itemErrorSchema,
 					itemData: item,
@@ -341,7 +340,6 @@ class ArrayField extends Component {
 			schema,
 			idSchema,
 			uiSchema,
-			formData,
 			disabled,
 			readonly,
 			autofocus,
@@ -351,7 +349,7 @@ class ArrayField extends Component {
 		} = this.props;
 		const items = this.props.formData;
 		const { widgets, definitions, formContext } = registry;
-		const itemsSchema = retrieveSchema(schema.items, definitions, formData);
+		const itemsSchema = retrieveSchema(schema.items, definitions);
 		const enumOptions = optionsList(itemsSchema);
 		const { widget = 'select', ...options } = {
 			...getUiOptions(uiSchema),
@@ -417,7 +415,6 @@ class ArrayField extends Component {
 		const {
 			schema,
 			uiSchema,
-			formData,
 			errorSchema,
 			idSchema,
 			name,
@@ -433,11 +430,11 @@ class ArrayField extends Component {
 		let items = this.props.formData;
 		const { ArrayFieldTemplate, definitions, fields } = registry;
 		const { TitleField } = fields;
-		const itemSchemas = schema.items.map((item, index) =>
-			retrieveSchema(item, definitions, formData[index]),
+		const itemSchemas = schema.items.map(item =>
+			retrieveSchema(item, definitions)
 		);
 		const additionalSchema = allowAdditionalItems(schema)
-			? retrieveSchema(schema.additionalItems, definitions, formData)
+			? retrieveSchema(schema.additionalItems, definitions)
 			: null;
 		const { addable = true } = getUiOptions(uiSchema);
 		const canAdd = addable && additionalSchema;
@@ -453,14 +450,11 @@ class ArrayField extends Component {
 			className: 'field field-array field-array-fixed-items',
 			disabled,
 			idSchema,
-			formData,
 			items: items.map((item, index) => {
 				const additional = index >= itemSchemas.length;
-				const itemSchema = additional
-					? retrieveSchema(schema.additionalItems, definitions, item)
-					: itemSchemas[index];
+				const itemSchema = additional ? additionalSchema : itemSchemas[index];
 				const itemIdPrefix = `${idSchema.$id}_${index}`;
-				const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions, item);
+				const itemIdSchema = toIdSchema(itemSchema, itemIdPrefix, definitions);
 
 				const itemErrorSchema = errorSchema ? errorSchema[index] : undefined;
 				let itemUiSchema = null;

--- a/packages/forms/src/fields/ArrayField.js
+++ b/packages/forms/src/fields/ArrayField.js
@@ -430,9 +430,7 @@ class ArrayField extends Component {
 		let items = this.props.formData;
 		const { ArrayFieldTemplate, definitions, fields } = registry;
 		const { TitleField } = fields;
-		const itemSchemas = schema.items.map(item =>
-			retrieveSchema(item, definitions)
-		);
+		const itemSchemas = schema.items.map(item => retrieveSchema(item, definitions));
 		const additionalSchema = allowAdditionalItems(schema)
 			? retrieveSchema(schema.additionalItems, definitions)
 			: null;

--- a/packages/forms/src/fields/ObjectField.js
+++ b/packages/forms/src/fields/ObjectField.js
@@ -90,7 +90,7 @@ class ObjectField extends Component {
 		} = this.props;
 		const { definitions, fields, formContext, widgets } = registry;
 		const { SchemaField, TitleField, DescriptionField } = fields;
-		const schema = retrieveSchema(this.props.schema, definitions, formData);
+		const schema = retrieveSchema(this.props.schema, definitions);
 		const { widget, ...options } = getUiOptions(uiSchema);
 
 		if (typeof widget === 'string') {

--- a/version.js
+++ b/version.js
@@ -67,7 +67,7 @@ const ADDONS = {
 	'react-autowhatever': '10.1.0',
 	'react-debounce-input': '3.1.0',
 	'react-immutable-proptypes': '2.1.0',
-	'react-jsonschema-form': '1.0.0',
+	'react-jsonschema-form': '0.51.0',
 	'react-tap-event-plugin': '2.0.0',
 	'react-virtualized': '9.10.1',
 	slugify: '1.1.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -467,7 +467,7 @@ ajv@^4.7.0, ajv@^4.9.1:
     co "^4.6.0"
     json-stable-stringify "^1.0.1"
 
-ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5, ajv@^5.2.3:
+ajv@^5.0.0, ajv@^5.1.0, ajv@^5.1.5:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-5.5.2.tgz#73b5eeca3fab653e3d3f9422b341ad42205dc965"
   dependencies:
@@ -7159,6 +7159,10 @@ jsonpointer@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/jsonpointer/-/jsonpointer-4.0.1.tgz#4fd92cb34e0e9db3c89c8622ecf51f9b978c6cb9"
 
+jsonschema@^1.2.0:
+  version "1.2.4"
+  resolved "https://registry.yarnpkg.com/jsonschema/-/jsonschema-1.2.4.tgz#a46bac5d3506a254465bc548876e267c6d0d6464"
+
 jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
@@ -9865,11 +9869,11 @@ react-inspector@^2.2.2:
     babel-runtime "^6.26.0"
     is-dom "^1.0.9"
 
-react-jsonschema-form@1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-1.0.0.tgz#53ce38384a5df08e9ddc0d83b435af255c063078"
+react-jsonschema-form@0.51.0:
+  version "0.51.0"
+  resolved "https://registry.yarnpkg.com/react-jsonschema-form/-/react-jsonschema-form-0.51.0.tgz#955ccf9e63a37d91fcddb714bfc1215cda1cef79"
   dependencies:
-    ajv "^5.2.3"
+    jsonschema "^1.2.0"
     lodash.topath "^4.5.2"
     prop-types "^15.5.8"
     setimmediate "^1.0.5"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
RJSF 1.0.0 introduce ajv as validator.
TCOMP v0 ( :( ) use strings for maxItems. This breaking change seems to have a great impact

**What is the chosen solution to this problem?**
Downgrade to the version just before 1.0.0, before the ajv PR.
We will have a warning because of the peer deps RJSF specifying react 15. But it should not be incompatible.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
