### PR TITLE
fix(theme): closed dropdown menu don't take space anymore

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -11,6 +11,12 @@
 				"tabWidth": 2,
 				"useTabs": false
 			}
+		},
+		{
+			"files": "**/*.scss",
+			"options": {
+				"printWidth": 1000
+			}
 		}
 	]
 }

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,6 +1,9 @@
 > sass-lint -q -v
 
 
+src/theme/_button-groups.scss
+  50:4  warning  Expected indentation of 2 tabs but found 3  indentation
+
 src/theme/_buttons.scss
   14:2  error  The keyword `all` should not be used with the property `transition`  no-transition-all
 
@@ -25,5 +28,5 @@ src/theme/_tables.scss
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 14 problems (10 errors, 4 warnings)
+✖ 15 problems (10 errors, 5 warnings)
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -1,9 +1,6 @@
 > sass-lint -q -v
 
 
-src/theme/_button-groups.scss
-  50:4  warning  Expected indentation of 2 tabs but found 3  indentation
-
 src/theme/_buttons.scss
   14:2  error  The keyword `all` should not be used with the property `transition`  no-transition-all
 
@@ -28,5 +25,5 @@ src/theme/_tables.scss
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 15 problems (10 errors, 5 warnings)
+✖ 14 problems (10 errors, 4 warnings)
 

--- a/packages/theme/src/theme/_button-groups.scss
+++ b/packages/theme/src/theme/_button-groups.scss
@@ -46,7 +46,8 @@
 		opacity: 0;
 		visibility: hidden;
 		transform: translateY(-15px);
-		transition: opacity 0.15s cubic-bezier(0, 0, 0.2, 1), transform 0.15s cubic-bezier(0, 0, 0.2, 1), visibility 0s;
+		transition: opacity 0.15s cubic-bezier(0, 0, 0.2, 1), transform 0.15s cubic-bezier(0, 0, 0.2, 1),
+			visibility 0s;
 		overflow-y: auto;
 	}
 

--- a/packages/theme/src/theme/_button-groups.scss
+++ b/packages/theme/src/theme/_button-groups.scss
@@ -42,7 +42,7 @@
 	}
 
 	> .dropdown-menu {
-		display: block;
+		display: none;
 		opacity: 0;
 		visibility: hidden;
 		transform: translateY(-15px);
@@ -52,6 +52,7 @@
 
 	&.open {
 		> .dropdown-menu {
+			display: block;
 			visibility: visible;
 			opacity: 1;
 			max-height: 320px;

--- a/packages/theme/src/theme/_button-groups.scss
+++ b/packages/theme/src/theme/_button-groups.scss
@@ -46,8 +46,7 @@
 		opacity: 0;
 		visibility: hidden;
 		transform: translateY(-15px);
-		transition: opacity 0.15s cubic-bezier(0, 0, 0.2, 1), transform 0.15s cubic-bezier(0, 0, 0.2, 1),
-			visibility 0s;
+		transition: opacity 0.15s cubic-bezier(0, 0, 0.2, 1), transform 0.15s cubic-bezier(0, 0, 0.2, 1), visibility 0s;
 		overflow-y: auto;
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TUI-147
Dropdown menu takes space even if it is closed.
That makes outiline surround it.
<img width="466" alt="capture d ecran 2018-06-04 a 14 46 49" src="https://user-images.githubusercontent.com/10761073/40918407-7a5a90b0-6806-11e8-80a1-7fb7b49a2195.png">

**What is the chosen solution to this problem?**
Set its display to none when it is closed to avoid taking any space
<img width="758" alt="capture d ecran 2018-06-04 a 14 46 32" src="https://user-images.githubusercontent.com/10761073/40918461-9e57d31a-6806-11e8-8b70-a61758bfce68.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
