### PR TITLE
feat(cmf): add cmf.collection.includes expression

### DIFF
--- a/packages/cmf/__tests__/expressions/index.test.js
+++ b/packages/cmf/__tests__/expressions/index.test.js
@@ -8,6 +8,8 @@ describe('expressions', () => {
 		expect(expressions['cmf.router.location']).toBeDefined();
 		expect(expressions['cmf.collections.get']).toBeDefined();
 		expect(expressions['cmf.components.get']).toBeDefined();
+		expect(expressions['cmf.collections.getIn.includes']).toBeDefined();
+		expect(expressions['cmf.components.getIn.includes']).toBeDefined();
 	});
 	describe('cmf.collections.get', () => {
 		it('should get collection content', () => {
@@ -19,18 +21,61 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(expressions['cmf.collections.get']({ context }, 'article.title', 'no title'))
-				.toBe('my title');
+			expect(expressions['cmf.collections.get']({ context }, 'article.title', 'no title')).toBe(
+				'my title',
+			);
 		});
-		it('should return default value if collection doesn\'t exists', () => {
+		it("should return default value if collection doesn't exists", () => {
 			const context = mock.context();
 			const state = mock.state();
 			context.store.getState = () => state;
 			state.cmf.collections = new Immutable.Map({});
-			expect(expressions['cmf.collections.get']({ context }, 'article.title', 'no title'))
-				.toBe('no title');
+			expect(expressions['cmf.collections.get']({ context }, 'article.title', 'no title')).toBe(
+				'no title',
+			);
 		});
 	});
+
+	describe('cmf.collections.getIn.includes', () => {
+		it('should return true if the value is present in the list', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.collections = new Immutable.Map({
+				article: new Immutable.Map({
+					title: 'title',
+					tags: new Immutable.List(['test', 'test2', 'test3']),
+				}),
+			});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test2'),
+			).toBe(true);
+		});
+		it('should return false if the value is not present in the list', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.collections = new Immutable.Map({
+				article: new Immutable.Map({
+					title: 'title',
+					tags: new Immutable.List(['test', 'test2', 'test3']),
+				}),
+			});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test4'),
+			).toBe(false);
+		});
+		it("should return false if collection doesn't exists", () => {
+			const context = mock.context();
+			const state = mock.state();
+			context.store.getState = () => state;
+			state.cmf.collections = new Immutable.Map({});
+			expect(
+				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test'),
+			).toBe(false);
+		});
+	});
+
 	describe('cmf.components.get', () => {
 		it('should get component state', () => {
 			const context = mock.context();
@@ -43,16 +88,54 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(expressions['cmf.components.get']({ context }, 'MyComponent.default.show', false))
-				.toBe(true);
+			expect(
+				expressions['cmf.components.get']({ context }, 'MyComponent.default.show', false),
+			).toBe(true);
 		});
 		it('should return default value if no component state', () => {
 			const context = mock.context();
 			const state = mock.state();
 			state.cmf.components = new Immutable.Map({});
 			context.store.getState = () => state;
-			expect(expressions['cmf.components.get']({ context }, 'MyComponent.default.show', false))
-				.toBe(false);
+			expect(
+				expressions['cmf.components.get']({ context }, 'MyComponent.default.show', false),
+			).toBe(false);
+		});
+	});
+
+	describe('cmf.components.getIn.includes', () => {
+		it('should return true if the value is present in the list', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.components = new Immutable.Map({
+				MyComponent: new Immutable.Map({
+					default: new Immutable.Map({
+						tags: new Immutable.List(['tag1', 'tag2', 'tag3']),
+						show: true,
+					}),
+				}),
+			});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.components.getIn.includes'](
+					{ context },
+					'MyComponent.default.tags',
+					'tag1',
+				),
+			).toBe(true);
+		});
+		it('should return default false if there is no component state', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.components = new Immutable.Map({});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.components.getIn.includes'](
+					{ context },
+					'MyComponent.default.tags',
+					'tag1',
+				),
+			).toBe(false);
 		});
 	});
 });

