### PR TITLE
feat(ObjectViewer): add support for injecting element next to item

### DIFF
--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -100,6 +100,7 @@ function getName(name) {
 
 export function LineItem({
 	name,
+	tag,
 	onMouseOver,
 	mouseOverData,
 	jsonpath,
@@ -130,6 +131,7 @@ export function LineItem({
 			{...props}
 		>
 			{getName(name)}
+			{tag}
 			{children}
 		</span>
 	);
@@ -232,7 +234,7 @@ export function getDataAbstract(data) {
 	return abstract;
 }
 
-export function ComplexItem({ data, name, opened, edited, jsonpath, info, onSelect, ...props }) {
+export function ComplexItem({ data, name, tag, opened, edited, tagged, jsonpath, info, onSelect, ...props }) {
 	const isOpened = opened.indexOf(jsonpath) !== -1;
 	const isEdited = edited.indexOf(jsonpath) !== -1 && !!props.onChange;
 
@@ -277,6 +279,7 @@ export function ComplexItem({ data, name, opened, edited, jsonpath, info, onSele
 					<TooltipTrigger className="offset" label={getDataAbstract(data)} tooltipPlacement="right">
 						<sup className="badge">{decoratedLength}</sup>
 					</TooltipTrigger>
+					{tag}
 					{isOpened ? (
 						<ul className={theme['vertical-line']}>
 							{info.keys.map((key, i) => (
@@ -288,6 +291,7 @@ export function ComplexItem({ data, name, opened, edited, jsonpath, info, onSele
 										jsonpath={getJSONPath(key, jsonpath, info.type)}
 										opened={opened}
 										edited={edited}
+										tagged={tagged}
 										onSelect={onSelect}
 									/>
 								</li>
@@ -328,17 +332,19 @@ ComplexItem.propTypes = {
 	}).isRequired,
 };
 
-export function Item({ data, name, opened, edited, jsonpath, ...props }) {
+export function Item({ data, name, opened, edited, tagged, jsonpath, ...props }) {
 	if (props.tupleLabel) {
 		COMPLEX_TYPES.push(props.tupleLabel);
 	}
 	const isEdited = edited.indexOf(jsonpath) !== -1 && !!props.onChange;
 	const isOpened = opened.indexOf(jsonpath) !== -1;
+	const tag = tagged && tagged[jsonpath];
 
 	if (data === undefined || data === null) {
 		return (
 			<LineItem
 				name={name}
+				tag={tag}
 				onMouseOver={props.onMouseOver}
 				mouseOverData={{ data, isOpened, isEdited }}
 				onSelect={props.onSelect}
@@ -349,6 +355,7 @@ export function Item({ data, name, opened, edited, jsonpath, ...props }) {
 	}
 
 	const info = getDataInfo(data, props.tupleLabel);
+	console.log(info);
 	const isNativeType = COMPLEX_TYPES.indexOf(info.type) === -1;
 
 	if (isNativeType) {
@@ -373,6 +380,7 @@ export function Item({ data, name, opened, edited, jsonpath, ...props }) {
 				{props.showType && (
 					<div className={`tc-object-viewer-line-type ${theme['line-type']}`}>({info.type})</div>
 				)}
+				{tag}
 			</LineItem>
 		);
 	}
@@ -381,6 +389,7 @@ export function Item({ data, name, opened, edited, jsonpath, ...props }) {
 		<ComplexItem
 			{...props}
 			name={name}
+			tag={tag}
 			jsonpath={jsonpath}
 			info={info}
 			data={data}
@@ -388,6 +397,7 @@ export function Item({ data, name, opened, edited, jsonpath, ...props }) {
 			onSelect={props.onSelect}
 			opened={opened}
 			edited={edited}
+			tagged={tagged}
 			selectedJsonpath={props.selectedJsonpath}
 		/>
 	);

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -369,7 +369,6 @@ export function Item({ data, name, opened, edited, tagged, jsonpath, ...props })
 	}
 
 	const info = getDataInfo(data, props.tupleLabel);
-	console.log(info);
 	const isNativeType = COMPLEX_TYPES.indexOf(info.type) === -1;
 
 	if (isNativeType) {

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -139,6 +139,7 @@ export function LineItem({
 
 LineItem.propTypes = {
 	name: PropTypes.string,
+	tag: PropTypes.node,
 	onMouseOver: PropTypes.func,
 	children: PropTypes.node,
 	mouseOverData: PropTypes.object, // eslint-disable-line react/forbid-prop-types
@@ -234,7 +235,18 @@ export function getDataAbstract(data) {
 	return abstract;
 }
 
-export function ComplexItem({ data, name, tag, opened, edited, tagged, jsonpath, info, onSelect, ...props }) {
+export function ComplexItem({
+	data,
+	name,
+	tag,
+	opened,
+	edited,
+	tagged,
+	jsonpath,
+	info,
+	onSelect,
+	...props
+}) {
 	const isOpened = opened.indexOf(jsonpath) !== -1;
 	const isEdited = edited.indexOf(jsonpath) !== -1 && !!props.onChange;
 
@@ -313,6 +325,8 @@ ComplexItem.propTypes = {
 		PropTypes.array,
 	]),
 	name: PropTypes.string,
+	tag: PropTypes.node,
+	tagged: PropTypes.objectOf(PropTypes.node),
 	opened: PropTypes.arrayOf(PropTypes.string).isRequired,
 	edited: PropTypes.arrayOf(PropTypes.string).isRequired,
 	jsonpath: PropTypes.string,
@@ -414,6 +428,7 @@ Item.propTypes = {
 	name: PropTypes.string,
 	opened: PropTypes.arrayOf(PropTypes.string),
 	edited: PropTypes.arrayOf(PropTypes.string),
+	tagged: PropTypes.objectOf(PropTypes.node),
 	jsonpath: PropTypes.string,
 	tupleLabel: PropTypes.string,
 	onMouseOver: PropTypes.func,

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
@@ -169,6 +169,28 @@ describe('JSONLike', () => {
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 
+		it('should render injected elements next to name/sup', () => {
+			const mockHandler = jest.fn();
+			const wrapper = shallow(
+				<ComplexItem
+					opened={['$']}
+					edited={[]}
+					tag={<span id="injected">hello world</span>}
+					onToggle={mockHandler}
+					onSelect={mockHandler}
+					info={{
+						type: 'string',
+					}}
+				/>,
+			);
+			expect(
+				wrapper
+					.find('TooltipTrigger+#injected')
+					.at(0)
+					.text(),
+			).toEqual('hello world');
+		});
+
 		// skeletton test to be activated when enzyme will fix
 		// https://github.com/airbnb/enzyme/issues/308
 		xit('don"t trigger wrapping form submit when used', () => {

--- a/packages/components/stories/ObjectViewer.js
+++ b/packages/components/stories/ObjectViewer.js
@@ -378,7 +378,7 @@ stories
 			/>
 		</div>
 	))
-	.addWithInfo('tree with tags', () => {
+	.addWithInfo('tree with injected elements', () => {
 		return (
 			<div>
 				<IconsProvider defaultIcons={icons} />

--- a/packages/components/stories/ObjectViewer.js
+++ b/packages/components/stories/ObjectViewer.js
@@ -5,11 +5,14 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import talendIcons from '@talend/icons/dist/react';
 
-import { ObjectViewer, IconsProvider } from '../src/index';
+import { ObjectViewer, Icon, IconsProvider, TooltipTrigger } from '../src/index';
 
 const icons = {
 	'talend-caret-down': talendIcons['talend-caret-down'],
 	'talend-chevron-left': talendIcons['talend-chevron-left'],
+	'talend-chain': talendIcons['talend-chain'],
+	'talend-check': talendIcons['talend-check'],
+	'talend-warning': talendIcons['talend-warning'],
 };
 
 const schema = new Map();
@@ -258,6 +261,53 @@ const rootOpenedTypeHandler = {
 	onToggle: action('onToggle'),
 };
 
+const withTagOnly = (
+	<span className="label label-default" style={{ marginLeft: '10px' }}>
+		REUSE
+	</span>
+);
+
+const withTagAndLink = (
+	<span style={{ marginLeft: '10px' }}>
+		<span className="label label-info">REPLACE</span>
+		<TooltipTrigger label="link to artifact" tooltipPlacement="right">
+			<a href="">
+				<Icon name="talend-chain" style={{ marginLeft: '10px', verticalAlign: 'text-bottom' }} />
+			</a>
+		</TooltipTrigger>
+	</span>
+);
+
+const withInfo = (
+	<span style={{ marginLeft: '10px', color: '#f0ad4e' }}>
+		<Icon name="talend-warning" style={{ verticalAlign: 'text-bottom' }} />
+		<span style={{ verticalAlign: 'text-bottom' }}>
+			Command has been executed but with warnings
+		</span>
+	</span>
+);
+
+const handlerTags = {
+	edited: ["$[0]['int']"],
+	opened: ['$', '$[0]', "$[0]['attributes']"],
+	tagged: {
+		'$[0]': withTagOnly,
+		"$[0]['attributes']": withTagAndLink,
+		"$[0]['name']": withTagAndLink,
+		"$[0]['rating']": withInfo,
+		"$[0]['null_value']": withTagOnly,
+		"$[0]['location']": withInfo,
+	},
+	onClick: action('onClick'),
+	onSelect: (e, jsonpath) => {
+		selectedJsonpath = jsonpath;
+		action('onSelect');
+	},
+	onSubmit: action('onSubmit'),
+	onChange: action('onChange'),
+	onToggle: action('onToggle'),
+};
+
 const stories = storiesOf('ObjectViewer', module);
 if (!stories.addWithInfo) {
 	stories.addWithInfo = stories.add;
@@ -328,6 +378,14 @@ stories
 			/>
 		</div>
 	))
+	.addWithInfo('tree with tags', () => {
+		return (
+			<div>
+				<IconsProvider defaultIcons={icons} />
+				<ObjectViewer data={data} {...handlerTags} />
+			</div>
+		);
+	})
 	.addWithInfo('tree with handler', () => (
 		<div>
 			<IconsProvider defaultIcons={icons} />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in TMC, we have this report view design, in which we need to show additional warning and status label right next to item name.
![objectviewer](https://user-images.githubusercontent.com/3214228/41147490-1b5dcdd0-6b39-11e8-8381-ff6eb6e1cd14.png)

**What is the chosen solution to this problem?**
Add a `tagged` prop, which should be a JSON object with jsonpath key and element value.
so ObjectViewer will render whatever element next to item name.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
