### PR TITLE
chores(doc): add a new filter

### DIFF
--- a/packages/icons/scripts/docs.js
+++ b/packages/icons/scripts/docs.js
@@ -39,6 +39,13 @@ const HTML_TPL = (icons, style) => `
 			.colormapping:hover > svg > g {
 				filter: none;
 			}
+
+			.gammacolormapping > svg > g {
+				filter: url(#colormapping);
+			}
+			.gammacolormapping:hover > svg > g {
+				filter: none;
+			}
 		</style>
 		<script>
 			function setSize(size) {
@@ -91,6 +98,7 @@ const HTML_TPL = (icons, style) => `
 				<select id="select-filter" class="form-control" onChange="setFilter(this.value)">
 					<option value="no-filter">No filter</option>
 					<option value="colormapping">Color mapping</option>
+					<option value="gammacolormapping">Gamma color mapping</option>
 				</select>
 			</div>
 			<div class="form-group">
@@ -108,6 +116,19 @@ const HTML_TPL = (icons, style) => `
 					0.47 0 0 0 0.53 
 					0.33 0 0 0 0.67 
 					0 0 0 1 0" />
+			</filter>
+			<filter id="gammacolormapping" color-interpolation-filters="sRGB">
+				<feColorMatrix in="SourceGraphic" type="saturate" values="0" result="grayscale" />
+				<feComponentTransfer in="grayscale" result="gammadarken">
+					<feFuncR type="gamma" amplitude="1" exponent="7" offset="0.0" />
+					<feFuncG type="gamma" amplitude="1" exponent="7" offset="0.0" />
+					<feFuncB type="gamma" amplitude="1" exponent="7" offset="0.0" />
+					<feFuncA type="gamma" amplitude="1" exponent="1" offset="0.0" />
+				</feComponentTransfer>
+				<feColorMatrix in="gammadarken" type="matrix" values="0.77 0 0 0 0.33
+				0 0.77 0 0 0.33 
+				0 0 0.77 0 0.33 
+				0    0 0 1 0" />
 			</filter>
 		</svg>
 	</body>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
we need a filter that map to a #555 color, whithout making ligh color becoming to light, and keep lighter colors
**What is the chosen solution to this problem?**
3 steps operation :
- removing the saturation value, so the svg is filtered to simple grayscale (1st feColorMatrix)
- mapping on the 3 color channel to a gamma function parametrized so lighter colors are almost not affected, and light and medium color are strongly darkened. (feComponentTransfer)
- and the last component matrix used to map the luminance information to a scale from white to target color.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