--- a/packages/cmf/__tests__/expressions/index.test.js
+++ b/packages/cmf/__tests__/expressions/index.test.js
@@ -8,8 +8,8 @@ describe('expressions', () => {
 		expect(expressions['cmf.router.location']).toBeDefined();
 		expect(expressions['cmf.collections.get']).toBeDefined();
 		expect(expressions['cmf.components.get']).toBeDefined();
-		expect(expressions['cmf.collections.getIn.includes']).toBeDefined();
-		expect(expressions['cmf.components.getIn.includes']).toBeDefined();
+		expect(expressions['cmf.collections.includes']).toBeDefined();
+		expect(expressions['cmf.components.includes']).toBeDefined();
 	});
 	describe('cmf.collections.get', () => {
 		it('should get collection content', () => {
@@ -36,7 +36,7 @@ describe('expressions', () => {
 		});
 	});
 
-	describe('cmf.collections.getIn.includes', () => {
+	describe('cmf.collections.includes', () => {
 		it('should return true if the value is present in the list', () => {
 			const context = mock.context();
 			const state = mock.state();
@@ -47,9 +47,9 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(
-				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test2'),
-			).toBe(true);
+			expect(expressions['cmf.collections.includes']({ context }, 'article.tags', 'test2')).toBe(
+				true,
+			);
 		});
 		it('should return false if the value is not present in the list', () => {
 			const context = mock.context();
@@ -61,18 +61,18 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(
-				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test4'),
-			).toBe(false);
+			expect(expressions['cmf.collections.includes']({ context }, 'article.tags', 'test4')).toBe(
+				false,
+			);
 		});
 		it("should return false if collection doesn't exists", () => {
 			const context = mock.context();
 			const state = mock.state();
 			context.store.getState = () => state;
 			state.cmf.collections = new Immutable.Map({});
-			expect(
-				expressions['cmf.collections.getIn.includes']({ context }, 'article.tags', 'test'),
-			).toBe(false);
+			expect(expressions['cmf.collections.includes']({ context }, 'article.tags', 'test')).toBe(
+				false,
+			);
 		});
 	});
 
@@ -103,7 +103,7 @@ describe('expressions', () => {
 		});
 	});
 
-	describe('cmf.components.getIn.includes', () => {
+	describe('cmf.components.includes', () => {
 		it('should return true if the value is present in the list', () => {
 			const context = mock.context();
 			const state = mock.state();
@@ -117,11 +117,7 @@ describe('expressions', () => {
 			});
 			context.store.getState = () => state;
 			expect(
-				expressions['cmf.components.getIn.includes'](
-					{ context },
-					'MyComponent.default.tags',
-					'tag1',
-				),
+				expressions['cmf.components.includes']({ context }, 'MyComponent.default.tags', 'tag1'),
 			).toBe(true);
 		});
 		it('should return default false if there is no component state', () => {
@@ -130,11 +126,7 @@ describe('expressions', () => {
 			state.cmf.components = new Immutable.Map({});
 			context.store.getState = () => state;
 			expect(
-				expressions['cmf.components.getIn.includes'](
-					{ context },
-					'MyComponent.default.tags',
-					'tag1',
-				),
+				expressions['cmf.components.includes']({ context }, 'MyComponent.default.tags', 'tag1'),
 			).toBe(false);
 		});
 	});

--- a/packages/cmf/src/expressions/getIn.includes.js
+++ b/packages/cmf/src/expressions/getIn.includes.js
@@ -1,0 +1,11 @@
+import _get from 'lodash/get';
+import Immutable from 'immutable';
+import curry from 'lodash/curry';
+
+function getInIncludes(statePath, { context }, immutablePath, value) {
+	return _get(context.store.getState(), statePath, new Immutable.Map())
+		.getIn(immutablePath.split('.'), new Immutable.List())
+		.includes(value);
+}
+
+export default curry(getInIncludes);

--- a/packages/cmf/src/expressions/getIn.includes.js
+++ b/packages/cmf/src/expressions/getIn.includes.js
@@ -1,11 +1,10 @@
 import _get from 'lodash/get';
 import Immutable from 'immutable';
-import curry from 'lodash/curry';
 
-function getInIncludes(statePath, { context }, immutablePath, value) {
-	return _get(context.store.getState(), statePath, new Immutable.Map())
-		.getIn(immutablePath.split('.'), new Immutable.List())
-		.includes(value);
+export default function getInIncludesClosure(statePath) {
+	return function getInIncludes({ context }, immutablePath, value) {
+		return _get(context.store.getState(), statePath, new Immutable.Map())
+			.getIn(immutablePath.split('.'), new Immutable.List())
+			.includes(value);
+	};
 }
-
-export default curry(getInIncludes);

--- a/packages/cmf/src/expressions/includes.js
+++ b/packages/cmf/src/expressions/includes.js
@@ -1,8 +1,8 @@
 import _get from 'lodash/get';
 import Immutable from 'immutable';
 
-export default function getInIncludesCurry(statePath) {
-	return function getInIncludes({ context }, immutablePath, value) {
+export default function getIncludesFunction(statePath) {
+	return function includes({ context }, immutablePath, value) {
 		return _get(context.store.getState(), statePath, new Immutable.Map())
 			.getIn(immutablePath.split('.'), new Immutable.List())
 			.includes(value);

--- a/packages/cmf/src/expressions/includes.js
+++ b/packages/cmf/src/expressions/includes.js
@@ -1,7 +1,7 @@
 import _get from 'lodash/get';
 import Immutable from 'immutable';
 
-export default function getInIncludesClosure(statePath) {
+export default function getInIncludesCurry(statePath) {
 	return function getInIncludes({ context }, immutablePath, value) {
 		return _get(context.store.getState(), statePath, new Immutable.Map())
 			.getIn(immutablePath.split('.'), new Immutable.List())

--- a/packages/cmf/src/expressions/index.js
+++ b/packages/cmf/src/expressions/index.js
@@ -5,8 +5,8 @@ import * as router from './router';
 export default {
 	'cmf.collections.get': getInState('cmf.collections'),
 	'cmf.components.get': getInState('cmf.components'),
-	'cmf.collections.getIn.includes': getInIncludes('cmf.collections'),
-	'cmf.components.getIn.includes': getInIncludes('cmf.components'),
+	'cmf.collections.includes': getInIncludes('cmf.collections'),
+	'cmf.components.includes': getInIncludes('cmf.components'),
 	'cmf.router.matchPath': router.matchPath,
 	'cmf.router.location': router.location,
 };

--- a/packages/cmf/src/expressions/index.js
+++ b/packages/cmf/src/expressions/index.js
@@ -1,9 +1,12 @@
 import getInState from './getInState';
+import getInIncludes from './getIn.includes';
 import * as router from './router';
 
 export default {
 	'cmf.collections.get': getInState('cmf.collections'),
 	'cmf.components.get': getInState('cmf.components'),
+	'cmf.collections.getIn.includes': getInIncludes('cmf.collections'),
+	'cmf.components.getIn.includes': getInIncludes('cmf.components'),
 	'cmf.router.matchPath': router.matchPath,
 	'cmf.router.location': router.location,
 };

--- a/packages/cmf/src/expressions/index.js
+++ b/packages/cmf/src/expressions/index.js
@@ -1,12 +1,12 @@
 import getInState from './getInState';
-import getInIncludes from './getIn.includes';
+import includes from './includes';
 import * as router from './router';
 
 export default {
 	'cmf.collections.get': getInState('cmf.collections'),
 	'cmf.components.get': getInState('cmf.components'),
-	'cmf.collections.includes': getInIncludes('cmf.collections'),
-	'cmf.components.includes': getInIncludes('cmf.components'),
+	'cmf.collections.includes': includes('cmf.collections'),
+	'cmf.components.includes': includes('cmf.components'),
 	'cmf.router.matchPath': router.matchPath,
 	'cmf.router.location': router.location,
 };

--- a/packages/cmf/src/expressions/index.md
+++ b/packages/cmf/src/expressions/index.md
@@ -76,13 +76,13 @@ export cmfConnect({mapStateToProps})(MyComponent)
 	}
 ```
 
-### getIn.includes
+### includes
 
 ```json
 	"props": {
 		"MyArticle#default": {
 			"renderIfExpression": {
-				"id": "cmf.collections.getIn.includes",
+				"id": "cmf.collections.includes",
 				"args": ["identity.entitlements", "ARTICLE_READ"]
 			},
 		}
@@ -106,13 +106,13 @@ let say you want to know the state of component
 	}
 ```
 
-### getIn.includes
+### includes
 
 ```json
 	"props": {
 		"AnOtherComponent#default": {
 			"enabledExpression": {
-				"id": "cmf.components.getIn.includes",
+				"id": "cmf.components.includes",
 				"args": ["MyArticle.default.myList","myAttriubte", false]
 			}
 		}

--- a/packages/cmf/src/expressions/index.md
+++ b/packages/cmf/src/expressions/index.md
@@ -13,7 +13,6 @@ cmf.registerInternals();
 Then you can use all internal expressions.
 For all the following example we take this component as example:
 
-
 ```javascript
 import React from 'react';
 import PropTypes from 'prop-types';
@@ -60,6 +59,8 @@ export cmfConnect({mapStateToProps})(MyComponent)
 
 ## cmf.collections
 
+### get
+
 ```json
 	"props": {
 		"MyArticle#default": {
@@ -75,16 +76,44 @@ export cmfConnect({mapStateToProps})(MyComponent)
 	}
 ```
 
+### getIn.includes
+
+```json
+	"props": {
+		"MyArticle#default": {
+			"renderIfExpression": {
+				"id": "cmf.collections.getIn.includes",
+				"args": ["identity.entitlements", "ARTICLE_READ"]
+			},
+		}
+	}
+```
+
 ## cmf.components
+
+### get
 
 let say you want to know the state of component
 
 ```json
 	"props": {
 		"AnOtherComponent#default": {
-			"active": {
+			"activeExpression": {
 				"id": "cmf.components.get",
 				"args": ["MyArticle.default.like", false]
+			}
+		}
+	}
+```
+
+### getIn.includes
+
+```json
+	"props": {
+		"AnOtherComponent#default": {
+			"enabledExpression": {
+				"id": "cmf.components.getIn.includes",
+				"args": ["MyArticle.default.myList","myAttriubte", false]
 			}
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Sometimes, information is not accessible with a getIn, as when we have a list in the store.
**What is the chosen solution to this problem?**
To provide access to this, i set here 2 new accessors to know if a value is present in a list in the store, theirs pretty names are :
- cmf.collections.includes
- cmf.components.includes

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
