### PR TITLE
chore(travis): avoid 2 heavy yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ matrix:
         - '8'
       before_install:
         # this install is necessary to get version.js dependencies
-        - yarn install
+        - npm install commander@^2.9.0
         - ./version.js
       script:
         - yarn test


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In travis, react 15 matrix, we have to
* run `./version.js` to update react version
* run `yarn install` to fetch the new dependencies versions

But version.js required dependencies. A first solution was to run `yarn install` before `./version.js`, implying 2 `yarn install` in the process.

**What is the chosen solution to this problem?**
Fetch only necessary `version.js` dependencies via a simple `npm install`, before running the script.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
