### PR TITLE
fix(cmf): add back support for view

### DIFF
--- a/packages/cmf/__tests__/route.test.js
+++ b/packages/cmf/__tests__/route.test.js
@@ -1,17 +1,13 @@
 /* eslint no-underscore-dangle: ["error", {"allow": ["_registry", "_isLocked"] }] */
 import React from 'react';
 import { shallow } from 'enzyme';
+import component from '../src/component';
 import route from '../src/route';
-import registry from '../src/registry';
 import mock from '../src/mock';
 
 describe('CMF route', () => {
 	it('registerComponent should be an alias to component.get', () => {
-		function C1() {}
-		const emptyRegistry = {};
-		registry.Registry._registry = emptyRegistry;
-		route.registerComponent('C1', C1);
-		expect(emptyRegistry['_.route.component:C1']).toBe(C1);
+		expect(route.registerComponent.wrappedFunction).toBe(component.register);
 	});
 });
 
@@ -19,7 +15,7 @@ describe('loadComponent behavior', () => {
 	it('should replace component by regitry one', () => {
 		const mockItem = {
 			component: 'TestContainer',
-			view: 'appmenu',
+			componentId: 'appmenu',
 		};
 		const obj = { fn: jest.fn() };
 		const component = obj.fn;
@@ -32,6 +28,23 @@ describe('loadComponent behavior', () => {
 		component();
 		expect(obj.fn).toHaveBeenCalled();
 		expect(mockItem.component.displayName).toBe('WithProps');
+	});
+
+	it('should wrap the component using cmfConnect', () => {
+		const mockItem = {
+			component: 'TestContainer',
+			componentId: 'test',
+		};
+		const Component = () => <div>test</div>;
+		Component.displayName = 'TestContainer';
+		const mockContext = mock.context();
+		mockContext.registry = {
+			'_.route.component:TestContainer': Component,
+		};
+		route.loadComponents(mockContext, mockItem);
+		expect(mockItem.component.WrappedComponent).not.toBe(Component);
+		expect(mockItem.component.WrappedComponent.displayName).toBe('Connect(CMF(TestContainer))');
+		expect(mockItem.component.WrappedComponent.WrappedComponent).toBe(Component);
 	});
 
 	it('should use the componentId to resolve the props for the component instead of using a view', () => {
@@ -53,7 +66,7 @@ describe('loadComponent behavior', () => {
 		// given
 		const mockItem = {
 			component: 'TestContainer',
-			view: 'appmenu',
+			componentId: 'appmenu',
 			onEnter: 'onEnterId',
 			onLeave: 'onLeaveId',
 		};

--- a/packages/cmf/src/deprecated.js
+++ b/packages/cmf/src/deprecated.js
@@ -16,7 +16,7 @@
  */
 export default function deprecated(fn, msg, log) {
 	let called = false;
-	return function wrapper() {
+	function wrapper() {
 		if (!called) {
 			called = true;
 			let message = msg;
@@ -38,4 +38,6 @@ export default function deprecated(fn, msg, log) {
 		}
 		return fn.apply(this, arguments);
 	};
+	wrapper.wrappedFunction = fn;
+	return wrapper;
 }

--- a/packages/cmf/src/route.js
+++ b/packages/cmf/src/route.js
@@ -8,6 +8,7 @@
 import PropTypes from 'prop-types';
 
 import React from 'react';
+import cmfConnect from './cmfConnect';
 import registry from './registry';
 import deprecated from './deprecated';
 import CONST from './constant';
@@ -49,10 +50,15 @@ function withProps(Component, item) {
 		// eslint-disable-next-line no-console
 		console.warn('DEPRECATED: view is deprecated please use componentId');
 	}
+	let CMFComponent = Component;
+	if (!Component.CMFContainer) {
+		CMFComponent = cmfConnect({})(Component);
+	}
 	const WithProps = props => (
-		<Component view={item.view} componentId={item.componentId} {...props} />
+		<CMFComponent view={item.view} componentId={item.componentId} {...props} />
 	);
 	WithProps.displayName = 'WithProps';
+	WithProps.WrappedComponent = CMFComponent;
 	WithProps.propTypes = {
 		view: PropTypes.string,
 		componentId: PropTypes.string,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If you register a function as a component and use it in the router, the view is not injected
Which I think is normal but we have legacy code.

**What is the chosen solution to this problem?**

Add back inject of the view but this time by using cmfConnect.
So we don't have two different implementation.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
