### PR TITLE
fix(cmf):handleDefaultHttpConfiguration

### DIFF
--- a/packages/cmf/__tests__/sagas/http.test.js
+++ b/packages/cmf/__tests__/sagas/http.test.js
@@ -122,9 +122,7 @@ describe('http.delete', () => {
 
 describe('handleBody', () => {
 	it('should manage the body of the response like text if no header', done => {
-		handleBody(
-			new Response('{"foo": 42}', {}),
-		).then(({ data, response }) => {
+		handleBody(new Response('{"foo": 42}', {})).then(({ data, response }) => {
 			expect(data).toBe('{"foo": 42}');
 			expect(response instanceof Response).toBeTruthy();
 			done();
@@ -464,15 +462,17 @@ describe('#httpFetch with CSRF handling configuration', () => {
 	beforeAll(() => {
 		HTTP.defaultConfig = null;
 
-		document.cookie = `${defaultHttpConfiguration.security
-			.CSRFTokenCookieKey}=${CSRFToken}; dwf_section_edit=True;`;
+		document.cookie = `${
+			defaultHttpConfiguration.security.CSRFTokenCookieKey
+		}=${CSRFToken}; dwf_section_edit=True;`;
 	});
 
 	afterAll(() => {
 		HTTP.defaultConfig = null;
 
-		document.cookie = `${defaultHttpConfiguration.security
-			.CSRFTokenCookieKey}=${CSRFToken}; dwf_section_edit=True; Max-Age=0`;
+		document.cookie = `${
+			defaultHttpConfiguration.security.CSRFTokenCookieKey
+		}=${CSRFToken}; dwf_section_edit=True; Max-Age=0`;
 	});
 
 	it('check if httpFetch is called with the security configuration', done => {
@@ -866,7 +866,7 @@ describe('setDefaultLanguage', () => {
 });
 
 describe('handleDefaultConfiguration', () => {
-	it('should merge the defaultHttpConfig with httpConfig', () => {
+	it('should return merge of the defaultHttpConfig with httpConfig', () => {
 		expect(
 			handleDefaultHttpConfiguration({
 				headers: {
@@ -883,5 +883,35 @@ describe('handleDefaultConfiguration', () => {
 				'content-type': 'application/json',
 			},
 		});
+	});
+
+	it(`should return merge the defaultHttpConfig with httpConfig
+	and not store it with partial application of the curryied function`, () => {
+		// given
+		const defaultHttpConfig = {
+			headers: {
+				'Accept-Language': 'fr',
+			},
+		};
+
+		const copyOfDefaultHttpConfig = {
+			headers: {
+				'Accept-Language': 'fr',
+			},
+		};
+
+		const httpConfig = {
+			headers: {
+				'content-type': 'application/json',
+			},
+		};
+		// when
+		const configuredHandleDefaultHttpConfiguration = handleDefaultHttpConfiguration(
+			defaultHttpConfig,
+		);
+		configuredHandleDefaultHttpConfiguration(httpConfig);
+		const resultTwo = configuredHandleDefaultHttpConfiguration({});
+		// expect
+		expect(resultTwo).toEqual(copyOfDefaultHttpConfig);
 	});
 });

--- a/packages/cmf/src/sagas/http.js
+++ b/packages/cmf/src/sagas/http.js
@@ -2,7 +2,6 @@ import { call, put } from 'redux-saga/effects';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
 import curry from 'lodash/curry';
-import cloneDeep from 'lodash/cloneDeep';
 
 import { mergeCSRFToken } from '../middlewares/http/csrfHandling';
 import {
@@ -285,7 +284,7 @@ export const handleDefaultHttpConfiguration = curry((defaultHttpConfig, httpConf
 	 * httpConfig override merged into defaultHttConfig.
 	 * a test with two sccessive call will detect this issue.
 	 */
-	merge(cloneDeep(defaultHttpConfig), httpConfig),
+	merge({}, defaultHttpConfig, httpConfig),
 );
 
 /**

--- a/packages/cmf/src/sagas/http.js
+++ b/packages/cmf/src/sagas/http.js
@@ -2,6 +2,7 @@ import { call, put } from 'redux-saga/effects';
 import merge from 'lodash/merge';
 import get from 'lodash/get';
 import curry from 'lodash/curry';
+import cloneDeep from 'lodash/cloneDeep';
 
 import { mergeCSRFToken } from '../middlewares/http/csrfHandling';
 import {
@@ -274,7 +275,17 @@ export function setDefaultLanguage(language) {
 }
 
 export const handleDefaultHttpConfiguration = curry((defaultHttpConfig, httpConfig) =>
-	merge(defaultHttpConfig, httpConfig),
+	/**
+	 * Wall of explain
+	 * merge mutate your object see https://lodash.com/docs/4.17.10#merge little note at the
+	 * end of the documentation, so why ? don't know but its bad.
+	 *
+	 * so defaultHttpConfig was mutated inside the curried function and applied to
+	 * all other call providing httpConfig, leading to interesting bug like having one time
+	 * httpConfig override merged into defaultHttConfig.
+	 * a test with two sccessive call will detect this issue.
+	 */
+	merge(cloneDeep(defaultHttpConfig), httpConfig),
 );
 
 /**


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
if you override one time the default config doing 
`yield call(http.get, `${API.streams}/${streamId}/logs`, {
		headers: {
			Accept: 'text/plain',
			'Content-Type': 'text/plain',
		},
	});`
instead of having this applied only for this call it will be applied to all subsequent call using `call(http.get)`

**What is the chosen solution to this problem?**
lodash merge is mutating the target object reference given to it, before returning it, crass but no big deal most of the time.
But here we where using it inside a curryed function that first take the default config and on subsequent call will try to merge temp override, issue being that the default config being mutated what was a one time application, was a whole app lifecycle application.

Solution ?
cloneDeep target object.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
