### PR TITLE
feat(components): Add 'warning' status to Status/CollapsiblePanel

### DIFF
--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -69,7 +69,8 @@ $tc-toggle-color: #555964 !default;
 	&.info,
 	&.success,
 	&.danger,
-	&.muted {
+	&.muted,
+	&.warning {
 		padding-left: 1px;
 		border-left: 4px solid;
 	}
@@ -88,6 +89,10 @@ $tc-toggle-color: #555964 !default;
 
 	&.muted {
 		border-left-color: $gray;
+	}
+
+	&.warning {
+		border-left-color: $brand-warning;
 	}
 
 	.toggle svg {

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -35,6 +35,7 @@ export const STATUS = {
 	SUCCESSFUL: 'successful',
 	FAILED: 'failed',
 	CANCELED: 'canceled',
+	WARNING: 'warning',
 };
 
 export function getbsStyleFromStatus(status) {
@@ -47,6 +48,8 @@ export function getbsStyleFromStatus(status) {
 			return 'danger';
 		case STATUS.CANCELED:
 			return 'muted';
+		case STATUS.WARNING:
+			return 'warning';
 		default:
 			return '';
 	}
@@ -88,7 +91,13 @@ export function Status({ status, label, icon, actions, progress }) {
 Status.displayName = 'Status';
 
 Status.propTypes = {
-	status: PropTypes.oneOf([STATUS.IN_PROGRESS, STATUS.SUCCESSFUL, STATUS.FAILED, STATUS.CANCELED]),
+	status: PropTypes.oneOf([
+		STATUS.IN_PROGRESS,
+		STATUS.SUCCESSFUL,
+		STATUS.FAILED,
+		STATUS.CANCELED,
+		STATUS.WARNING,
+	]),
 	label: PropTypes.string.isRequired,
 	icon: PropTypes.string,
 	actions: Actions.propTypes.actions,

--- a/packages/components/src/Status/Status.scss
+++ b/packages/components/src/Status/Status.scss
@@ -34,6 +34,10 @@ $tc-status-space-btn-icon-label: 5px !default;
 		&.muted {
 			color: $gray;
 		}
+
+		&.warning {
+			color: $brand-warning;
+		}
 	}
 
 	&-actions {

--- a/packages/components/stories/CollapsiblePanel.js
+++ b/packages/components/stories/CollapsiblePanel.js
@@ -10,6 +10,7 @@ const icons = {
 	'talend-download': talendIcons['talend-download'],
 	'talend-check': talendIcons['talend-check'],
 	'talend-caret-down': talendIcons['talend-caret-down'],
+	'talend-warning': talendIcons['talend-warning'],
 };
 
 const content = [
@@ -72,13 +73,7 @@ const label4 = {
 };
 
 const propsPanel = {
-	header: [
-		status,
-		label1,
-		label2,
-		button,
-		label3,
-	],
+	header: [status, label1, label2, button, label3],
 };
 
 const propsPanelWithActions = {
@@ -116,17 +111,10 @@ const propsCollapsiblePanel = {
 };
 
 const propsInProgressCollapsiblePanel = {
-	header: [
-		status,
-		label1,
-		label4,
-		button,
-		label3,
-	],
+	header: [status, label1, label4, button, label3],
 	content,
 	onToggle: action('onToggle'),
 };
-
 
 const propsFailedCollapsiblePanel = {
 	header: [
@@ -140,10 +128,20 @@ const propsFailedCollapsiblePanel = {
 	onToggle: action('onToggle'),
 };
 
-
 const propsSuccessfulCollapsiblePanel = {
 	header: [
-		{ ...status, status: 'successful', label: 'Successful',  icon: 'talend-check' },
+		{ ...status, status: 'successful', label: 'Successful', icon: 'talend-check' },
+		label1,
+		label4,
+		button,
+		label3,
+	],
+	content,
+	onToggle: action('onToggle'),
+};
+const propsWarningCollapsiblePanel = {
+	header: [
+		{ ...status, status: 'warning', label: 'Warning', icon: 'talend-warning' },
 		label1,
 		label4,
 		button,
@@ -178,12 +176,7 @@ const propsCollapsiblePanelWithHeaderGroups = {
 };
 
 const propsCollapsiblePanelWithHeaderGroupsWithProgress = {
-	header: [
-		{ ...status, progress: '70' },
-		label1,
-		label4,
-		[button, label3],
-	],
+	header: [{ ...status, progress: '70' }, label1, label4, [button, label3]],
 	content,
 	onToggle: action('onToggle'),
 	expanded: true,
@@ -209,17 +202,15 @@ const timeStamp = {
 };
 
 const propsCollapsibleSelectablePanel = {
-	header: [
-		[version1, readOnlyLabel],
-		timeStamp,
-	],
+	header: [[version1, readOnlyLabel], timeStamp],
 	content: {
 		head: [
 			{
 				label: '21 steps',
 				bsStyle: 'default',
 				tooltipPlacement: 'top',
-			}, {
+			},
+			{
 				label: 'by Henry-Mayeul de Benque',
 				bsStyle: 'default',
 				tooltipPlacement: 'top',
@@ -241,10 +232,7 @@ const propsCollapsibleSelectedPanel = {
 };
 
 const propsSelectedPanelWithoutContent = {
-	header: [
-		[version1, readOnlyLabel],
-		timeStamp,
-	],
+	header: [[version1, readOnlyLabel], timeStamp],
 	onSelect: action('onselect'),
 	onToggle: action('onToggle'),
 	expanded: true,
@@ -254,10 +242,7 @@ const propsSelectedPanelWithoutContent = {
 
 const propsCollapsibleSelectablePanelWithoutTag = {
 	...propsSelectedPanelWithoutContent,
-	header: [
-		version1,
-		timeStamp,
-	],
+	header: [version1, timeStamp],
 	theme: 'descriptive-panel',
 };
 
@@ -325,10 +310,10 @@ storiesOf('CollapsiblePanel', module)
 			</div>
 			<p>Selected key/Value CollapsiblePanel:</p>
 			<div id="selected-key-value">
-				<CollapsiblePanel {...propsCollapsiblePanel} status={'selected'}/>
+				<CollapsiblePanel {...propsCollapsiblePanel} status={'selected'} />
 			</div>
 			<p>Selected key/Value CollapsiblePanel without content:</p>
-			<CollapsiblePanel {...propsPanelWithoutActions} status={'selected'}/>
+			<CollapsiblePanel {...propsPanelWithoutActions} status={'selected'} />
 		</div>
 	))
 	.addWithInfo('Status Collapsible', () => (
@@ -336,15 +321,19 @@ storiesOf('CollapsiblePanel', module)
 			<IconsProvider defaultIcons={icons} />
 			<p>CollapsiblePanel with status info:</p>
 			<div id="status-info">
-				<CollapsiblePanel {...propsInProgressCollapsiblePanel} status={'inProgress'}/>
+				<CollapsiblePanel {...propsInProgressCollapsiblePanel} status={'inProgress'} />
 			</div>
 			<p>CollapsiblePanel with status successful:</p>
 			<div id="status-success">
-				<CollapsiblePanel {...propsSuccessfulCollapsiblePanel} status={'successful'}/>
+				<CollapsiblePanel {...propsSuccessfulCollapsiblePanel} status={'successful'} />
 			</div>
 			<p>CollapsiblePanel with status failed:</p>
 			<div id="status-failed">
 				<CollapsiblePanel {...propsFailedCollapsiblePanel} status={'failed'} />
+			</div>
+			<p>CollapsiblePanel with status warning:</p>
+			<div id="status-warning">
+				<CollapsiblePanel {...propsWarningCollapsiblePanel} status={'warning'} />
 			</div>
 			<p>CollapsiblePanel with status canceled:</p>
 			<div id="status-canceled">

--- a/packages/components/stories/Status.js
+++ b/packages/components/stories/Status.js
@@ -25,50 +25,58 @@ const myStatus = {
 	actions: [deleteAction],
 };
 
-storiesOf('Status', module)
-	.addWithInfo('default', () => (
-		<div>
-			<IconsProvider />
-			<h1>Status</h1>
-			<h2>Definition</h2>
-			<p>
-				The status component displays a label with icon and when the mouse is over the
-				label, the component displays a button to let the user dispatch
-			</p>
-			<h2>Examples</h2>
-			<h3>Status is <code>successful</code></h3>
-			<Status {...myStatus} />
-			<h3>Status is <code>inProgress</code></h3>
-			<Status
-				{...{ ...myStatus, actions: [cancelAction, deleteAction] }}
-				status={'inProgress'}
-				label={'In Progress'}
-				icon={''}
-			/>
-			<h3>Status is <code>failed</code></h3>
-			<Status
-				{...myStatus}
-				status={'failed'}
-				label={'Failed'}
-				icon={'talend-cross'}
-			/>
-			<h3>Status is <code>canceled</code></h3>
-			<Status
-				{...myStatus}
-				status={'canceled'}
-				label={'Canceled'}
-				icon={'talend-cross'}
-			/>
-			<h3>Status without actions</h3>
-			<Status {...{ ...myStatus, actions: [] }} />
-			<h3>Status is <code>inProgress</code> with progress</h3>
-			<Status
-				{...{ ...myStatus, actions: [cancelAction, deleteAction] }}
-				status={'inProgress'}
-				label={'In Progress'}
-				icon={''}
-				progress="50"
-			/>
-			<br />
-		</div>
-	));
+storiesOf('Status', module).addWithInfo('default', () => (
+	<div>
+		<IconsProvider />
+		<h1>Status</h1>
+		<h2>Definition</h2>
+		<p>
+			The status component displays a label with icon and when the mouse is over the label, the
+			component displays a button to let the user dispatch
+		</p>
+		<h2>Examples</h2>
+		<h3>
+			Status is <code>successful</code>
+		</h3>
+		<Status {...myStatus} />
+		<h3>
+			Status is <code>inProgress</code>
+		</h3>
+		<Status
+			{...{ ...myStatus, actions: [cancelAction, deleteAction] }}
+			status={'inProgress'}
+			label={'In Progress'}
+			icon={''}
+		/>
+		<h3>
+			Status is <code>warning</code>
+		</h3>
+		<Status
+			{...{ ...myStatus, actions: [cancelAction] }}
+			status={'warning'}
+			label={'Warning'}
+			icon={'talend-warning'}
+		/>
+		<h3>
+			Status is <code>failed</code>
+		</h3>
+		<Status {...myStatus} status={'failed'} label={'Failed'} icon={'talend-cross'} />
+		<h3>
+			Status is <code>canceled</code>
+		</h3>
+		<Status {...myStatus} status={'canceled'} label={'Canceled'} icon={'talend-cross'} />
+		<h3>Status without actions</h3>
+		<Status {...{ ...myStatus, actions: [] }} />
+		<h3>
+			Status is <code>inProgress</code> with progress
+		</h3>
+		<Status
+			{...{ ...myStatus, actions: [cancelAction, deleteAction] }}
+			status={'inProgress'}
+			label={'In Progress'}
+			icon={''}
+			progress="50"
+		/>
+		<br />
+	</div>
+));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In TMC UI we need a warning status which indicate the operation is finished but with warnings.
**What is the chosen solution to this problem?**
Add 'warning' status to Status/CollapsiblePanel.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
