### PR TITLE
feat(component/step2): selection of the calendar 

### DIFF
--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import Immutable from 'immutable';
 import theme from './DateTimePicker.scss';
 import DateTimeView from '../views/DateTimeView';
 import MonthYearView from '../views/MonthYearView';
@@ -14,10 +13,10 @@ class DateTimePicker extends React.Component {
 
 		this.state = {
 			isDateTimeView: true,
-			currentCalendar: Immutable.Map({
+			currentCalendar: {
 				monthIndex: now.getMonth(),
 				year: now.getFullYear(),
-			}),
+			},
 		};
 
 		this.setDateTimeView = this.setView.bind(this, true);
@@ -29,7 +28,10 @@ class DateTimePicker extends React.Component {
 
 	onMonthYearSelected(newCalendar) {
 		this.setState(previousState => ({
-			currentCalendar: previousState.currentCalendar.merge(newCalendar),
+			currentCalendar: {
+				...previousState.currentCalendar,
+				...newCalendar,
+			},
 		}));
 	}
 
@@ -51,15 +53,15 @@ class DateTimePicker extends React.Component {
 		if (this.state.isDateTimeView) {
 			viewElement = (<DateTimeView
 				onTitleClick={this.setMonthYearView}
-				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
-				yearSelected={this.state.currentCalendar.get('year')}
+				monthIndexSelected={this.state.currentCalendar.monthIndex}
+				yearSelected={this.state.currentCalendar.year}
 				onMonthYearSelected={this.onMonthYearSelected}
 			/>);
 		} else {
 			viewElement = (<MonthYearView
 				onBackClick={this.setDateTimeView}
-				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
-				yearSelected={this.state.currentCalendar.get('year')}
+				monthIndexSelected={this.state.currentCalendar.monthIndex}
+				yearSelected={this.state.currentCalendar.year}
 				onMonthSelected={this.onMonthSelected}
 				onYearSelected={this.onYearSelected}
 			/>);

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -38,10 +38,8 @@ class DateTimePicker extends React.Component {
 		}));
 	}
 
-	setView(isDateTime) {
-		this.setState({
-			isDateTimeView: isDateTime,
-		});
+	setView(isDateTimeView) {
+		this.setState({ isDateTimeView });
 	}
 
 	render() {

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -43,34 +43,29 @@ class DateTimePicker extends React.Component {
 	}
 
 	render() {
-		const dateTimeView = (
-			<DateTimeView
+		let viewElement;
+
+		if (this.state.isDateTimeView) {
+			viewElement = (<DateTimeView
 				onTitleClick={this.setMonthYearView}
 				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
 				onMonthSelected={this.onMonthSelected}
 				onYearSelected={this.onYearSelected}
-			/>
-		);
-
-		const monthYearView = (
-			<MonthYearView
+			/>);
+		} else {
+			viewElement = (<MonthYearView
 				onBackClick={this.setDateTimeView}
 				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
 				onMonthSelected={this.onMonthSelected}
 				onYearSelected={this.onYearSelected}
-			/>
-		);
-
-
-		const viewComponent = this.state.isDateTimeView
-			? dateTimeView
-			: monthYearView;
+			/>);
+		}
 
 		return (
 			<div className={theme.container}>
-				{viewComponent}
+				{viewElement}
 			</div>
 		);
 	}

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -24,18 +24,21 @@ class DateTimePicker extends React.Component {
 		this.setMonthYearView = this.setView.bind(this, false);
 		this.onMonthSelected = this.onMonthSelected.bind(this);
 		this.onYearSelected = this.onYearSelected.bind(this);
+		this.onMonthYearSelected = this.onMonthYearSelected.bind(this);
+	}
+
+	onMonthYearSelected(newCalendar) {
+		this.setState(previousState => ({
+			currentCalendar: previousState.currentCalendar.merge(newCalendar),
+		}));
 	}
 
 	onMonthSelected(monthIndex) {
-		this.setState(previousState => ({
-			currentCalendar: previousState.currentCalendar.merge({ monthIndex }),
-		}));
+		this.onMonthYearSelected({ monthIndex });
 	}
 
 	onYearSelected(year) {
-		this.setState(previousState => ({
-			currentCalendar: previousState.currentCalendar.merge({ year }),
-		}));
+		this.onMonthYearSelected({ year });
 	}
 
 	setView(isDateTimeView) {
@@ -50,8 +53,7 @@ class DateTimePicker extends React.Component {
 				onTitleClick={this.setMonthYearView}
 				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
-				onMonthSelected={this.onMonthSelected}
-				onYearSelected={this.onYearSelected}
+				onMonthYearSelected={this.onMonthYearSelected}
 			/>);
 		} else {
 			viewElement = (<MonthYearView

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -21,12 +21,12 @@ class DateTimePicker extends React.Component {
 
 		this.setDateTimeView = this.setView.bind(this, true);
 		this.setMonthYearView = this.setView.bind(this, false);
-		this.onMonthSelected = this.onMonthSelected.bind(this);
-		this.onYearSelected = this.onYearSelected.bind(this);
-		this.onMonthYearSelected = this.onMonthYearSelected.bind(this);
+		this.onSelectMonth = this.onSelectMonth.bind(this);
+		this.onSelectYear = this.onSelectYear.bind(this);
+		this.onSelectMonthYear = this.onSelectMonthYear.bind(this);
 	}
 
-	onMonthYearSelected(newCalendar) {
+	onSelectMonthYear(newCalendar) {
 		this.setState(previousState => ({
 			currentCalendar: {
 				...previousState.currentCalendar,
@@ -35,12 +35,12 @@ class DateTimePicker extends React.Component {
 		}));
 	}
 
-	onMonthSelected(monthIndex) {
-		this.onMonthYearSelected({ monthIndex });
+	onSelectMonth(monthIndex) {
+		this.onSelectMonthYear({ monthIndex });
 	}
 
-	onYearSelected(year) {
-		this.onMonthYearSelected({ year });
+	onSelectYear(year) {
+		this.onSelectMonthYear({ year });
 	}
 
 	setView(isDateTimeView) {
@@ -52,18 +52,18 @@ class DateTimePicker extends React.Component {
 
 		if (this.state.isDateTimeView) {
 			viewElement = (<DateTimeView
-				onTitleClick={this.setMonthYearView}
-				monthIndexSelected={this.state.currentCalendar.monthIndex}
-				yearSelected={this.state.currentCalendar.year}
-				onMonthYearSelected={this.onMonthYearSelected}
+				onClickTitle={this.setMonthYearView}
+				selectedMonthIndex={this.state.currentCalendar.monthIndex}
+				selectedYear={this.state.currentCalendar.year}
+				onSelectMonthYear={this.onSelectMonthYear}
 			/>);
 		} else {
 			viewElement = (<MonthYearView
-				onBackClick={this.setDateTimeView}
-				monthIndexSelected={this.state.currentCalendar.monthIndex}
-				yearSelected={this.state.currentCalendar.year}
-				onMonthSelected={this.onMonthSelected}
-				onYearSelected={this.onYearSelected}
+				onClickBack={this.setDateTimeView}
+				selectedMonthIndex={this.state.currentCalendar.monthIndex}
+				selectedYear={this.state.currentCalendar.year}
+				onSelectMonth={this.onSelectMonth}
+				onSelectYear={this.onSelectYear}
 			/>);
 		}
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import Immutable from 'immutable';
 import theme from './DateTimePicker.scss';
 import DateTimeView from '../views/DateTimeView';
 import MonthYearView from '../views/MonthYearView';
@@ -9,25 +10,20 @@ class DateTimePicker extends React.Component {
 	constructor(props) {
 		super(props);
 
+		const now = new Date();
+
 		this.state = {
 			isCalendarView: true,
+			currentCalendar: Immutable.Map({
+				monthIndex: now.getMonth(),
+				year: now.getFullYear(),
+			}),
 		};
 
 		this.onDateTimeViewTitleClick = this.onDateTimeViewTitleClick.bind(this);
 		this.onMonthYearViewBackClick = this.onMonthYearViewBackClick.bind(this);
-
-
-		this.dateTimeView = (
-			<DateTimeView
-				onTitleClick={this.onDateTimeViewTitleClick}
-			/>
-		);
-
-		this.monthYearView = (
-			<MonthYearView
-				onBackClick={this.onMonthYearViewBackClick}
-			/>
-		);
+		this.onMonthSelected = this.onMonthSelected.bind(this);
+		this.onYearSelected = this.onYearSelected.bind(this);
 	}
 
 	onDateTimeViewTitleClick() {
@@ -42,10 +38,39 @@ class DateTimePicker extends React.Component {
 		});
 	}
 
+	onMonthSelected(monthIndex) {
+		this.setState(previousState => ({
+			currentCalendar: previousState.currentCalendar.merge({ monthIndex }),
+		}));
+	}
+
+	onYearSelected(year) {
+		this.setState(previousState => ({
+			currentCalendar: previousState.currentCalendar.merge({ year }),
+		}));
+	}
+
 	render() {
+		const dateTimeView = (
+			<DateTimeView
+				onTitleClick={this.onDateTimeViewTitleClick}
+			/>
+		);
+
+		const monthYearView = (
+			<MonthYearView
+				onBackClick={this.onMonthYearViewBackClick}
+				monthSelected={this.state.currentCalendar.get('monthIndex')}
+				yearSelected={this.state.currentCalendar.get('year')}
+				onMonthSelected={this.onMonthSelected}
+				onYearSelected={this.onYearSelected}
+			/>
+		);
+
+
 		const viewComponent = this.state.isCalendarView
-			? this.dateTimeView
-			: this.monthYearView;
+			? dateTimeView
+			: monthYearView;
 
 		return (
 			<div className={theme.container}>

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -4,17 +4,55 @@ import theme from './DateTimePicker.scss';
 import DateTimeView from '../views/DateTimeView';
 import MonthYearView from '../views/MonthYearView';
 
-function DateTimePicker(props) {
-	const isCalendarView = true;
-	const viewComponent = isCalendarView
-		? <DateTimeView />
-		: <MonthYearView />;
+class DateTimePicker extends React.Component {
 
-	return (
-		<div className={theme.container}>
-			{viewComponent}
-		</div>
-	);
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			isCalendarView: true,
+		};
+
+		this.onDateTimeViewTitleClick = this.onDateTimeViewTitleClick.bind(this);
+		this.onMonthYearViewBackClick = this.onMonthYearViewBackClick.bind(this);
+
+
+		this.dateTimeView = (
+			<DateTimeView
+				onTitleClick={this.onDateTimeViewTitleClick}
+			/>
+		);
+
+		this.monthYearView = (
+			<MonthYearView
+				onBackClick={this.onMonthYearViewBackClick}
+			/>
+		);
+	}
+
+	onDateTimeViewTitleClick() {
+		this.setState({
+			isCalendarView: false,
+		});
+	}
+
+	onMonthYearViewBackClick() {
+		this.setState({
+			isCalendarView: true,
+		});
+	}
+
+	render() {
+		const viewComponent = this.state.isCalendarView
+			? this.dateTimeView
+			: this.monthYearView;
+
+		return (
+			<div className={theme.container}>
+				{viewComponent}
+			</div>
+		);
+	}
 }
 
 DateTimePicker.propTypes = {

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -56,6 +56,8 @@ class DateTimePicker extends React.Component {
 				onTitleClick={this.onDateTimeViewTitleClick}
 				monthSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
+				onMonthSelected={this.onMonthSelected}
+				onYearSelected={this.onYearSelected}
 			/>
 		);
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -54,6 +54,8 @@ class DateTimePicker extends React.Component {
 		const dateTimeView = (
 			<DateTimeView
 				onTitleClick={this.onDateTimeViewTitleClick}
+				monthSelected={this.state.currentCalendar.get('monthIndex')}
+				yearSelected={this.state.currentCalendar.get('year')}
 			/>
 		);
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -13,29 +13,17 @@ class DateTimePicker extends React.Component {
 		const now = new Date();
 
 		this.state = {
-			isCalendarView: true,
+			isDateTimeView: true,
 			currentCalendar: Immutable.Map({
 				monthIndex: now.getMonth(),
 				year: now.getFullYear(),
 			}),
 		};
 
-		this.onDateTimeViewTitleClick = this.onDateTimeViewTitleClick.bind(this);
-		this.onMonthYearViewBackClick = this.onMonthYearViewBackClick.bind(this);
+		this.setDateTimeView = this.setView.bind(this, true);
+		this.setMonthYearView = this.setView.bind(this, false);
 		this.onMonthSelected = this.onMonthSelected.bind(this);
 		this.onYearSelected = this.onYearSelected.bind(this);
-	}
-
-	onDateTimeViewTitleClick() {
-		this.setState({
-			isCalendarView: false,
-		});
-	}
-
-	onMonthYearViewBackClick() {
-		this.setState({
-			isCalendarView: true,
-		});
 	}
 
 	onMonthSelected(monthIndex) {
@@ -50,11 +38,17 @@ class DateTimePicker extends React.Component {
 		}));
 	}
 
+	setView(isDateTime) {
+		this.setState({
+			isDateTimeView: isDateTime,
+		});
+	}
+
 	render() {
 		const dateTimeView = (
 			<DateTimeView
-				onTitleClick={this.onDateTimeViewTitleClick}
-				monthSelected={this.state.currentCalendar.get('monthIndex')}
+				onTitleClick={this.setMonthYearView}
+				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
 				onMonthSelected={this.onMonthSelected}
 				onYearSelected={this.onYearSelected}
@@ -63,8 +57,8 @@ class DateTimePicker extends React.Component {
 
 		const monthYearView = (
 			<MonthYearView
-				onBackClick={this.onMonthYearViewBackClick}
-				monthSelected={this.state.currentCalendar.get('monthIndex')}
+				onBackClick={this.setDateTimeView}
+				monthIndexSelected={this.state.currentCalendar.get('monthIndex')}
 				yearSelected={this.state.currentCalendar.get('year')}
 				onMonthSelected={this.onMonthSelected}
 				onYearSelected={this.onYearSelected}
@@ -72,7 +66,7 @@ class DateTimePicker extends React.Component {
 		);
 
 
-		const viewComponent = this.state.isCalendarView
+		const viewComponent = this.state.isDateTimeView
 			? dateTimeView
 			: monthYearView;
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.test.js
@@ -16,7 +16,7 @@ describe('DateTimePicker', () => {
 		const wrapper = shallow(<DateTimePicker />);
 
 		wrapper.setState({
-			isCalendarView: true,
+			isDateTimeView: true,
 		});
 
 		expect(wrapper.find(DateTimeView).exists()).toBe(true);
@@ -27,7 +27,7 @@ describe('DateTimePicker', () => {
 		const wrapper = shallow(<DateTimePicker />);
 
 		wrapper.setState({
-			isCalendarView: false,
+			isDateTimeView: false,
 		});
 
 		expect(wrapper.find(DateTimeView).exists()).toBe(false);

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.test.js
@@ -2,13 +2,35 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import DateTimePicker from './DateTimePicker.component';
+import DateTimeView from '../views/DateTimeView';
+import MonthYearView from '../views/MonthYearView';
 
 describe('DateTimePicker', () => {
-	it('should render a DateTimePicker', () => {
-		// when
+	it('should render', () => {
 		const wrapper = shallow(<DateTimePicker />);
 
-		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render with the DateTimeView', () => {
+		const wrapper = shallow(<DateTimePicker />);
+
+		wrapper.setState({
+			isCalendarView: true,
+		});
+
+		expect(wrapper.find(DateTimeView).exists()).toBe(true);
+		expect(wrapper.find(MonthYearView).exists()).toBe(false);
+	});
+
+	it('should render with the MonthYearView', () => {
+		const wrapper = shallow(<DateTimePicker />);
+
+		wrapper.setState({
+			isCalendarView: false,
+		});
+
+		expect(wrapper.find(DateTimeView).exists()).toBe(false);
+		expect(wrapper.find(MonthYearView).exists()).toBe(true);
 	});
 });

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -6,9 +6,8 @@ exports[`DateTimePicker should render 1`] = `
 >
   <DateTimeView
     monthIndexSelected={5}
-    onMonthSelected={[Function]}
+    onMonthYearSelected={[Function]}
     onTitleClick={[Function]}
-    onYearSelected={[Function]}
     yearSelected={2018}
   />
 </div>

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -5,10 +5,10 @@ exports[`DateTimePicker should render 1`] = `
   className="theme-container"
 >
   <DateTimeView
-    monthIndexSelected={5}
-    onMonthYearSelected={[Function]}
-    onTitleClick={[Function]}
-    yearSelected={2018}
+    onSelectMonthYear={[Function]}
+    onClickTitle={[Function]}
+    selectedMonthIndex={5}
+    selectedYear={2018}
   />
 </div>
 `;

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -5,8 +5,8 @@ exports[`DateTimePicker should render 1`] = `
   className="theme-container"
 >
   <DateTimeView
-    onSelectMonthYear={[Function]}
     onClickTitle={[Function]}
+    onSelectMonthYear={[Function]}
     selectedMonthIndex={5}
     selectedYear={2018}
   />

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateTimePicker should render a DateTimePicker 1`] = `
+exports[`DateTimePicker should render 1`] = `
 <div
   className="theme-container"
 >

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -4,6 +4,8 @@ exports[`DateTimePicker should render a DateTimePicker 1`] = `
 <div
   className="theme-container"
 >
-  <DateTimeView />
+  <DateTimeView
+    onTitleClick={[Function]}
+  />
 </div>
 `;

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -6,7 +6,9 @@ exports[`DateTimePicker should render 1`] = `
 >
   <DateTimeView
     monthSelected={5}
+    onMonthSelected={[Function]}
     onTitleClick={[Function]}
+    onYearSelected={[Function]}
     yearSelected={2018}
   />
 </div>

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -5,7 +5,7 @@ exports[`DateTimePicker should render 1`] = `
   className="theme-container"
 >
   <DateTimeView
-    monthSelected={5}
+    monthIndexSelected={5}
     onMonthSelected={[Function]}
     onTitleClick={[Function]}
     onYearSelected={[Function]}

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -5,7 +5,9 @@ exports[`DateTimePicker should render a DateTimePicker 1`] = `
   className="theme-container"
 >
   <DateTimeView
+    monthSelected={5}
     onTitleClick={[Function]}
+    yearSelected={2018}
   />
 </div>
 `;

--- a/packages/components/src/DateTimePickers/IconButton/IconButton.component.js
+++ b/packages/components/src/DateTimePickers/IconButton/IconButton.component.js
@@ -35,10 +35,10 @@ function IconButton(props) {
 }
 
 IconButton.propTypes = {
-	onClick: PropTypes.func,
 	icon: PropTypes.shape({
 		...Icon.propTypes,
 	}).isRequired,
+	onClick: PropTypes.func,
 	className: PropTypes.string,
 };
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -19,12 +19,6 @@ const monthsRows = chunk(months, 3);
 
 class MonthPicker extends React.PureComponent {
 
-	onSelect(index) {
-		return () => {
-			this.props.onSelect(index);
-		};
-	}
-
 	isSelected(index) {
 		return index === this.props.selectedMonthIndex;
 	}
@@ -43,7 +37,7 @@ class MonthPicker extends React.PureComponent {
 									aria-label={`Select '${month.name}'`}
 									isSelected={this.isSelected(month.index)}
 									label={month.name}
-									onClick={this.onSelect(month.index)}
+									onClick={() => this.props.onSelect(month.index)}
 								/>
 							</div>
 						)}

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -21,15 +21,10 @@ function MonthPicker(props) {
 	const isSelected = index =>
 		index === props.selectedMonthIndex;
 
-	const onSelect = index => {
-		if (props.onSelect === undefined) {
-			return undefined;
-		}
-
-		return () => {
+	const onSelect = index => (
+		() => {
 			props.onSelect(index);
-		};
-	};
+		});
 
 	return (
 		<div className={theme.container}>
@@ -56,7 +51,7 @@ function MonthPicker(props) {
 
 MonthPicker.propTypes = {
 	selectedMonthIndex: PropTypes.number,
-	onSelect: PropTypes.func,
+	onSelect: PropTypes.func.isRequired,
 };
 
 export default MonthPicker;

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -17,36 +17,41 @@ const months = indexes.map(index => ({
 }));
 const monthsRows = chunk(months, 3);
 
-function MonthPicker(props) {
-	const isSelected = index =>
-		index === props.selectedMonthIndex;
+class MonthPicker extends React.PureComponent {
 
-	const onSelect = index => (
-		() => {
-			props.onSelect(index);
-		});
+	onSelect(index) {
+		return () => {
+			this.props.onSelect(index);
+		};
+	}
 
-	return (
-		<div className={theme.container}>
-			{monthsRows.map((monthsRow, i) =>
-				<div className={theme.row} key={i}>
-					{monthsRow.map(month =>
-						<div
-							key={month.index}
-							className={theme.month}
-						>
-							<PickerAction
-								aria-label={`Select '${month.name}'`}
-								isSelected={isSelected(month.index)}
-								label={month.name}
-								onClick={onSelect(month.index)}
-							/>
-						</div>
-					)}
-				</div>
-			)}
-		</div>
-	);
+	isSelected(index) {
+		return index === this.props.selectedMonthIndex;
+	}
+
+	render() {
+		return (
+			<div className={theme.container}>
+				{monthsRows.map((monthsRow, i) =>
+					<div className={theme.row} key={i}>
+						{monthsRow.map(month =>
+							<div
+								key={month.index}
+								className={theme.month}
+							>
+								<PickerAction
+									aria-label={`Select '${month.name}'`}
+									isSelected={this.isSelected(month.index)}
+									label={month.name}
+									onClick={this.onSelect(month.index)}
+								/>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		);
+	}
 }
 
 MonthPicker.propTypes = {

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -19,15 +19,15 @@ const monthsRows = chunk(months, 3);
 
 function MonthPicker(props) {
 	const isSelected = index =>
-		index === props.monthIndexSelected;
+		index === props.selectedMonthIndex;
 
-	const onMonthSelected = index => {
-		if (props.onMonthSelected === undefined) {
+	const onSelect = index => {
+		if (props.onSelect === undefined) {
 			return undefined;
 		}
 
 		return () => {
-			props.onMonthSelected(index);
+			props.onSelect(index);
 		};
 	};
 
@@ -44,7 +44,7 @@ function MonthPicker(props) {
 								aria-label={`Select '${month.name}'`}
 								isSelected={isSelected(month.index)}
 								label={month.name}
-								onClick={onMonthSelected(month.index)}
+								onClick={onSelect(month.index)}
 							/>
 						</div>
 					)}
@@ -55,8 +55,8 @@ function MonthPicker(props) {
 }
 
 MonthPicker.propTypes = {
-	monthIndexSelected: PropTypes.number,
-	onMonthSelected: PropTypes.func,
+	selectedMonthIndex: PropTypes.number,
+	onSelect: PropTypes.func,
 };
 
 export default MonthPicker;

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -22,13 +22,13 @@ function MonthPicker(props) {
 		index === props.monthIndexSelected;
 
 	const onMonthSelected = index => {
-		const eventHandler = () => {
+		if (props.onMonthSelected === undefined) {
+			return undefined;
+		}
+
+		return () => {
 			props.onMonthSelected(index);
 		};
-
-		return props.onMonthSelected === undefined
-			? undefined
-			: eventHandler;
 	};
 
 	return (

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -18,28 +18,37 @@ function MonthPicker(props) {
 		'October',
 		'November',
 		'December',
-	];
+	].map((month, i) => ({
+		name: month,
+		index: i,
+	}));
 
 	const monthsRows = chunk(months, 3);
-	const selectedMonth = 'September';
 
-	function isSelected(m) {
-		return selectedMonth === m;
+	function isSelected(index) {
+		return index === props.currentMonth;
+	}
+
+	function onMonthSelected(index) {
+		return () => {
+			props.onMonthSelected(index);
+		};
 	}
 
 	return (
 		<div className={theme.container}>
 			{monthsRows.map((monthsRow, i) =>
 				<div className={theme.row} key={i}>
-					{monthsRow.map((month, j) =>
+					{monthsRow.map(month =>
 						<div
-							key={j}
+							key={month.index}
 							className={theme.month}
 						>
 							<PickerAction
-								aria-label={`Select '${month}'`}
-								isSelected={isSelected(month)}
-								label={month}
+								aria-label={`Select '${month.name}'`}
+								isSelected={isSelected(month.index)}
+								label={month.name}
+								onClick={onMonthSelected(month.index)}
 							/>
 						</div>
 					)}
@@ -50,6 +59,8 @@ function MonthPicker(props) {
 }
 
 MonthPicker.propTypes = {
+	currentMonth: PropTypes.number,
+	onMonthSelected: PropTypes.func,
 };
 
 export default MonthPicker;

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -18,15 +18,18 @@ const months = indexes.map(index => ({
 const monthsRows = chunk(months, 3);
 
 function MonthPicker(props) {
-	function isSelected(index) {
-		return index === props.monthSelected;
-	}
+	const isSelected = index =>
+		index === props.monthIndexSelected;
 
-	function onMonthSelected(index) {
-		return props.onMonthSelected && (() => {
+	const onMonthSelected = index => {
+		const eventHandler = () => {
 			props.onMonthSelected(index);
-		});
-	}
+		};
+
+		return props.onMonthSelected === undefined
+			? undefined
+			: eventHandler;
+	};
 
 	return (
 		<div className={theme.container}>
@@ -52,7 +55,7 @@ function MonthPicker(props) {
 }
 
 MonthPicker.propTypes = {
-	monthSelected: PropTypes.number,
+	monthIndexSelected: PropTypes.number,
 	onMonthSelected: PropTypes.func,
 };
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -1,30 +1,23 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { chunk } from 'lodash';
+import add_months from 'date-fns/add_months';
+import format from 'date-fns/format';
 import theme from './MonthPicker.scss';
 import PickerAction from '../../PickerAction';
 
+const baseDate = new Date(0);
+const indexes = (new Array(12))
+	.fill(0)
+	.map((_, i) => i);
+
+const months = indexes.map(index => ({
+	index,
+	name: format(add_months(baseDate, index), 'MMMM'),
+}));
+const monthsRows = chunk(months, 3);
+
 function MonthPicker(props) {
-	const months = [
-		'January',
-		'February',
-		'March',
-		'April',
-		'May',
-		'June',
-		'July',
-		'August',
-		'September',
-		'October',
-		'November',
-		'December',
-	].map((month, i) => ({
-		name: month,
-		index: i,
-	}));
-
-	const monthsRows = chunk(months, 3);
-
 	function isSelected(index) {
 		return index === props.currentMonth;
 	}

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -19,7 +19,7 @@ const monthsRows = chunk(months, 3);
 
 function MonthPicker(props) {
 	function isSelected(index) {
-		return index === props.currentMonth;
+		return index === props.monthSelected;
 	}
 
 	function onMonthSelected(index) {
@@ -52,7 +52,7 @@ function MonthPicker(props) {
 }
 
 MonthPicker.propTypes = {
-	currentMonth: PropTypes.number,
+	monthSelected: PropTypes.number,
 	onMonthSelected: PropTypes.func,
 };
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { chunk } from 'lodash';
-import add_months from 'date-fns/add_months';
+import addMonths from 'date-fns/add_months';
 import format from 'date-fns/format';
 import theme from './MonthPicker.scss';
 import PickerAction from '../../PickerAction';
@@ -13,7 +13,7 @@ const indexes = (new Array(12))
 
 const months = indexes.map(index => ({
 	index,
-	name: format(add_months(baseDate, index), 'MMMM'),
+	name: format(addMonths(baseDate, index), 'MMMM'),
 }));
 const monthsRows = chunk(months, 3);
 
@@ -23,9 +23,9 @@ function MonthPicker(props) {
 	}
 
 	function onMonthSelected(index) {
-		return () => {
+		return props.onMonthSelected && (() => {
 			props.onMonthSelected(index);
-		};
+		});
 	}
 
 	return (

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -43,8 +43,6 @@ describe('MonthPicker', () => {
 			.first()
 			.find('PickerAction');
 
-		expect(juneAction.length).toBe(1);
-
 		juneAction.simulate('click');
 
 		expect(onSelect).toHaveBeenCalledWith(monthIndexToSelect);

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -13,7 +13,7 @@ describe('MonthPicker', () => {
 	it('should have exactly one selected month', () => {
 		const monthIndex = 8;
 		const wrapper = shallow(<MonthPicker
-			monthIndexSelected={monthIndex}
+			selectedMonthIndex={monthIndex}
 		/>);
 
 		const actions = wrapper.find('PickerAction');
@@ -29,10 +29,10 @@ describe('MonthPicker', () => {
 
 	it('should callback with the month index picked', () => {
 		const monthIndexToSelect = 5;
-		const onMonthSelected = jest.fn();
+		const onSelect = jest.fn();
 
 		const wrapper = shallow(<MonthPicker
-			onMonthSelected={onMonthSelected}
+			onSelect={onSelect}
 		/>);
 
 		const juneAction = wrapper
@@ -44,6 +44,6 @@ describe('MonthPicker', () => {
 
 		juneAction.simulate('click');
 
-		expect(onMonthSelected).toHaveBeenCalledWith(monthIndexToSelect);
+		expect(onSelect).toHaveBeenCalledWith(monthIndexToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -44,7 +44,6 @@ describe('MonthPicker', () => {
 
 		juneAction.simulate('click');
 
-		expect(onMonthSelected).toHaveBeenCalledTimes(1);
 		expect(onMonthSelected).toHaveBeenCalledWith(monthIndexToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -20,14 +20,7 @@ describe('MonthPicker', () => {
 
 		expect(actions.length).toBe(12);
 
-		const unselectedActions = actions.filterWhere(action => action.prop('isSelected') === false);
 		const selectedActions = actions.filterWhere(action => action.prop('isSelected') === true);
-
-		expect(unselectedActions.length).toBe(11);
-
-		unselectedActions.forEach(action => {
-			expect(action.parent().key()).not.toBe(monthIndex.toString());
-		});
 
 		expect(selectedActions.length).toBe(1);
 		const selectedAction = selectedActions.first();

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -51,11 +51,7 @@ describe('MonthPicker', () => {
 
 		juneAction.simulate('click');
 
-		// One call
-		expect(spy.mock.calls.length).toBe(1);
-		// One argument
-		expect(spy.mock.calls[0].length).toBe(1);
-		// The correct index
-		expect(spy.mock.calls[0][0]).toBe(monthIndexToSelect);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(monthIndexToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -35,10 +35,10 @@ describe('MonthPicker', () => {
 			onMonthSelected={onMonthSelected}
 		/>);
 
-		const juneAction = wrapper.findWhere(n =>
-			n.name() === 'PickerAction'
-			&& n.parent().key() === monthIndexToSelect.toString()
-		);
+		const juneAction = wrapper
+			.findWhere(n => n.key() === monthIndexToSelect.toString())
+			.first()
+			.find('PickerAction');
 
 		expect(juneAction.length).toBe(1);
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -5,7 +5,9 @@ import MonthPicker from './MonthPicker.component';
 
 describe('MonthPicker', () => {
 	it('should render', () => {
-		const wrapper = shallow(<MonthPicker />);
+		const wrapper = shallow(<MonthPicker
+			onSelect={() => {}}
+		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -14,6 +16,7 @@ describe('MonthPicker', () => {
 		const monthIndex = 8;
 		const wrapper = shallow(<MonthPicker
 			selectedMonthIndex={monthIndex}
+			onSelect={() => {}}
 		/>);
 
 		const actions = wrapper.find('PickerAction');

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -16,7 +16,7 @@ describe('MonthPicker', () => {
 			monthIndexSelected={monthIndex}
 		/>);
 
-		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const actions = wrapper.find('PickerAction');
 
 		expect(actions.length).toBe(12);
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -36,10 +36,10 @@ describe('MonthPicker', () => {
 
 	it('should callback with the month index picked', () => {
 		const monthIndexToSelect = 5;
-		const spy = jest.fn();
+		const onMonthSelected = jest.fn();
 
 		const wrapper = shallow(<MonthPicker
-			onMonthSelected={spy}
+			onMonthSelected={onMonthSelected}
 		/>);
 
 		const juneAction = wrapper.findWhere(n =>
@@ -51,7 +51,7 @@ describe('MonthPicker', () => {
 
 		juneAction.simulate('click');
 
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(monthIndexToSelect);
+		expect(onMonthSelected).toHaveBeenCalledTimes(1);
+		expect(onMonthSelected).toHaveBeenCalledWith(monthIndexToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -4,11 +4,55 @@ import { shallow } from 'enzyme';
 import MonthPicker from './MonthPicker.component';
 
 describe('MonthPicker', () => {
-	it('should render a MonthPicker', () => {
-		// when
+	it('should render', () => {
 		const wrapper = shallow(<MonthPicker />);
 
-		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should have exactly one selected month', () => {
+		const wrapper = shallow(<MonthPicker
+			currentMonth={8}
+		/>);
+
+		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+
+		expect(actions.length).toBe(12);
+
+		const unselectedActions = actions.filterWhere(action => action.prop('isSelected') === false);
+		const selectedActions = actions.filterWhere(action => action.prop('isSelected') === true);
+
+		expect(unselectedActions.length).toBe(11);
+		expect(selectedActions.length).toBe(1);
+
+		unselectedActions.forEach(action => {
+			expect(action.parent().key()).not.toBe('8');
+		});
+
+		selectedActions.forEach(action => {
+			expect(action.parent().key()).toBe('8');
+		});
+	});
+
+	it('should callback with the month index picked', () => {
+		const monthIndexToSelect = 5;
+		const spy = jest.fn();
+
+		const wrapper = shallow(<MonthPicker
+			onMonthSelected={spy}
+		/>);
+
+		const juneAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.parent().key() === monthIndexToSelect.toString());
+
+		expect(juneAction.length).toBe(1);
+
+		juneAction.simulate('click');
+
+		// One call
+		expect(spy.mock.calls.length).toBe(1);
+		// One argument
+		expect(spy.mock.calls[0].length).toBe(1);
+		// The correct index
+		expect(spy.mock.calls[0][0]).toBe(monthIndexToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -11,8 +11,9 @@ describe('MonthPicker', () => {
 	});
 
 	it('should have exactly one selected month', () => {
+		const monthIndex = 8;
 		const wrapper = shallow(<MonthPicker
-			monthSelected={8}
+			monthIndexSelected={monthIndex}
 		/>);
 
 		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
@@ -25,12 +26,12 @@ describe('MonthPicker', () => {
 		expect(unselectedActions.length).toBe(11);
 
 		unselectedActions.forEach(action => {
-			expect(action.parent().key()).not.toBe('8');
+			expect(action.parent().key()).not.toBe(monthIndex.toString());
 		});
 
 		expect(selectedActions.length).toBe(1);
 		const selectedAction = selectedActions.first();
-		expect(selectedAction.parent().key()).toBe('8');
+		expect(selectedAction.parent().key()).toBe(monthIndex.toString());
 	});
 
 	it('should callback with the month index picked', () => {
@@ -41,7 +42,10 @@ describe('MonthPicker', () => {
 			onMonthSelected={spy}
 		/>);
 
-		const juneAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.parent().key() === monthIndexToSelect.toString());
+		const juneAction = wrapper.findWhere(n =>
+			n.name() === 'PickerAction'
+			&& n.parent().key() === monthIndexToSelect.toString()
+		);
 
 		expect(juneAction.length).toBe(1);
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -23,15 +23,14 @@ describe('MonthPicker', () => {
 		const selectedActions = actions.filterWhere(action => action.prop('isSelected') === true);
 
 		expect(unselectedActions.length).toBe(11);
-		expect(selectedActions.length).toBe(1);
 
 		unselectedActions.forEach(action => {
 			expect(action.parent().key()).not.toBe('8');
 		});
 
-		selectedActions.forEach(action => {
-			expect(action.parent().key()).toBe('8');
-		});
+		expect(selectedActions.length).toBe(1);
+		const selectedAction = selectedActions.first();
+		expect(selectedAction.parent().key()).toBe('8');
 	});
 
 	it('should callback with the month index picked', () => {

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.test.js
@@ -12,7 +12,7 @@ describe('MonthPicker', () => {
 
 	it('should have exactly one selected month', () => {
 		const wrapper = shallow(<MonthPicker
-			currentMonth={8}
+			monthSelected={8}
 		/>);
 
 		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
@@ -14,7 +14,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'January'"
         isSelected={false}
         label="January"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -24,7 +24,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'February'"
         isSelected={false}
         label="February"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -34,7 +34,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'March'"
         isSelected={false}
         label="March"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -48,7 +48,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'April'"
         isSelected={false}
         label="April"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -58,7 +58,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'May'"
         isSelected={false}
         label="May"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -68,7 +68,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'June'"
         isSelected={false}
         label="June"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -82,7 +82,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'July'"
         isSelected={false}
         label="July"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -92,7 +92,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'August'"
         isSelected={false}
         label="August"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -102,7 +102,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'September'"
         isSelected={false}
         label="September"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -116,7 +116,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'October'"
         isSelected={false}
         label="October"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -126,7 +126,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'November'"
         isSelected={false}
         label="November"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -136,7 +136,7 @@ exports[`MonthPicker should render 1`] = `
         aria-label="Select 'December'"
         isSelected={false}
         label="December"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`MonthPicker should render a MonthPicker 1`] = `
+exports[`MonthPicker should render 1`] = `
 <div
   className="theme-container"
 >
@@ -14,7 +14,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'January'"
         isSelected={false}
         label="January"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -24,7 +24,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'February'"
         isSelected={false}
         label="February"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -34,7 +34,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'March'"
         isSelected={false}
         label="March"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
   </div>
@@ -48,7 +48,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'April'"
         isSelected={false}
         label="April"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -58,7 +58,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'May'"
         isSelected={false}
         label="May"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -68,7 +68,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'June'"
         isSelected={false}
         label="June"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
   </div>
@@ -82,7 +82,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'July'"
         isSelected={false}
         label="July"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -92,7 +92,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'August'"
         isSelected={false}
         label="August"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -102,7 +102,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'September'"
         isSelected={false}
         label="September"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
   </div>
@@ -116,7 +116,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'October'"
         isSelected={false}
         label="October"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -126,7 +126,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'November'"
         isSelected={false}
         label="November"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -136,7 +136,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'December'"
         isSelected={false}
         label="December"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/__snapshots__/MonthPicker.test.js.snap
@@ -14,6 +14,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'January'"
         isSelected={false}
         label="January"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -23,6 +24,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'February'"
         isSelected={false}
         label="February"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -32,6 +34,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'March'"
         isSelected={false}
         label="March"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -45,6 +48,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'April'"
         isSelected={false}
         label="April"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -54,6 +58,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'May'"
         isSelected={false}
         label="May"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -63,6 +68,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'June'"
         isSelected={false}
         label="June"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -76,6 +82,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'July'"
         isSelected={false}
         label="July"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -85,6 +92,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'August'"
         isSelected={false}
         label="August"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -92,8 +100,9 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
     >
       <PickerAction
         aria-label="Select 'September'"
-        isSelected={true}
+        isSelected={false}
         label="September"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -107,6 +116,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'October'"
         isSelected={false}
         label="October"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -116,6 +126,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'November'"
         isSelected={false}
         label="November"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -125,6 +136,7 @@ exports[`MonthPicker should render a MonthPicker 1`] = `
         aria-label="Select 'December'"
         isSelected={false}
         label="December"
+        onClick={[Function]}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -1,12 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import addYears from 'date-fns/add_years';
-import setYear from 'date-fns/set_year';
 import theme from './YearPicker.scss';
 import IconButton from '../../IconButton';
 import PickerAction from '../../PickerAction';
-
-const baseDate = new Date(0);
 
 class YearPicker extends React.Component {
 
@@ -18,13 +14,11 @@ class YearPicker extends React.Component {
 			? props.yearSelected
 			: now.getFullYear();
 
-		const middleDate = setYear(baseDate, middleYear);
-		const firstDate = addYears(middleDate, -2);
+		const firstYear = middleYear - 2;
 
 		this.years = (new Array(5))
 			.fill(0)
-			.map((_, i) => addYears(firstDate, i))
-			.map(date => date.getFullYear());
+			.map((_, i) => firstYear + i);
 	}
 
 	render() {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -20,14 +20,7 @@ class YearPicker extends React.Component {
 			.fill(0)
 			.map((_, i) => firstYear + i);
 
-		this.onSelect = this.onSelect.bind(this);
 		this.isSelected = this.isSelected.bind(this);
-	}
-
-	onSelect(year) {
-		return () => {
-			this.props.onSelect(year);
-		};
 	}
 
 	isSelected(year) {
@@ -55,7 +48,7 @@ class YearPicker extends React.Component {
 								aria-label={`Select '${year}'`}
 								isSelected={this.isSelected(year)}
 								label={year.toString()}
-								onClick={this.onSelect(year)}
+								onClick={() => this.props.onSelect(year)}
 							/>
 						</div>
 					)}

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -25,10 +25,6 @@ class YearPicker extends React.Component {
 	}
 
 	onSelect(year) {
-		if (this.props.onSelect === undefined) {
-			return undefined;
-		}
-
 		return () => {
 			this.props.onSelect(year);
 		};
@@ -79,7 +75,7 @@ class YearPicker extends React.Component {
 
 YearPicker.propTypes = {
 	selectedYear: PropTypes.number,
-	onSelect: PropTypes.func,
+	onSelect: PropTypes.func.isRequired,
 };
 
 export default YearPicker;

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -19,22 +19,26 @@ class YearPicker extends React.Component {
 		this.years = (new Array(5))
 			.fill(0)
 			.map((_, i) => firstYear + i);
+
+		this.onSelect = this.onSelect.bind(this);
+		this.isSelected = this.isSelected.bind(this);
+	}
+
+	onSelect(year) {
+		if (this.props.onSelect === undefined) {
+			return undefined;
+		}
+
+		return () => {
+			this.props.onSelect(year);
+		};
+	}
+
+	isSelected(year) {
+		return year === this.props.selectedYear;
 	}
 
 	render() {
-		const isSelected = year =>
-			year === this.props.selectedYear;
-
-		const onSelect = year => {
-			if (this.props.onSelect === undefined) {
-				return undefined;
-			}
-
-			return () => {
-				this.props.onSelect(year);
-			};
-		};
-
 		return (
 			<div className={theme.container}>
 				<IconButton
@@ -53,9 +57,9 @@ class YearPicker extends React.Component {
 						>
 							<PickerAction
 								aria-label={`Select '${year}'`}
-								isSelected={isSelected(year)}
+								isSelected={this.isSelected(year)}
 								label={year.toString()}
-								onClick={onSelect(year)}
+								onClick={this.onSelect(year)}
 							/>
 						</div>
 					)}

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -10,8 +10,8 @@ class YearPicker extends React.Component {
 		super(props);
 
 		const now = new Date();
-		const middleYear = props.yearSelected !== undefined
-			? props.yearSelected
+		const middleYear = props.selectedYear !== undefined
+			? props.selectedYear
 			: now.getFullYear();
 
 		const firstYear = middleYear - 2;
@@ -23,15 +23,15 @@ class YearPicker extends React.Component {
 
 	render() {
 		const isSelected = year =>
-			year === this.props.yearSelected;
+			year === this.props.selectedYear;
 
-		const onYearSelected = year => {
-			if (this.props.onYearSelected === undefined) {
+		const onSelect = year => {
+			if (this.props.onSelect === undefined) {
 				return undefined;
 			}
 
 			return () => {
-				this.props.onYearSelected(year);
+				this.props.onSelect(year);
 			};
 		};
 
@@ -55,7 +55,7 @@ class YearPicker extends React.Component {
 								aria-label={`Select '${year}'`}
 								isSelected={isSelected(year)}
 								label={year.toString()}
-								onClick={onYearSelected(year)}
+								onClick={onSelect(year)}
 							/>
 						</div>
 					)}
@@ -74,8 +74,8 @@ class YearPicker extends React.Component {
 }
 
 YearPicker.propTypes = {
-	yearSelected: PropTypes.number,
-	onYearSelected: PropTypes.func,
+	selectedYear: PropTypes.number,
+	onSelect: PropTypes.func,
 };
 
 export default YearPicker;

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -26,13 +26,13 @@ class YearPicker extends React.Component {
 			year === this.props.yearSelected;
 
 		const onYearSelected = year => {
-			const eventHandler = () => {
+			if (this.props.onYearSelected === undefined) {
+				return undefined;
+			}
+
+			return () => {
 				this.props.onYearSelected(year);
 			};
-
-			return this.props.onYearSelected === undefined
-				? undefined
-				: eventHandler;
 		};
 
 		return (

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -10,8 +10,8 @@ const baseDate = new Date(0);
 
 function YearPicker(props) {
 	const now = new Date();
-	const middleYear = props.currentYear !== undefined
-		? props.currentYear
+	const middleYear = props.yearSelected !== undefined
+		? props.yearSelected
 		: now.getFullYear();
 
 	const middleDate = setYear(baseDate, middleYear);
@@ -23,7 +23,7 @@ function YearPicker(props) {
 		.map(date => date.getFullYear());
 
 	function isSelected(year) {
-		return year === props.currentYear;
+		return year === props.yearSelected;
 	}
 
 	function onYearSelected(year) {
@@ -70,7 +70,7 @@ function YearPicker(props) {
 }
 
 YearPicker.propTypes = {
-	currentYear: PropTypes.number,
+	yearSelected: PropTypes.number,
 	onYearSelected: PropTypes.func,
 };
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -1,20 +1,26 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import addYears from 'date-fns/add_years';
+import setYear from 'date-fns/set_year';
 import theme from './YearPicker.scss';
 import IconButton from '../../IconButton';
 import PickerAction from '../../PickerAction';
 
+const baseDate = new Date(0);
+
 function YearPicker(props) {
-	const years = [
-		2010,
-		2011,
-		2012,
-		2013,
-		2014,
-		2015,
-		2016,
-		2017,
-	].slice(0, 5);
+	const now = new Date();
+	const middleYear = props.currentYear !== undefined
+		? props.currentYear
+		: now.getFullYear();
+
+	const middleDate = setYear(baseDate, middleYear);
+	const firstDate = addYears(middleDate, -2);
+
+	const years = (new Array(5))
+		.fill(0)
+		.map((_, i) => addYears(firstDate, i))
+		.map(date => date.getFullYear());
 
 	function isSelected(year) {
 		return year === props.currentYear;

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -21,9 +21,9 @@ function YearPicker(props) {
 	}
 
 	function onYearSelected(year) {
-		return () => {
+		return props.onYearSelected && (() => {
 			props.onYearSelected(year);
-		};
+		});
 	}
 
 	return (

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -31,10 +31,15 @@ class YearPicker extends React.Component {
 		const isSelected = year =>
 			year === this.props.yearSelected;
 
-		const onYearSelected = year =>
-			this.props.onYearSelected && (() => {
+		const onYearSelected = year => {
+			const eventHandler = () => {
 				this.props.onYearSelected(year);
-			});
+			};
+
+			return this.props.onYearSelected === undefined
+				? undefined
+				: eventHandler;
+		};
 
 		return (
 			<div className={theme.container}>

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -8,65 +8,70 @@ import PickerAction from '../../PickerAction';
 
 const baseDate = new Date(0);
 
-function YearPicker(props) {
-	const now = new Date();
-	const middleYear = props.yearSelected !== undefined
-		? props.yearSelected
-		: now.getFullYear();
+class YearPicker extends React.Component {
 
-	const middleDate = setYear(baseDate, middleYear);
-	const firstDate = addYears(middleDate, -2);
+	constructor(props) {
+		super(props);
 
-	const years = (new Array(5))
-		.fill(0)
-		.map((_, i) => addYears(firstDate, i))
-		.map(date => date.getFullYear());
+		const now = new Date();
+		const middleYear = props.yearSelected !== undefined
+			? props.yearSelected
+			: now.getFullYear();
 
-	function isSelected(year) {
-		return year === props.yearSelected;
+		const middleDate = setYear(baseDate, middleYear);
+		const firstDate = addYears(middleDate, -2);
+
+		this.years = (new Array(5))
+			.fill(0)
+			.map((_, i) => addYears(firstDate, i))
+			.map(date => date.getFullYear());
 	}
 
-	function onYearSelected(year) {
-		return props.onYearSelected && (() => {
-			props.onYearSelected(year);
-		});
-	}
+	render() {
+		const isSelected = year =>
+			year === this.props.yearSelected;
 
-	return (
-		<div className={theme.container}>
-			<IconButton
-				icon={{
-					name: 'talend-chevron-left',
-					transform: 'rotate-90',
-				}}
-				className={theme['action-up']}
-				aria-label="Scroll to previous years"
-			/>
-			<div className={theme.years}>
-				{years.map(year =>
-					<div
-						key={year}
-						className={theme.year}
-					>
-						<PickerAction
-							aria-label={`Select '${year}'`}
-							isSelected={isSelected(year)}
-							label={year.toString()}
-							onClick={onYearSelected(year)}
-						/>
-					</div>
-				)}
+		const onYearSelected = year =>
+			this.props.onYearSelected && (() => {
+				this.props.onYearSelected(year);
+			});
+
+		return (
+			<div className={theme.container}>
+				<IconButton
+					icon={{
+						name: 'talend-chevron-left',
+						transform: 'rotate-90',
+					}}
+					className={theme['action-up']}
+					aria-label="Scroll to previous years"
+				/>
+				<div className={theme.years}>
+					{this.years.map(year =>
+						<div
+							key={year}
+							className={theme.year}
+						>
+							<PickerAction
+								aria-label={`Select '${year}'`}
+								isSelected={isSelected(year)}
+								label={year.toString()}
+								onClick={onYearSelected(year)}
+							/>
+						</div>
+					)}
+				</div>
+				<IconButton
+					icon={{
+						name: 'talend-chevron-left',
+						transform: 'rotate-270',
+					}}
+					className={theme['action-down']}
+					aria-label="Scroll to next years"
+				/>
 			</div>
-			<IconButton
-				icon={{
-					name: 'talend-chevron-left',
-					transform: 'rotate-270',
-				}}
-				className={theme['action-down']}
-				aria-label="Scroll to next years"
-			/>
-		</div>
-	);
+		);
+	}
 }
 
 YearPicker.propTypes = {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -16,10 +16,14 @@ function YearPicker(props) {
 		2017,
 	].slice(0, 5);
 
-	const selectedYear = 2012;
+	function isSelected(year) {
+		return year === props.currentYear;
+	}
 
-	function isSelected(y) {
-		return selectedYear === y;
+	function onYearSelected(year) {
+		return () => {
+			props.onYearSelected(year);
+		};
 	}
 
 	return (
@@ -33,15 +37,16 @@ function YearPicker(props) {
 				aria-label="Scroll to previous years"
 			/>
 			<div className={theme.years}>
-				{years.map((year, i) =>
+				{years.map(year =>
 					<div
-						key={i}
+						key={year}
 						className={theme.year}
 					>
 						<PickerAction
 							aria-label={`Select '${year}'`}
 							isSelected={isSelected(year)}
 							label={year.toString()}
+							onClick={onYearSelected(year)}
 						/>
 					</div>
 				)}
@@ -59,6 +64,8 @@ function YearPicker(props) {
 }
 
 YearPicker.propTypes = {
+	currentYear: PropTypes.number,
+	onYearSelected: PropTypes.func,
 };
 
 export default YearPicker;

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -17,7 +17,7 @@ describe('YearPicker', () => {
 			yearSelected={2012}
 		/>);
 
-		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const actions = wrapper.find('PickerAction');
 
 		expect(actions.length).toBe(5);
 
@@ -60,7 +60,7 @@ describe('YearPicker', () => {
 
 	it('should default render with current year in middle when "yearSelected" prop not provided', () => {
 		const wrapper = shallow(<YearPicker />);
-		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const actions = wrapper.find('PickerAction');
 		const now = new Date();
 		const currentYear = now.getFullYear().toString();
 
@@ -72,7 +72,7 @@ describe('YearPicker', () => {
 		const wrapper = shallow(<YearPicker
 			yearSelected={year}
 		/>);
-		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const actions = wrapper.find('PickerAction');
 
 		expect(actions.at(2).prop('label')).toBe(year.toString());
 	});
@@ -84,7 +84,7 @@ describe('YearPicker', () => {
 		const wrapper = shallow(<YearPicker
 			yearSelected={defaultYear}
 		/>);
-		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const actions = wrapper.find('PickerAction');
 
 		expect(actions.at(2).prop('label')).toBe(defaultYear.toString());
 
@@ -94,7 +94,7 @@ describe('YearPicker', () => {
 		});
 
 		// The middle year still remain the same
-		const newActions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const newActions = wrapper.find('PickerAction');
 		expect(newActions.at(2).prop('label')).toBe(defaultYear.toString());
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -54,12 +54,8 @@ describe('YearPicker', () => {
 
 		nextYearAction.simulate('click');
 
-		// One call
-		expect(spy.mock.calls.length).toBe(1);
-		// One argument
-		expect(spy.mock.calls[0].length).toBe(1);
-		// The correct index
-		expect(spy.mock.calls[0][0]).toBe(yearToSelect);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(yearToSelect);
 	});
 
 	it('should default render with current year in middle when "yearSelected" prop not provided', () => {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -38,11 +38,11 @@ describe('YearPicker', () => {
 
 	it('should callback with the year picked', () => {
 		const yearToSelect = 2013;
-		const spy = jest.fn();
+		const onYearSelected = jest.fn();
 
 		const wrapper = shallow(<YearPicker
 			yearSelected={2012}
-			onYearSelected={spy}
+			onYearSelected={onYearSelected}
 		/>);
 
 		const nextYearAction = wrapper.findWhere(n =>
@@ -54,8 +54,8 @@ describe('YearPicker', () => {
 
 		nextYearAction.simulate('click');
 
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(yearToSelect);
+		expect(onYearSelected).toHaveBeenCalledTimes(1);
+		expect(onYearSelected).toHaveBeenCalledWith(yearToSelect);
 	});
 
 	it('should default render with current year in middle when "yearSelected" prop not provided', () => {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -45,8 +45,6 @@ describe('YearPicker', () => {
 			.find('PickerAction')
 			.findWhere(n => n.prop('label') === yearToSelect.toString());
 
-		expect(nextYearAction.length).toBe(1);
-
 		nextYearAction.simulate('click');
 
 		expect(onSelect).toHaveBeenCalledWith(yearToSelect);
@@ -61,17 +59,6 @@ describe('YearPicker', () => {
 		const currentYear = now.getFullYear().toString();
 
 		expect(actions.at(2).prop('label')).toBe(currentYear);
-	});
-
-	it('should render with "selectedYear" prop as the middle year if provided', () => {
-		const year = 2005;
-		const wrapper = shallow(<YearPicker
-			selectedYear={year}
-			onSelect={() => {}}
-		/>);
-		const actions = wrapper.find('PickerAction');
-
-		expect(actions.at(2).prop('label')).toBe(year.toString());
 	});
 
 	it('should not update the years range if the selected year change', () => {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -39,10 +39,9 @@ describe('YearPicker', () => {
 			onYearSelected={onYearSelected}
 		/>);
 
-		const nextYearAction = wrapper.findWhere(n =>
-			n.name() === 'PickerAction'
-			&& n.prop('label') === yearToSelect.toString()
-		);
+		const nextYearAction = wrapper
+			.find('PickerAction')
+			.findWhere(n => n.prop('label') === yearToSelect.toString());
 
 		expect(nextYearAction.length).toBe(1);
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -6,7 +6,7 @@ import YearPicker from './YearPicker.component';
 describe('YearPicker', () => {
 	it('should render', () => {
 		const wrapper = shallow(<YearPicker
-			yearSelected={2012}
+			selectedYear={2012}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -14,7 +14,7 @@ describe('YearPicker', () => {
 
 	it('should have exactly one selected year', () => {
 		const wrapper = shallow(<YearPicker
-			yearSelected={2012}
+			selectedYear={2012}
 		/>);
 
 		const actions = wrapper.find('PickerAction');
@@ -32,11 +32,11 @@ describe('YearPicker', () => {
 
 	it('should callback with the year picked', () => {
 		const yearToSelect = 2013;
-		const onYearSelected = jest.fn();
+		const onSelect = jest.fn();
 
 		const wrapper = shallow(<YearPicker
-			yearSelected={2012}
-			onYearSelected={onYearSelected}
+			selectedYear={2012}
+			onSelect={onSelect}
 		/>);
 
 		const nextYearAction = wrapper
@@ -47,10 +47,10 @@ describe('YearPicker', () => {
 
 		nextYearAction.simulate('click');
 
-		expect(onYearSelected).toHaveBeenCalledWith(yearToSelect);
+		expect(onSelect).toHaveBeenCalledWith(yearToSelect);
 	});
 
-	it('should default render with current year in middle when "yearSelected" prop not provided', () => {
+	it('should default render with current year in middle when "selectedYear" prop not provided', () => {
 		const wrapper = shallow(<YearPicker />);
 		const actions = wrapper.find('PickerAction');
 		const now = new Date();
@@ -59,10 +59,10 @@ describe('YearPicker', () => {
 		expect(actions.at(2).prop('label')).toBe(currentYear);
 	});
 
-	it('should render with "yearSelected" prop as the middle year if provided', () => {
+	it('should render with "selectedYear" prop as the middle year if provided', () => {
 		const year = 2005;
 		const wrapper = shallow(<YearPicker
-			yearSelected={year}
+			selectedYear={year}
 		/>);
 		const actions = wrapper.find('PickerAction');
 
@@ -74,7 +74,7 @@ describe('YearPicker', () => {
 		const yearToSelect = 2020;
 
 		const wrapper = shallow(<YearPicker
-			yearSelected={defaultYear}
+			selectedYear={defaultYear}
 		/>);
 		const actions = wrapper.find('PickerAction');
 
@@ -82,7 +82,7 @@ describe('YearPicker', () => {
 
 		// When year selected change
 		wrapper.setProps({
-			yearSelected: yearToSelect,
+			selectedYear: yearToSelect,
 		});
 
 		// The middle year still remain the same

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -21,15 +21,9 @@ describe('YearPicker', () => {
 
 		expect(actions.length).toBe(5);
 
-		const unselectedActions = actions.filterWhere(action => action.prop('isSelected') === false);
 		const selectedActions = actions.filterWhere(action => action.prop('isSelected') === true);
 
-		expect(unselectedActions.length).toBe(4);
 		expect(selectedActions.length).toBe(1);
-
-		unselectedActions.forEach(action => {
-			expect(action.prop('label')).not.toBe('2012');
-		});
 
 		selectedActions.forEach(action => {
 			expect(action.prop('label')).toBe('2012');

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -7,6 +7,7 @@ describe('YearPicker', () => {
 	it('should render', () => {
 		const wrapper = shallow(<YearPicker
 			selectedYear={2012}
+			onSelect={() => {}}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -15,6 +16,7 @@ describe('YearPicker', () => {
 	it('should have exactly one selected year', () => {
 		const wrapper = shallow(<YearPicker
 			selectedYear={2012}
+			onSelect={() => {}}
 		/>);
 
 		const actions = wrapper.find('PickerAction');
@@ -51,7 +53,9 @@ describe('YearPicker', () => {
 	});
 
 	it('should default render with current year in middle when "selectedYear" prop not provided', () => {
-		const wrapper = shallow(<YearPicker />);
+		const wrapper = shallow(<YearPicker
+			onSelect={() => {}}
+		/>);
 		const actions = wrapper.find('PickerAction');
 		const now = new Date();
 		const currentYear = now.getFullYear().toString();
@@ -63,6 +67,7 @@ describe('YearPicker', () => {
 		const year = 2005;
 		const wrapper = shallow(<YearPicker
 			selectedYear={year}
+			onSelect={() => {}}
 		/>);
 		const actions = wrapper.find('PickerAction');
 
@@ -75,6 +80,7 @@ describe('YearPicker', () => {
 
 		const wrapper = shallow(<YearPicker
 			selectedYear={defaultYear}
+			onSelect={() => {}}
 		/>);
 		const actions = wrapper.find('PickerAction');
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -47,7 +47,6 @@ describe('YearPicker', () => {
 
 		nextYearAction.simulate('click');
 
-		expect(onYearSelected).toHaveBeenCalledTimes(1);
 		expect(onYearSelected).toHaveBeenCalledWith(yearToSelect);
 	});
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -77,4 +77,25 @@ describe('YearPicker', () => {
 
 		expect(actions.at(2).prop('label')).toBe(year.toString());
 	});
+
+	it('should not update the years range if the selected year change', () => {
+		const defaultYear = 2005;
+		const yearToSelect = 2020;
+
+		const wrapper = shallow(<YearPicker
+			yearSelected={defaultYear}
+		/>);
+		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+
+		expect(actions.at(2).prop('label')).toBe(defaultYear.toString());
+
+		// When year selected change
+		wrapper.setProps({
+			yearSelected: yearToSelect,
+		});
+
+		// The middle year still remain the same
+		const newActions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		expect(newActions.at(2).prop('label')).toBe(defaultYear.toString());
+	});
 });

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -6,7 +6,7 @@ import YearPicker from './YearPicker.component';
 describe('YearPicker', () => {
 	it('should render', () => {
 		const wrapper = shallow(<YearPicker
-			currentYear={2012}
+			yearSelected={2012}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -14,7 +14,7 @@ describe('YearPicker', () => {
 
 	it('should have exactly one selected year', () => {
 		const wrapper = shallow(<YearPicker
-			currentYear={2012}
+			yearSelected={2012}
 		/>);
 
 		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
@@ -41,11 +41,11 @@ describe('YearPicker', () => {
 		const spy = jest.fn();
 
 		const wrapper = shallow(<YearPicker
-			currentYear={2012}
+			yearSelected={2012}
 			onYearSelected={spy}
 		/>);
 
-		const nextYearAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.parent().key() === yearToSelect.toString());
+		const nextYearAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.prop('label') === yearToSelect.toString());
 
 		expect(nextYearAction.length).toBe(1);
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -58,4 +58,23 @@ describe('YearPicker', () => {
 		// The correct index
 		expect(spy.mock.calls[0][0]).toBe(yearToSelect);
 	});
+
+	it('should default render with current year in middle', () => {
+		const wrapper = shallow(<YearPicker />);
+		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+		const now = new Date();
+		const currentYear = now.getFullYear().toString();
+
+		expect(actions.at(2).prop('label')).toBe(currentYear);
+	});
+
+	it('should render with yearSelected prop as the middle year if provided', () => {
+		const year = 2005;
+		const wrapper = shallow(<YearPicker
+			yearSelected={year}
+		/>);
+		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+
+		expect(actions.at(2).prop('label')).toBe(year.toString());
+	});
 });

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -2,13 +2,58 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import YearPicker from './YearPicker.component';
+import theme from './YearPicker.test';
 
 describe('YearPicker', () => {
-	it('should render a YearPicker', () => {
-		// when
+	it('should render', () => {
 		const wrapper = shallow(<YearPicker />);
 
-		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should have exactly one selected year', () => {
+		const wrapper = shallow(<YearPicker
+			currentYear={2012}
+		/>);
+
+		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
+
+		expect(actions.length).toBe(5);
+
+		const unselectedActions = actions.filterWhere(action => action.prop('isSelected') === false);
+		const selectedActions = actions.filterWhere(action => action.prop('isSelected') === true);
+
+		expect(unselectedActions.length).toBe(4);
+		expect(selectedActions.length).toBe(1);
+
+		unselectedActions.forEach(action => {
+			expect(action.prop('label')).not.toBe('2012');
+		});
+
+		selectedActions.forEach(action => {
+			expect(action.prop('label')).toBe('2012');
+		});
+	});
+
+	it('should callback with the year picked', () => {
+		const yearToSelect = 2013;
+		const spy = jest.fn();
+
+		const wrapper = shallow(<YearPicker
+			onYearSelected={spy}
+		/>);
+
+		const nextYearAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.parent().key() === yearToSelect.toString());
+
+		expect(nextYearAction.length).toBe(1);
+
+		nextYearAction.simulate('click');
+
+		// One call
+		expect(spy.mock.calls.length).toBe(1);
+		// One argument
+		expect(spy.mock.calls[0].length).toBe(1);
+		// The correct index
+		expect(spy.mock.calls[0][0]).toBe(yearToSelect);
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -45,7 +45,10 @@ describe('YearPicker', () => {
 			onYearSelected={spy}
 		/>);
 
-		const nextYearAction = wrapper.findWhere(n => n.name() === 'PickerAction' && n.prop('label') === yearToSelect.toString());
+		const nextYearAction = wrapper.findWhere(n =>
+			n.name() === 'PickerAction'
+			&& n.prop('label') === yearToSelect.toString()
+		);
 
 		expect(nextYearAction.length).toBe(1);
 
@@ -59,7 +62,7 @@ describe('YearPicker', () => {
 		expect(spy.mock.calls[0][0]).toBe(yearToSelect);
 	});
 
-	it('should default render with current year in middle', () => {
+	it('should default render with current year in middle when "yearSelected" prop not provided', () => {
 		const wrapper = shallow(<YearPicker />);
 		const actions = wrapper.findWhere(n => n.name() === 'PickerAction');
 		const now = new Date();
@@ -68,7 +71,7 @@ describe('YearPicker', () => {
 		expect(actions.at(2).prop('label')).toBe(currentYear);
 	});
 
-	it('should render with yearSelected prop as the middle year if provided', () => {
+	it('should render with "yearSelected" prop as the middle year if provided', () => {
 		const year = 2005;
 		const wrapper = shallow(<YearPicker
 			yearSelected={year}

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -2,11 +2,12 @@ import React from 'react';
 import { shallow } from 'enzyme';
 
 import YearPicker from './YearPicker.component';
-import theme from './YearPicker.test';
 
 describe('YearPicker', () => {
 	it('should render', () => {
-		const wrapper = shallow(<YearPicker />);
+		const wrapper = shallow(<YearPicker
+			currentYear={2012}
+		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -40,6 +41,7 @@ describe('YearPicker', () => {
 		const spy = jest.fn();
 
 		const wrapper = shallow(<YearPicker
+			currentYear={2012}
 			onYearSelected={spy}
 		/>);
 

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
@@ -24,7 +24,7 @@ exports[`YearPicker should render 1`] = `
         aria-label="Select '2010'"
         isSelected={false}
         label="2010"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -34,7 +34,7 @@ exports[`YearPicker should render 1`] = `
         aria-label="Select '2011'"
         isSelected={false}
         label="2011"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -44,7 +44,7 @@ exports[`YearPicker should render 1`] = `
         aria-label="Select '2012'"
         isSelected={true}
         label="2012"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -54,7 +54,7 @@ exports[`YearPicker should render 1`] = `
         aria-label="Select '2013'"
         isSelected={false}
         label="2013"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
     <div
@@ -64,7 +64,7 @@ exports[`YearPicker should render 1`] = `
         aria-label="Select '2014'"
         isSelected={false}
         label="2014"
-        onClick={undefined}
+        onClick={[Function]}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
@@ -24,6 +24,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2010'"
         isSelected={false}
         label="2010"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -33,6 +34,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2011'"
         isSelected={false}
         label="2011"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -40,8 +42,9 @@ exports[`YearPicker should render a YearPicker 1`] = `
     >
       <PickerAction
         aria-label="Select '2012'"
-        isSelected={true}
+        isSelected={false}
         label="2012"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -51,6 +54,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2013'"
         isSelected={false}
         label="2013"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -60,6 +64,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2014'"
         isSelected={false}
         label="2014"
+        onClick={[Function]}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
@@ -42,7 +42,7 @@ exports[`YearPicker should render 1`] = `
     >
       <PickerAction
         aria-label="Select '2012'"
-        isSelected={false}
+        isSelected={true}
         label="2012"
         onClick={undefined}
       />

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`YearPicker should render a YearPicker 1`] = `
+exports[`YearPicker should render 1`] = `
 <div
   className="theme-container"
 >
@@ -24,7 +24,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2010'"
         isSelected={false}
         label="2010"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -34,7 +34,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2011'"
         isSelected={false}
         label="2011"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -44,7 +44,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2012'"
         isSelected={false}
         label="2012"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -54,7 +54,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2013'"
         isSelected={false}
         label="2013"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
     <div
@@ -64,7 +64,7 @@ exports[`YearPicker should render a YearPicker 1`] = `
         aria-label="Select '2014'"
         isSelected={false}
         label="2014"
-        onClick={[Function]}
+        onClick={undefined}
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -30,17 +30,14 @@ class DateTimeView extends React.Component {
 		const monthIndexIncremented = this.props.monthIndexSelected + monthIncrement;
 		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
+		const newYear = this.props.yearSelected + yearIncrement;
 
-		if (this.props.onMonthSelected !== undefined) {
-			this.props.onMonthSelected(newMonthIndex);
-		}
 
-		if (
-			this.props.onYearSelected !== undefined
-			&& yearIncrement !== 0
-		) {
-			const newYear = this.props.yearSelected + yearIncrement;
-			this.props.onYearSelected(newYear);
+		if (this.props.onMonthYearSelected !== undefined) {
+			this.props.onMonthYearSelected({
+				monthIndex: newMonthIndex,
+				year: newYear,
+			});
 		}
 	}
 
@@ -95,8 +92,7 @@ DateTimeView.propTypes = {
 	monthIndexSelected: PropTypes.number.isRequired,
 	yearSelected: PropTypes.number.isRequired,
 	onTitleClick: PropTypes.func,
-	onMonthSelected: PropTypes.func,
-	onYearSelected: PropTypes.func,
+	onMonthYearSelected: PropTypes.func,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -8,13 +8,13 @@ import theme from './DateTimeView.scss';
 
 /**
  * Get the positive euclidean modulo number from a dividend and a divisor
- * @param {number} a Dividend
- * @param {number} b Divisor
+ * @param {number} dividend Dividend
+ * @param {number} divisor Divisor
  * @return The positive euclidean modulo
  */
-export function euclideanModulo(a, b) {
-	const m = ((a % b) + b) % b;
-	return m < 0 ? m + Math.abs(b) : m;
+export function euclideanModulo(dividend, divisor) {
+	const modulo = ((dividend % divisor) + divisor) % divisor;
+	return modulo < 0 ? modulo + Math.abs(divisor) : modulo;
 }
 
 class DateTimeView extends React.Component {

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -32,13 +32,10 @@ class DateTimeView extends React.Component {
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
 		const newYear = this.props.selectedYear + yearIncrement;
 
-
-		if (this.props.onSelectMonthYear !== undefined) {
-			this.props.onSelectMonthYear({
-				monthIndex: newMonthIndex,
-				year: newYear,
-			});
-		}
+		this.props.onSelectMonthYear({
+			monthIndex: newMonthIndex,
+			year: newYear,
+		});
 	}
 
 	render() {
@@ -91,8 +88,8 @@ class DateTimeView extends React.Component {
 DateTimeView.propTypes = {
 	selectedMonthIndex: PropTypes.number.isRequired,
 	selectedYear: PropTypes.number.isRequired,
-	onClickTitle: PropTypes.func,
-	onSelectMonthYear: PropTypes.func,
+	onClickTitle: PropTypes.func.isRequired,
+	onSelectMonthYear: PropTypes.func.isRequired,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -10,7 +10,7 @@ import theme from './DateTimeView.scss';
  * Get the positive euclidean modulo number from a dividend and a divisor
  * @param {number} dividend Dividend
  * @param {number} divisor Divisor
- * @return The positive euclidean modulo
+ * @return {number} The positive euclidean modulo
  */
 export function euclideanModulo(dividend, divisor) {
 	const modulo = ((dividend % divisor) + divisor) % divisor;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -27,14 +27,14 @@ class DateTimeView extends React.Component {
 	}
 
 	incrementMonthIndex(monthIncrement) {
-		const monthIndexIncremented = this.props.monthIndexSelected + monthIncrement;
+		const monthIndexIncremented = this.props.selectedMonthIndex + monthIncrement;
 		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
-		const newYear = this.props.yearSelected + yearIncrement;
+		const newYear = this.props.selectedYear + yearIncrement;
 
 
-		if (this.props.onMonthYearSelected !== undefined) {
-			this.props.onMonthYearSelected({
+		if (this.props.onSelectMonthYear !== undefined) {
+			this.props.onSelectMonthYear({
 				monthIndex: newMonthIndex,
 				year: newYear,
 			});
@@ -51,11 +51,11 @@ class DateTimeView extends React.Component {
 				onClick={this.incrementMonthIndexDown}
 			/>,
 			middleElement: <HeaderTitle
-				monthIndex={this.props.monthIndexSelected}
-				year={this.props.yearSelected}
+				monthIndex={this.props.selectedMonthIndex}
+				year={this.props.selectedYear}
 				button={{
 					'aria-label': 'Switch to month and year pickers view',
-					onClick: this.props.onTitleClick,
+					onClick: this.props.onClickTitle,
 				}}
 			/>,
 			rightElement: <IconButton
@@ -89,10 +89,10 @@ class DateTimeView extends React.Component {
 }
 
 DateTimeView.propTypes = {
-	monthIndexSelected: PropTypes.number.isRequired,
-	yearSelected: PropTypes.number.isRequired,
-	onTitleClick: PropTypes.func,
-	onMonthYearSelected: PropTypes.func,
+	selectedMonthIndex: PropTypes.number.isRequired,
+	selectedYear: PropTypes.number.isRequired,
+	onClickTitle: PropTypes.func,
+	onSelectMonthYear: PropTypes.func,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -18,6 +18,7 @@ function DateTimeView(props) {
 			label="Septembre 2017"
 			button={{
 				'aria-label': 'Switch to month and year pickers view',
+				onClick: props.onTitleClick,
 			}}
 		/>,
 		rightElement: <IconButton
@@ -49,6 +50,7 @@ function DateTimeView(props) {
 }
 
 DateTimeView.propTypes = {
+	onTitleClick: PropTypes.func,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -6,54 +6,97 @@ import IconButton from '../../IconButton';
 import HeaderTitle from '../HeaderTitle';
 import theme from './DateTimeView.scss';
 
-function DateTimeView(props) {
-	const header = {
-		leftElement: <IconButton
-			icon={{
-				name: 'talend-chevron-left',
-			}}
-			aria-label="Display previous calendar month"
-		/>,
-		middleElement: <HeaderTitle
-			month={props.monthSelected}
-			year={props.yearSelected}
-			button={{
-				'aria-label': 'Switch to month and year pickers view',
-				onClick: props.onTitleClick,
-			}}
-		/>,
-		rightElement: <IconButton
-			icon={{
-				name: 'talend-chevron-left',
-				transform: 'rotate-180',
-			}}
-			aria-label="Display next calendar month"
-		/>,
-	};
+/**
+ * Get the positive euclidean modulo number from a dividend and a divisor
+ * @param {number} a Dividend
+ * @param {number} b Divisor
+ * @return The positive euclidean modulo
+ */
+function euclideanModulo(a, b) {
+	const m = ((a % b) + b) % b;
+	return m < 0 ? m + Math.abs(b) : m;
+}
 
-	const bodyElement = (
-		<div className={theme.body}>
-			<div className={theme.date}>
-				<DatePicker />
+class DateTimeView extends React.Component {
+
+	constructor(props) {
+		super(props);
+
+		this.incrementMonthIndexDown = this.incrementMonthIndex.bind(this, -1);
+		this.incrementMonthIndexUp = this.incrementMonthIndex.bind(this, 1);
+	}
+
+	incrementMonthIndex(monthIncrement) {
+		const monthIndexIncremented = this.props.monthSelected + monthIncrement;
+		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
+		const yearIncrement = Math.floor(monthIndexIncremented / 12);
+
+		if (this.props.onMonthSelected !== undefined) {
+			this.props.onMonthSelected(newMonthIndex);
+		}
+
+		if (
+			this.props.onYearSelected !== undefined
+			&& yearIncrement !== 0
+		) {
+			const newYear = this.props.yearSelected + yearIncrement;
+			this.props.onYearSelected(newYear);
+		}
+	}
+
+	render() {
+		const header = {
+			leftElement: <IconButton
+				icon={{
+					name: 'talend-chevron-left',
+				}}
+				aria-label="Display previous calendar month"
+				onClick={this.incrementMonthIndexDown}
+			/>,
+			middleElement: <HeaderTitle
+				month={this.props.monthSelected}
+				year={this.props.yearSelected}
+				button={{
+					'aria-label': 'Switch to month and year pickers view',
+					onClick: this.props.onTitleClick,
+				}}
+			/>,
+			rightElement: <IconButton
+				icon={{
+					name: 'talend-chevron-left',
+					transform: 'rotate-180',
+				}}
+				aria-label="Display next calendar month"
+				onClick={this.incrementMonthIndexUp}
+			/>,
+		};
+
+		const bodyElement = (
+			<div className={theme.body}>
+				<div className={theme.date}>
+					<DatePicker />
+				</div>
+				<div className={theme.time}>
+
+				</div>
 			</div>
-			<div className={theme.time}>
+		);
 
-			</div>
-		</div>
-	);
-
-	return (
-		<ViewLayout
-			header={header}
-			bodyElement={bodyElement}
-		/>
-	);
+		return (
+			<ViewLayout
+				header={header}
+				bodyElement={bodyElement}
+			/>
+		);
+	}
 }
 
 DateTimeView.propTypes = {
-	onTitleClick: PropTypes.func,
 	monthSelected: PropTypes.number.isRequired,
 	yearSelected: PropTypes.number.isRequired,
+	onTitleClick: PropTypes.func,
+	onMonthSelected: PropTypes.func,
+	onYearSelected: PropTypes.func,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -15,7 +15,8 @@ function DateTimeView(props) {
 			aria-label="Display previous calendar month"
 		/>,
 		middleElement: <HeaderTitle
-			label="Septembre 2017"
+			month={8}
+			year={2017}
 			button={{
 				'aria-label': 'Switch to month and year pickers view',
 				onClick: props.onTitleClick,

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -27,7 +27,7 @@ class DateTimeView extends React.Component {
 	}
 
 	incrementMonthIndex(monthIncrement) {
-		const monthIndexIncremented = this.props.monthSelected + monthIncrement;
+		const monthIndexIncremented = this.props.monthIndexSelected + monthIncrement;
 		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
 
@@ -54,7 +54,7 @@ class DateTimeView extends React.Component {
 				onClick={this.incrementMonthIndexDown}
 			/>,
 			middleElement: <HeaderTitle
-				month={this.props.monthSelected}
+				monthIndex={this.props.monthIndexSelected}
 				year={this.props.yearSelected}
 				button={{
 					'aria-label': 'Switch to month and year pickers view',
@@ -92,7 +92,7 @@ class DateTimeView extends React.Component {
 }
 
 DateTimeView.propTypes = {
-	monthSelected: PropTypes.number.isRequired,
+	monthIndexSelected: PropTypes.number.isRequired,
 	yearSelected: PropTypes.number.isRequired,
 	onTitleClick: PropTypes.func,
 	onMonthSelected: PropTypes.func,

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -12,7 +12,7 @@ import theme from './DateTimeView.scss';
  * @param {number} b Divisor
  * @return The positive euclidean modulo
  */
-function euclideanModulo(a, b) {
+export function euclideanModulo(a, b) {
 	const m = ((a % b) + b) % b;
 	return m < 0 ? m + Math.abs(b) : m;
 }

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -15,8 +15,8 @@ function DateTimeView(props) {
 			aria-label="Display previous calendar month"
 		/>,
 		middleElement: <HeaderTitle
-			month={8}
-			year={2017}
+			month={props.monthSelected}
+			year={props.yearSelected}
 			button={{
 				'aria-label': 'Switch to month and year pickers view',
 				onClick: props.onTitleClick,
@@ -52,6 +52,8 @@ function DateTimeView(props) {
 
 DateTimeView.propTypes = {
 	onTitleClick: PropTypes.func,
+	monthSelected: PropTypes.number.isRequired,
+	yearSelected: PropTypes.number.isRequired,
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -36,7 +36,7 @@ describe('DateTimeView', () => {
 		expect(onClickTitle).toHaveBeenCalledTimes(1);
 	});
 
-	describe('should callback when month switched with the new month index and year', () => {
+	describe('month switch management', () => {
 		function getActions(wrapper) {
 			return wrapper.find('ViewLayout').shallow().find('IconButton');
 		}
@@ -49,7 +49,7 @@ describe('DateTimeView', () => {
 			return getActions(wrapper).last();
 		}
 
-		it('in simple previous case', () => {
+		it('should trigger callback when previous month is clicked with previous month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={5}
@@ -69,7 +69,7 @@ describe('DateTimeView', () => {
 			});
 		});
 
-		it('in simple next case', () => {
+		it('should trigger callback when next month is clicked with next month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={5}
@@ -88,7 +88,7 @@ describe('DateTimeView', () => {
 			});
 		});
 
-		it('in advance previous case', () => {
+		it('should trigger callback when previous month is clicked with last month of year and previous year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={0}
@@ -107,7 +107,7 @@ describe('DateTimeView', () => {
 			});
 		});
 
-		it('in advance next case', () => {
+		it('should trigger callback when next month is clicked with first month of year and next year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={11}

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -28,108 +28,140 @@ describe('DateTimeView', () => {
 		expect(onTitleClick).toHaveBeenCalledTimes(1);
 	});
 
-	it('should callback with the month index updated', () => {
-		const onMonthSelected = jest.fn();
-		const wrapper = shallow(<DateTimeView
-			monthIndexSelected={5}
-			yearSelected={2006}
-			onMonthSelected={onMonthSelected}
-		/>);
+	describe('should callback when switch month', () => {
+		function getActions(wrapper) {
+			return wrapper.find('ViewLayout').shallow().find('IconButton');
+		}
 
-		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
-		const previousAction = monthActions.first();
-		const nextAction = monthActions.last();
+		function getPreviousAction(wrapper) {
+			return getActions(wrapper).first();
+		}
 
-		// Simple previous case
-		wrapper.setProps({
-			monthIndexSelected: 5,
-			yearSelected: 2006,
+		function getNextAction(wrapper) {
+			return getActions(wrapper).last();
+		}
+
+		describe('with the month index updated', () => {
+			it('in simple previous case', () => {
+				const onMonthSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={5}
+					yearSelected={2006}
+					onMonthSelected={onMonthSelected}
+				/>);
+
+				const previousAction = getPreviousAction(wrapper);
+				previousAction.simulate('click');
+
+				expect(onMonthSelected).toHaveBeenCalledTimes(1);
+				expect(onMonthSelected).toHaveBeenCalledWith(4);
+			});
+
+			it('in simple next case', () => {
+				const onMonthSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={5}
+					yearSelected={2006}
+					onMonthSelected={onMonthSelected}
+				/>);
+
+				const nextAction = getNextAction(wrapper);
+				nextAction.simulate('click');
+
+				expect(onMonthSelected).toHaveBeenCalledTimes(1);
+				expect(onMonthSelected).toHaveBeenCalledWith(6);
+			});
+
+			it('in advance previous case', () => {
+				const onMonthSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={0}
+					yearSelected={2006}
+					onMonthSelected={onMonthSelected}
+				/>);
+
+				const previousAction = getPreviousAction(wrapper);
+				previousAction.simulate('click');
+
+				expect(onMonthSelected).toHaveBeenCalledTimes(1);
+				expect(onMonthSelected).toHaveBeenCalledWith(11);
+			});
+
+			it('in advance next case', () => {
+				const onMonthSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={11}
+					yearSelected={2006}
+					onMonthSelected={onMonthSelected}
+				/>);
+
+				const nextAction = getNextAction(wrapper);
+				nextAction.simulate('click');
+
+				expect(onMonthSelected).toHaveBeenCalledTimes(1);
+				expect(onMonthSelected).toHaveBeenCalledWith(0);
+			});
 		});
-		onMonthSelected.mockClear();
-		previousAction.simulate('click');
-		expect(onMonthSelected).toHaveBeenCalledTimes(1);
-		expect(onMonthSelected).toHaveBeenCalledWith(4);
 
-		// Simple next case
-		wrapper.setProps({
-			monthIndexSelected: 5,
-			yearSelected: 2006,
+		describe('with the year updated if needed', () => {
+			it('in simple previous case', () => {
+				const onYearSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={5}
+					yearSelected={2006}
+					onYearSelected={onYearSelected}
+				/>);
+
+				const previousAction = getPreviousAction(wrapper);
+				previousAction.simulate('click');
+
+				expect(onYearSelected).not.toHaveBeenCalled();
+			});
+
+			it('in simple next case', () => {
+				const onYearSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={5}
+					yearSelected={2006}
+					onYearSelected={onYearSelected}
+				/>);
+
+				const nextAction = getNextAction(wrapper);
+				nextAction.simulate('click');
+
+				expect(onYearSelected).not.toHaveBeenCalled();
+			});
+
+			it('in advance previous case', () => {
+				const onYearSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={0}
+					yearSelected={2006}
+					onYearSelected={onYearSelected}
+				/>);
+
+				const previousAction = getPreviousAction(wrapper);
+				previousAction.simulate('click');
+
+				expect(onYearSelected).toHaveBeenCalledTimes(1);
+				expect(onYearSelected).toHaveBeenCalledWith(2005);
+			});
+
+			it('in advance next case', () => {
+				const onYearSelected = jest.fn();
+				const wrapper = shallow(<DateTimeView
+					monthIndexSelected={11}
+					yearSelected={2006}
+					onYearSelected={onYearSelected}
+				/>);
+
+				const nextAction = getNextAction(wrapper);
+				nextAction.simulate('click');
+
+				expect(onYearSelected).toHaveBeenCalledTimes(1);
+				expect(onYearSelected).toHaveBeenCalledWith(2007);
+			});
 		});
-		onMonthSelected.mockClear();
-		nextAction.simulate('click');
-		expect(onMonthSelected).toHaveBeenCalledTimes(1);
-		expect(onMonthSelected).toHaveBeenCalledWith(6);
-
-		// Advance previous case
-		wrapper.setProps({
-			monthIndexSelected: 0,
-			yearSelected: 2006,
-		});
-		onMonthSelected.mockClear();
-		previousAction.simulate('click');
-		expect(onMonthSelected).toHaveBeenCalledTimes(1);
-		expect(onMonthSelected).toHaveBeenCalledWith(11);
-
-		// Advance next case
-		wrapper.setProps({
-			monthIndexSelected: 11,
-			yearSelected: 2006,
-		});
-		onMonthSelected.mockClear();
-		nextAction.simulate('click');
-		expect(onMonthSelected).toHaveBeenCalledTimes(1);
-		expect(onMonthSelected).toHaveBeenCalledWith(0);
-	});
-
-	it('should callback with the year updated', () => {
-		const onYearSelected = jest.fn();
-		const wrapper = shallow(<DateTimeView
-			monthIndexSelected={5}
-			yearSelected={2006}
-			onYearSelected={onYearSelected}
-		/>);
-
-		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
-		const previousAction = monthActions.first();
-		const nextAction = monthActions.last();
-
-		// Simple previous case
-		wrapper.setProps({
-			monthIndexSelected: 5,
-			yearSelected: 2006,
-		});
-		onYearSelected.mockClear();
-		previousAction.simulate('click');
-		expect(onYearSelected).not.toHaveBeenCalled();
-
-		// Simple next case
-		wrapper.setProps({
-			monthIndexSelected: 5,
-			yearSelected: 2006,
-		});
-		onYearSelected.mockClear();
-		nextAction.simulate('click');
-		expect(onYearSelected).not.toHaveBeenCalled();
-
-		// Advance previous case
-		wrapper.setProps({
-			monthIndexSelected: 0,
-			yearSelected: 2006,
-		});
-		onYearSelected.mockClear();
-		previousAction.simulate('click');
-		expect(onYearSelected).toHaveBeenCalledTimes(1);
-		expect(onYearSelected).toHaveBeenCalledWith(2005);
-
-		// Advance next case
-		wrapper.setProps({
-			monthIndexSelected: 11,
-			yearSelected: 2006,
-		});
-		onYearSelected.mockClear();
-		nextAction.simulate('click');
-		expect(onYearSelected).toHaveBeenCalledTimes(1);
-		expect(onYearSelected).toHaveBeenCalledWith(2007);
 	});
 });
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -21,10 +21,15 @@ describe('DateTimeView', () => {
 			onTitleClick={onTitleClick}
 		/>);
 
-		const headerClickFn = wrapper.find('ViewLayout').shallow()
-			.find('HeaderTitle').props().button.onClick;
+		const titleAction = wrapper
+			.find('ViewLayout')
+			.shallow()
+			.find('HeaderTitle')
+			.first()
+			.shallow()
+			.find('button');
 
-		headerClickFn();
+		titleAction.simulate('click');
 		expect(onTitleClick).toHaveBeenCalledTimes(1);
 	});
 
@@ -50,6 +55,7 @@ describe('DateTimeView', () => {
 			/>);
 
 			const previousAction = getPreviousAction(wrapper);
+
 			previousAction.simulate('click');
 
 			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -14,26 +14,26 @@ describe('DateTimeView', () => {
 	});
 
 	it('should callback when title is clicked', () => {
-		const spy = jest.fn();
+		const onTitleClick = jest.fn();
 		const wrapper = shallow(<DateTimeView
 			monthIndexSelected={5}
 			yearSelected={2006}
-			onTitleClick={spy}
+			onTitleClick={onTitleClick}
 		/>);
 
 		const headerClickFn = wrapper.find('ViewLayout').shallow()
 			.find('HeaderTitle').props().button.onClick;
 
 		headerClickFn();
-		expect(spy).toHaveBeenCalledTimes(1);
+		expect(onTitleClick).toHaveBeenCalledTimes(1);
 	});
 
 	it('should callback with the month index updated', () => {
-		const spy = jest.fn();
+		const onMonthSelected = jest.fn();
 		const wrapper = shallow(<DateTimeView
 			monthIndexSelected={5}
 			yearSelected={2006}
-			onMonthSelected={spy}
+			onMonthSelected={onMonthSelected}
 		/>);
 
 		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
@@ -45,48 +45,48 @@ describe('DateTimeView', () => {
 			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onMonthSelected.mockClear();
 		previousAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(4);
+		expect(onMonthSelected).toHaveBeenCalledTimes(1);
+		expect(onMonthSelected).toHaveBeenCalledWith(4);
 
 		// Simple next case
 		wrapper.setProps({
 			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onMonthSelected.mockClear();
 		nextAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(6);
+		expect(onMonthSelected).toHaveBeenCalledTimes(1);
+		expect(onMonthSelected).toHaveBeenCalledWith(6);
 
 		// Advance previous case
 		wrapper.setProps({
 			monthIndexSelected: 0,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onMonthSelected.mockClear();
 		previousAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(11);
+		expect(onMonthSelected).toHaveBeenCalledTimes(1);
+		expect(onMonthSelected).toHaveBeenCalledWith(11);
 
 		// Advance next case
 		wrapper.setProps({
 			monthIndexSelected: 11,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onMonthSelected.mockClear();
 		nextAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(0);
+		expect(onMonthSelected).toHaveBeenCalledTimes(1);
+		expect(onMonthSelected).toHaveBeenCalledWith(0);
 	});
 
 	it('should callback with the year updated', () => {
-		const spy = jest.fn();
+		const onYearSelected = jest.fn();
 		const wrapper = shallow(<DateTimeView
 			monthIndexSelected={5}
 			yearSelected={2006}
-			onYearSelected={spy}
+			onYearSelected={onYearSelected}
 		/>);
 
 		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
@@ -98,38 +98,38 @@ describe('DateTimeView', () => {
 			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onYearSelected.mockClear();
 		previousAction.simulate('click');
-		expect(spy).not.toHaveBeenCalled();
+		expect(onYearSelected).not.toHaveBeenCalled();
 
 		// Simple next case
 		wrapper.setProps({
 			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onYearSelected.mockClear();
 		nextAction.simulate('click');
-		expect(spy).not.toHaveBeenCalled();
+		expect(onYearSelected).not.toHaveBeenCalled();
 
 		// Advance previous case
 		wrapper.setProps({
 			monthIndexSelected: 0,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onYearSelected.mockClear();
 		previousAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(2005);
+		expect(onYearSelected).toHaveBeenCalledTimes(1);
+		expect(onYearSelected).toHaveBeenCalledWith(2005);
 
 		// Advance next case
 		wrapper.setProps({
 			monthIndexSelected: 11,
 			yearSelected: 2006,
 		});
-		spy.mockClear();
+		onYearSelected.mockClear();
 		nextAction.simulate('click');
-		expect(spy).toHaveBeenCalledTimes(1);
-		expect(spy).toHaveBeenCalledWith(2007);
+		expect(onYearSelected).toHaveBeenCalledTimes(1);
+		expect(onYearSelected).toHaveBeenCalledWith(2007);
 	});
 });
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -28,7 +28,7 @@ describe('DateTimeView', () => {
 		expect(onTitleClick).toHaveBeenCalledTimes(1);
 	});
 
-	describe('should callback when switch month', () => {
+	describe('should callback when month switched with the new month index and year', () => {
 		function getActions(wrapper) {
 			return wrapper.find('ViewLayout').shallow().find('IconButton');
 		}
@@ -41,125 +41,75 @@ describe('DateTimeView', () => {
 			return getActions(wrapper).last();
 		}
 
-		describe('with the month index updated', () => {
-			it('in simple previous case', () => {
-				const onMonthSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={5}
-					yearSelected={2006}
-					onMonthSelected={onMonthSelected}
-				/>);
+		it('in simple previous case', () => {
+			const onMonthYearSelected = jest.fn();
+			const wrapper = shallow(<DateTimeView
+				monthIndexSelected={5}
+				yearSelected={2006}
+				onMonthYearSelected={onMonthYearSelected}
+			/>);
 
-				const previousAction = getPreviousAction(wrapper);
-				previousAction.simulate('click');
+			const previousAction = getPreviousAction(wrapper);
+			previousAction.simulate('click');
 
-				expect(onMonthSelected).toHaveBeenCalledTimes(1);
-				expect(onMonthSelected).toHaveBeenCalledWith(4);
-			});
-
-			it('in simple next case', () => {
-				const onMonthSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={5}
-					yearSelected={2006}
-					onMonthSelected={onMonthSelected}
-				/>);
-
-				const nextAction = getNextAction(wrapper);
-				nextAction.simulate('click');
-
-				expect(onMonthSelected).toHaveBeenCalledTimes(1);
-				expect(onMonthSelected).toHaveBeenCalledWith(6);
-			});
-
-			it('in advance previous case', () => {
-				const onMonthSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={0}
-					yearSelected={2006}
-					onMonthSelected={onMonthSelected}
-				/>);
-
-				const previousAction = getPreviousAction(wrapper);
-				previousAction.simulate('click');
-
-				expect(onMonthSelected).toHaveBeenCalledTimes(1);
-				expect(onMonthSelected).toHaveBeenCalledWith(11);
-			});
-
-			it('in advance next case', () => {
-				const onMonthSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={11}
-					yearSelected={2006}
-					onMonthSelected={onMonthSelected}
-				/>);
-
-				const nextAction = getNextAction(wrapper);
-				nextAction.simulate('click');
-
-				expect(onMonthSelected).toHaveBeenCalledTimes(1);
-				expect(onMonthSelected).toHaveBeenCalledWith(0);
+			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
+			expect(onMonthYearSelected).toHaveBeenCalledWith({
+				monthIndex: 4,
+				year: 2006,
 			});
 		});
 
-		describe('with the year updated if needed', () => {
-			it('in simple previous case', () => {
-				const onYearSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={5}
-					yearSelected={2006}
-					onYearSelected={onYearSelected}
-				/>);
+		it('in simple next case', () => {
+			const onMonthYearSelected = jest.fn();
+			const wrapper = shallow(<DateTimeView
+				monthIndexSelected={5}
+				yearSelected={2006}
+				onMonthYearSelected={onMonthYearSelected}
+			/>);
 
-				const previousAction = getPreviousAction(wrapper);
-				previousAction.simulate('click');
+			const nextAction = getNextAction(wrapper);
+			nextAction.simulate('click');
 
-				expect(onYearSelected).not.toHaveBeenCalled();
+			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
+			expect(onMonthYearSelected).toHaveBeenCalledWith({
+				monthIndex: 6,
+				year: 2006,
 			});
+		});
 
-			it('in simple next case', () => {
-				const onYearSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={5}
-					yearSelected={2006}
-					onYearSelected={onYearSelected}
-				/>);
+		it('in advance previous case', () => {
+			const onMonthYearSelected = jest.fn();
+			const wrapper = shallow(<DateTimeView
+				monthIndexSelected={0}
+				yearSelected={2006}
+				onMonthYearSelected={onMonthYearSelected}
+			/>);
 
-				const nextAction = getNextAction(wrapper);
-				nextAction.simulate('click');
+			const previousAction = getPreviousAction(wrapper);
+			previousAction.simulate('click');
 
-				expect(onYearSelected).not.toHaveBeenCalled();
+			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
+			expect(onMonthYearSelected).toHaveBeenCalledWith({
+				monthIndex: 11,
+				year: 2005,
 			});
+		});
 
-			it('in advance previous case', () => {
-				const onYearSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={0}
-					yearSelected={2006}
-					onYearSelected={onYearSelected}
-				/>);
+		it('in advance next case', () => {
+			const onMonthYearSelected = jest.fn();
+			const wrapper = shallow(<DateTimeView
+				monthIndexSelected={11}
+				yearSelected={2006}
+				onMonthYearSelected={onMonthYearSelected}
+			/>);
 
-				const previousAction = getPreviousAction(wrapper);
-				previousAction.simulate('click');
+			const nextAction = getNextAction(wrapper);
+			nextAction.simulate('click');
 
-				expect(onYearSelected).toHaveBeenCalledTimes(1);
-				expect(onYearSelected).toHaveBeenCalledWith(2005);
-			});
-
-			it('in advance next case', () => {
-				const onYearSelected = jest.fn();
-				const wrapper = shallow(<DateTimeView
-					monthIndexSelected={11}
-					yearSelected={2006}
-					onYearSelected={onYearSelected}
-				/>);
-
-				const nextAction = getNextAction(wrapper);
-				nextAction.simulate('click');
-
-				expect(onYearSelected).toHaveBeenCalledTimes(1);
-				expect(onYearSelected).toHaveBeenCalledWith(2007);
+			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
+			expect(onMonthYearSelected).toHaveBeenCalledWith({
+				monthIndex: 0,
+				year: 2007,
 			});
 		});
 	});

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -8,6 +8,8 @@ describe('DateTimeView', () => {
 		const wrapper = shallow(<DateTimeView
 			selectedMonthIndex={5}
 			selectedYear={2006}
+			onClickTitle={() => {}}
+			onSelectMonthYear={() => {}}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -19,6 +21,7 @@ describe('DateTimeView', () => {
 			selectedMonthIndex={5}
 			selectedYear={2006}
 			onClickTitle={onClickTitle}
+			onSelectMonthYear={() => {}}
 		/>);
 
 		const titleAction = wrapper
@@ -51,6 +54,7 @@ describe('DateTimeView', () => {
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={5}
 				selectedYear={2006}
+				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
@@ -70,6 +74,7 @@ describe('DateTimeView', () => {
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={5}
 				selectedYear={2006}
+				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
@@ -88,6 +93,7 @@ describe('DateTimeView', () => {
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={0}
 				selectedYear={2006}
+				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
@@ -106,6 +112,7 @@ describe('DateTimeView', () => {
 			const wrapper = shallow(<DateTimeView
 				selectedMonthIndex={11}
 				selectedYear={2006}
+				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 			/>);
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -25,7 +25,7 @@ describe('DateTimeView', () => {
 			.find('HeaderTitle').props().button.onClick;
 
 		headerClickFn();
-		expect(spy.mock.calls.length).toBe(1);
+		expect(spy).toHaveBeenCalledTimes(1);
 	});
 
 	it('should callback with the month index updated', () => {
@@ -47,8 +47,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(4);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(4);
 
 		// Simple next case
 		wrapper.setProps({
@@ -57,8 +57,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(6);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(6);
 
 		// Advance previous case
 		wrapper.setProps({
@@ -67,8 +67,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(11);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(11);
 
 		// Advance next case
 		wrapper.setProps({
@@ -77,8 +77,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(0);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(0);
 	});
 
 	it('should callback with the year updated', () => {
@@ -100,7 +100,7 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(0);
+		expect(spy).not.toHaveBeenCalled();
 
 		// Simple next case
 		wrapper.setProps({
@@ -109,7 +109,7 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(0);
+		expect(spy).not.toHaveBeenCalled();
 
 		// Advance previous case
 		wrapper.setProps({
@@ -118,8 +118,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(2005);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(2005);
 
 		// Advance next case
 		wrapper.setProps({
@@ -128,8 +128,8 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
-		expect(spy.mock.calls.length).toBe(1);
-		expect(spy.mock.calls[0][0]).toBe(2007);
+		expect(spy).toHaveBeenCalledTimes(1);
+		expect(spy).toHaveBeenCalledWith(2007);
 	});
 });
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -6,19 +6,19 @@ import DateTimeView, { euclideanModulo } from './DateTimeView.component';
 describe('DateTimeView', () => {
 	it('should render', () => {
 		const wrapper = shallow(<DateTimeView
-			monthIndexSelected={5}
-			yearSelected={2006}
+			selectedMonthIndex={5}
+			selectedYear={2006}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
 	it('should callback when title is clicked', () => {
-		const onTitleClick = jest.fn();
+		const onClickTitle = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			monthIndexSelected={5}
-			yearSelected={2006}
-			onTitleClick={onTitleClick}
+			selectedMonthIndex={5}
+			selectedYear={2006}
+			onClickTitle={onClickTitle}
 		/>);
 
 		const titleAction = wrapper
@@ -30,7 +30,7 @@ describe('DateTimeView', () => {
 			.find('button');
 
 		titleAction.simulate('click');
-		expect(onTitleClick).toHaveBeenCalledTimes(1);
+		expect(onClickTitle).toHaveBeenCalledTimes(1);
 	});
 
 	describe('should callback when month switched with the new month index and year', () => {
@@ -47,73 +47,73 @@ describe('DateTimeView', () => {
 		}
 
 		it('in simple previous case', () => {
-			const onMonthYearSelected = jest.fn();
+			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				monthIndexSelected={5}
-				yearSelected={2006}
-				onMonthYearSelected={onMonthYearSelected}
+				selectedMonthIndex={5}
+				selectedYear={2006}
+				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
 			const previousAction = getPreviousAction(wrapper);
 
 			previousAction.simulate('click');
 
-			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
-			expect(onMonthYearSelected).toHaveBeenCalledWith({
+			expect(onSelectMonthYear).toHaveBeenCalledTimes(1);
+			expect(onSelectMonthYear).toHaveBeenCalledWith({
 				monthIndex: 4,
 				year: 2006,
 			});
 		});
 
 		it('in simple next case', () => {
-			const onMonthYearSelected = jest.fn();
+			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				monthIndexSelected={5}
-				yearSelected={2006}
-				onMonthYearSelected={onMonthYearSelected}
+				selectedMonthIndex={5}
+				selectedYear={2006}
+				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
 			const nextAction = getNextAction(wrapper);
 			nextAction.simulate('click');
 
-			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
-			expect(onMonthYearSelected).toHaveBeenCalledWith({
+			expect(onSelectMonthYear).toHaveBeenCalledTimes(1);
+			expect(onSelectMonthYear).toHaveBeenCalledWith({
 				monthIndex: 6,
 				year: 2006,
 			});
 		});
 
 		it('in advance previous case', () => {
-			const onMonthYearSelected = jest.fn();
+			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				monthIndexSelected={0}
-				yearSelected={2006}
-				onMonthYearSelected={onMonthYearSelected}
+				selectedMonthIndex={0}
+				selectedYear={2006}
+				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
 			const previousAction = getPreviousAction(wrapper);
 			previousAction.simulate('click');
 
-			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
-			expect(onMonthYearSelected).toHaveBeenCalledWith({
+			expect(onSelectMonthYear).toHaveBeenCalledTimes(1);
+			expect(onSelectMonthYear).toHaveBeenCalledWith({
 				monthIndex: 11,
 				year: 2005,
 			});
 		});
 
 		it('in advance next case', () => {
-			const onMonthYearSelected = jest.fn();
+			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				monthIndexSelected={11}
-				yearSelected={2006}
-				onMonthYearSelected={onMonthYearSelected}
+				selectedMonthIndex={11}
+				selectedYear={2006}
+				onSelectMonthYear={onSelectMonthYear}
 			/>);
 
 			const nextAction = getNextAction(wrapper);
 			nextAction.simulate('click');
 
-			expect(onMonthYearSelected).toHaveBeenCalledTimes(1);
-			expect(onMonthYearSelected).toHaveBeenCalledWith({
+			expect(onSelectMonthYear).toHaveBeenCalledTimes(1);
+			expect(onSelectMonthYear).toHaveBeenCalledWith({
 				monthIndex: 0,
 				year: 2007,
 			});

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -13,7 +13,22 @@ describe('DateTimeView', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should callback with the new month index selected', () => {
+	it('should callback when title is clicked', () => {
+		const spy = jest.fn();
+		const wrapper = shallow(<DateTimeView
+			monthSelected={5}
+			yearSelected={2006}
+			onTitleClick={spy}
+		/>);
+
+		const headerClickFn = wrapper.find('ViewLayout').shallow()
+			.find('HeaderTitle').props().button.onClick;
+
+		headerClickFn();
+		expect(spy.mock.calls.length).toBe(1);
+	});
+
+	it('should callback with the month index updated', () => {
 		const spy = jest.fn();
 		const wrapper = shallow(<DateTimeView
 			monthSelected={5}
@@ -32,6 +47,7 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
 		expect(spy.mock.calls[0][0]).toBe(4);
 
 		// Simple next case
@@ -41,6 +57,7 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
 		expect(spy.mock.calls[0][0]).toBe(6);
 
 		// Advance previous case
@@ -50,6 +67,7 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		previousAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
 		expect(spy.mock.calls[0][0]).toBe(11);
 
 		// Advance next case
@@ -59,10 +77,11 @@ describe('DateTimeView', () => {
 		});
 		spy.mockClear();
 		nextAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
 		expect(spy.mock.calls[0][0]).toBe(0);
 	});
 
-	it('should callback with the new year selected if changed', () => {
+	it('should callback with the year updated', () => {
 		const spy = jest.fn();
 		const wrapper = shallow(<DateTimeView
 			monthSelected={5}

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import DateTimeView from './DateTimeView.component';
+import DateTimeView, { euclideanModulo } from './DateTimeView.component';
 
 describe('DateTimeView', () => {
 	it('should render', () => {
@@ -111,5 +111,27 @@ describe('DateTimeView', () => {
 		nextAction.simulate('click');
 		expect(spy.mock.calls.length).toBe(1);
 		expect(spy.mock.calls[0][0]).toBe(2007);
+	});
+});
+
+describe('euclideanModulo', () => {
+	it('should give a positive modulo whatever the input', () => {
+		// Dividend lower than divisor (for absolute values)
+		expect(euclideanModulo(5, 12)).toBe(5);
+		expect(euclideanModulo(-7, 18)).toBe(11);
+		expect(euclideanModulo(-4, -7)).toBe(3);
+		expect(euclideanModulo(13, -527)).toBe(13);
+
+		// Dividend greater than divisor (for absolute values)
+		expect(euclideanModulo(12, 5)).toBe(2);
+		expect(euclideanModulo(-527, 13)).toBe(6);
+		expect(euclideanModulo(-7, -4)).toBe(1);
+		expect(euclideanModulo(18, -7)).toBe(4);
+
+		// Dividend equal than divisor (for absolute values)
+		expect(euclideanModulo(12, 12)).toBe(0);
+		expect(euclideanModulo(-527, 527)).toBe(0);
+		expect(euclideanModulo(-7, -7)).toBe(0);
+		expect(euclideanModulo(18, -18)).toBe(0);
 	});
 });

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -6,7 +6,7 @@ import DateTimeView, { euclideanModulo } from './DateTimeView.component';
 describe('DateTimeView', () => {
 	it('should render', () => {
 		const wrapper = shallow(<DateTimeView
-			monthSelected={5}
+			monthIndexSelected={5}
 			yearSelected={2006}
 		/>);
 
@@ -16,7 +16,7 @@ describe('DateTimeView', () => {
 	it('should callback when title is clicked', () => {
 		const spy = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			monthSelected={5}
+			monthIndexSelected={5}
 			yearSelected={2006}
 			onTitleClick={spy}
 		/>);
@@ -31,7 +31,7 @@ describe('DateTimeView', () => {
 	it('should callback with the month index updated', () => {
 		const spy = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			monthSelected={5}
+			monthIndexSelected={5}
 			yearSelected={2006}
 			onMonthSelected={spy}
 		/>);
@@ -42,7 +42,7 @@ describe('DateTimeView', () => {
 
 		// Simple previous case
 		wrapper.setProps({
-			monthSelected: 5,
+			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -52,7 +52,7 @@ describe('DateTimeView', () => {
 
 		// Simple next case
 		wrapper.setProps({
-			monthSelected: 5,
+			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -62,7 +62,7 @@ describe('DateTimeView', () => {
 
 		// Advance previous case
 		wrapper.setProps({
-			monthSelected: 0,
+			monthIndexSelected: 0,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -72,7 +72,7 @@ describe('DateTimeView', () => {
 
 		// Advance next case
 		wrapper.setProps({
-			monthSelected: 11,
+			monthIndexSelected: 11,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -84,7 +84,7 @@ describe('DateTimeView', () => {
 	it('should callback with the year updated', () => {
 		const spy = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			monthSelected={5}
+			monthIndexSelected={5}
 			yearSelected={2006}
 			onYearSelected={spy}
 		/>);
@@ -95,7 +95,7 @@ describe('DateTimeView', () => {
 
 		// Simple previous case
 		wrapper.setProps({
-			monthSelected: 5,
+			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -104,7 +104,7 @@ describe('DateTimeView', () => {
 
 		// Simple next case
 		wrapper.setProps({
-			monthSelected: 5,
+			monthIndexSelected: 5,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -113,7 +113,7 @@ describe('DateTimeView', () => {
 
 		// Advance previous case
 		wrapper.setProps({
-			monthSelected: 0,
+			monthIndexSelected: 0,
 			yearSelected: 2006,
 		});
 		spy.mockClear();
@@ -123,7 +123,7 @@ describe('DateTimeView', () => {
 
 		// Advance next case
 		wrapper.setProps({
-			monthSelected: 11,
+			monthIndexSelected: 11,
 			yearSelected: 2006,
 		});
 		spy.mockClear();

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -6,7 +6,10 @@ import DateTimeView from './DateTimeView.component';
 describe('DateTimeView', () => {
 	it('should render a DateTimeView', () => {
 		// when
-		const wrapper = shallow(<DateTimeView />);
+		const wrapper = shallow(<DateTimeView
+			monthSelected={5}
+			yearSelected={2006}
+		/>);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -4,14 +4,112 @@ import { shallow } from 'enzyme';
 import DateTimeView from './DateTimeView.component';
 
 describe('DateTimeView', () => {
-	it('should render a DateTimeView', () => {
-		// when
+	it('should render', () => {
 		const wrapper = shallow(<DateTimeView
 			monthSelected={5}
 			yearSelected={2006}
 		/>);
 
-		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should callback with the new month index selected', () => {
+		const spy = jest.fn();
+		const wrapper = shallow(<DateTimeView
+			monthSelected={5}
+			yearSelected={2006}
+			onMonthSelected={spy}
+		/>);
+
+		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
+		const previousAction = monthActions.first();
+		const nextAction = monthActions.last();
+
+		// Simple previous case
+		wrapper.setProps({
+			monthSelected: 5,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		previousAction.simulate('click');
+		expect(spy.mock.calls[0][0]).toBe(4);
+
+		// Simple next case
+		wrapper.setProps({
+			monthSelected: 5,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		nextAction.simulate('click');
+		expect(spy.mock.calls[0][0]).toBe(6);
+
+		// Advance previous case
+		wrapper.setProps({
+			monthSelected: 0,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		previousAction.simulate('click');
+		expect(spy.mock.calls[0][0]).toBe(11);
+
+		// Advance next case
+		wrapper.setProps({
+			monthSelected: 11,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		nextAction.simulate('click');
+		expect(spy.mock.calls[0][0]).toBe(0);
+	});
+
+	it('should callback with the new year selected if changed', () => {
+		const spy = jest.fn();
+		const wrapper = shallow(<DateTimeView
+			monthSelected={5}
+			yearSelected={2006}
+			onYearSelected={spy}
+		/>);
+
+		const monthActions = wrapper.find('ViewLayout').shallow().find('IconButton');
+		const previousAction = monthActions.first();
+		const nextAction = monthActions.last();
+
+		// Simple previous case
+		wrapper.setProps({
+			monthSelected: 5,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		previousAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(0);
+
+		// Simple next case
+		wrapper.setProps({
+			monthSelected: 5,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		nextAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(0);
+
+		// Advance previous case
+		wrapper.setProps({
+			monthSelected: 0,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		previousAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
+		expect(spy.mock.calls[0][0]).toBe(2005);
+
+		// Advance next case
+		wrapper.setProps({
+			monthSelected: 11,
+			yearSelected: 2006,
+		});
+		spy.mockClear();
+		nextAction.simulate('click');
+		expect(spy.mock.calls.length).toBe(1);
+		expect(spy.mock.calls[0][0]).toBe(2007);
 	});
 });

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -31,7 +31,7 @@ exports[`DateTimeView should render 1`] = `
         button={
             Object {
                 "aria-label": "Switch to month and year pickers view",
-                "onClick": undefined,
+                "onClick": [Function],
               }
         }
         monthIndex={5}

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -30,6 +30,7 @@ exports[`DateTimeView should render a DateTimeView 1`] = `
         button={
             Object {
                 "aria-label": "Switch to month and year pickers view",
+                "onClick": undefined,
               }
         }
         label="Septembre 2017"

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -33,7 +33,8 @@ exports[`DateTimeView should render a DateTimeView 1`] = `
                 "onClick": undefined,
               }
         }
-        label="Septembre 2017"
+        month={8}
+        year={2017}
     />,
       "rightElement": <IconButton
         aria-label="Display next calendar month"

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`DateTimeView should render a DateTimeView 1`] = `
+exports[`DateTimeView should render 1`] = `
 <ViewLayout
   bodyElement={
     <div
@@ -25,6 +25,7 @@ exports[`DateTimeView should render a DateTimeView 1`] = `
                 "name": "talend-chevron-left",
               }
         }
+        onClick={[Function]}
     />,
       "middleElement": <HeaderTitle
         button={
@@ -44,6 +45,7 @@ exports[`DateTimeView should render a DateTimeView 1`] = `
                 "transform": "rotate-180",
               }
         }
+        onClick={[Function]}
     />,
     }
   }

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -34,7 +34,7 @@ exports[`DateTimeView should render 1`] = `
                 "onClick": undefined,
               }
         }
-        month={5}
+        monthIndex={5}
         year={2006}
     />,
       "rightElement": <IconButton

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -33,8 +33,8 @@ exports[`DateTimeView should render a DateTimeView 1`] = `
                 "onClick": undefined,
               }
         }
-        month={8}
-        year={2017}
+        month={5}
+        year={2006}
     />,
       "rightElement": <IconButton
         aria-label="Display next calendar month"

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -25,11 +25,9 @@ function HeaderTitle(props) {
 	const date = setYear(setMonth(new Date(0), props.monthIndex), props.year);
 	const label = format(date, 'MMMM YYYY');
 
-	const element = isButton
+	return isButton
 		? <button type="button" {... propsToSpread}>{label}</button>
 		: <span {...propsToSpread}>{label}</span>;
-
-	return element;
 }
 
 HeaderTitle.propTypes = {

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import setYear from 'date-fns/set_year';
+import setMonth from 'date-fns/set_month';
+import format from 'date-fns/format';
 import theme from './HeaderTitle.scss';
 
 function HeaderTitle(props) {
@@ -19,16 +22,20 @@ function HeaderTitle(props) {
 		...(isButton ? props.button : {}),
 	};
 
+	const date = setYear(setMonth(new Date(0), props.month), props.year);
+	const label = format(date, 'MMMM YYYY');
+
 	const element = isButton
-		? <button {... propsToSpread}>{props.label}</button>
-		: <span {...propsToSpread}>{props.label}</span>;
+		? <button {... propsToSpread}>{label}</button>
+		: <span {...propsToSpread}>{label}</span>;
 
 	return element;
 }
 
 HeaderTitle.propTypes = {
+	month: PropTypes.number.isRequired,
+	year: PropTypes.number.isRequired,
 	button: PropTypes.object,
-	label: PropTypes.string,
 	className: PropTypes.string,
 };
 

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -22,7 +22,7 @@ function HeaderTitle(props) {
 		...(isButton ? props.button : {}),
 	};
 
-	const date = setYear(setMonth(new Date(0), props.month), props.year);
+	const date = setYear(setMonth(new Date(0), props.monthIndex), props.year);
 	const label = format(date, 'MMMM YYYY');
 
 	const element = isButton
@@ -33,7 +33,7 @@ function HeaderTitle(props) {
 }
 
 HeaderTitle.propTypes = {
-	month: PropTypes.number.isRequired,
+	monthIndex: PropTypes.number.isRequired,
 	year: PropTypes.number.isRequired,
 	button: PropTypes.object,
 	className: PropTypes.string,

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -26,7 +26,7 @@ function HeaderTitle(props) {
 	const label = format(date, 'MMMM YYYY');
 
 	const element = isButton
-		? <button {... propsToSpread}>{label}</button>
+		? <button type="button" {... propsToSpread}>{label}</button>
 		: <span {...propsToSpread}>{label}</span>;
 
 	return element;

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.test.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.test.js
@@ -7,7 +7,10 @@ describe('HeaderTitle', () => {
 	it('should render a span', () => {
 		// When
 		const wrapper = shallow(
-			<HeaderTitle />
+			<HeaderTitle
+				month={8}
+				year={2012}
+			/>
 		);
 
 		// Then
@@ -18,11 +21,34 @@ describe('HeaderTitle', () => {
 	it('should render a button', () => {
 		// When
 		const wrapper = shallow(
-			<HeaderTitle button={{ whateverButtonProp: 'whateverValue' }} />
+			<HeaderTitle
+				month={8}
+				year={2012}
+				button={{ whateverButtonProp: 'whateverValue' }}
+			/>
 		);
 
 		// Then
 		expect(wrapper.name()).toEqual('button');
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render the correct date and format', () => {
+		const wrapperSpan = shallow(
+			<HeaderTitle
+				month={2}
+				year={2001}
+			/>
+		);
+		const wrapperButton = shallow(
+			<HeaderTitle
+				month={11}
+				year={2002}
+				button={{ whateverButtonProp: 'whateverValue' }}
+			/>
+		);
+
+		expect(wrapperSpan.text()).toBe('March 2001');
+		expect(wrapperButton.text()).toBe('December 2002');
 	});
 });

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.test.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.test.js
@@ -8,7 +8,7 @@ describe('HeaderTitle', () => {
 		// When
 		const wrapper = shallow(
 			<HeaderTitle
-				month={8}
+				monthIndex={8}
 				year={2012}
 			/>
 		);
@@ -22,7 +22,7 @@ describe('HeaderTitle', () => {
 		// When
 		const wrapper = shallow(
 			<HeaderTitle
-				month={8}
+				monthIndex={8}
 				year={2012}
 				button={{ whateverButtonProp: 'whateverValue' }}
 			/>
@@ -36,15 +36,14 @@ describe('HeaderTitle', () => {
 	it('should render the correct date and format', () => {
 		const wrapperSpan = shallow(
 			<HeaderTitle
-				month={2}
+				monthIndex={2}
 				year={2001}
 			/>
 		);
 		const wrapperButton = shallow(
 			<HeaderTitle
-				month={11}
+				monthIndex={11}
 				year={2002}
-				button={{ whateverButtonProp: 'whateverValue' }}
 			/>
 		);
 

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
@@ -4,11 +4,15 @@ exports[`HeaderTitle should render a button 1`] = `
 <button
   className="theme-common theme-button"
   whateverButtonProp="whateverValue"
-/>
+>
+  September 2012
+</button>
 `;
 
 exports[`HeaderTitle should render a span 1`] = `
 <span
   className="theme-common"
-/>
+>
+  September 2012
+</span>
 `;

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
@@ -3,6 +3,7 @@
 exports[`HeaderTitle should render a button 1`] = `
 <button
   className="theme-common theme-button"
+  type="button"
   whateverButtonProp="whateverValue"
 >
   September 2012

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -52,9 +52,9 @@ function MonthYearView(props) {
 MonthYearView.propTypes = {
 	selectedMonthIndex: PropTypes.number.isRequired,
 	selectedYear: PropTypes.number.isRequired,
-	onClickBack: PropTypes.func,
-	onSelectMonth: PropTypes.func,
-	onSelectYear: PropTypes.func,
+	onClickBack: PropTypes.func.isRequired,
+	onSelectMonth: PropTypes.func.isRequired,
+	onSelectYear: PropTypes.func.isRequired,
 };
 
 export default MonthYearView;

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -16,11 +16,11 @@ function MonthYearView(props) {
 			}}
 			className={theme['action-left']}
 			aria-label="Switch back to date and time pickers view"
-			onClick={props.onBackClick}
+			onClick={props.onClickBack}
 		/>,
 		middleElement: <HeaderTitle
-			monthIndex={props.monthIndexSelected}
-			year={props.yearSelected}
+			monthIndex={props.selectedMonthIndex}
+			year={props.selectedYear}
 		/>,
 	};
 
@@ -28,14 +28,14 @@ function MonthYearView(props) {
 		<div className={theme.body}>
 			<div className={theme.month}>
 				<MonthPicker
-					monthIndexSelected={props.monthIndexSelected}
-					onMonthSelected={props.onMonthSelected}
+					selectedMonthIndex={props.selectedMonthIndex}
+					onSelect={props.onSelectMonth}
 				/>
 			</div>
 			<div className={theme.year}>
 				<YearPicker
-					yearSelected={props.yearSelected}
-					onYearSelected={props.onYearSelected}
+					selectedYear={props.selectedYear}
+					onSelect={props.onSelectYear}
 				/>
 			</div>
 		</div>
@@ -50,11 +50,11 @@ function MonthYearView(props) {
 }
 
 MonthYearView.propTypes = {
-	monthIndexSelected: PropTypes.number.isRequired,
-	yearSelected: PropTypes.number.isRequired,
-	onBackClick: PropTypes.func,
-	onMonthSelected: PropTypes.func,
-	onYearSelected: PropTypes.func,
+	selectedMonthIndex: PropTypes.number.isRequired,
+	selectedYear: PropTypes.number.isRequired,
+	onClickBack: PropTypes.func,
+	onSelectMonth: PropTypes.func,
+	onSelectYear: PropTypes.func,
 };
 
 export default MonthYearView;

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -7,53 +7,46 @@ import ViewLayout from '../ViewLayout';
 import IconButton from '../../IconButton';
 import HeaderTitle from '../HeaderTitle';
 
-class MonthYearView extends React.Component {
+function MonthYearView(props) {
+	const header = {
+		leftElement: <IconButton
+			icon={{
+				name: 'talend-arrow-left',
+				className: theme['action-left-icon'],
+			}}
+			className={theme['action-left']}
+			aria-label="Switch back to date and time pickers view"
+			onClick={props.onBackClick}
+		/>,
+		middleElement: <HeaderTitle
+			monthIndex={props.monthIndexSelected}
+			year={props.yearSelected}
+		/>,
+	};
 
-	constructor(props) {
-		super(props);
-	}
-
-	render() {
-		const header = {
-			leftElement: <IconButton
-				icon={{
-					name: 'talend-arrow-left',
-					className: theme['action-left-icon'],
-				}}
-				className={theme['action-left']}
-				aria-label="Switch back to date and time pickers view"
-				onClick={this.props.onBackClick}
-			/>,
-			middleElement: <HeaderTitle
-				monthIndex={this.props.monthIndexSelected}
-				year={this.props.yearSelected}
-			/>,
-		};
-
-		const bodyElement = (
-			<div className={theme.body}>
-				<div className={theme.month}>
-					<MonthPicker
-						monthIndexSelected={this.props.monthIndexSelected}
-						onMonthSelected={this.props.onMonthSelected}
-					/>
-				</div>
-				<div className={theme.year}>
-					<YearPicker
-						yearSelected={this.props.yearSelected}
-						onYearSelected={this.props.onYearSelected}
-					/>
-				</div>
+	const bodyElement = (
+		<div className={theme.body}>
+			<div className={theme.month}>
+				<MonthPicker
+					monthIndexSelected={props.monthIndexSelected}
+					onMonthSelected={props.onMonthSelected}
+				/>
 			</div>
-		);
+			<div className={theme.year}>
+				<YearPicker
+					yearSelected={props.yearSelected}
+					onYearSelected={props.onYearSelected}
+				/>
+			</div>
+		</div>
+	);
 
-		return (
-			<ViewLayout
-				header={header}
-				bodyElement={bodyElement}
-			/>
-		);
-	}
+	return (
+		<ViewLayout
+			header={header}
+			bodyElement={bodyElement}
+		/>
+	);
 }
 
 MonthYearView.propTypes = {

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -25,7 +25,8 @@ class MonthYearView extends React.Component {
 				onClick={this.props.onBackClick}
 			/>,
 			middleElement: <HeaderTitle
-				label="Septembre 2017"
+				month={8}
+				year={2017}
 			/>,
 		};
 

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -7,39 +7,56 @@ import ViewLayout from '../ViewLayout';
 import IconButton from '../../IconButton';
 import HeaderTitle from '../HeaderTitle';
 
-function MonthYearView(props) {
-	const header = {
-		leftElement: <IconButton
-			icon={{
-				name: 'talend-arrow-left',
-				className: theme['action-left-icon'],
-			}}
-			className={theme['action-left']}
-			aria-label="Switch back to date and time pickers view"
-			onClick={props.onBackClick}
-		/>,
-		middleElement: <HeaderTitle
-			label="Septembre 2017"
-		/>,
-	};
+class MonthYearView extends React.Component {
 
-	const bodyElement = (
-		<div className={theme.body}>
-			<div className={theme.month}>
-				<MonthPicker />
-			</div>
-			<div className={theme.year}>
-				<YearPicker />
-			</div>
-		</div>
-	);
+	constructor(props) {
+		super(props);
 
-	return (
-		<ViewLayout
-			header={header}
-			bodyElement={bodyElement}
-		/>
-	);
+		this.onMonthSelected = this.onMonthSelected.bind(this);
+	}
+
+	onMonthSelected(index) {
+		console.log(index);
+	}
+
+	render() {
+		const header = {
+			leftElement: <IconButton
+				icon={{
+					name: 'talend-arrow-left',
+					className: theme['action-left-icon'],
+				}}
+				className={theme['action-left']}
+				aria-label="Switch back to date and time pickers view"
+				onClick={this.props.onBackClick}
+			/>,
+			middleElement: <HeaderTitle
+				label="Septembre 2017"
+			/>,
+		};
+
+
+		const bodyElement = (
+			<div className={theme.body}>
+				<div className={theme.month}>
+					<MonthPicker
+						currentMonth={8}
+						onMonthSelected={this.onMonthSelected}
+					/>
+				</div>
+				<div className={theme.year}>
+					<YearPicker />
+				</div>
+			</div>
+		);
+
+		return (
+			<ViewLayout
+				header={header}
+				bodyElement={bodyElement}
+			/>
+		);
+	}
 }
 
 MonthYearView.propTypes = {

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -11,17 +11,6 @@ class MonthYearView extends React.Component {
 
 	constructor(props) {
 		super(props);
-
-		this.onMonthSelected = this.onMonthSelected.bind(this);
-		this.onYearSelected = this.onYearSelected.bind(this);
-	}
-
-	onMonthSelected(index) {
-		console.log(index);
-	}
-
-	onYearSelected(year) {
-		console.log(year);
 	}
 
 	render() {
@@ -45,14 +34,14 @@ class MonthYearView extends React.Component {
 			<div className={theme.body}>
 				<div className={theme.month}>
 					<MonthPicker
-						currentMonth={8}
-						onMonthSelected={this.onMonthSelected}
+						currentMonth={this.props.monthSelected}
+						onMonthSelected={this.props.onMonthSelected}
 					/>
 				</div>
 				<div className={theme.year}>
 					<YearPicker
-						currentYear={2012}
-						onYearSelected={this.onYearSelected}
+						currentYear={this.props.yearSelected}
+						onYearSelected={this.props.onYearSelected}
 					/>
 				</div>
 			</div>
@@ -69,6 +58,10 @@ class MonthYearView extends React.Component {
 
 MonthYearView.propTypes = {
 	onBackClick: PropTypes.func,
+	monthSelected: PropTypes.number,
+	yearSelected: PropTypes.number,
+	onMonthSelected: PropTypes.func,
+	onYearSelected: PropTypes.func,
 };
 
 export default MonthYearView;

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -34,13 +34,13 @@ class MonthYearView extends React.Component {
 			<div className={theme.body}>
 				<div className={theme.month}>
 					<MonthPicker
-						currentMonth={this.props.monthSelected}
+						monthSelected={this.props.monthSelected}
 						onMonthSelected={this.props.onMonthSelected}
 					/>
 				</div>
 				<div className={theme.year}>
 					<YearPicker
-						currentYear={this.props.yearSelected}
+						yearSelected={this.props.yearSelected}
 						onYearSelected={this.props.onYearSelected}
 					/>
 				</div>

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -25,7 +25,7 @@ class MonthYearView extends React.Component {
 				onClick={this.props.onBackClick}
 			/>,
 			middleElement: <HeaderTitle
-				month={this.props.monthSelected}
+				monthIndex={this.props.monthIndexSelected}
 				year={this.props.yearSelected}
 			/>,
 		};
@@ -34,7 +34,7 @@ class MonthYearView extends React.Component {
 			<div className={theme.body}>
 				<div className={theme.month}>
 					<MonthPicker
-						monthSelected={this.props.monthSelected}
+						monthIndexSelected={this.props.monthIndexSelected}
 						onMonthSelected={this.props.onMonthSelected}
 					/>
 				</div>
@@ -57,9 +57,9 @@ class MonthYearView extends React.Component {
 }
 
 MonthYearView.propTypes = {
-	onBackClick: PropTypes.func,
-	monthSelected: PropTypes.number.isRequired,
+	monthIndexSelected: PropTypes.number.isRequired,
 	yearSelected: PropTypes.number.isRequired,
+	onBackClick: PropTypes.func,
 	onMonthSelected: PropTypes.func,
 	onYearSelected: PropTypes.func,
 };

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -25,11 +25,10 @@ class MonthYearView extends React.Component {
 				onClick={this.props.onBackClick}
 			/>,
 			middleElement: <HeaderTitle
-				month={8}
-				year={2017}
+				month={this.props.monthSelected}
+				year={this.props.yearSelected}
 			/>,
 		};
-
 
 		const bodyElement = (
 			<div className={theme.body}>
@@ -59,8 +58,8 @@ class MonthYearView extends React.Component {
 
 MonthYearView.propTypes = {
 	onBackClick: PropTypes.func,
-	monthSelected: PropTypes.number,
-	yearSelected: PropTypes.number,
+	monthSelected: PropTypes.number.isRequired,
+	yearSelected: PropTypes.number.isRequired,
 	onMonthSelected: PropTypes.func,
 	onYearSelected: PropTypes.func,
 };

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -13,10 +13,15 @@ class MonthYearView extends React.Component {
 		super(props);
 
 		this.onMonthSelected = this.onMonthSelected.bind(this);
+		this.onYearSelected = this.onYearSelected.bind(this);
 	}
 
 	onMonthSelected(index) {
 		console.log(index);
+	}
+
+	onYearSelected(year) {
+		console.log(year);
 	}
 
 	render() {
@@ -45,7 +50,10 @@ class MonthYearView extends React.Component {
 					/>
 				</div>
 				<div className={theme.year}>
-					<YearPicker />
+					<YearPicker
+						currentYear={2012}
+						onYearSelected={this.onYearSelected}
+					/>
 				</div>
 			</div>
 		);

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.component.js
@@ -16,6 +16,7 @@ function MonthYearView(props) {
 			}}
 			className={theme['action-left']}
 			aria-label="Switch back to date and time pickers view"
+			onClick={props.onBackClick}
 		/>,
 		middleElement: <HeaderTitle
 			label="Septembre 2017"
@@ -42,6 +43,7 @@ function MonthYearView(props) {
 }
 
 MonthYearView.propTypes = {
+	onBackClick: PropTypes.func,
 };
 
 export default MonthYearView;

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
@@ -7,8 +7,8 @@ describe('MonthYearView', () => {
 	it('should render a MonthYearView', () => {
 		// when
 		const wrapper = shallow(<MonthYearView
-			monthIndexSelected={8}
-			yearSelected={2012}
+			selectedMonthIndex={8}
+			selectedYear={2012}
 		/>);
 
 		// then

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
@@ -9,6 +9,9 @@ describe('MonthYearView', () => {
 		const wrapper = shallow(<MonthYearView
 			selectedMonthIndex={8}
 			selectedYear={2012}
+			onClickBack={() => {}}
+			onSelectMonth={() => {}}
+			onSelectYear={() => {}}
 		/>);
 
 		// then

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
@@ -7,7 +7,7 @@ describe('MonthYearView', () => {
 	it('should render a MonthYearView', () => {
 		// when
 		const wrapper = shallow(<MonthYearView
-			monthSelected={8}
+			monthIndexSelected={8}
 			yearSelected={2012}
 		/>);
 

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
@@ -6,7 +6,13 @@ import MonthYearView from './MonthYearView.component';
 describe('MonthYearView', () => {
 	it('should render a MonthYearView', () => {
 		// when
-		const wrapper = shallow(<MonthYearView />);
+		const wrapper = shallow(<MonthYearView
+			onBackClick={() => {}}
+			monthSelected={8}
+			yearSelected={2012}
+			onMonthSelected={() => {}}
+			onYearSelected={() => {}}
+		/>);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/MonthYearView.test.js
@@ -7,11 +7,8 @@ describe('MonthYearView', () => {
 	it('should render a MonthYearView', () => {
 		// when
 		const wrapper = shallow(<MonthYearView
-			onBackClick={() => {}}
 			monthSelected={8}
 			yearSelected={2012}
-			onMonthSelected={() => {}}
-			onYearSelected={() => {}}
 		/>);
 
 		// then

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -10,7 +10,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-month"
       >
         <MonthPicker
-          onSelect={undefined}
+          onSelect={[Function]}
           selectedMonthIndex={8}
         />
       </div>
@@ -18,7 +18,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-year"
       >
         <YearPicker
-          onSelect={undefined}
+          onSelect={[Function]}
           selectedYear={2012}
         />
       </div>
@@ -35,7 +35,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
                 "name": "talend-arrow-left",
               }
         }
-        onClick={undefined}
+        onClick={[Function]}
     />,
       "middleElement": <HeaderTitle
         monthIndex={8}

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -10,16 +10,16 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-month"
       >
         <MonthPicker
-          monthIndexSelected={8}
-          onMonthSelected={undefined}
+          onSelectMonth={undefined}
+          selectedMonthIndex={8}
         />
       </div>
       <div
         className="theme-year"
       >
         <YearPicker
-          onYearSelected={undefined}
-          yearSelected={2012}
+          onSelect={undefined}
+          selectedYear={2012}
         />
       </div>
     </div>

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -10,7 +10,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-month"
       >
         <MonthPicker
-          onSelectMonth={undefined}
+          onSelect={undefined}
           selectedMonthIndex={8}
         />
       </div>

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -10,7 +10,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-month"
       >
         <MonthPicker
-          currentMonth={8}
+          monthSelected={8}
           onMonthSelected={[Function]}
         />
       </div>
@@ -18,7 +18,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-year"
       >
         <YearPicker
-          currentYear={2012}
+          yearSelected={2012}
           onYearSelected={[Function]}
         />
       </div>

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -17,7 +17,10 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
       <div
         className="theme-year"
       >
-        <YearPicker />
+        <YearPicker
+          currentYear={2012}
+          onYearSelected={[Function]}
+        />
       </div>
     </div>
   }

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -11,14 +11,14 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
       >
         <MonthPicker
           monthSelected={8}
-          onMonthSelected={[Function]}
+          onMonthSelected={undefined}
         />
       </div>
       <div
         className="theme-year"
       >
         <YearPicker
-          onYearSelected={[Function]}
+          onYearSelected={undefined}
           yearSelected={2012}
         />
       </div>
@@ -35,11 +35,11 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
                 "name": "talend-arrow-left",
               }
         }
-        onClick={[Function]}
+        onClick={undefined}
     />,
       "middleElement": <HeaderTitle
         month={8}
-        year={2017}
+        year={2012}
     />,
     }
   }

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -9,7 +9,10 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
       <div
         className="theme-month"
       >
-        <MonthPicker />
+        <MonthPicker
+          currentMonth={8}
+          onMonthSelected={[Function]}
+        />
       </div>
       <div
         className="theme-year"
@@ -29,6 +32,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
                 "name": "talend-arrow-left",
               }
         }
+        onClick={undefined}
     />,
       "middleElement": <HeaderTitle
         label="Septembre 2017"

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -18,8 +18,8 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-year"
       >
         <YearPicker
-          yearSelected={2012}
           onYearSelected={[Function]}
+          yearSelected={2012}
         />
       </div>
     </div>

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -38,7 +38,8 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         onClick={[Function]}
     />,
       "middleElement": <HeaderTitle
-        label="Septembre 2017"
+        month={8}
+        year={2017}
     />,
     }
   }

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -10,7 +10,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         className="theme-month"
       >
         <MonthPicker
-          monthSelected={8}
+          monthIndexSelected={8}
           onMonthSelected={undefined}
         />
       </div>
@@ -38,7 +38,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
         onClick={undefined}
     />,
       "middleElement": <HeaderTitle
-        month={8}
+        monthIndex={8}
         year={2012}
     />,
     }

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -35,7 +35,7 @@ exports[`MonthYearView should render a MonthYearView 1`] = `
                 "name": "talend-arrow-left",
               }
         }
-        onClick={undefined}
+        onClick={[Function]}
     />,
       "middleElement": <HeaderTitle
         label="Septembre 2017"

--- a/packages/components/stories/DateTimePicker.js
+++ b/packages/components/stories/DateTimePicker.js
@@ -6,10 +6,17 @@ import DateTimePicker from '../src/DateTimePickers';
 
 
 storiesOf('DateTimePicker', module)
-	.add('Full DateTimePicker structure', () => (
+	.add('Full DateTimePicker', () => (
 		<div>
-			<h1>DateTimePicker structure</h1>
+			<h1>DateTimePicker</h1>
 			<IconsProvider />
+			<ul>
+				<li>Width is defined by the parent (here fixed to 320px) but is responsive </li>
+				<li>Height is responsive relatively to the default font-size</li>
+				<li>The outer border style (black) is here just as visual
+					shape indication, it's not part of the component rendered</li>
+			</ul>
+
 			<div style={{ width: '320px', border: '1px solid black' }}>
 				<DateTimePicker />
 			</div>

--- a/packages/components/stories/DateTimePicker.js
+++ b/packages/components/stories/DateTimePicker.js
@@ -13,7 +13,7 @@ storiesOf('DateTimePicker', module)
 		<div>
 			<h1>DateTimePicker structure</h1>
 			<IconsProvider />
-			<div style={{ width: '320px' }}>
+			<div style={{ width: '320px', border: '1px solid black' }}>
 				<DateTimePicker />
 			</div>
 		</div>

--- a/packages/components/stories/DateTimePicker.js
+++ b/packages/components/stories/DateTimePicker.js
@@ -2,10 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { IconsProvider } from '../src/index';
 
-import DateTimePicker, {
-	DateTimeView,
-	MonthYearView,
-} from '../src/DateTimePickers';
+import DateTimePicker from '../src/DateTimePickers';
 
 
 storiesOf('DateTimePicker', module)
@@ -15,24 +12,6 @@ storiesOf('DateTimePicker', module)
 			<IconsProvider />
 			<div style={{ width: '320px', border: '1px solid black' }}>
 				<DateTimePicker />
-			</div>
-		</div>
-	))
-	.add('Date/Time view structure', () => (
-		<div>
-			<h1>Date/Time structure</h1>
-			<IconsProvider />
-			<div style={{ width: '320px', height: '25rem', border: '1px solid black' }}>
-				<DateTimeView />
-			</div>
-		</div>
-	))
-	.add('Month/Year view structure', () => (
-		<div>
-			<h1>Month/Year structure</h1>
-			<IconsProvider />
-			<div style={{ width: '320px', height: '25rem', border: '1px solid black' }}>
-				<MonthYearView />
 			</div>
 		</div>
 	));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Widget interaction to get the month and year on which the calendar (final date picker) will be based.

**What is the chosen solution to this problem?**
DOING IT !

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
