### PR TITLE
fix(a11y): Buttons get :hover styles on :focus

### DIFF
--- a/packages/theme/src/theme/_visual-helpers.scss
+++ b/packages/theme/src/theme/_visual-helpers.scss
@@ -64,7 +64,8 @@
 			}
 
 			:global(.btn) {
-				&:hover {
+				&:hover,
+				&:focus {
 					box-shadow: 0 200px 100px -100px rgba(255, 255, 255, 0.12) inset;
 				}
 			}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`focus` status is sometimes not visible on buttons (like in HeaderBar component) while they can have an `hover` visible status. This can be problematic when using keyboard navigation

**What is the chosen solution to this problem?**
Use `hover` rules on `focus` status

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
