### PR TITLE
feat(datagrid): remove the global flag when using test

### DIFF
--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
@@ -12,8 +12,8 @@ export const REG_EXP_LEADING_TRAILING_WHITE_SPACE_CHARACTERS = /(^\s*)?([\s\S]*?
 export const REG_EXP_HAS_WHITE_SPACE_CHARACTERS = /(^\s*)?([\s\S]*?)(\s*$)/;
 const REG_EXP_REPLACED_WHITE_SPACE_CHARACTERS = /(\t| |\n)/g;
 const REG_EXP_CAPTUR_LINE_FEEDING = /(\n)/g;
-const REG_EXP_LINE_FEEDING = /\n/g;
-const REG_EXP_WHITE_SPACE_CHARACTERS = /^\s/g;
+const REG_EXP_LINE_FEEDING = /\n/;
+const REG_EXP_WHITE_SPACE_CHARACTERS = /^\s/;
 
 /**
  * replaceCharacterByIcon - replace a character by the corresponding icon

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
@@ -13,6 +13,15 @@ describe('FormatValue', () => {
 
 	it('should return true when there is leading empty space in the string', () => {
 		// eslint-disable-next-line no-irregular-whitespace
+		expect(
+			hasWhiteSpaceCharacters(`row3
+-2`),
+		).toBe(true);
+
+		expect(
+			hasWhiteSpaceCharacters(`row3
+-2`),
+		).toBe(true);
 		expect(hasWhiteSpaceCharacters('﻿l')).toBe(true);
 	});
 

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
@@ -13,15 +13,6 @@ describe('FormatValue', () => {
 
 	it('should return true when there is leading empty space in the string', () => {
 		// eslint-disable-next-line no-irregular-whitespace
-		expect(
-			hasWhiteSpaceCharacters(`row3
--2`),
-		).toBe(true);
-
-		expect(
-			hasWhiteSpaceCharacters(`row3
--2`),
-		).toBe(true);
 		expect(hasWhiteSpaceCharacters('﻿l')).toBe(true);
 	});
 
@@ -32,6 +23,11 @@ describe('FormatValue', () => {
 
 	it('should return true when there is line feeding in the string', () => {
 		// eslint-disable-next-line no-irregular-whitespace
+		expect(
+			hasWhiteSpaceCharacters(`loreum
+lopsum`),
+		).toBe(true);
+
 		expect(
 			hasWhiteSpaceCharacters(`loreum
 lopsum`),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
result different with the same expression

const regExp = /\n/g; 
console.log(regExp.test('dfdf\ndsfsdf')); // return true
console.log(regExp.test('dfdf\ndsfsdf'));// return false
console.log(regExp.test('dfdf\ndsfsdf')); // return true

If the regex has the global flag set, test() will advance the lastIndex of the regex. A subsequent use of test() will start the search at the substring of str specified by lastIndex (exec() will also advance the lastIndex property).

test works like exec and keep a pointer on the current found element

**What is the chosen solution to this problem?**
fix that

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
