### PR TITLE
fix(datagrid): error when the value is null

### DIFF
--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
@@ -83,6 +83,10 @@ function replaceCharacterByIcon(value, t) {
  * @return {boolean}       indicate if the string to test has white space
  */
 export function hasWhiteSpaceCharacters(value) {
+	if (!value || typeof value !== 'string') {
+		return false;
+	}
+
 	const hiddenCharsRegExpMatch = value.match(REG_EXP_HAS_WHITE_SPACE_CHARACTERS);
 
 	if (hiddenCharsRegExpMatch[1] || hiddenCharsRegExpMatch[3]) {

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
@@ -17,12 +17,10 @@ describe('FormatValue', () => {
 	});
 
 	it('should return true when there is trailing empty space in the string', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters('l﻿')).toBe(true);
 	});
 
 	it('should return true when there is line feeding in the string', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(
 			hasWhiteSpaceCharacters(`loreum
 lopsum`),
@@ -35,32 +33,26 @@ lopsum`),
 	});
 
 	it('should return false when there is no white space', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters('loreum lopsum')).toBe(false);
 	});
 
 	it('should return false where the string is empty', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters('')).toBe(false);
 	});
 
 	it('test return false when the string has only with alpha', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters('a')).toBe(false);
 	});
 
 	it('test return true when the string has only white characters', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters(' ')).toBe(true);
 	});
 
 	it('test return false when the string is empty', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters()).toBe(false);
 	});
 
 	it('test return false when the string is not a string', () => {
-		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters(1)).toBe(false);
 	});
 });

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
@@ -54,12 +54,12 @@ lopsum`),
 		expect(hasWhiteSpaceCharacters(' ')).toBe(true);
 	});
 
-	it('test return true when the string has only white characters', () => {
+	it('test return false when the string is empty', () => {
 		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters()).toBe(false);
 	});
 
-	it('test return true when the string has only white characters', () => {
+	it('test return false when the string is not a string', () => {
 		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters(1)).toBe(false);
 	});

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.test.js
@@ -53,4 +53,14 @@ lopsum`),
 		// eslint-disable-next-line no-irregular-whitespace
 		expect(hasWhiteSpaceCharacters(' ')).toBe(true);
 	});
+
+	it('test return true when the string has only white characters', () => {
+		// eslint-disable-next-line no-irregular-whitespace
+		expect(hasWhiteSpaceCharacters()).toBe(false);
+	});
+
+	it('test return true when the string has only white characters', () => {
+		// eslint-disable-next-line no-irregular-whitespace
+		expect(hasWhiteSpaceCharacters(1)).toBe(false);
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Uncaught TypeError: Cannot read property 'match' of undefined when you show an empty value in a cell.

**What is the chosen solution to this problem?**
fix this error

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
