### PR TITLE
feat(component/step3): calendar management

### DIFF
--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -62,8 +62,7 @@ class DateTimePicker extends React.Component {
 		if (this.state.isDateTimeView) {
 			viewElement = (<DateTimeView
 				onClickTitle={this.setMonthYearView}
-				selectedMonthIndex={this.state.calendar.monthIndex}
-				selectedYear={this.state.calendar.year}
+				selectedCalendar={this.state.calendar}
 				onSelectMonthYear={this.onSelectCalendarMonthYear}
 				onSelectDate={this.onSelectDate}
 				selectedDate={this.state.selectedDate}

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -17,6 +17,7 @@ class DateTimePicker extends React.Component {
 				monthIndex: now.getMonth(),
 				year: now.getFullYear(),
 			},
+			selectedDate: undefined,
 		};
 
 		this.setDateTimeView = this.setView.bind(this, true);
@@ -24,6 +25,11 @@ class DateTimePicker extends React.Component {
 		this.onSelectMonth = this.onSelectMonth.bind(this);
 		this.onSelectYear = this.onSelectYear.bind(this);
 		this.onSelectMonthYear = this.onSelectMonthYear.bind(this);
+		this.onSelectDate = this.onSelectDate.bind(this);
+	}
+
+	onSelectDate(selectedDate) {
+		this.setState({ selectedDate });
 	}
 
 	onSelectMonthYear(newCalendar) {
@@ -56,6 +62,8 @@ class DateTimePicker extends React.Component {
 				selectedMonthIndex={this.state.currentCalendar.monthIndex}
 				selectedYear={this.state.currentCalendar.year}
 				onSelectMonthYear={this.onSelectMonthYear}
+				onSelectDate={this.onSelectDate}
+				selectedDate={this.state.selectedDate}
 			/>);
 		} else {
 			viewElement = (<MonthYearView

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -40,16 +40,12 @@ class DateTimePicker extends React.Component {
 		}));
 	}
 
-	onSelectCalendarMonth(index) {
-		this.onSelectCalendarMonthYear({
-			monthIndex: index,
-		});
+	onSelectCalendarMonth(monthIndex) {
+		this.onSelectCalendarMonthYear({ monthIndex });
 	}
 
-	onSelectCalendarYear(calendarYear) {
-		this.onSelectCalendarMonthYear({
-			year: calendarYear,
-		});
+	onSelectCalendarYear(year) {
+		this.onSelectCalendarMonthYear({ year });
 	}
 
 	setView(isDateTimeView) {

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -13,7 +13,7 @@ class DateTimePicker extends React.Component {
 
 		this.state = {
 			isDateTimeView: true,
-			currentCalendar: {
+			calendar: {
 				monthIndex: now.getMonth(),
 				year: now.getFullYear(),
 			},
@@ -22,9 +22,9 @@ class DateTimePicker extends React.Component {
 
 		this.setDateTimeView = this.setView.bind(this, true);
 		this.setMonthYearView = this.setView.bind(this, false);
-		this.onSelectMonth = this.onSelectMonth.bind(this);
-		this.onSelectYear = this.onSelectYear.bind(this);
-		this.onSelectMonthYear = this.onSelectMonthYear.bind(this);
+		this.onSelectCalendarMonth = this.onSelectCalendarMonth.bind(this);
+		this.onSelectCalendarYear = this.onSelectCalendarYear.bind(this);
+		this.onSelectCalendarMonthYear = this.onSelectCalendarMonthYear.bind(this);
 		this.onSelectDate = this.onSelectDate.bind(this);
 	}
 
@@ -32,21 +32,25 @@ class DateTimePicker extends React.Component {
 		this.setState({ selectedDate });
 	}
 
-	onSelectMonthYear(newCalendar) {
+	onSelectCalendarMonthYear(newCalendar) {
 		this.setState(previousState => ({
-			currentCalendar: {
-				...previousState.currentCalendar,
+			calendar: {
+				...previousState.calendar,
 				...newCalendar,
 			},
 		}));
 	}
 
-	onSelectMonth(monthIndex) {
-		this.onSelectMonthYear({ monthIndex });
+	onSelectCalendarMonth(calendarMonthIndex) {
+		this.onSelectCalendarMonthYear({
+			monthIndex: calendarMonthIndex,
+		});
 	}
 
-	onSelectYear(year) {
-		this.onSelectMonthYear({ year });
+	onSelectCalendarYear(calendarYear) {
+		this.onSelectCalendarMonthYear({
+			year: calendarYear,
+		});
 	}
 
 	setView(isDateTimeView) {
@@ -59,19 +63,19 @@ class DateTimePicker extends React.Component {
 		if (this.state.isDateTimeView) {
 			viewElement = (<DateTimeView
 				onClickTitle={this.setMonthYearView}
-				selectedMonthIndex={this.state.currentCalendar.monthIndex}
-				selectedYear={this.state.currentCalendar.year}
-				onSelectMonthYear={this.onSelectMonthYear}
+				selectedMonthIndex={this.state.calendar.monthIndex}
+				selectedYear={this.state.calendar.year}
+				onSelectMonthYear={this.onSelectCalendarMonthYear}
 				onSelectDate={this.onSelectDate}
 				selectedDate={this.state.selectedDate}
 			/>);
 		} else {
 			viewElement = (<MonthYearView
 				onClickBack={this.setDateTimeView}
-				selectedMonthIndex={this.state.currentCalendar.monthIndex}
-				selectedYear={this.state.currentCalendar.year}
-				onSelectMonth={this.onSelectMonth}
-				onSelectYear={this.onSelectYear}
+				selectedMonthIndex={this.state.calendar.monthIndex}
+				selectedYear={this.state.calendar.year}
+				onSelectMonth={this.onSelectCalendarMonth}
+				onSelectYear={this.onSelectCalendarYear}
 			/>);
 		}
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -17,7 +17,6 @@ class DateTimePicker extends React.Component {
 				monthIndex: now.getMonth(),
 				year: now.getFullYear(),
 			},
-			selectedDate: undefined,
 		};
 
 		this.setDateTimeView = this.setView.bind(this, true);
@@ -41,9 +40,9 @@ class DateTimePicker extends React.Component {
 		}));
 	}
 
-	onSelectCalendarMonth(calendarMonthIndex) {
+	onSelectCalendarMonth(index) {
 		this.onSelectCalendarMonthYear({
-			monthIndex: calendarMonthIndex,
+			monthIndex: index,
 		});
 	}
 

--- a/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/DateTimePicker/DateTimePicker.component.js
@@ -58,7 +58,7 @@ class DateTimePicker extends React.Component {
 		if (this.state.isDateTimeView) {
 			viewElement = (<DateTimeView
 				onClickTitle={this.setMonthYearView}
-				selectedCalendar={this.state.calendar}
+				calendar={this.state.calendar}
 				onSelectMonthYear={this.onSelectCalendarMonthYear}
 				onSelectDate={this.onSelectDate}
 				selectedDate={this.state.selectedDate}

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -6,7 +6,9 @@ exports[`DateTimePicker should render 1`] = `
 >
   <DateTimeView
     onClickTitle={[Function]}
+    onSelectDate={[Function]}
     onSelectMonthYear={[Function]}
+    selectedDate={undefined}
     selectedMonthIndex={5}
     selectedYear={2018}
   />

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -8,9 +8,13 @@ exports[`DateTimePicker should render 1`] = `
     onClickTitle={[Function]}
     onSelectDate={[Function]}
     onSelectMonthYear={[Function]}
+    selectedCalendar={
+      Object {
+        "monthIndex": 5,
+        "year": 2018,
+      }
+    }
     selectedDate={undefined}
-    selectedMonthIndex={5}
-    selectedYear={2018}
   />
 </div>
 `;

--- a/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -5,15 +5,15 @@ exports[`DateTimePicker should render 1`] = `
   className="theme-container"
 >
   <DateTimeView
-    onClickTitle={[Function]}
-    onSelectDate={[Function]}
-    onSelectMonthYear={[Function]}
-    selectedCalendar={
+    calendar={
       Object {
         "monthIndex": 5,
         "year": 2018,
       }
     }
+    onClickTitle={[Function]}
+    onSelectDate={[Function]}
+    onSelectMonthYear={[Function]}
     selectedDate={undefined}
   />
 </div>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -55,7 +55,6 @@ class DatePicker extends React.Component {
 
 		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex, firstDayOfWeek) => `${year}-${monthIndex}|${firstDayOfWeek}`);
 
-		this.selectedDay = new Date(2018, 5, 12);
 		this.disabledDays = [
 			new Date(2018, 5, 6),
 			new Date(2018, 5, 15),
@@ -63,7 +62,8 @@ class DatePicker extends React.Component {
 	}
 
 	isSelectedDay(date) {
-		return isSameDay(this.selectedDay, date);
+		return this.props.selectedDate !== undefined
+			&& isSameDay(this.props.selectedDate, date);
 	}
 
 	isDisabledDay(date) {
@@ -138,6 +138,7 @@ DatePicker.propTypes = {
 		year: PropTypes.number.isRequired,
 	}).isRequired,
 	currentDate: PropTypes.instanceOf(Date).isRequired,
+	selectedDate: PropTypes.instanceOf(Date),
 };
 
 export default DatePicker;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -116,7 +116,7 @@ class DatePicker extends React.Component {
 										{
 											this.isCurrentMonth(date) &&
 											<DayPickerAction
-												label={dateNumber.toString()}
+												label={dateNumber}
 												isSelected={this.isSelectedDate(date)}
 												isDisabled={isDisabled}
 												isToday={isToday(date)}

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -104,7 +104,7 @@ class DatePicker extends React.Component {
 		return (
 			<div className={theme.container}>
 				<div className={theme['calendar-header']}>
-					<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
+					<div className={classNames(theme['calendar-row'])}>
 						{dayNames.map((dayName, i) =>
 							<abbr
 								className={theme['calendar-item']}

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -31,15 +31,15 @@ const getDayNames = memoize(buildDayNames);
 
 class DatePicker extends React.Component {
 
-	static buildWeeks(year, monthIndex) {
+	static buildWeeks(year, monthIndex, firstDayOfWeek) {
 		const firstDateOfMonth = new Date(year, monthIndex);
 		const firstDateOfCalendar = startOfWeek(firstDateOfMonth, {
-			weekStartsOn: FIRST_DAY_OF_WEEK,
+			weekStartsOn: firstDayOfWeek,
 		});
 
 		const lastDateOfMonth = endOfMonth(firstDateOfMonth);
 		const diffWeeks = differenceInCalendarWeeks(lastDateOfMonth, firstDateOfCalendar, {
-			weekStartsOn: FIRST_DAY_OF_WEEK,
+			weekStartsOn: firstDayOfWeek,
 		});
 		const nbWeeksToRender = diffWeeks + 1;
 
@@ -53,7 +53,7 @@ class DatePicker extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex) => `${year}-${monthIndex}`);
+		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex, firstDayOfWeek) => `${year}-${monthIndex}|${firstDayOfWeek}`);
 
 		this.selectedDay = new Date(2018, 5, 12);
 		this.disabledDays = [
@@ -82,7 +82,7 @@ class DatePicker extends React.Component {
 	render() {
 		const { year, monthIndex } = this.props.calendar;
 
-		const weeks = this.getWeeks(year, monthIndex);
+		const weeks = this.getWeeks(year, monthIndex, FIRST_DAY_OF_WEEK);
 		const dayNames = getDayNames(FIRST_DAY_OF_WEEK);
 
 		return (

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -16,19 +16,30 @@ import addDays from 'date-fns/add_days';
 import theme from './DatePicker.scss';
 import DayPickerAction from './DayPickerAction';
 
-const firstDayOfweek = 1;
+const FIRST_DAY_OF_WEEK = 1;
+const BASE_DATE = new Date(0);
+
+function buildDayNames(firstDayOfweek) {
+	return (new Array(7))
+		.fill(0)
+		.map((_, i) => (i + firstDayOfweek) % 7)
+		.map(dayOfWeek => setDay(BASE_DATE, dayOfWeek))
+		.map(headerDate => format(headerDate, 'dddd'));
+}
+
+const getDayNames = memoize(buildDayNames);
 
 class DatePicker extends React.Component {
 
 	static buildWeeks(year, monthIndex) {
 		const firstDateOfMonth = new Date(year, monthIndex);
 		const firstDateOfCalendar = startOfWeek(firstDateOfMonth, {
-			weekStartsOn: firstDayOfweek,
+			weekStartsOn: FIRST_DAY_OF_WEEK,
 		});
 
 		const lastDateOfMonth = endOfMonth(firstDateOfMonth);
 		const diffWeeks = differenceInCalendarWeeks(lastDateOfMonth, firstDateOfCalendar, {
-			weekStartsOn: firstDayOfweek,
+			weekStartsOn: FIRST_DAY_OF_WEEK,
 		});
 		const nbWeeksToRender = diffWeeks + 1;
 
@@ -41,14 +52,6 @@ class DatePicker extends React.Component {
 
 	constructor(props) {
 		super(props);
-
-		const baseDate = new Date(0);
-
-		this.dayNames = (new Array(7))
-			.fill(0)
-			.map((_, i) => (i + firstDayOfweek) % 7)
-			.map(dayOfWeek => setDay(baseDate, dayOfWeek))
-			.map(headerDate => format(headerDate, 'dddd'));
 
 		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex) => `${year}-${monthIndex}`);
 
@@ -80,11 +83,12 @@ class DatePicker extends React.Component {
 		const { year, monthIndex } = this.props.calendar;
 
 		const weeks = this.getWeeks(year, monthIndex);
+		const dayNames = getDayNames(FIRST_DAY_OF_WEEK);
 
 		return (
 			<div className={theme.container}>
 				<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
-					{this.dayNames.map((dayName, i) =>
+					{dayNames.map((dayName, i) =>
 						<abbr
 							className={theme['calendar-item']}
 							key={i}

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -62,30 +62,12 @@ class DatePicker extends React.Component {
 			&& isSameDay(this.props.selectedDate, date);
 	}
 
-	isDisabledDate(dateToCheck) {
-		const disabledRules = this.props.disabledRules;
-		if (!disabledRules) {
+	isDisabledDate(date) {
+		if (!this.props.isDisabledChecker) {
 			return false;
 		}
 
-		return disabledRules
-			.some(disabledRule => {
-				if (typeof disabledRules !== 'object') {
-					return false;
-				}
-
-				switch (disabledRule.constructor) {
-					case Date:
-						return isSameDay(disabledRule, dateToCheck);
-
-					case Array:
-						return disabledRule
-							.some(disabledDateRule => isSameDay(disabledDateRule, dateToCheck));
-
-					default:
-						return false;
-				}
-			});
+		return this.props.isDisabledChecker(date);
 	}
 
 	isCurrentMonth(date) {
@@ -157,10 +139,7 @@ DatePicker.propTypes = {
 	}).isRequired,
 	onSelect: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
-	disabledRules: PropTypes.arrayOf(PropTypes.oneOfType([
-		PropTypes.instanceOf(Date),
-		PropTypes.arrayOf(PropTypes.instanceOf(Date)),
-	])),
+	isDisabledChecker: PropTypes.func,
 };
 
 export default DatePicker;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -103,47 +103,51 @@ class DatePicker extends React.Component {
 
 		return (
 			<div className={theme.container}>
-				<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
-					{dayNames.map((dayName, i) =>
-						<abbr
-							className={theme['calendar-item']}
-							key={i}
-							title={dayName}
-						>
-							{dayName.charAt(0)}
-						</abbr>
-					)}
-				</div>
-
-				<hr className={theme.separator} />
-
-				{weeks.map((week, i) =>
-					<div
-						className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
-						key={i}
-					>
-						{week.map((date, j) =>
-							<div
+				<div className={theme['calendar-header']}>
+					<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
+						{dayNames.map((dayName, i) =>
+							<abbr
 								className={theme['calendar-item']}
-								key={j}
+								key={i}
+								title={dayName}
 							>
-								{
-									this.isCurrentMonth(date) &&
-									<DayPickerAction
-										label={getDate(date).toString()}
-										isSelected={this.isSelectedDate(date)}
-										isDisabled={this.isDisabledDate(date)}
-										isToday={this.isToday(date)}
-										aria-label={this.isDisabledDate(date)
-											? 'Unselectable date'
-											: `Select '${getDate(date)}'`}
-										onClick={() => { this.props.onSelect(date); }}
-									/>
-								}
-							</div>
+								{dayName.charAt(0)}
+							</abbr>
 						)}
 					</div>
-				)}
+					<hr className={theme.separator} />
+				</div>
+
+
+				<div className={theme['calendar-body']}>
+					{weeks.map((week, i) =>
+						<div
+							className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
+							key={i}
+						>
+							{week.map((date, j) =>
+								<div
+									className={theme['calendar-item']}
+									key={j}
+								>
+									{
+										this.isCurrentMonth(date) &&
+										<DayPickerAction
+											label={getDate(date).toString()}
+											isSelected={this.isSelectedDate(date)}
+											isDisabled={this.isDisabledDate(date)}
+											isToday={this.isToday(date)}
+											aria-label={this.isDisabledDate(date)
+												? 'Unselectable date'
+												: `Select '${getDate(date)}'`}
+											onClick={() => { this.props.onSelect(date); }}
+										/>
+									}
+								</div>
+							)}
+						</div>
+					)}
+				</div>
 			</div>
 		);
 	}

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -82,11 +82,11 @@ class DatePicker extends React.Component {
 
 		return (
 			<div className={theme.container}>
-				<div className={classNames('calendar-header', theme['calendar-header'])}>
-					<div className={classNames('calendar-row', theme['calendar-row'])}>
+				<div className={classNames('tc-date-picker-calendar-header', theme['calendar-header'])}>
+					<div className={classNames('tc-date-picker-calendar-row', theme['calendar-row'])}>
 						{dayNames.map((dayName, i) =>
 							<abbr
-								className={classNames('calendar-item', theme['calendar-item'])}
+								className={classNames('tc-date-picker-calendar-item', theme['calendar-item'])}
 								key={i}
 								title={dayName}
 							>
@@ -98,10 +98,10 @@ class DatePicker extends React.Component {
 				</div>
 
 
-				<div className={classNames('calendar-body', theme['calendar-body'])}>
+				<div className={classNames('tc-date-picker-calendar-body', theme['calendar-body'])}>
 					{weeks.map((week, i) =>
 						<div
-							className={classNames('calendar-row', theme['calendar-row'])}
+							className={classNames('tc-date-picker-calendar-row', theme['calendar-row'])}
 							key={i}
 						>
 							{week.map((date, j) => {
@@ -110,7 +110,7 @@ class DatePicker extends React.Component {
 
 								return (
 									<div
-										className={classNames('calendar-item', theme['calendar-item'])}
+										className={classNames('tc-date-picker-calendar-item', theme['calendar-item'])}
 										key={j}
 									>
 										{

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -100,11 +100,11 @@ class DatePicker extends React.Component {
 
 		return (
 			<div className={theme.container}>
-				<div className={theme['calendar-header']}>
-					<div className={classNames(theme['calendar-row'])}>
+				<div className={classNames('calendar-header', theme['calendar-header'])}>
+					<div className={classNames('calendar-row', theme['calendar-row'])}>
 						{dayNames.map((dayName, i) =>
 							<abbr
-								className={theme['calendar-item']}
+								className={classNames('calendar-item', theme['calendar-item'])}
 								key={i}
 								title={dayName}
 							>
@@ -116,15 +116,15 @@ class DatePicker extends React.Component {
 				</div>
 
 
-				<div className={theme['calendar-body']}>
+				<div className={classNames('calendar-body', theme['calendar-body'])}>
 					{weeks.map((week, i) =>
 						<div
-							className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
+							className={classNames('calendar-row', 'calendar-body-row', theme['calendar-row'], theme['calendar-body-row'])}
 							key={i}
 						>
 							{week.map((date, j) =>
 								<div
-									className={theme['calendar-item']}
+									className={classNames('calendar-item', theme['calendar-item'])}
 									key={j}
 								>
 									{

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -121,6 +121,7 @@ class DatePicker extends React.Component {
 										aria-label={this.isDisabledDay(date)
 											? 'Unselectable date'
 											: `Select '${getDate(date)}'`}
+										onClick={() => { this.props.onSelect(date); }}
 									/>
 								}
 							</div>
@@ -138,6 +139,7 @@ DatePicker.propTypes = {
 		year: PropTypes.number.isRequired,
 	}).isRequired,
 	currentDate: PropTypes.instanceOf(Date).isRequired,
+	onSelect: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
 };
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -43,11 +43,11 @@ class DatePicker extends React.Component {
 		});
 		const nbWeeksToRender = diffWeeks + 1;
 
-		const days = (new Array(7 * nbWeeksToRender))
+		const dates = (new Array(7 * nbWeeksToRender))
 						.fill(0)
 						.map((_, i) => addDays(firstDateOfCalendar, i));
 
-		return chunk(days, 7);
+		return chunk(dates, 7);
 	}
 
 	constructor(props) {
@@ -56,12 +56,12 @@ class DatePicker extends React.Component {
 		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex, firstDayOfWeek) => `${year}-${monthIndex}|${firstDayOfWeek}`);
 	}
 
-	isSelectedDay(date) {
+	isSelectedDate(date) {
 		return this.props.selectedDate !== undefined
 			&& isSameDay(this.props.selectedDate, date);
 	}
 
-	isDisabledDay(dateToCheck) {
+	isDisabledDate(dateToCheck) {
 		const disabledRules = this.props.disabledRules;
 		if (!disabledRules) {
 			return false;
@@ -87,8 +87,8 @@ class DatePicker extends React.Component {
 			});
 	}
 
-	isCurrentDay(date) {
-		return isSameDay(this.props.currentDate, date);
+	isToday(date) {
+		return isSameDay(this.props.today, date);
 	}
 
 	isCurrentMonth(date) {
@@ -131,10 +131,10 @@ class DatePicker extends React.Component {
 									this.isCurrentMonth(date) &&
 									<DayPickerAction
 										label={getDate(date).toString()}
-										isSelectedDay={this.isSelectedDay(date)}
-										isDisabledDay={this.isDisabledDay(date)}
-										isCurrentDay={this.isCurrentDay(date)}
-										aria-label={this.isDisabledDay(date)
+										isSelected={this.isSelectedDate(date)}
+										isDisabled={this.isDisabledDate(date)}
+										isToday={this.isToday(date)}
+										aria-label={this.isDisabledDate(date)
 											? 'Unselectable date'
 											: `Select '${getDate(date)}'`}
 										onClick={() => { this.props.onSelect(date); }}
@@ -154,7 +154,7 @@ DatePicker.propTypes = {
 		monthIndex: PropTypes.number.isRequired,
 		year: PropTypes.number.isRequired,
 	}).isRequired,
-	currentDate: PropTypes.instanceOf(Date).isRequired,
+	today: PropTypes.instanceOf(Date).isRequired,
 	onSelect: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
 	disabledRules: PropTypes.arrayOf(PropTypes.oneOfType([

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -4,77 +4,84 @@ import classNames from 'classnames';
 import theme from './DatePicker.scss';
 import DayPickerAction from './DayPickerAction';
 
-function DatePicker(props) {
-	const dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
-	const days = (new Array(7))
-					.fill(0)
-					.map((_, i) => i + 1);
+class DatePicker extends React.Component {
 
-	const weeks = (new Array(4))
-		.fill(0)
-		.map((_, i) =>
-			days.map(x => ({
-				number: x + (i * 7),
-			}))
-		);
+	constructor(props) {
+		super(props);
 
-	const selectedDay = 12;
-	const currentDay = 20;
-	const disabledDays = [6, 15];
+		this.dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+		const days = (new Array(7))
+						.fill(0)
+						.map((_, i) => i + 1);
 
-	function isSelectedDay(n) {
-		return selectedDay === n;
+		this.weeks = (new Array(4))
+			.fill(0)
+			.map((_, i) =>
+				days.map(x => ({
+					number: x + (i * 7),
+				}))
+			);
+
+		this.selectedDay = 12;
+		this.currentDay = 20;
+		this.disabledDays = [6, 15];
 	}
 
-	function isCurrentDay(n) {
-		return currentDay === n;
+	isSelectedDay(n) {
+		return this.selectedDay === n;
 	}
 
-	function isDisabledDay(n) {
-		return disabledDays.includes(n);
+	isCurrentDay(n) {
+		return this.currentDay === n;
 	}
 
-	return (
-		<div className={theme.container}>
-			<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
-				{dayNames.map((dayName, i) =>
-					<abbr
-						className={theme['calendar-item']}
-						key={i}
-						title={dayName}
-					>
-						{dayName.charAt(0)}
-					</abbr>
-				)}
-			</div>
+	isDisabledDay(n) {
+		return this.disabledDays.includes(n);
+	}
 
-			<hr className={theme.separator} />
-
-			{weeks.map((week, i) =>
-				<div
-					className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
-					key={i}
-				>
-					{week.map((day, j) =>
-						<div
+	render() {
+		return (
+			<div className={theme.container}>
+				<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
+					{this.dayNames.map((dayName, i) =>
+						<abbr
 							className={theme['calendar-item']}
-							key={j}
+							key={i}
+							title={dayName}
 						>
-							<DayPickerAction
-								label={day.number.toString()}
-								isSelectedDay={isSelectedDay(day.number)}
-								isDisabledDay={isDisabledDay(day.number)}
-								isCurrentDay={isCurrentDay(day.number)}
-								aria-label={isDisabledDay(day.number)
-									? 'Unselectable date'
-									: `Select '${day.number}'`}
-							/>
-						</div>
+							{dayName.charAt(0)}
+						</abbr>
 					)}
 				</div>
-			)}
-		</div>
-	);
+
+				<hr className={theme.separator} />
+
+				{this.weeks.map((week, i) =>
+					<div
+						className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
+						key={i}
+					>
+						{week.map((day, j) =>
+							<div
+								className={theme['calendar-item']}
+								key={j}
+							>
+								<DayPickerAction
+									label={day.number.toString()}
+									isSelectedDay={this.isSelectedDay(day.number)}
+									isDisabledDay={this.isDisabledDay(day.number)}
+									isCurrentDay={this.isCurrentDay(day.number)}
+									aria-label={this.isDisabledDay(day.number)
+										? 'Unselectable date'
+										: `Select '${day.number}'`}
+								/>
+							</div>
+						)}
+					</div>
+				)}
+			</div>
+		);
+	}
 }
 
 DatePicker.propTypes = {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -1,26 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import memoize from 'lodash/memoize';
 import theme from './DatePicker.scss';
 import DayPickerAction from './DayPickerAction';
 
 class DatePicker extends React.Component {
 
-	constructor(props) {
-		super(props);
-
-		this.dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+	static buildWeeks(year, monthIndex) {
 		const days = (new Array(7))
 						.fill(0)
 						.map((_, i) => i + 1);
 
-		this.weeks = (new Array(4))
+		return (new Array(4))
 			.fill(0)
 			.map((_, i) =>
 				days.map(x => ({
 					number: x + (i * 7),
 				}))
 			);
+	}
+
+	constructor(props) {
+		super(props);
+
+		this.dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex) => `${year}-${monthIndex}`);
 
 		this.selectedDay = 12;
 		this.currentDay = 20;
@@ -40,6 +46,10 @@ class DatePicker extends React.Component {
 	}
 
 	render() {
+		const { year, monthIndex } = this.props.calendar;
+
+		const weeks = this.getWeeks(year, monthIndex);
+
 		return (
 			<div className={theme.container}>
 				<div className={classNames(theme['calendar-row'], theme['calendar-header-row'])}>
@@ -56,7 +66,7 @@ class DatePicker extends React.Component {
 
 				<hr className={theme.separator} />
 
-				{this.weeks.map((week, i) =>
+				{weeks.map((week, i) =>
 					<div
 						className={classNames(theme['calendar-row'], theme['calendar-body-row'])}
 						key={i}
@@ -85,6 +95,10 @@ class DatePicker extends React.Component {
 }
 
 DatePicker.propTypes = {
+	calendar: PropTypes.shape({
+		monthIndex: PropTypes.number.isRequired,
+		year: PropTypes.number.isRequired,
+	}).isRequired,
 };
 
 export default DatePicker;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -3,9 +3,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import memoize from 'lodash/memoize';
 import { chunk } from 'lodash';
+import format from 'date-fns/format';
 import endOfMonth from 'date-fns/end_of_month';
 import startOfWeek from 'date-fns/start_of_week';
 import getDate from 'date-fns/get_date';
+import setDay from 'date-fns/set_day';
 import getMonth from 'date-fns/get_month';
 import isSameDay from 'date-fns/is_same_day';
 import differenceInCalendarWeeks from 'date-fns/difference_in_calendar_weeks';
@@ -14,10 +16,11 @@ import addDays from 'date-fns/add_days';
 import theme from './DatePicker.scss';
 import DayPickerAction from './DayPickerAction';
 
+const firstDayOfweek = 1;
+
 class DatePicker extends React.Component {
 
 	static buildWeeks(year, monthIndex) {
-		const firstDayOfweek = 1;
 		const firstDateOfMonth = new Date(year, monthIndex);
 		const firstDateOfCalendar = startOfWeek(firstDateOfMonth, {
 			weekStartsOn: firstDayOfweek,
@@ -39,7 +42,13 @@ class DatePicker extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.dayNames = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+		const baseDate = new Date(0);
+
+		this.dayNames = (new Array(7))
+			.fill(0)
+			.map((_, i) => (i + firstDayOfweek) % 7)
+			.map(dayOfWeek => setDay(baseDate, dayOfWeek))
+			.map(headerDate => format(headerDate, 'dddd'));
 
 		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex) => `${year}-${monthIndex}`);
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -6,6 +6,7 @@ import { chunk } from 'lodash';
 import format from 'date-fns/format';
 import endOfMonth from 'date-fns/end_of_month';
 import startOfWeek from 'date-fns/start_of_week';
+import isToday from 'date-fns/is_today';
 import getDate from 'date-fns/get_date';
 import setDay from 'date-fns/set_day';
 import getMonth from 'date-fns/get_month';
@@ -87,10 +88,6 @@ class DatePicker extends React.Component {
 			});
 	}
 
-	isToday(date) {
-		return isSameDay(this.props.today, date);
-	}
-
 	isCurrentMonth(date) {
 		return getMonth(date) === this.props.calendar.monthIndex;
 	}
@@ -136,7 +133,7 @@ class DatePicker extends React.Component {
 											label={getDate(date).toString()}
 											isSelected={this.isSelectedDate(date)}
 											isDisabled={this.isDisabledDate(date)}
-											isToday={this.isToday(date)}
+											isToday={isToday(date)}
 											aria-label={this.isDisabledDate(date)
 												? 'Unselectable date'
 												: `Select '${getDate(date)}'`}
@@ -158,7 +155,6 @@ DatePicker.propTypes = {
 		monthIndex: PropTypes.number.isRequired,
 		year: PropTypes.number.isRequired,
 	}).isRequired,
-	today: PropTypes.instanceOf(Date).isRequired,
 	onSelect: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
 	disabledRules: PropTypes.arrayOf(PropTypes.oneOfType([

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -104,26 +104,31 @@ class DatePicker extends React.Component {
 							className={classNames('calendar-row', theme['calendar-row'])}
 							key={i}
 						>
-							{week.map((date, j) =>
-								<div
-									className={classNames('calendar-item', theme['calendar-item'])}
-									key={j}
-								>
-									{
-										this.isCurrentMonth(date) &&
-										<DayPickerAction
-											label={getDate(date).toString()}
-											isSelected={this.isSelectedDate(date)}
-											isDisabled={this.isDisabledDate(date)}
-											isToday={isToday(date)}
-											aria-label={this.isDisabledDate(date)
-												? 'Unselectable date'
-												: `Select '${getDate(date)}'`}
-											onClick={() => { this.props.onSelect(date); }}
-										/>
-									}
-								</div>
-							)}
+							{week.map((date, j) => {
+								const isDisabled = this.isDisabledDate(date);
+								const dateNumber = getDate(date);
+
+								return (
+									<div
+										className={classNames('calendar-item', theme['calendar-item'])}
+										key={j}
+									>
+										{
+											this.isCurrentMonth(date) &&
+											<DayPickerAction
+												label={dateNumber.toString()}
+												isSelected={this.isSelectedDate(date)}
+												isDisabled={isDisabled}
+												isToday={isToday(date)}
+												aria-label={isDisabled
+													? 'Unselectable date'
+													: `Select '${dateNumber}'`}
+												onClick={() => { this.props.onSelect(date); }}
+											/>
+										}
+									</div>
+								);
+							})}
 						</div>
 					)}
 				</div>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -54,11 +54,6 @@ class DatePicker extends React.Component {
 		super(props);
 
 		this.getWeeks = memoize(DatePicker.buildWeeks, (year, monthIndex, firstDayOfWeek) => `${year}-${monthIndex}|${firstDayOfWeek}`);
-
-		this.disabledDays = [
-			new Date(2018, 5, 6),
-			new Date(2018, 5, 15),
-		];
 	}
 
 	isSelectedDay(date) {
@@ -66,9 +61,30 @@ class DatePicker extends React.Component {
 			&& isSameDay(this.props.selectedDate, date);
 	}
 
-	isDisabledDay(date) {
-		return this.disabledDays
-			.some(disabledDay => isSameDay(disabledDay, date));
+	isDisabledDay(dateToCheck) {
+		const disabledRules = this.props.disabledRules;
+		if (!disabledRules) {
+			return false;
+		}
+
+		return disabledRules
+			.some(disabledRule => {
+				if (typeof disabledRules !== 'object') {
+					return false;
+				}
+
+				switch (disabledRule.constructor) {
+					case Date:
+						return isSameDay(disabledRule, dateToCheck);
+
+					case Array:
+						return disabledRule
+							.some(disabledDateRule => isSameDay(disabledDateRule, dateToCheck));
+
+					default:
+						return false;
+				}
+			});
 	}
 
 	isCurrentDay(date) {
@@ -141,6 +157,10 @@ DatePicker.propTypes = {
 	currentDate: PropTypes.instanceOf(Date).isRequired,
 	onSelect: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
+	disabledRules: PropTypes.arrayOf(PropTypes.oneOfType([
+		PropTypes.instanceOf(Date),
+		PropTypes.arrayOf(PropTypes.instanceOf(Date)),
+	])),
 };
 
 export default DatePicker;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -119,7 +119,7 @@ class DatePicker extends React.Component {
 				<div className={classNames('calendar-body', theme['calendar-body'])}>
 					{weeks.map((week, i) =>
 						<div
-							className={classNames('calendar-row', 'calendar-body-row', theme['calendar-row'], theme['calendar-body-row'])}
+							className={classNames('calendar-row', theme['calendar-row'])}
 							key={i}
 						>
 							{week.map((date, j) =>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.scss
@@ -6,46 +6,45 @@
     display: flex;
     height: 100%;
     flex-direction: column;
+}
+
+.calendar-row {
+    display: flex;
+}
+
+.calendar-item {
+    display: flex;
+    flex: 1;
+    justify-content: center;
+    align-content: center;
+}
+
+.calendar-header {
+    .calendar-row {
+        color: $gray;
+
+        abbr[title] {
+           font-variant: none;
+           border: none;
+           text-decoration: none;
+        }
+    }
+}
+
+.separator {
+    width: calc(100% - 2rem);
+    border: none;
+    border-bottom: $border-default;
+    margin: 0 auto;
+}
+
+.calendar-body {
+    display: flex;
+    flex-direction: column;
+    justify-content: space-evenly;
+    flex: 1;
 
     .calendar-row {
-        display: flex;
-    }
-
-    .calendar-item {
-        display: flex;
         flex: 1;
-        justify-content: center;
-        align-content: center;
-    }
-
-    .calendar-header {
-        .calendar-header-row {
-            color: $gray;
-
-            abbr[title] {
-               font-variant: none;
-               border: none;
-               text-decoration: none;
-            }
-        }
-
-        .separator {
-            width: calc(100% - 2rem);
-            border: none;
-            border-bottom: $border-default;
-            margin: 0 auto;
-        }
-    }
-
-
-    .calendar-body {
-        display: flex;
-        flex-direction: column;
-        justify-content: space-evenly;
-        flex: 1;
-
-        .calendar-row {
-            flex: 1;
-        }
     }
 }

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.scss
@@ -6,7 +6,6 @@
     display: flex;
     height: 100%;
     flex-direction: column;
-    justify-content: space-evenly;
 
     .calendar-row {
         display: flex;
@@ -19,20 +18,34 @@
         align-content: center;
     }
 
-    .calendar-header-row {
-        color: $gray;
+    .calendar-header {
+        .calendar-header-row {
+            color: $gray;
 
-        abbr[title] {
-           font-variant: none;
-           border: none;
-           text-decoration: none;
+            abbr[title] {
+               font-variant: none;
+               border: none;
+               text-decoration: none;
+            }
+        }
+
+        .separator {
+            width: calc(100% - 2rem);
+            border: none;
+            border-bottom: $border-default;
+            margin: 0 auto;
         }
     }
 
-    .separator {
-        width: calc(100% - 2rem);
-        border: none;
-        border-bottom: $border-default;
-        margin: 0 auto;
+
+    .calendar-body {
+        display: flex;
+        flex-direction: column;
+        justify-content: space-evenly;
+        flex: 1;
+
+        .calendar-row {
+            flex: 1;
+        }
     }
 }

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -10,12 +10,244 @@ describe('DatePicker', () => {
 			monthIndex: 6,
 		};
 
-		// when
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
 		/>);
 
-		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	describe('first date in the correct day column (Monday as first column)', () => {
+		function getFirstRowCellText(wrapper, column) {
+			return wrapper
+				.find('.theme-calendar-body-row')
+				.first()
+				.find('.theme-calendar-item')
+				.at(column - 1)
+				.find('DayPickerAction')
+				.prop('label');
+		}
+
+		it('should have monday in the 1st column for january 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 0,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getFirstRowCellText(wrapper, 1)).toBe('1');
+		});
+
+		it('should have thursday in the 4th column for march 2018 ', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 2,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getFirstRowCellText(wrapper, 4)).toBe('1');
+		});
+
+		it('should have sunday in the 7th column for april 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 3,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getFirstRowCellText(wrapper, 7)).toBe('1');
+		});
+	});
+
+
+	describe('last date in the correct day column (Monday as first column)', () => {
+		function getLastRowCellText(wrapper, column) {
+			return wrapper
+				.find('.theme-calendar-body-row')
+				.last()
+				.find('.theme-calendar-item')
+				.at(column - 1)
+				.find('DayPickerAction')
+				.prop('label');
+		}
+
+		it('should have monday in the 1st column for april 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 3,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getLastRowCellText(wrapper, 1)).toBe('30');
+		});
+
+		it('should have thursday in the 4th column for may 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 4,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getLastRowCellText(wrapper, 4)).toBe('31');
+		});
+
+		it('should have sunday in the 7th column for september 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 8,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(getLastRowCellText(wrapper, 7)).toBe('30');
+		});
+	});
+
+	describe('number of weeks displayed', () => {
+		function nbOfWeeksRendered(wrapper) {
+			return wrapper.find('.theme-calendar-body-row').length;
+		}
+
+		it('should have 4 weeks for february 2010', () => {
+			const calendar = {
+				year: 2010,
+				monthIndex: 1,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(nbOfWeeksRendered(wrapper)).toBe(4);
+		});
+
+		it('should have 5 weeks for june 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 5,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(nbOfWeeksRendered(wrapper)).toBe(5);
+		});
+
+		it('should have 6 weeks for october 2017', () => {
+			const calendar = {
+				year: 2017,
+				monthIndex: 9,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			expect(nbOfWeeksRendered(wrapper)).toBe(6);
+		});
+	});
+
+	describe('contiguous ordered numbers', () => {
+		function getDayNumbers(wrapper) {
+			return wrapper
+				.find('.theme-calendar-body-row .theme-calendar-item')
+				.find('DayPickerAction')
+				.map(action => action.prop('label'))
+				.map(label => parseInt(label, 10));
+		}
+
+		function ascSorting(a, b) {
+			return a - b;
+		}
+
+		it('should have contiguous numbers for july 2018', () => {
+			const calendar = {
+				year: 2018,
+				monthIndex: 6,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			const days = getDayNumbers(wrapper);
+			const copy = [...days];
+			days.sort(ascSorting);
+			expect(days).toEqual(copy);
+			expect(days[0]).toBe(1);
+			expect(days).toHaveLength(31);
+		});
+
+		it('should have contiguous numbers for february 2016', () => {
+			const calendar = {
+				year: 2016,
+				monthIndex: 1,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			const days = getDayNumbers(wrapper);
+			const copy = [...days];
+			days.sort(ascSorting);
+			expect(days).toEqual(copy);
+			expect(days[0]).toBe(1);
+			expect(days).toHaveLength(29);
+		});
+
+		it('should have contiguous numbers for february 2017', () => {
+			const calendar = {
+				year: 2017,
+				monthIndex: 1,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			const days = getDayNumbers(wrapper);
+			const copy = [...days];
+			days.sort(ascSorting);
+			expect(days).toEqual(copy);
+			expect(days[0]).toBe(1);
+			expect(days).toHaveLength(28);
+		});
+
+		it('should have contiguous numbers for november 2022', () => {
+			const calendar = {
+				year: 2022,
+				monthIndex: 10,
+			};
+
+			const wrapper = shallow(<DatePicker
+				calendar={calendar}
+			/>);
+
+			const days = getDayNumbers(wrapper);
+			const copy = [...days];
+			days.sort(ascSorting);
+			expect(days).toEqual(copy);
+			expect(days[0]).toBe(1);
+			expect(days).toHaveLength(30);
+		});
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -42,9 +42,9 @@ describe('DatePicker', () => {
 		describe('first date of month in the correct grid column (Monday as first day of week)', () => {
 			function getFirstRowCellText(wrapper, column) {
 				return wrapper
-					.find('.theme-calendar-body-row')
+					.find('.calendar-body-row')
 					.first()
-					.find('.theme-calendar-item')
+					.find('.calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
 					.prop('label');
@@ -97,9 +97,9 @@ describe('DatePicker', () => {
 		describe('last date in the correct day column (Monday as first column)', () => {
 			function getLastRowCellText(wrapper, column) {
 				return wrapper
-					.find('.theme-calendar-body-row')
+					.find('.calendar-body-row')
 					.last()
-					.find('.theme-calendar-item')
+					.find('.calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
 					.prop('label');
@@ -150,7 +150,7 @@ describe('DatePicker', () => {
 
 		describe('number of weeks displayed', () => {
 			function nbOfWeeksRendered(wrapper) {
-				return wrapper.find('.theme-calendar-body-row').length;
+				return wrapper.find('.calendar-body-row').length;
 			}
 
 			it('should have 4 weeks for february 2010', () => {
@@ -199,7 +199,7 @@ describe('DatePicker', () => {
 		describe('contiguous ordered numbers', () => {
 			function getDayNumbers(wrapper) {
 				return wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item')
+					.find('.calendar-body-row .calendar-item')
 					.find('DayPickerAction')
 					.map(action => action.prop('label'))
 					.map(label => parseInt(label, 10));
@@ -301,7 +301,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -323,7 +323,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -344,7 +344,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -360,7 +360,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const newDayItems = newWrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(newDayItems).toHaveLength(1);
@@ -385,7 +385,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -405,7 +405,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -426,7 +426,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -453,7 +453,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const dayPickerAction = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('label') === dayToSelect.toString());
 
 				dayPickerAction.simulate('click');
@@ -475,7 +475,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDates = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledDates).toHaveLength(0);
@@ -501,7 +501,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDates = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledDates).toHaveLength(0);
@@ -534,7 +534,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDays = wrapper
-					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.find('.calendar-body-row .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'))
 					.map(item => item.prop('label'));
 
@@ -563,7 +563,7 @@ describe('DatePicker', () => {
 			const sequenceExpected = sequence.map(day => day[0].toUpperCase());
 
 			const sequenceRendered = wrapper
-				.find('.theme-calendar-header .theme-calendar-item')
+				.find('.calendar-header .calendar-item')
 				.map(item => item.text());
 
 			expect(sequenceRendered).toEqual(sequenceExpected);

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -56,7 +56,8 @@ describe('DatePicker', () => {
 					.find('.calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
-					.prop('label');
+					.prop('label')
+					.toString();
 			}
 
 			it('should have the first date of month in 1st column when it\'s monday', () => {
@@ -111,7 +112,8 @@ describe('DatePicker', () => {
 					.find('.calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
-					.prop('label');
+					.prop('label')
+					.toString();
 			}
 
 			it('should have the last date of month in 1st column when it\'s monday', () => {
@@ -315,7 +317,7 @@ describe('DatePicker', () => {
 
 				expect(currentDayItems).toHaveLength(1);
 				const item = currentDayItems.first();
-				expect(item.prop('label')).toBe('13');
+				expect(item.prop('label').toString()).toBe('13');
 			});
 
 			it('should not render specifically any date if today is out of displayed calendar', () => {
@@ -358,7 +360,7 @@ describe('DatePicker', () => {
 
 				expect(currentDayItems).toHaveLength(1);
 				const item = currentDayItems.first();
-				expect(item.prop('label')).toBe('16');
+				expect(item.prop('label').toString()).toBe('16');
 
 				// Change to next day
 				mockIsTodayWith(new Date(2018, 5, 17));
@@ -374,7 +376,7 @@ describe('DatePicker', () => {
 
 				expect(newDayItems).toHaveLength(1);
 				const newItem = newDayItems.first();
-				expect(newItem.prop('label')).toBe('17');
+				expect(newItem.prop('label').toString()).toBe('17');
 			});
 		});
 
@@ -399,7 +401,7 @@ describe('DatePicker', () => {
 
 				expect(currentDayItems).toHaveLength(1);
 				const item = currentDayItems.first();
-				expect(item.prop('label')).toBe('12');
+				expect(item.prop('label').toString()).toBe('12');
 			});
 
 			it('should not render specifically a date if no selected date given', () => {
@@ -463,7 +465,7 @@ describe('DatePicker', () => {
 
 				const dayPickerAction = wrapper
 					.find('.calendar-body .calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('label') === dayToSelect.toString());
+					.filterWhere(item => item.prop('label').toString() === dayToSelect.toString());
 
 				dayPickerAction.simulate('click');
 
@@ -539,7 +541,7 @@ describe('DatePicker', () => {
 				const disabledActionsLabels = wrapper
 					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'))
-					.map(item => item.prop('label'));
+					.map(item => item.prop('label').toString());
 
 				const expectedDisabledLabels = disabledDatesDefined
 					.map(date => date.getDate().toString());

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -39,7 +39,7 @@ describe('DatePicker', () => {
 	});
 
 	describe('body calendar', () => {
-		describe('first date of month in the correct grid column (Monday as first day of week)', () => {
+		describe('first date of month in the correct grid column (When monday as first day of week)', () => {
 			function getFirstRowCellText(wrapper, column) {
 				return wrapper
 					.find('.calendar-body .calendar-row')
@@ -50,7 +50,7 @@ describe('DatePicker', () => {
 					.prop('label');
 			}
 
-			it('should have monday in the 1st column for january 2018', () => {
+			it('should have the first date of month in 1st column when it\'s monday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 0,
@@ -64,7 +64,7 @@ describe('DatePicker', () => {
 				expect(getFirstRowCellText(wrapper, 1)).toBe('1');
 			});
 
-			it('should have thursday in the 4th column for march 2018 ', () => {
+			it('should have the first date of month in 4th column when it\'s thursday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 2,
@@ -78,7 +78,7 @@ describe('DatePicker', () => {
 				expect(getFirstRowCellText(wrapper, 4)).toBe('1');
 			});
 
-			it('should have sunday in the 7th column for april 2018', () => {
+			it('should have the first date of month in 7th column when it\'s sunday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 3,
@@ -94,7 +94,7 @@ describe('DatePicker', () => {
 		});
 
 
-		describe('last date in the correct day column (Monday as first column)', () => {
+		describe('last date of month in the correct grid column (When monday as first day of week)', () => {
 			function getLastRowCellText(wrapper, column) {
 				return wrapper
 					.find('.calendar-body .calendar-row')
@@ -105,7 +105,7 @@ describe('DatePicker', () => {
 					.prop('label');
 			}
 
-			it('should have monday in the 1st column for april 2018', () => {
+			it('should have the last date of month in 1st column when it\'s monday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 3,
@@ -119,7 +119,7 @@ describe('DatePicker', () => {
 				expect(getLastRowCellText(wrapper, 1)).toBe('30');
 			});
 
-			it('should have thursday in the 4th column for may 2018', () => {
+			it('should have the last date of month in 4th column when it\'s thursday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 4,
@@ -133,7 +133,7 @@ describe('DatePicker', () => {
 				expect(getLastRowCellText(wrapper, 4)).toBe('31');
 			});
 
-			it('should have sunday in the 7th column for september 2018', () => {
+			it('should have the last date of month in 7th column when it\'s sunday', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 8,
@@ -209,7 +209,7 @@ describe('DatePicker', () => {
 				return a - b;
 			}
 
-			it('should have contiguous numbers for july 2018 (31 days)', () => {
+			it('should have contiguous numbers on a 31 days month', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 6,
@@ -228,7 +228,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(31);
 			});
 
-			it('should have contiguous numbers for february 2016 (29 days)', () => {
+			it('should have contiguous numbers on a 29 days month', () => {
 				const calendar = {
 					year: 2016,
 					monthIndex: 1,
@@ -247,7 +247,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(29);
 			});
 
-			it('should have contiguous numbers for february 2017 (28 days)', () => {
+			it('should have contiguous numbers on a 28 days month', () => {
 				const calendar = {
 					year: 2017,
 					monthIndex: 1,
@@ -266,7 +266,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(28);
 			});
 
-			it('should have contiguous numbers for november 2022 (30 days)', () => {
+			it('should have contiguous numbers on a 30 days month', () => {
 				const calendar = {
 					year: 2022,
 					monthIndex: 10,
@@ -286,8 +286,8 @@ describe('DatePicker', () => {
 			});
 		});
 
-		describe('current date', () => {
-			it('should render specifically the current date', () => {
+		describe('today', () => {
+			it('should render specifically the today date', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
@@ -309,7 +309,7 @@ describe('DatePicker', () => {
 				expect(item.prop('label')).toBe('13');
 			});
 
-			it('should not render specifically a date if current date is out of displayed month', () => {
+			it('should not render specifically any date if today is out of displayed calendar', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
@@ -329,7 +329,7 @@ describe('DatePicker', () => {
 				expect(currentDayItems).toHaveLength(0);
 			});
 
-			it('should have updated the current today day if has changed between two renders', () => {
+			it('should have updated the date marked as today if today date has changed between two renders', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
@@ -411,7 +411,7 @@ describe('DatePicker', () => {
 				expect(currentDayItems).toHaveLength(0);
 			});
 
-			it('should not render specifically a date if selected date is out of displayed month', () => {
+			it('should not render specifically a date if selected date is out of displayed calendar', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
@@ -434,7 +434,7 @@ describe('DatePicker', () => {
 		});
 
 		describe('date selection', () => {
-			it('should callback with the date corresponding to the day of month clicked', () => {
+			it('should callback with the date picked', () => {
 				const onSelect = jest.fn();
 
 				const calendar = {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import DatePicker from './DatePicker.component';
 
 describe('DatePicker', () => {
-	const currentDate = new Date(2018, 5, 20);
+	const today = new Date(2018, 5, 20);
 
 	it('should render a DatePicker', () => {
 		const calendar = {
@@ -20,7 +20,7 @@ describe('DatePicker', () => {
 
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
-			currentDate={currentDate}
+			today={today}
 			selectedDate={selectedDate}
 			onSelect={() => {}}
 			disabledRules={disabledDates}
@@ -49,7 +49,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -64,7 +64,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -79,7 +79,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -107,7 +107,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -122,7 +122,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -137,7 +137,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -158,7 +158,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -173,7 +173,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -188,7 +188,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -217,7 +217,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -237,7 +237,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -257,7 +257,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -277,7 +277,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -301,13 +301,13 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={date}
+					today={date}
 					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isCurrentDay'));
+					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
 				const item = currentDayItems.first();
@@ -324,13 +324,13 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={date}
+					today={date}
 					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isCurrentDay'));
+					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(0);
 			});
@@ -347,14 +347,14 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					selectedDate={selectedDate}
 					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isSelectedDay'));
+					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(1);
 				const item = currentDayItems.first();
@@ -369,13 +369,13 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isSelectedDay'));
+					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
 			});
@@ -390,14 +390,14 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					selectedDate={selectedDate}
 					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isSelectedDay'));
+					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
 			});
@@ -418,7 +418,7 @@ describe('DatePicker', () => {
 				const selectedDate = new Date(2018, 5, 12);
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					selectedDate={selectedDate}
 					onSelect={onSelect}
 				/>);
@@ -442,7 +442,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -468,7 +468,7 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 					disabledRules={disabledRules}
 				/>);
@@ -502,14 +502,14 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					currentDate={currentDate}
+					today={today}
 					onSelect={() => {}}
 					disabledRules={disabledRules}
 				/>);
 
 				const disabledDays = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
-					.filterWhere(item => item.prop('isDisabledDay'))
+					.filterWhere(item => item.prop('isDisabled'))
 					.map(item => item.prop('label'));
 
 				const expectedDisabledDays = [d1, d2, d3, d4]
@@ -531,7 +531,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
-				currentDate={currentDate}
+				today={today}
 				onSelect={() => {}}
 			/>);
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -12,6 +12,12 @@ describe('DatePicker', () => {
 			isSameDay(date, newToday));
 	}
 
+	function getDisabledChecker(disabledDates) {
+		return date => disabledDates.some(
+			disabledDate => isSameDay(disabledDate, date)
+		);
+	}
+
 	beforeEach(() => {
 		mockIsTodayWith(new Date(2018, 5, 20));
 	});
@@ -26,13 +32,16 @@ describe('DatePicker', () => {
 			new Date(2018, 5, 6),
 			new Date(2018, 5, 15),
 		];
+
+		const isDisabledChecker = getDisabledChecker(disabledDates);
+
 		const selectedDate = new Date(2018, 5, 12);
 
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
 			selectedDate={selectedDate}
 			onSelect={() => {}}
-			disabledRules={disabledDates}
+			isDisabledChecker={isDisabledChecker}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -462,8 +471,8 @@ describe('DatePicker', () => {
 			});
 		});
 
-		describe('disabled rules', () => {
-			it('should not have any disabled date if no rule set', () => {
+		describe('disabled checker', () => {
+			it('should not have any disabled date action if no checker set', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
@@ -474,74 +483,68 @@ describe('DatePicker', () => {
 					onSelect={() => {}}
 				/>);
 
-				const disabledDates = wrapper
+				const disabledActions = wrapper
 					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
-				expect(disabledDates).toHaveLength(0);
+				expect(disabledActions).toHaveLength(0);
 			});
 
-			it('should not have any disabled date if rules are not matching the current month calendar', () => {
+			it('should not have any disabled date action if checker have no date matching the current month calendar', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
 				};
 
-				const disabledRules = [
+				const disabledDatesDefined = [
 					new Date(2018, 4, 17),
-					[
-						new Date(2018, 6, 26),
-					],
+					new Date(2018, 6, 26),
 				];
+
+				const isDisabledChecker = getDisabledChecker(disabledDatesDefined);
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					onSelect={() => {}}
-					disabledRules={disabledRules}
+					isDisabledChecker={isDisabledChecker}
 				/>);
 
-				const disabledDates = wrapper
+				const disabledActions = wrapper
 					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
-				expect(disabledDates).toHaveLength(0);
+				expect(disabledActions).toHaveLength(0);
 			});
 
-			it('should have disabled single date and array of single date', () => {
+			it('should disable the specific dates defined in the checker', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,
 				};
 
-				const d1 = new Date(2018, 5, 17);
-				const d2 = new Date(2018, 5, 26);
-				const d3 = new Date(2018, 5, 28);
-				const d4 = new Date(2018, 5, 30);
-
-				const disabledRules = [
-					d1,
-					[
-						d2,
-						d3,
-						d4,
-					],
+				const disabledDatesDefined = [
+					new Date(2018, 5, 17),
+					new Date(2018, 5, 26),
+					new Date(2018, 5, 28),
+					new Date(2018, 5, 30),
 				];
+				const isDisabledChecker = getDisabledChecker(disabledDatesDefined);
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					onSelect={() => {}}
-					disabledRules={disabledRules}
+					isDisabledChecker={isDisabledChecker}
 				/>);
 
-				const disabledDays = wrapper
+				const disabledActionsLabels = wrapper
 					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'))
 					.map(item => item.prop('label'));
 
-				const expectedDisabledDays = [d1, d2, d3, d4]
+				const expectedDisabledLabels = disabledDatesDefined
 					.map(date => date.getDate().toString());
 
-				expect(disabledDays).toEqual(expectedDisabledDays);
+				expect(disabledActionsLabels).toEqual(expectedDisabledLabels);
 			});
 		});
 	});

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -11,10 +11,12 @@ describe('DatePicker', () => {
 			year: 2018,
 			monthIndex: 5,
 		};
+		const selectedDate = new Date(2018, 5, 12);
 
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
 			currentDate={currentDate}
+			selectedDate={selectedDate}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -307,6 +309,70 @@ describe('DatePicker', () => {
 				const currentDayItems = wrapper
 					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isCurrentDay'));
+
+				expect(currentDayItems).toHaveLength(0);
+			});
+		});
+
+		describe('selected date', () => {
+			it('should render specifically the selected date', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const selectedDate = new Date(2018, 5, 12);
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					selectedDate={selectedDate}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isSelectedDay'));
+
+				expect(currentDayItems).toHaveLength(1);
+				const item = currentDayItems.first();
+				expect(item.prop('label')).toBe('12');
+			});
+
+			it('should not render specifically a date if no selected date given', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isSelectedDay'));
+
+				expect(currentDayItems).toHaveLength(0);
+			});
+
+			it('should not render specifically a date if selected date is out of displayed month', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const selectedDate = new Date(2018, 4, 12);
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					selectedDate={selectedDate}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isSelectedDay'));
 
 				expect(currentDayItems).toHaveLength(0);
 			});

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -267,6 +267,50 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(30);
 			});
 		});
+
+		describe('current date', () => {
+			it('should render specifically the current date', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const date = new Date(2018, 5, 13);
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={date}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isCurrentDay'));
+
+				expect(currentDayItems).toHaveLength(1);
+				const item = currentDayItems.first();
+				expect(item.prop('label')).toBe('13');
+			});
+
+			it('should not render specifically a date if current date is out of displayed month', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const date = new Date(2018, 4, 13);
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={date}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isCurrentDay'));
+
+				expect(currentDayItems).toHaveLength(0);
+			});
+		});
 	});
 
 	describe('header calendar', () => {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -1,10 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-
+import isSameDay from 'date-fns/is_same_day';
+import isToday from 'date-fns/is_today';
 import DatePicker from './DatePicker.component';
 
+jest.mock('date-fns/is_today');
+
 describe('DatePicker', () => {
-	const today = new Date(2018, 5, 20);
+	function mockIsTodayWith(newToday) {
+		isToday.mockImplementation(date =>
+			isSameDay(date, newToday));
+	}
+
+	beforeEach(() => {
+		mockIsTodayWith(new Date(2018, 5, 20));
+	});
 
 	it('should render a DatePicker', () => {
 		const calendar = {
@@ -20,7 +30,6 @@ describe('DatePicker', () => {
 
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
-			today={today}
 			selectedDate={selectedDate}
 			onSelect={() => {}}
 			disabledRules={disabledDates}
@@ -49,7 +58,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -64,7 +72,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -79,7 +86,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -107,7 +113,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -122,7 +127,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -137,7 +141,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -158,7 +161,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -173,7 +175,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -188,7 +189,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -217,7 +217,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -237,7 +236,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -257,7 +255,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -277,7 +274,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -297,11 +293,10 @@ describe('DatePicker', () => {
 					monthIndex: 5,
 				};
 
-				const date = new Date(2018, 5, 13);
+				mockIsTodayWith(new Date(2018, 5, 13));
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={date}
 					onSelect={() => {}}
 				/>);
 
@@ -320,11 +315,10 @@ describe('DatePicker', () => {
 					monthIndex: 5,
 				};
 
-				const date = new Date(2018, 4, 13);
+				mockIsTodayWith(new Date(2018, 4, 13));
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={date}
 					onSelect={() => {}}
 				/>);
 
@@ -333,6 +327,45 @@ describe('DatePicker', () => {
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(0);
+			});
+
+			it.only('should have updated the current today day if has changed between two renders', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				// First day
+				mockIsTodayWith(new Date(2018, 5, 16));
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					onSelect={() => {}}
+				/>);
+
+				const currentDayItems = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(dayItem => dayItem.prop('isToday'));
+
+				expect(currentDayItems).toHaveLength(1);
+				const item = currentDayItems.first();
+				expect(item.prop('label')).toBe('16');
+
+				// Change to next day
+				mockIsTodayWith(new Date(2018, 5, 17));
+
+				const newWrapper = shallow(<DatePicker
+					calendar={calendar}
+					onSelect={() => {}}
+				/>);
+
+				const newDayItems = newWrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(dayItem => dayItem.prop('isToday'));
+
+				expect(newDayItems).toHaveLength(1);
+				const newItem = newDayItems.first();
+				expect(newItem.prop('label')).toBe('17');
 			});
 		});
 
@@ -347,7 +380,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					selectedDate={selectedDate}
 					onSelect={() => {}}
 				/>);
@@ -369,7 +401,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -390,7 +421,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					selectedDate={selectedDate}
 					onSelect={() => {}}
 				/>);
@@ -418,7 +448,6 @@ describe('DatePicker', () => {
 				const selectedDate = new Date(2018, 5, 12);
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					selectedDate={selectedDate}
 					onSelect={onSelect}
 				/>);
@@ -442,7 +471,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 				/>);
 
@@ -468,7 +496,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 					disabledRules={disabledRules}
 				/>);
@@ -502,7 +529,6 @@ describe('DatePicker', () => {
 
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
-					today={today}
 					onSelect={() => {}}
 					disabledRules={disabledRules}
 				/>);
@@ -531,7 +557,6 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
-				today={today}
 				onSelect={() => {}}
 			/>);
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -11,6 +11,11 @@ describe('DatePicker', () => {
 			year: 2018,
 			monthIndex: 5,
 		};
+
+		const disabledDates = [
+			new Date(2018, 5, 6),
+			new Date(2018, 5, 15),
+		];
 		const selectedDate = new Date(2018, 5, 12);
 
 		const wrapper = shallow(<DatePicker
@@ -18,6 +23,7 @@ describe('DatePicker', () => {
 			currentDate={currentDate}
 			selectedDate={selectedDate}
 			onSelect={() => {}}
+			disabledRules={disabledDates}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -424,6 +430,92 @@ describe('DatePicker', () => {
 				dayPickerAction.simulate('click');
 
 				expect(onSelect).toHaveBeenCalledWith(expectedNewSelectedDate);
+			});
+		});
+
+		describe('disabled rules', () => {
+			it('should not have any disabled date if no rule set', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					onSelect={() => {}}
+				/>);
+
+				const disabledDates = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isDisabled'));
+
+				expect(disabledDates).toHaveLength(0);
+			});
+
+			it('should not have any disabled date if rules are not matching the current month calendar', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const disabledRules = [
+					new Date(2018, 4, 17),
+					[
+						new Date(2018, 6, 26),
+					],
+				];
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					onSelect={() => {}}
+					disabledRules={disabledRules}
+				/>);
+
+				const disabledDates = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isDisabled'));
+
+				expect(disabledDates).toHaveLength(0);
+			});
+
+			it('should have disabled single date and array of single date', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const d1 = new Date(2018, 5, 17);
+				const d2 = new Date(2018, 5, 26);
+				const d3 = new Date(2018, 5, 28);
+				const d4 = new Date(2018, 5, 30);
+
+				const disabledRules = [
+					d1,
+					[
+						d2,
+						d3,
+						d4,
+					],
+				];
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					onSelect={() => {}}
+					disabledRules={disabledRules}
+				/>);
+
+				const disabledDays = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('isDisabledDay'))
+					.map(item => item.prop('label'));
+
+				const expectedDisabledDays = [d1, d2, d3, d4]
+					.map(date => date.getDate().toString());
+
+				expect(disabledDays).toEqual(expectedDisabledDays);
 			});
 		});
 	});

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -42,7 +42,7 @@ describe('DatePicker', () => {
 		describe('first date of month in the correct grid column (Monday as first day of week)', () => {
 			function getFirstRowCellText(wrapper, column) {
 				return wrapper
-					.find('.calendar-body-row')
+					.find('.calendar-body .calendar-row')
 					.first()
 					.find('.calendar-item')
 					.at(column - 1)
@@ -97,7 +97,7 @@ describe('DatePicker', () => {
 		describe('last date in the correct day column (Monday as first column)', () => {
 			function getLastRowCellText(wrapper, column) {
 				return wrapper
-					.find('.calendar-body-row')
+					.find('.calendar-body .calendar-row')
 					.last()
 					.find('.calendar-item')
 					.at(column - 1)
@@ -150,7 +150,7 @@ describe('DatePicker', () => {
 
 		describe('number of weeks displayed', () => {
 			function nbOfWeeksRendered(wrapper) {
-				return wrapper.find('.calendar-body-row').length;
+				return wrapper.find('.calendar-body .calendar-row').length;
 			}
 
 			it('should have 4 weeks for february 2010', () => {
@@ -199,7 +199,7 @@ describe('DatePicker', () => {
 		describe('contiguous ordered numbers', () => {
 			function getDayNumbers(wrapper) {
 				return wrapper
-					.find('.calendar-body-row .calendar-item')
+					.find('.calendar-body .calendar-item')
 					.find('DayPickerAction')
 					.map(action => action.prop('label'))
 					.map(label => parseInt(label, 10));
@@ -301,7 +301,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -323,7 +323,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -344,7 +344,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -360,7 +360,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const newDayItems = newWrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(newDayItems).toHaveLength(1);
@@ -385,7 +385,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -405,7 +405,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -426,7 +426,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -453,7 +453,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const dayPickerAction = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('label') === dayToSelect.toString());
 
 				dayPickerAction.simulate('click');
@@ -475,7 +475,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDates = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledDates).toHaveLength(0);
@@ -501,7 +501,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDates = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledDates).toHaveLength(0);
@@ -534,7 +534,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledDays = wrapper
-					.find('.calendar-body-row .calendar-item DayPickerAction')
+					.find('.calendar-body .calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'))
 					.map(item => item.prop('label'));
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -538,7 +538,7 @@ describe('DatePicker', () => {
 			const sequenceExpected = sequence.map(day => day[0].toUpperCase());
 
 			const sequenceRendered = wrapper
-				.find('.theme-calendar-header-row .theme-calendar-item')
+				.find('.theme-calendar-header .theme-calendar-item')
 				.map(item => item.text());
 
 			expect(sequenceRendered).toEqual(sequenceExpected);

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -207,17 +207,13 @@ describe('DatePicker', () => {
 			});
 		});
 
-		describe('contiguous ordered numbers', () => {
+		describe('right number of days in month', () => {
 			function getDayNumbers(wrapper) {
 				return wrapper
 					.find('.calendar-body .calendar-item')
 					.find('DayPickerAction')
 					.map(action => action.prop('label'))
 					.map(label => parseInt(label, 10));
-			}
-
-			function ascSorting(a, b) {
-				return a - b;
 			}
 
 			it('should have contiguous numbers on a 31 days month', () => {
@@ -232,10 +228,6 @@ describe('DatePicker', () => {
 				/>);
 
 				const days = getDayNumbers(wrapper);
-				const copy = [...days];
-				days.sort(ascSorting);
-				expect(days).toEqual(copy);
-				expect(days[0]).toBe(1);
 				expect(days).toHaveLength(31);
 			});
 
@@ -251,10 +243,6 @@ describe('DatePicker', () => {
 				/>);
 
 				const days = getDayNumbers(wrapper);
-				const copy = [...days];
-				days.sort(ascSorting);
-				expect(days).toEqual(copy);
-				expect(days[0]).toBe(1);
 				expect(days).toHaveLength(29);
 			});
 
@@ -270,14 +258,10 @@ describe('DatePicker', () => {
 				/>);
 
 				const days = getDayNumbers(wrapper);
-				const copy = [...days];
-				days.sort(ascSorting);
-				expect(days).toEqual(copy);
-				expect(days[0]).toBe(1);
 				expect(days).toHaveLength(28);
 			});
 
-			it('should have contiguous numbers on a 30 days month', () => {
+			it('should have the right number of days on a 30 days month', () => {
 				const calendar = {
 					year: 2022,
 					monthIndex: 10,
@@ -289,10 +273,6 @@ describe('DatePicker', () => {
 				/>);
 
 				const days = getDayNumbers(wrapper);
-				const copy = [...days];
-				days.sort(ascSorting);
-				expect(days).toEqual(copy);
-				expect(days[0]).toBe(1);
 				expect(days).toHaveLength(30);
 			});
 		});

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -20,135 +20,259 @@ describe('DatePicker', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	describe('first date in the correct day column (Monday as first column)', () => {
-		function getFirstRowCellText(wrapper, column) {
-			return wrapper
-				.find('.theme-calendar-body-row')
-				.first()
-				.find('.theme-calendar-item')
-				.at(column - 1)
-				.find('DayPickerAction')
-				.prop('label');
-		}
+	describe('body calendar', () => {
+		describe('first date in the correct day column (Monday as first column)', () => {
+			function getFirstRowCellText(wrapper, column) {
+				return wrapper
+					.find('.theme-calendar-body-row')
+					.first()
+					.find('.theme-calendar-item')
+					.at(column - 1)
+					.find('DayPickerAction')
+					.prop('label');
+			}
 
-		it('should have monday in the 1st column for january 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 0,
-			};
+			it('should have monday in the 1st column for january 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 0,
+				};
 
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
 
-			expect(getFirstRowCellText(wrapper, 1)).toBe('1');
+				expect(getFirstRowCellText(wrapper, 1)).toBe('1');
+			});
+
+			it('should have thursday in the 4th column for march 2018 ', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 2,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(getFirstRowCellText(wrapper, 4)).toBe('1');
+			});
+
+			it('should have sunday in the 7th column for april 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 3,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(getFirstRowCellText(wrapper, 7)).toBe('1');
+			});
 		});
 
-		it('should have thursday in the 4th column for march 2018 ', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 2,
-			};
 
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
+		describe('last date in the correct day column (Monday as first column)', () => {
+			function getLastRowCellText(wrapper, column) {
+				return wrapper
+					.find('.theme-calendar-body-row')
+					.last()
+					.find('.theme-calendar-item')
+					.at(column - 1)
+					.find('DayPickerAction')
+					.prop('label');
+			}
 
-			expect(getFirstRowCellText(wrapper, 4)).toBe('1');
+			it('should have monday in the 1st column for april 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 3,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(getLastRowCellText(wrapper, 1)).toBe('30');
+			});
+
+			it('should have thursday in the 4th column for may 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 4,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(getLastRowCellText(wrapper, 4)).toBe('31');
+			});
+
+			it('should have sunday in the 7th column for september 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 8,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(getLastRowCellText(wrapper, 7)).toBe('30');
+			});
 		});
 
-		it('should have sunday in the 7th column for april 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 3,
-			};
+		describe('number of weeks displayed', () => {
+			function nbOfWeeksRendered(wrapper) {
+				return wrapper.find('.theme-calendar-body-row').length;
+			}
 
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
+			it('should have 4 weeks for february 2010', () => {
+				const calendar = {
+					year: 2010,
+					monthIndex: 1,
+				};
 
-			expect(getFirstRowCellText(wrapper, 7)).toBe('1');
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(nbOfWeeksRendered(wrapper)).toBe(4);
+			});
+
+			it('should have 5 weeks for june 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(nbOfWeeksRendered(wrapper)).toBe(5);
+			});
+
+			it('should have 6 weeks for october 2017', () => {
+				const calendar = {
+					year: 2017,
+					monthIndex: 9,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				expect(nbOfWeeksRendered(wrapper)).toBe(6);
+			});
+		});
+
+		describe('contiguous ordered numbers', () => {
+			function getDayNumbers(wrapper) {
+				return wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item')
+					.find('DayPickerAction')
+					.map(action => action.prop('label'))
+					.map(label => parseInt(label, 10));
+			}
+
+			function ascSorting(a, b) {
+				return a - b;
+			}
+
+			it('should have contiguous numbers for july 2018', () => {
+				const calendar = {
+					year: 2018,
+					monthIndex: 6,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				const days = getDayNumbers(wrapper);
+				const copy = [...days];
+				days.sort(ascSorting);
+				expect(days).toEqual(copy);
+				expect(days[0]).toBe(1);
+				expect(days).toHaveLength(31);
+			});
+
+			it('should have contiguous numbers for february 2016', () => {
+				const calendar = {
+					year: 2016,
+					monthIndex: 1,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				const days = getDayNumbers(wrapper);
+				const copy = [...days];
+				days.sort(ascSorting);
+				expect(days).toEqual(copy);
+				expect(days[0]).toBe(1);
+				expect(days).toHaveLength(29);
+			});
+
+			it('should have contiguous numbers for february 2017', () => {
+				const calendar = {
+					year: 2017,
+					monthIndex: 1,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				const days = getDayNumbers(wrapper);
+				const copy = [...days];
+				days.sort(ascSorting);
+				expect(days).toEqual(copy);
+				expect(days[0]).toBe(1);
+				expect(days).toHaveLength(28);
+			});
+
+			it('should have contiguous numbers for november 2022', () => {
+				const calendar = {
+					year: 2022,
+					monthIndex: 10,
+				};
+
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+				/>);
+
+				const days = getDayNumbers(wrapper);
+				const copy = [...days];
+				days.sort(ascSorting);
+				expect(days).toEqual(copy);
+				expect(days[0]).toBe(1);
+				expect(days).toHaveLength(30);
+			});
 		});
 	});
 
+	describe('header calendar', () => {
+		it('should display the exact days sequence', () => {
+			const sequence = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
 
-	describe('last date in the correct day column (Monday as first column)', () => {
-		function getLastRowCellText(wrapper, column) {
-			return wrapper
-				.find('.theme-calendar-body-row')
-				.last()
-				.find('.theme-calendar-item')
-				.at(column - 1)
-				.find('DayPickerAction')
-				.prop('label');
-		}
-
-		it('should have monday in the 1st column for april 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 3,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			expect(getLastRowCellText(wrapper, 1)).toBe('30');
-		});
-
-		it('should have thursday in the 4th column for may 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 4,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			expect(getLastRowCellText(wrapper, 4)).toBe('31');
-		});
-
-		it('should have sunday in the 7th column for september 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 8,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			expect(getLastRowCellText(wrapper, 7)).toBe('30');
-		});
-	});
-
-	describe('number of weeks displayed', () => {
-		function nbOfWeeksRendered(wrapper) {
-			return wrapper.find('.theme-calendar-body-row').length;
-		}
-
-		it('should have 4 weeks for february 2010', () => {
-			const calendar = {
-				year: 2010,
-				monthIndex: 1,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			expect(nbOfWeeksRendered(wrapper)).toBe(4);
-		});
-
-		it('should have 5 weeks for june 2018', () => {
 			const calendar = {
 				year: 2018,
 				monthIndex: 5,
@@ -159,111 +283,13 @@ describe('DatePicker', () => {
 				currentDate={currentDate}
 			/>);
 
-			expect(nbOfWeeksRendered(wrapper)).toBe(5);
-		});
+			const sequenceExpected = sequence.map(day => day[0].toUpperCase());
 
-		it('should have 6 weeks for october 2017', () => {
-			const calendar = {
-				year: 2017,
-				monthIndex: 9,
-			};
+			const sequenceRendered = wrapper
+				.find('.theme-calendar-header-row .theme-calendar-item')
+				.map(item => item.text());
 
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			expect(nbOfWeeksRendered(wrapper)).toBe(6);
-		});
-	});
-
-	describe('contiguous ordered numbers', () => {
-		function getDayNumbers(wrapper) {
-			return wrapper
-				.find('.theme-calendar-body-row .theme-calendar-item')
-				.find('DayPickerAction')
-				.map(action => action.prop('label'))
-				.map(label => parseInt(label, 10));
-		}
-
-		function ascSorting(a, b) {
-			return a - b;
-		}
-
-		it('should have contiguous numbers for july 2018', () => {
-			const calendar = {
-				year: 2018,
-				monthIndex: 6,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			const days = getDayNumbers(wrapper);
-			const copy = [...days];
-			days.sort(ascSorting);
-			expect(days).toEqual(copy);
-			expect(days[0]).toBe(1);
-			expect(days).toHaveLength(31);
-		});
-
-		it('should have contiguous numbers for february 2016', () => {
-			const calendar = {
-				year: 2016,
-				monthIndex: 1,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			const days = getDayNumbers(wrapper);
-			const copy = [...days];
-			days.sort(ascSorting);
-			expect(days).toEqual(copy);
-			expect(days[0]).toBe(1);
-			expect(days).toHaveLength(29);
-		});
-
-		it('should have contiguous numbers for february 2017', () => {
-			const calendar = {
-				year: 2017,
-				monthIndex: 1,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			const days = getDayNumbers(wrapper);
-			const copy = [...days];
-			days.sort(ascSorting);
-			expect(days).toEqual(copy);
-			expect(days[0]).toBe(1);
-			expect(days).toHaveLength(28);
-		});
-
-		it('should have contiguous numbers for november 2022', () => {
-			const calendar = {
-				year: 2022,
-				monthIndex: 10,
-			};
-
-			const wrapper = shallow(<DatePicker
-				calendar={calendar}
-				currentDate={currentDate}
-			/>);
-
-			const days = getDayNumbers(wrapper);
-			const copy = [...days];
-			days.sort(ascSorting);
-			expect(days).toEqual(copy);
-			expect(days[0]).toBe(1);
-			expect(days).toHaveLength(30);
+			expect(sequenceRendered).toEqual(sequenceExpected);
 		});
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -51,9 +51,9 @@ describe('DatePicker', () => {
 		describe('first date of month in the correct grid column (When monday as first day of week)', () => {
 			function getFirstRowCellText(wrapper, column) {
 				return wrapper
-					.find('.calendar-body .calendar-row')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-row')
 					.first()
-					.find('.calendar-item')
+					.find('.tc-date-picker-calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
 					.prop('label')
@@ -107,9 +107,9 @@ describe('DatePicker', () => {
 		describe('last date of month in the correct grid column (When monday as first day of week)', () => {
 			function getLastRowCellText(wrapper, column) {
 				return wrapper
-					.find('.calendar-body .calendar-row')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-row')
 					.last()
-					.find('.calendar-item')
+					.find('.tc-date-picker-calendar-item')
 					.at(column - 1)
 					.find('DayPickerAction')
 					.prop('label')
@@ -161,7 +161,7 @@ describe('DatePicker', () => {
 
 		describe('number of weeks displayed', () => {
 			function nbOfWeeksRendered(wrapper) {
-				return wrapper.find('.calendar-body .calendar-row').length;
+				return wrapper.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-row').length;
 			}
 
 			it('should have 4 weeks for february 2010', () => {
@@ -210,7 +210,7 @@ describe('DatePicker', () => {
 		describe('right number of days in month', () => {
 			function getDayNumbers(wrapper) {
 				return wrapper
-					.find('.calendar-body .calendar-item')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item')
 					.find('DayPickerAction')
 					.map(action => action.prop('label'))
 					.map(label => parseInt(label, 10));
@@ -292,7 +292,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -314,7 +314,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -335,7 +335,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -351,7 +351,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const newDayItems = newWrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(dayItem => dayItem.prop('isToday'));
 
 				expect(newDayItems).toHaveLength(1);
@@ -376,7 +376,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(1);
@@ -396,7 +396,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -417,7 +417,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const currentDayItems = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isSelected'));
 
 				expect(currentDayItems).toHaveLength(0);
@@ -444,7 +444,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const dayPickerAction = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('label').toString() === dayToSelect.toString());
 
 				dayPickerAction.simulate('click');
@@ -466,7 +466,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledActions = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledActions).toHaveLength(0);
@@ -492,7 +492,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledActions = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'));
 
 				expect(disabledActions).toHaveLength(0);
@@ -519,7 +519,7 @@ describe('DatePicker', () => {
 				/>);
 
 				const disabledActionsLabels = wrapper
-					.find('.calendar-body .calendar-item DayPickerAction')
+					.find('.tc-date-picker-calendar-body .tc-date-picker-calendar-item DayPickerAction')
 					.filterWhere(item => item.prop('isDisabled'))
 					.map(item => item.prop('label').toString());
 
@@ -548,7 +548,7 @@ describe('DatePicker', () => {
 			const sequenceExpected = sequence.map(day => day[0].toUpperCase());
 
 			const sequenceRendered = wrapper
-				.find('.calendar-header .calendar-item')
+				.find('.tc-date-picker-calendar-header .tc-date-picker-calendar-item')
 				.map(item => item.text());
 
 			expect(sequenceRendered).toEqual(sequenceExpected);

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -329,7 +329,7 @@ describe('DatePicker', () => {
 				expect(currentDayItems).toHaveLength(0);
 			});
 
-			it.only('should have updated the current today day if has changed between two renders', () => {
+			it('should have updated the current today day if has changed between two renders', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 5,

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -4,14 +4,17 @@ import { shallow } from 'enzyme';
 import DatePicker from './DatePicker.component';
 
 describe('DatePicker', () => {
+	const currentDate = new Date(2018, 5, 20);
+
 	it('should render a DatePicker', () => {
 		const calendar = {
 			year: 2018,
-			monthIndex: 6,
+			monthIndex: 5,
 		};
 
 		const wrapper = shallow(<DatePicker
 			calendar={calendar}
+			currentDate={currentDate}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -36,6 +39,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getFirstRowCellText(wrapper, 1)).toBe('1');
@@ -49,6 +53,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getFirstRowCellText(wrapper, 4)).toBe('1');
@@ -62,6 +67,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getFirstRowCellText(wrapper, 7)).toBe('1');
@@ -88,6 +94,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getLastRowCellText(wrapper, 1)).toBe('30');
@@ -101,6 +108,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getLastRowCellText(wrapper, 4)).toBe('31');
@@ -114,6 +122,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(getLastRowCellText(wrapper, 7)).toBe('30');
@@ -133,6 +142,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(nbOfWeeksRendered(wrapper)).toBe(4);
@@ -146,6 +156,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(nbOfWeeksRendered(wrapper)).toBe(5);
@@ -159,6 +170,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			expect(nbOfWeeksRendered(wrapper)).toBe(6);
@@ -186,6 +198,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			const days = getDayNumbers(wrapper);
@@ -204,6 +217,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			const days = getDayNumbers(wrapper);
@@ -222,6 +236,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			const days = getDayNumbers(wrapper);
@@ -240,6 +255,7 @@ describe('DatePicker', () => {
 
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
+				currentDate={currentDate}
 			/>);
 
 			const days = getDayNumbers(wrapper);

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -17,6 +17,7 @@ describe('DatePicker', () => {
 			calendar={calendar}
 			currentDate={currentDate}
 			selectedDate={selectedDate}
+			onSelect={() => {}}
 		/>);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -43,6 +44,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getFirstRowCellText(wrapper, 1)).toBe('1');
@@ -57,6 +59,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getFirstRowCellText(wrapper, 4)).toBe('1');
@@ -71,6 +74,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getFirstRowCellText(wrapper, 7)).toBe('1');
@@ -98,6 +102,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getLastRowCellText(wrapper, 1)).toBe('30');
@@ -112,6 +117,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getLastRowCellText(wrapper, 4)).toBe('31');
@@ -126,6 +132,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(getLastRowCellText(wrapper, 7)).toBe('30');
@@ -146,6 +153,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(nbOfWeeksRendered(wrapper)).toBe(4);
@@ -160,6 +168,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(nbOfWeeksRendered(wrapper)).toBe(5);
@@ -174,6 +183,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				expect(nbOfWeeksRendered(wrapper)).toBe(6);
@@ -202,6 +212,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				const days = getDayNumbers(wrapper);
@@ -221,6 +232,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				const days = getDayNumbers(wrapper);
@@ -240,6 +252,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				const days = getDayNumbers(wrapper);
@@ -259,6 +272,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				const days = getDayNumbers(wrapper);
@@ -282,6 +296,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={date}
+					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
@@ -304,6 +319,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={date}
+					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
@@ -327,6 +343,7 @@ describe('DatePicker', () => {
 					calendar={calendar}
 					currentDate={currentDate}
 					selectedDate={selectedDate}
+					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
@@ -347,6 +364,7 @@ describe('DatePicker', () => {
 				const wrapper = shallow(<DatePicker
 					calendar={calendar}
 					currentDate={currentDate}
+					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
@@ -368,6 +386,7 @@ describe('DatePicker', () => {
 					calendar={calendar}
 					currentDate={currentDate}
 					selectedDate={selectedDate}
+					onSelect={() => {}}
 				/>);
 
 				const currentDayItems = wrapper
@@ -375,6 +394,36 @@ describe('DatePicker', () => {
 					.filterWhere(item => item.prop('isSelectedDay'));
 
 				expect(currentDayItems).toHaveLength(0);
+			});
+		});
+
+		describe('date selection', () => {
+			it('should callback with the date corresponding to the day of month clicked', () => {
+				const onSelect = jest.fn();
+
+				const calendar = {
+					year: 2018,
+					monthIndex: 5,
+				};
+
+				const dayToSelect = 8;
+				const expectedNewSelectedDate = new Date(2018, 5, dayToSelect);
+
+				const selectedDate = new Date(2018, 5, 12);
+				const wrapper = shallow(<DatePicker
+					calendar={calendar}
+					currentDate={currentDate}
+					selectedDate={selectedDate}
+					onSelect={onSelect}
+				/>);
+
+				const dayPickerAction = wrapper
+					.find('.theme-calendar-body-row .theme-calendar-item DayPickerAction')
+					.filterWhere(item => item.prop('label') === dayToSelect.toString());
+
+				dayPickerAction.simulate('click');
+
+				expect(onSelect).toHaveBeenCalledWith(expectedNewSelectedDate);
 			});
 		});
 	});
@@ -391,6 +440,7 @@ describe('DatePicker', () => {
 			const wrapper = shallow(<DatePicker
 				calendar={calendar}
 				currentDate={currentDate}
+				onSelect={() => {}}
 			/>);
 
 			const sequenceExpected = sequence.map(day => day[0].toUpperCase());

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -5,8 +5,15 @@ import DatePicker from './DatePicker.component';
 
 describe('DatePicker', () => {
 	it('should render a DatePicker', () => {
+		const calendar = {
+			year: 2018,
+			monthIndex: 6,
+		};
+
 		// when
-		const wrapper = shallow(<DatePicker />);
+		const wrapper = shallow(<DatePicker
+			calendar={calendar}
+		/>);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -39,7 +39,7 @@ describe('DatePicker', () => {
 	});
 
 	describe('body calendar', () => {
-		describe('first date in the correct day column (Monday as first column)', () => {
+		describe('first date of month in the correct grid column (Monday as first day of week)', () => {
 			function getFirstRowCellText(wrapper, column) {
 				return wrapper
 					.find('.theme-calendar-body-row')
@@ -209,7 +209,7 @@ describe('DatePicker', () => {
 				return a - b;
 			}
 
-			it('should have contiguous numbers for july 2018', () => {
+			it('should have contiguous numbers for july 2018 (31 days)', () => {
 				const calendar = {
 					year: 2018,
 					monthIndex: 6,
@@ -228,7 +228,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(31);
 			});
 
-			it('should have contiguous numbers for february 2016', () => {
+			it('should have contiguous numbers for february 2016 (29 days)', () => {
 				const calendar = {
 					year: 2016,
 					monthIndex: 1,
@@ -247,7 +247,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(29);
 			});
 
-			it('should have contiguous numbers for february 2017', () => {
+			it('should have contiguous numbers for february 2017 (28 days)', () => {
 				const calendar = {
 					year: 2017,
 					monthIndex: 1,
@@ -266,7 +266,7 @@ describe('DatePicker', () => {
 				expect(days).toHaveLength(28);
 			});
 
-			it('should have contiguous numbers for november 2022', () => {
+			it('should have contiguous numbers for november 2022 (30 days)', () => {
 				const calendar = {
 					year: 2022,
 					monthIndex: 10,

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
@@ -39,7 +39,10 @@ function DayPickerAction(props) {
 }
 
 DayPickerAction.propTypes = {
-	label: PropTypes.string,
+	label: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.number,
+	]),
 	className: PropTypes.string,
 	isSelected: PropTypes.bool,
 	isDisabled: PropTypes.bool,

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
@@ -6,9 +6,9 @@ import theme from './DayPickerAction.scss';
 function DayPickerAction(props) {
 	const {
 		label,
-		isSelectedDay,
-		isDisabledDay,
-		isCurrentDay,
+		isSelected,
+		isDisabled,
+		isToday,
 		className: propClassName,
 		...rest
 	} = props;
@@ -16,8 +16,8 @@ function DayPickerAction(props) {
 	const className = classNames(
 		theme.action,
 		{
-			[theme.selected]: isSelectedDay,
-			[theme.today]: isCurrentDay,
+			[theme.selected]: isSelected,
+			[theme.today]: isToday,
 		},
 		propClassName,
 	);
@@ -25,7 +25,7 @@ function DayPickerAction(props) {
 	return (
 		<button
 			type="button"
-			disabled={isDisabledDay}
+			disabled={isDisabled}
 			className={className}
 			{...rest}
 		>
@@ -37,9 +37,9 @@ function DayPickerAction(props) {
 DayPickerAction.propTypes = {
 	label: PropTypes.string,
 	className: PropTypes.string,
-	isSelectedDay: PropTypes.bool,
-	isDisabledDay: PropTypes.bool,
-	isCurrentDay: PropTypes.bool,
+	isSelected: PropTypes.bool,
+	isDisabled: PropTypes.bool,
+	isToday: PropTypes.bool,
 };
 
 export default DayPickerAction;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.component.js
@@ -29,7 +29,11 @@ function DayPickerAction(props) {
 			className={className}
 			{...rest}
 		>
-			{label}
+			<span
+				className={theme.label}
+			>
+				{label}
+			</span>
 		</button>
 	);
 }

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
@@ -1,26 +1,43 @@
 @import '../../../mixins';
 
 .action {
+    display: flex;
     background: none;
     border: none;
-    width: 2em;
-    height: 2em;
-    border-radius: 50%;
+    justify-content: center;
+    align-content: center;
+    padding: 0;
+    width: 100%;
+
+    .label {
+        width: 2em;
+        height: 2em;
+        line-height: 2em;
+        border-radius: 50%;
+    }
 
     &:hover {
-        background-color: $concrete;
+        .label {
+            background-color: $concrete;
+        }
     }
 
     &:disabled {
-        color: $silver-chalice;
-        background-color: transparent;
+        .label {
+            color: $silver-chalice;
+            background-color: transparent;
+        }
     }
 
     &.today {
-        background-color: rgba($slate-gray, 0.12);
+        .label {
+            background-color: rgba($slate-gray, 0.12);
+        }
     }
 
     &.selected {
-        @include picker-action-selected;
+        .label {
+            @include picker-action-selected;
+        }
     }
 }

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
@@ -31,7 +31,6 @@
 
     &.today {
         .label {
-            background-color: rgba($slate-gray, 0.12);
             position: relative;
 
             &::after {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.scss
@@ -32,6 +32,16 @@
     &.today {
         .label {
             background-color: rgba($slate-gray, 0.12);
+            position: relative;
+
+            &::after {
+                content: '*';
+                color: red;
+                line-height: normal;
+                position: absolute;
+                top: 0;
+                right: 0;
+            }
         }
     }
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/DayPickerAction.test.js
@@ -23,7 +23,7 @@ describe('DayPickerAction', () => {
 			<DayPickerAction
 				label="36"
 				className="my-day-picker-class"
-				isDisabledDay
+				isDisabled
 			/>
 		);
 
@@ -37,7 +37,7 @@ describe('DayPickerAction', () => {
 			<DayPickerAction
 				label="36"
 				className="my-day-picker-class"
-				isCurrentDay
+				isToday
 			/>
 		);
 
@@ -51,7 +51,7 @@ describe('DayPickerAction', () => {
 			<DayPickerAction
 				label="36"
 				className="my-day-picker-class"
-				isSelectedDay
+				isSelected
 			/>
 		);
 

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/__snapshots__/DayPickerAction.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DayPickerAction/__snapshots__/DayPickerAction.test.js.snap
@@ -6,7 +6,11 @@ exports[`DayPickerAction should render a disabled day 1`] = `
   disabled={true}
   type="button"
 >
-  36
+  <span
+    className="theme-label"
+  >
+    36
+  </span>
 </button>
 `;
 
@@ -16,7 +20,11 @@ exports[`DayPickerAction should render a selected day 1`] = `
   disabled={undefined}
   type="button"
 >
-  36
+  <span
+    className="theme-label"
+  >
+    36
+  </span>
 </button>
 `;
 
@@ -26,7 +34,11 @@ exports[`DayPickerAction should render a simple day 1`] = `
   disabled={undefined}
   type="button"
 >
-  36
+  <span
+    className="theme-label"
+  >
+    36
+  </span>
 </button>
 `;
 
@@ -36,6 +48,10 @@ exports[`DayPickerAction should render a today day 1`] = `
   disabled={undefined}
   type="button"
 >
-  36
+  <span
+    className="theme-label"
+  >
+    36
+  </span>
 </button>
 `;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -5,49 +5,49 @@ exports[`DatePicker should render a DatePicker 1`] = `
   className="theme-container"
 >
   <div
-    className="theme-calendar-header"
+    className="calendar-header theme-calendar-header"
   >
     <div
-      className="theme-calendar-row"
+      className="calendar-row theme-calendar-row"
     >
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Monday"
       >
         M
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Tuesday"
       >
         T
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Wednesday"
       >
         W
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Thursday"
       >
         T
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Friday"
       >
         F
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Saturday"
       >
         S
       </abbr>
       <abbr
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
         title="Sunday"
       >
         S
@@ -58,25 +58,25 @@ exports[`DatePicker should render a DatePicker 1`] = `
     />
   </div>
   <div
-    className="theme-calendar-body"
+    className="calendar-body theme-calendar-body"
   >
     <div
-      className="theme-calendar-row theme-calendar-body-row"
+      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
     >
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       />
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       />
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       />
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       />
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '1'"
@@ -88,7 +88,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '2'"
@@ -100,7 +100,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '3'"
@@ -113,10 +113,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="theme-calendar-row theme-calendar-body-row"
+      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
     >
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '4'"
@@ -128,7 +128,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '5'"
@@ -140,7 +140,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Unselectable date"
@@ -152,7 +152,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '7'"
@@ -164,7 +164,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '8'"
@@ -176,7 +176,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '9'"
@@ -188,7 +188,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '10'"
@@ -201,10 +201,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="theme-calendar-row theme-calendar-body-row"
+      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
     >
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '11'"
@@ -216,7 +216,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '12'"
@@ -228,7 +228,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '13'"
@@ -240,7 +240,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '14'"
@@ -252,7 +252,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Unselectable date"
@@ -264,7 +264,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '16'"
@@ -276,7 +276,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '17'"
@@ -289,10 +289,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="theme-calendar-row theme-calendar-body-row"
+      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
     >
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '18'"
@@ -304,7 +304,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '19'"
@@ -316,7 +316,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '20'"
@@ -328,7 +328,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '21'"
@@ -340,7 +340,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '22'"
@@ -352,7 +352,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '23'"
@@ -364,7 +364,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '24'"
@@ -377,10 +377,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="theme-calendar-row theme-calendar-body-row"
+      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
     >
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '25'"
@@ -392,7 +392,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '26'"
@@ -404,7 +404,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '27'"
@@ -416,7 +416,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '28'"
@@ -428,7 +428,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '29'"
@@ -440,7 +440,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '30'"
@@ -452,7 +452,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="theme-calendar-item"
+        className="calendar-item theme-calendar-item"
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -73,9 +73,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '1'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="1"
         onClick={[Function]}
       />
@@ -85,9 +85,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '2'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="2"
         onClick={[Function]}
       />
@@ -97,9 +97,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '3'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="3"
         onClick={[Function]}
       />
@@ -113,9 +113,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '4'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="4"
         onClick={[Function]}
       />
@@ -125,9 +125,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '5'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="5"
         onClick={[Function]}
       />
@@ -137,9 +137,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Unselectable date"
-        isCurrentDay={false}
-        isDisabledDay={true}
-        isSelectedDay={false}
+        isDisabled={true}
+        isSelected={false}
+        isToday={false}
         label="6"
         onClick={[Function]}
       />
@@ -149,9 +149,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '7'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="7"
         onClick={[Function]}
       />
@@ -161,9 +161,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '8'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="8"
         onClick={[Function]}
       />
@@ -173,9 +173,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '9'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="9"
         onClick={[Function]}
       />
@@ -185,9 +185,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '10'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="10"
         onClick={[Function]}
       />
@@ -201,9 +201,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '11'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="11"
         onClick={[Function]}
       />
@@ -213,9 +213,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '12'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={true}
+        isDisabled={false}
+        isSelected={true}
+        isToday={false}
         label="12"
         onClick={[Function]}
       />
@@ -225,9 +225,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '13'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="13"
         onClick={[Function]}
       />
@@ -237,9 +237,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '14'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="14"
         onClick={[Function]}
       />
@@ -249,9 +249,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Unselectable date"
-        isCurrentDay={false}
-        isDisabledDay={true}
-        isSelectedDay={false}
+        isDisabled={true}
+        isSelected={false}
+        isToday={false}
         label="15"
         onClick={[Function]}
       />
@@ -261,9 +261,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '16'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="16"
         onClick={[Function]}
       />
@@ -273,9 +273,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '17'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="17"
         onClick={[Function]}
       />
@@ -289,9 +289,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '18'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="18"
         onClick={[Function]}
       />
@@ -301,9 +301,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '19'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="19"
         onClick={[Function]}
       />
@@ -313,9 +313,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '20'"
-        isCurrentDay={true}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={true}
         label="20"
         onClick={[Function]}
       />
@@ -325,9 +325,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '21'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="21"
         onClick={[Function]}
       />
@@ -337,9 +337,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '22'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="22"
         onClick={[Function]}
       />
@@ -349,9 +349,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '23'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="23"
         onClick={[Function]}
       />
@@ -361,9 +361,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '24'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="24"
         onClick={[Function]}
       />
@@ -377,9 +377,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '25'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="25"
         onClick={[Function]}
       />
@@ -389,9 +389,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '26'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="26"
         onClick={[Function]}
       />
@@ -401,9 +401,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '27'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="27"
         onClick={[Function]}
       />
@@ -413,9 +413,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '28'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="28"
         onClick={[Function]}
       />
@@ -425,9 +425,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '29'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="29"
         onClick={[Function]}
       />
@@ -437,9 +437,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
     >
       <DayPickerAction
         aria-label="Select '30'"
-        isCurrentDay={false}
-        isDisabledDay={false}
-        isSelectedDay={false}
+        isDisabled={false}
+        isSelected={false}
+        isToday={false}
         label="30"
         onClick={[Function]}
       />

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -83,7 +83,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="1"
+          label={1}
           onClick={[Function]}
         />
       </div>
@@ -95,7 +95,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="2"
+          label={2}
           onClick={[Function]}
         />
       </div>
@@ -107,7 +107,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="3"
+          label={3}
           onClick={[Function]}
         />
       </div>
@@ -123,7 +123,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="4"
+          label={4}
           onClick={[Function]}
         />
       </div>
@@ -135,7 +135,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="5"
+          label={5}
           onClick={[Function]}
         />
       </div>
@@ -147,7 +147,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={true}
           isSelected={false}
           isToday={false}
-          label="6"
+          label={6}
           onClick={[Function]}
         />
       </div>
@@ -159,7 +159,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="7"
+          label={7}
           onClick={[Function]}
         />
       </div>
@@ -171,7 +171,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="8"
+          label={8}
           onClick={[Function]}
         />
       </div>
@@ -183,7 +183,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="9"
+          label={9}
           onClick={[Function]}
         />
       </div>
@@ -195,7 +195,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="10"
+          label={10}
           onClick={[Function]}
         />
       </div>
@@ -211,7 +211,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="11"
+          label={11}
           onClick={[Function]}
         />
       </div>
@@ -223,7 +223,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={true}
           isToday={false}
-          label="12"
+          label={12}
           onClick={[Function]}
         />
       </div>
@@ -235,7 +235,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="13"
+          label={13}
           onClick={[Function]}
         />
       </div>
@@ -247,7 +247,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="14"
+          label={14}
           onClick={[Function]}
         />
       </div>
@@ -259,7 +259,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={true}
           isSelected={false}
           isToday={false}
-          label="15"
+          label={15}
           onClick={[Function]}
         />
       </div>
@@ -271,7 +271,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="16"
+          label={16}
           onClick={[Function]}
         />
       </div>
@@ -283,7 +283,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="17"
+          label={17}
           onClick={[Function]}
         />
       </div>
@@ -299,7 +299,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="18"
+          label={18}
           onClick={[Function]}
         />
       </div>
@@ -311,7 +311,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="19"
+          label={19}
           onClick={[Function]}
         />
       </div>
@@ -323,7 +323,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={true}
-          label="20"
+          label={20}
           onClick={[Function]}
         />
       </div>
@@ -335,7 +335,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="21"
+          label={21}
           onClick={[Function]}
         />
       </div>
@@ -347,7 +347,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="22"
+          label={22}
           onClick={[Function]}
         />
       </div>
@@ -359,7 +359,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="23"
+          label={23}
           onClick={[Function]}
         />
       </div>
@@ -371,7 +371,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="24"
+          label={24}
           onClick={[Function]}
         />
       </div>
@@ -387,7 +387,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="25"
+          label={25}
           onClick={[Function]}
         />
       </div>
@@ -399,7 +399,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="26"
+          label={26}
           onClick={[Function]}
         />
       </div>
@@ -411,7 +411,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="27"
+          label={27}
           onClick={[Function]}
         />
       </div>
@@ -423,7 +423,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="28"
+          label={28}
           onClick={[Function]}
         />
       </div>
@@ -435,7 +435,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="29"
+          label={29}
           onClick={[Function]}
         />
       </div>
@@ -447,7 +447,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
           isDisabled={false}
           isSelected={false}
           isToday={false}
-          label="30"
+          label={30}
           onClick={[Function]}
         />
       </div>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -5,448 +5,456 @@ exports[`DatePicker should render a DatePicker 1`] = `
   className="theme-container"
 >
   <div
-    className="theme-calendar-row theme-calendar-header-row"
-  >
-    <abbr
-      className="theme-calendar-item"
-      title="Monday"
-    >
-      M
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Tuesday"
-    >
-      T
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Wednesday"
-    >
-      W
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Thursday"
-    >
-      T
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Friday"
-    >
-      F
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Saturday"
-    >
-      S
-    </abbr>
-    <abbr
-      className="theme-calendar-item"
-      title="Sunday"
-    >
-      S
-    </abbr>
-  </div>
-  <hr
-    className="theme-separator"
-  />
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
+    className="theme-calendar-header"
   >
     <div
-      className="theme-calendar-item"
-    />
-    <div
-      className="theme-calendar-item"
-    />
-    <div
-      className="theme-calendar-item"
-    />
-    <div
-      className="theme-calendar-item"
-    />
-    <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-header-row"
     >
-      <DayPickerAction
-        aria-label="Select '1'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="1"
-        onClick={[Function]}
-      />
+      <abbr
+        className="theme-calendar-item"
+        title="Monday"
+      >
+        M
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Tuesday"
+      >
+        T
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Wednesday"
+      >
+        W
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Thursday"
+      >
+        T
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Friday"
+      >
+        F
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Saturday"
+      >
+        S
+      </abbr>
+      <abbr
+        className="theme-calendar-item"
+        title="Sunday"
+      >
+        S
+      </abbr>
     </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '2'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="2"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '3'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="3"
-        onClick={[Function]}
-      />
-    </div>
+    <hr
+      className="theme-separator"
+    />
   </div>
   <div
-    className="theme-calendar-row theme-calendar-body-row"
+    className="theme-calendar-body"
   >
     <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-body-row"
     >
-      <DayPickerAction
-        aria-label="Select '4'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="4"
-        onClick={[Function]}
+      <div
+        className="theme-calendar-item"
       />
+      <div
+        className="theme-calendar-item"
+      />
+      <div
+        className="theme-calendar-item"
+      />
+      <div
+        className="theme-calendar-item"
+      />
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '1'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="1"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '2'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="2"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '3'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="3"
+          onClick={[Function]}
+        />
+      </div>
     </div>
     <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-body-row"
     >
-      <DayPickerAction
-        aria-label="Select '5'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="5"
-        onClick={[Function]}
-      />
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '4'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="4"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '5'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="5"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Unselectable date"
+          isDisabled={true}
+          isSelected={false}
+          isToday={false}
+          label="6"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '7'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="7"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '8'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="8"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '9'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="9"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '10'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="10"
+          onClick={[Function]}
+        />
+      </div>
     </div>
     <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-body-row"
     >
-      <DayPickerAction
-        aria-label="Unselectable date"
-        isDisabled={true}
-        isSelected={false}
-        isToday={false}
-        label="6"
-        onClick={[Function]}
-      />
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '11'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="11"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '12'"
+          isDisabled={false}
+          isSelected={true}
+          isToday={false}
+          label="12"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '13'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="13"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '14'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="14"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Unselectable date"
+          isDisabled={true}
+          isSelected={false}
+          isToday={false}
+          label="15"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '16'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="16"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '17'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="17"
+          onClick={[Function]}
+        />
+      </div>
     </div>
     <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-body-row"
     >
-      <DayPickerAction
-        aria-label="Select '7'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="7"
-        onClick={[Function]}
-      />
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '18'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="18"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '19'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="19"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '20'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={true}
+          label="20"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '21'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="21"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '22'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="22"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '23'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="23"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '24'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="24"
+          onClick={[Function]}
+        />
+      </div>
     </div>
     <div
-      className="theme-calendar-item"
+      className="theme-calendar-row theme-calendar-body-row"
     >
-      <DayPickerAction
-        aria-label="Select '8'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="8"
-        onClick={[Function]}
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '25'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="25"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '26'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="26"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '27'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="27"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '28'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="28"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '29'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="29"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
+      >
+        <DayPickerAction
+          aria-label="Select '30'"
+          isDisabled={false}
+          isSelected={false}
+          isToday={false}
+          label="30"
+          onClick={[Function]}
+        />
+      </div>
+      <div
+        className="theme-calendar-item"
       />
     </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '9'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="9"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '10'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="10"
-        onClick={[Function]}
-      />
-    </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '11'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="11"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '12'"
-        isDisabled={false}
-        isSelected={true}
-        isToday={false}
-        label="12"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '13'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="13"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '14'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="14"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Unselectable date"
-        isDisabled={true}
-        isSelected={false}
-        isToday={false}
-        label="15"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '16'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="16"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '17'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="17"
-        onClick={[Function]}
-      />
-    </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '18'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="18"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '19'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="19"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '20'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={true}
-        label="20"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '21'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="21"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '22'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="22"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '23'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="23"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '24'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="24"
-        onClick={[Function]}
-      />
-    </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '25'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="25"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '26'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="26"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '27'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="27"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '28'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="28"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '29'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="29"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    >
-      <DayPickerAction
-        aria-label="Select '30'"
-        isDisabled={false}
-        isSelected={false}
-        isToday={false}
-        label="30"
-        onClick={[Function]}
-      />
-    </div>
-    <div
-      className="theme-calendar-item"
-    />
   </div>
 </div>
 `;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -77,6 +77,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="1"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -88,6 +89,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="2"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -99,6 +101,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="3"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -114,6 +117,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="4"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -125,6 +129,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="5"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -136,6 +141,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={true}
         isSelectedDay={false}
         label="6"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -147,6 +153,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="7"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -158,6 +165,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="8"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -169,6 +177,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="9"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -180,6 +189,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="10"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -195,6 +205,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="11"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -206,6 +217,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={true}
         label="12"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -217,6 +229,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="13"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -228,6 +241,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="14"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -239,6 +253,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={true}
         isSelectedDay={false}
         label="15"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -250,6 +265,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="16"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -261,6 +277,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="17"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -276,6 +293,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="18"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -287,6 +305,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="19"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -298,6 +317,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="20"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -309,6 +329,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="21"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -320,6 +341,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="22"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -331,6 +353,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="23"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -342,6 +365,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="24"
+        onClick={[Function]}
       />
     </div>
   </div>
@@ -357,6 +381,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="25"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -368,6 +393,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="26"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -379,6 +405,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="27"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -390,6 +417,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="28"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -401,6 +429,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="29"
+        onClick={[Function]}
       />
     </div>
     <div
@@ -412,6 +441,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         isDisabledDay={false}
         isSelectedDay={false}
         label="30"
+        onClick={[Function]}
       />
     </div>
     <div

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -5,49 +5,49 @@ exports[`DatePicker should render a DatePicker 1`] = `
   className="theme-container"
 >
   <div
-    className="calendar-header theme-calendar-header"
+    className="tc-date-picker-calendar-header theme-calendar-header"
   >
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Monday"
       >
         M
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Tuesday"
       >
         T
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Wednesday"
       >
         W
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Thursday"
       >
         T
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Friday"
       >
         F
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Saturday"
       >
         S
       </abbr>
       <abbr
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
         title="Sunday"
       >
         S
@@ -58,25 +58,25 @@ exports[`DatePicker should render a DatePicker 1`] = `
     />
   </div>
   <div
-    className="calendar-body theme-calendar-body"
+    className="tc-date-picker-calendar-body theme-calendar-body"
   >
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       />
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       />
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       />
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       />
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '1'"
@@ -88,7 +88,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '2'"
@@ -100,7 +100,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '3'"
@@ -113,10 +113,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '4'"
@@ -128,7 +128,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '5'"
@@ -140,7 +140,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Unselectable date"
@@ -152,7 +152,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '7'"
@@ -164,7 +164,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '8'"
@@ -176,7 +176,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '9'"
@@ -188,7 +188,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '10'"
@@ -201,10 +201,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '11'"
@@ -216,7 +216,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '12'"
@@ -228,7 +228,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '13'"
@@ -240,7 +240,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '14'"
@@ -252,7 +252,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Unselectable date"
@@ -264,7 +264,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '16'"
@@ -276,7 +276,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '17'"
@@ -289,10 +289,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '18'"
@@ -304,7 +304,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '19'"
@@ -316,7 +316,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '20'"
@@ -328,7 +328,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '21'"
@@ -340,7 +340,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '22'"
@@ -352,7 +352,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '23'"
@@ -364,7 +364,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '24'"
@@ -377,10 +377,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row theme-calendar-row"
+      className="tc-date-picker-calendar-row theme-calendar-row"
     >
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '25'"
@@ -392,7 +392,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '26'"
@@ -404,7 +404,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '27'"
@@ -416,7 +416,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '28'"
@@ -428,7 +428,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '29'"
@@ -440,7 +440,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       >
         <DayPickerAction
           aria-label="Select '30'"
@@ -452,7 +452,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
         />
       </div>
       <div
-        className="calendar-item theme-calendar-item"
+        className="tc-date-picker-calendar-item theme-calendar-item"
       />
     </div>
   </div>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -58,6 +58,18 @@ exports[`DatePicker should render a DatePicker 1`] = `
   >
     <div
       className="theme-calendar-item"
+    />
+    <div
+      className="theme-calendar-item"
+    />
+    <div
+      className="theme-calendar-item"
+    />
+    <div
+      className="theme-calendar-item"
+    />
+    <div
+      className="theme-calendar-item"
     >
       <DayPickerAction
         aria-label="Select '1'"
@@ -89,6 +101,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="3"
       />
     </div>
+  </div>
+  <div
+    className="theme-calendar-row theme-calendar-body-row"
+  >
     <div
       className="theme-calendar-item"
     >
@@ -133,10 +149,6 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="7"
       />
     </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
     <div
       className="theme-calendar-item"
     >
@@ -170,6 +182,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="10"
       />
     </div>
+  </div>
+  <div
+    className="theme-calendar-row theme-calendar-body-row"
+  >
     <div
       className="theme-calendar-item"
     >
@@ -214,10 +230,6 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="14"
       />
     </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
     <div
       className="theme-calendar-item"
     >
@@ -251,6 +263,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="17"
       />
     </div>
+  </div>
+  <div
+    className="theme-calendar-row theme-calendar-body-row"
+  >
     <div
       className="theme-calendar-item"
     >
@@ -295,10 +311,6 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="21"
       />
     </div>
-  </div>
-  <div
-    className="theme-calendar-row theme-calendar-body-row"
-  >
     <div
       className="theme-calendar-item"
     >
@@ -332,6 +344,10 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="24"
       />
     </div>
+  </div>
+  <div
+    className="theme-calendar-row theme-calendar-body-row"
+  >
     <div
       className="theme-calendar-item"
     >
@@ -376,6 +392,31 @@ exports[`DatePicker should render a DatePicker 1`] = `
         label="28"
       />
     </div>
+    <div
+      className="theme-calendar-item"
+    >
+      <DayPickerAction
+        aria-label="Select '29'"
+        isCurrentDay={false}
+        isDisabledDay={false}
+        isSelectedDay={false}
+        label="29"
+      />
+    </div>
+    <div
+      className="theme-calendar-item"
+    >
+      <DayPickerAction
+        aria-label="Select '30'"
+        isCurrentDay={false}
+        isDisabledDay={false}
+        isSelectedDay={false}
+        label="30"
+      />
+    </div>
+    <div
+      className="theme-calendar-item"
+    />
   </div>
 </div>
 `;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -61,7 +61,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
     className="calendar-body theme-calendar-body"
   >
     <div
-      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
+      className="calendar-row theme-calendar-row"
     >
       <div
         className="calendar-item theme-calendar-item"
@@ -113,7 +113,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
+      className="calendar-row theme-calendar-row"
     >
       <div
         className="calendar-item theme-calendar-item"
@@ -201,7 +201,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
+      className="calendar-row theme-calendar-row"
     >
       <div
         className="calendar-item theme-calendar-item"
@@ -289,7 +289,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
+      className="calendar-row theme-calendar-row"
     >
       <div
         className="calendar-item theme-calendar-item"
@@ -377,7 +377,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
       </div>
     </div>
     <div
-      className="calendar-row calendar-body-row theme-calendar-row theme-calendar-body-row"
+      className="calendar-row theme-calendar-row"
     >
       <div
         className="calendar-item theme-calendar-item"

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -8,7 +8,7 @@ exports[`DatePicker should render a DatePicker 1`] = `
     className="theme-calendar-header"
   >
     <div
-      className="theme-calendar-row theme-calendar-header-row"
+      className="theme-calendar-row"
     >
       <abbr
         className="theme-calendar-item"

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -80,6 +80,7 @@ class DateTimeView extends React.Component {
 					<DatePicker
 						calendar={currentCalendar}
 						currentDate={this.state.currentDate}
+						selectedDate={this.props.selectedDate}
 					/>
 				</div>
 				<div className={theme.time}>
@@ -102,6 +103,7 @@ DateTimeView.propTypes = {
 	selectedYear: PropTypes.number.isRequired,
 	onClickTitle: PropTypes.func.isRequired,
 	onSelectMonthYear: PropTypes.func.isRequired,
+	selectedDate: PropTypes.instanceOf(Date),
 };
 
 export default DateTimeView;

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -27,10 +27,10 @@ class DateTimeView extends React.Component {
 	}
 
 	incrementMonthIndex(monthIncrement) {
-		const monthIndexIncremented = this.props.selectedMonthIndex + monthIncrement;
+		const monthIndexIncremented = this.props.selectedCalendar.monthIndex + monthIncrement;
 		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
-		const newYear = this.props.selectedYear + yearIncrement;
+		const newYear = this.props.selectedCalendar.year + yearIncrement;
 
 		this.props.onSelectMonthYear({
 			monthIndex: newMonthIndex,
@@ -48,8 +48,8 @@ class DateTimeView extends React.Component {
 				onClick={this.incrementMonthIndexDown}
 			/>,
 			middleElement: <HeaderTitle
-				monthIndex={this.props.selectedMonthIndex}
-				year={this.props.selectedYear}
+				monthIndex={this.props.selectedCalendar.monthIndex}
+				year={this.props.selectedCalendar.year}
 				button={{
 					'aria-label': 'Switch to month and year pickers view',
 					onClick: this.props.onClickTitle,
@@ -65,16 +65,11 @@ class DateTimeView extends React.Component {
 			/>,
 		};
 
-		const calendar = {
-			year: this.props.selectedYear,
-			monthIndex: this.props.selectedMonthIndex,
-		};
-
 		const bodyElement = (
 			<div className={theme.body}>
 				<div className={theme.date}>
 					<DatePicker
-						calendar={calendar}
+						calendar={this.props.selectedCalendar}
 						selectedDate={this.props.selectedDate}
 						onSelect={this.props.onSelectDate}
 					/>
@@ -95,8 +90,10 @@ class DateTimeView extends React.Component {
 }
 
 DateTimeView.propTypes = {
-	selectedMonthIndex: PropTypes.number.isRequired,
-	selectedYear: PropTypes.number.isRequired,
+	selectedCalendar: PropTypes.shape({
+		monthIndex: PropTypes.number.isRequired,
+		year: PropTypes.number.isRequired,
+	}).isRequired,
 	onClickTitle: PropTypes.func.isRequired,
 	onSelectMonthYear: PropTypes.func.isRequired,
 	onSelectDate: PropTypes.func.isRequired,

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -27,10 +27,10 @@ class DateTimeView extends React.Component {
 	}
 
 	incrementMonthIndex(monthIncrement) {
-		const monthIndexIncremented = this.props.selectedCalendar.monthIndex + monthIncrement;
+		const monthIndexIncremented = this.props.calendar.monthIndex + monthIncrement;
 		const newMonthIndex = euclideanModulo(monthIndexIncremented, 12);
 		const yearIncrement = Math.floor(monthIndexIncremented / 12);
-		const newYear = this.props.selectedCalendar.year + yearIncrement;
+		const newYear = this.props.calendar.year + yearIncrement;
 
 		this.props.onSelectMonthYear({
 			monthIndex: newMonthIndex,
@@ -48,8 +48,8 @@ class DateTimeView extends React.Component {
 				onClick={this.incrementMonthIndexDown}
 			/>,
 			middleElement: <HeaderTitle
-				monthIndex={this.props.selectedCalendar.monthIndex}
-				year={this.props.selectedCalendar.year}
+				monthIndex={this.props.calendar.monthIndex}
+				year={this.props.calendar.year}
 				button={{
 					'aria-label': 'Switch to month and year pickers view',
 					onClick: this.props.onClickTitle,
@@ -69,7 +69,7 @@ class DateTimeView extends React.Component {
 			<div className={theme.body}>
 				<div className={theme.date}>
 					<DatePicker
-						calendar={this.props.selectedCalendar}
+						calendar={this.props.calendar}
 						selectedDate={this.props.selectedDate}
 						onSelect={this.props.onSelectDate}
 					/>
@@ -90,7 +90,7 @@ class DateTimeView extends React.Component {
 }
 
 DateTimeView.propTypes = {
-	selectedCalendar: PropTypes.shape({
+	calendar: PropTypes.shape({
 		monthIndex: PropTypes.number.isRequired,
 		year: PropTypes.number.isRequired,
 	}).isRequired,

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -65,10 +65,17 @@ class DateTimeView extends React.Component {
 			/>,
 		};
 
+		const currentCalendar = {
+			year: this.props.selectedYear,
+			monthIndex: this.props.selectedMonthIndex,
+		};
+
 		const bodyElement = (
 			<div className={theme.body}>
 				<div className={theme.date}>
-					<DatePicker />
+					<DatePicker
+						calendar={currentCalendar}
+					/>
 				</div>
 				<div className={theme.time}>
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -22,10 +22,6 @@ class DateTimeView extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.state = {
-			today: new Date(),
-		};
-
 		this.incrementMonthIndexDown = this.incrementMonthIndex.bind(this, -1);
 		this.incrementMonthIndexUp = this.incrementMonthIndex.bind(this, 1);
 	}
@@ -79,7 +75,6 @@ class DateTimeView extends React.Component {
 				<div className={theme.date}>
 					<DatePicker
 						calendar={calendar}
-						today={this.state.today}
 						selectedDate={this.props.selectedDate}
 						onSelect={this.props.onSelectDate}
 					/>

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -23,7 +23,7 @@ class DateTimeView extends React.Component {
 		super(props);
 
 		this.state = {
-			currentDate: new Date(),
+			today: new Date(),
 		};
 
 		this.incrementMonthIndexDown = this.incrementMonthIndex.bind(this, -1);
@@ -69,7 +69,7 @@ class DateTimeView extends React.Component {
 			/>,
 		};
 
-		const currentCalendar = {
+		const calendar = {
 			year: this.props.selectedYear,
 			monthIndex: this.props.selectedMonthIndex,
 		};
@@ -78,8 +78,8 @@ class DateTimeView extends React.Component {
 			<div className={theme.body}>
 				<div className={theme.date}>
 					<DatePicker
-						calendar={currentCalendar}
-						currentDate={this.state.currentDate}
+						calendar={calendar}
+						today={this.state.today}
 						selectedDate={this.props.selectedDate}
 						onSelect={this.props.onSelectDate}
 					/>

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -22,6 +22,10 @@ class DateTimeView extends React.Component {
 	constructor(props) {
 		super(props);
 
+		this.state = {
+			currentDate: new Date(),
+		};
+
 		this.incrementMonthIndexDown = this.incrementMonthIndex.bind(this, -1);
 		this.incrementMonthIndexUp = this.incrementMonthIndex.bind(this, 1);
 	}
@@ -75,6 +79,7 @@ class DateTimeView extends React.Component {
 				<div className={theme.date}>
 					<DatePicker
 						calendar={currentCalendar}
+						currentDate={this.state.currentDate}
 					/>
 				</div>
 				<div className={theme.time}>

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.component.js
@@ -81,6 +81,7 @@ class DateTimeView extends React.Component {
 						calendar={currentCalendar}
 						currentDate={this.state.currentDate}
 						selectedDate={this.props.selectedDate}
+						onSelect={this.props.onSelectDate}
 					/>
 				</div>
 				<div className={theme.time}>
@@ -103,6 +104,7 @@ DateTimeView.propTypes = {
 	selectedYear: PropTypes.number.isRequired,
 	onClickTitle: PropTypes.func.isRequired,
 	onSelectMonthYear: PropTypes.func.isRequired,
+	onSelectDate: PropTypes.func.isRequired,
 	selectedDate: PropTypes.instanceOf(Date),
 };
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -14,7 +14,7 @@ describe('DateTimeView', () => {
 		/>);
 
 		wrapper.setState({
-			currentDate: new Date(2018, 5, 20),
+			today: new Date(2018, 5, 20),
 		});
 
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -13,10 +13,6 @@ describe('DateTimeView', () => {
 			onSelectDate={() => {}}
 		/>);
 
-		wrapper.setState({
-			today: new Date(2018, 5, 20),
-		});
-
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -6,8 +6,10 @@ import DateTimeView, { euclideanModulo } from './DateTimeView.component';
 describe('DateTimeView', () => {
 	it('should render', () => {
 		const wrapper = shallow(<DateTimeView
-			selectedMonthIndex={5}
-			selectedYear={2006}
+			selectedCalendar={{
+				monthIndex: 5,
+				year: 2006,
+			}}
 			onClickTitle={() => {}}
 			onSelectMonthYear={() => {}}
 			onSelectDate={() => {}}
@@ -19,8 +21,10 @@ describe('DateTimeView', () => {
 	it('should callback when title is clicked', () => {
 		const onClickTitle = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			selectedMonthIndex={5}
-			selectedYear={2006}
+			selectedCalendar={{
+				monthIndex: 5,
+				year: 2006,
+			}}
 			onClickTitle={onClickTitle}
 			onSelectMonthYear={() => {}}
 			onSelectDate={() => {}}
@@ -54,8 +58,10 @@ describe('DateTimeView', () => {
 		it('should trigger callback when previous month is clicked with previous month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedMonthIndex={5}
-				selectedYear={2006}
+				selectedCalendar={{
+					monthIndex: 5,
+					year: 2006,
+				}}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 				onSelectDate={() => {}}
@@ -75,8 +81,10 @@ describe('DateTimeView', () => {
 		it('should trigger callback when next month is clicked with next month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedMonthIndex={5}
-				selectedYear={2006}
+				selectedCalendar={{
+					monthIndex: 5,
+					year: 2006,
+				}}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 				onSelectDate={() => {}}
@@ -95,8 +103,10 @@ describe('DateTimeView', () => {
 		it('should trigger callback when previous month is clicked with last month of year and previous year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedMonthIndex={0}
-				selectedYear={2006}
+				selectedCalendar={{
+					monthIndex: 0,
+					year: 2006,
+				}}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 				onSelectDate={() => {}}
@@ -115,8 +125,10 @@ describe('DateTimeView', () => {
 		it('should trigger callback when next month is clicked with first month of year and next year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedMonthIndex={11}
-				selectedYear={2006}
+				selectedCalendar={{
+					monthIndex: 11,
+					year: 2006,
+				}}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
 				onSelectDate={() => {}}

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -6,7 +6,7 @@ import DateTimeView, { euclideanModulo } from './DateTimeView.component';
 describe('DateTimeView', () => {
 	it('should render', () => {
 		const wrapper = shallow(<DateTimeView
-			selectedCalendar={{
+			calendar={{
 				monthIndex: 5,
 				year: 2006,
 			}}
@@ -21,7 +21,7 @@ describe('DateTimeView', () => {
 	it('should callback when title is clicked', () => {
 		const onClickTitle = jest.fn();
 		const wrapper = shallow(<DateTimeView
-			selectedCalendar={{
+			calendar={{
 				monthIndex: 5,
 				year: 2006,
 			}}
@@ -58,7 +58,7 @@ describe('DateTimeView', () => {
 		it('should trigger callback when previous month is clicked with previous month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedCalendar={{
+				calendar={{
 					monthIndex: 5,
 					year: 2006,
 				}}
@@ -81,7 +81,7 @@ describe('DateTimeView', () => {
 		it('should trigger callback when next month is clicked with next month and current year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedCalendar={{
+				calendar={{
 					monthIndex: 5,
 					year: 2006,
 				}}
@@ -103,7 +103,7 @@ describe('DateTimeView', () => {
 		it('should trigger callback when previous month is clicked with last month of year and previous year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedCalendar={{
+				calendar={{
 					monthIndex: 0,
 					year: 2006,
 				}}
@@ -125,7 +125,7 @@ describe('DateTimeView', () => {
 		it('should trigger callback when next month is clicked with first month of year and next year', () => {
 			const onSelectMonthYear = jest.fn();
 			const wrapper = shallow(<DateTimeView
-				selectedCalendar={{
+				calendar={{
 					monthIndex: 11,
 					year: 2006,
 				}}

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -10,6 +10,7 @@ describe('DateTimeView', () => {
 			selectedYear={2006}
 			onClickTitle={() => {}}
 			onSelectMonthYear={() => {}}
+			onSelectDate={() => {}}
 		/>);
 
 		wrapper.setState({
@@ -26,6 +27,7 @@ describe('DateTimeView', () => {
 			selectedYear={2006}
 			onClickTitle={onClickTitle}
 			onSelectMonthYear={() => {}}
+			onSelectDate={() => {}}
 		/>);
 
 		const titleAction = wrapper
@@ -60,6 +62,7 @@ describe('DateTimeView', () => {
 				selectedYear={2006}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
+				onSelectDate={() => {}}
 			/>);
 
 			const previousAction = getPreviousAction(wrapper);
@@ -80,6 +83,7 @@ describe('DateTimeView', () => {
 				selectedYear={2006}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
+				onSelectDate={() => {}}
 			/>);
 
 			const nextAction = getNextAction(wrapper);
@@ -99,6 +103,7 @@ describe('DateTimeView', () => {
 				selectedYear={2006}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
+				onSelectDate={() => {}}
 			/>);
 
 			const previousAction = getPreviousAction(wrapper);
@@ -118,6 +123,7 @@ describe('DateTimeView', () => {
 				selectedYear={2006}
 				onClickTitle={() => {}}
 				onSelectMonthYear={onSelectMonthYear}
+				onSelectDate={() => {}}
 			/>);
 
 			const nextAction = getNextAction(wrapper);

--- a/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/DateTimeView.test.js
@@ -12,6 +12,10 @@ describe('DateTimeView', () => {
 			onSelectMonthYear={() => {}}
 		/>);
 
+		wrapper.setState({
+			currentDate: new Date(2018, 5, 20),
+		});
+
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -16,9 +16,9 @@ exports[`DateTimeView should render 1`] = `
               "year": 2006,
             }
           }
-          currentDate={2018-06-19T22:00:00.000Z}
           onSelect={[Function]}
           selectedDate={undefined}
+          today={2018-06-19T22:00:00.000Z}
         />
       </div>
       <div

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -16,6 +16,7 @@ exports[`DateTimeView should render 1`] = `
               "year": 2006,
             }
           }
+          currentDate={2018-06-19T22:00:00.000Z}
         />
       </div>
       <div

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -18,7 +18,6 @@ exports[`DateTimeView should render 1`] = `
           }
           onSelect={[Function]}
           selectedDate={undefined}
-          today={2018-06-19T22:00:00.000Z}
         />
       </div>
       <div

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -17,6 +17,8 @@ exports[`DateTimeView should render 1`] = `
             }
           }
           currentDate={2018-06-19T22:00:00.000Z}
+          onSelect={[Function]}
+          selectedDate={undefined}
         />
       </div>
       <div

--- a/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -9,7 +9,14 @@ exports[`DateTimeView should render 1`] = `
       <div
         className="theme-date"
       >
-        <DatePicker />
+        <DatePicker
+          calendar={
+            Object {
+              "monthIndex": 5,
+              "year": 2006,
+            }
+          }
+        />
       </div>
       <div
         className="theme-time"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,82 +2,6 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.0.0-beta.44.tgz#2a02643368de80916162be70865c97774f3adbd9"
-  dependencies:
-    "@babel/highlight" "7.0.0-beta.44"
-
-"@babel/generator@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.0.0-beta.44.tgz#c7e67b9b5284afcf69b309b50d7d37f3e5033d42"
-  dependencies:
-    "@babel/types" "7.0.0-beta.44"
-    jsesc "^2.5.1"
-    lodash "^4.2.0"
-    source-map "^0.5.0"
-    trim-right "^1.0.1"
-
-"@babel/helper-function-name@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.0.0-beta.44.tgz#e18552aaae2231100a6e485e03854bc3532d44dd"
-  dependencies:
-    "@babel/helper-get-function-arity" "7.0.0-beta.44"
-    "@babel/template" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-
-"@babel/helper-get-function-arity@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.0.0-beta.44.tgz#d03ca6dd2b9f7b0b1e6b32c56c72836140db3a15"
-  dependencies:
-    "@babel/types" "7.0.0-beta.44"
-
-"@babel/helper-split-export-declaration@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.0.0-beta.44.tgz#c0b351735e0fbcb3822c8ad8db4e583b05ebd9dc"
-  dependencies:
-    "@babel/types" "7.0.0-beta.44"
-
-"@babel/highlight@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.0.0-beta.44.tgz#18c94ce543916a80553edcdcf681890b200747d5"
-  dependencies:
-    chalk "^2.0.0"
-    esutils "^2.0.2"
-    js-tokens "^3.0.0"
-
-"@babel/template@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.0.0-beta.44.tgz#f8832f4fdcee5d59bf515e595fc5106c529b394f"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    lodash "^4.2.0"
-
-"@babel/traverse@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.0.0-beta.44.tgz#a970a2c45477ad18017e2e465a0606feee0d2966"
-  dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/generator" "7.0.0-beta.44"
-    "@babel/helper-function-name" "7.0.0-beta.44"
-    "@babel/helper-split-export-declaration" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    debug "^3.1.0"
-    globals "^11.1.0"
-    invariant "^2.2.0"
-    lodash "^4.2.0"
-
-"@babel/types@7.0.0-beta.44":
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.0.0-beta.44.tgz#6b1b164591f77dec0a0342aca995f2d046b3a757"
-  dependencies:
-    esutils "^2.0.2"
-    lodash "^4.2.0"
-    to-fast-properties "^2.0.0"
-
 "@kadira/react-storybook-addon-info@^3.3.0":
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/@kadira/react-storybook-addon-info/-/react-storybook-addon-info-3.4.0.tgz#f603dba8750f93318c33aa96f1e7bdfeeb61b7b0"
@@ -870,6 +794,14 @@ babel-cli@^6.26.0:
   optionalDependencies:
     chokidar "^1.6.1"
 
+babel-code-frame@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-7.0.0-beta.0.tgz#418a7b5f3f7dc9a4670e61b1158b4c5661bec98d"
+  dependencies:
+    chalk "^2.0.0"
+    esutils "^2.0.2"
+    js-tokens "^3.0.0"
+
 babel-code-frame@^6.11.0, babel-code-frame@^6.16.0, babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"
@@ -902,16 +834,14 @@ babel-core@^6.0.0, babel-core@^6.26.0:
     slash "^1.0.0"
     source-map "^0.5.6"
 
-babel-eslint@8.2.3:
-  version "8.2.3"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.2.3.tgz#1a2e6681cc9bc4473c32899e59915e19cd6733cf"
+babel-eslint@8.0.1:
+  version "8.0.1"
+  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-8.0.1.tgz#5d718be7a328625d006022eb293ed3008cbd6346"
   dependencies:
-    "@babel/code-frame" "7.0.0-beta.44"
-    "@babel/traverse" "7.0.0-beta.44"
-    "@babel/types" "7.0.0-beta.44"
-    babylon "7.0.0-beta.44"
-    eslint-scope "~3.7.1"
-    eslint-visitor-keys "^1.0.0"
+    babel-code-frame "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
 
 babel-generator@^6.18.0, babel-generator@^6.26.0:
   version "6.26.0"
@@ -993,6 +923,15 @@ babel-helper-flip-expressions@^0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/babel-helper-flip-expressions/-/babel-helper-flip-expressions-0.2.0.tgz#160d2090a3d9f9c64a750905321a0bc218f884ec"
 
+babel-helper-function-name@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-7.0.0-beta.0.tgz#d1b6779b647e5c5c31ebeb05e13b998e4d352d56"
+  dependencies:
+    babel-helper-get-function-arity "7.0.0-beta.0"
+    babel-template "7.0.0-beta.0"
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+
 babel-helper-function-name@^6.24.1:
   version "6.24.1"
   resolved "https://registry.yarnpkg.com/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz#d3475b8c03ed98242a25b48351ab18399d3580a9"
@@ -1002,6 +941,12 @@ babel-helper-function-name@^6.24.1:
     babel-template "^6.24.1"
     babel-traverse "^6.24.1"
     babel-types "^6.24.1"
+
+babel-helper-get-function-arity@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-helper-get-function-arity/-/babel-helper-get-function-arity-7.0.0-beta.0.tgz#9d1ab7213bb5efe1ef1638a8ea1489969b5a8b6e"
+  dependencies:
+    babel-types "7.0.0-beta.0"
 
 babel-helper-get-function-arity@^6.24.1:
   version "6.24.1"
@@ -1095,6 +1040,10 @@ babel-loader@^7.1.2:
     find-cache-dir "^1.0.0"
     loader-utils "^1.0.2"
     mkdirp "^0.5.1"
+
+babel-messages@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-messages/-/babel-messages-7.0.0-beta.0.tgz#6df01296e49fc8fbd0637394326a167f36da817b"
 
 babel-messages@^6.23.0:
   version "6.23.0"
@@ -1831,6 +1780,15 @@ babel-standalone@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-standalone/-/babel-standalone-6.26.0.tgz#15fb3d35f2c456695815ebf1ed96fe7f015b6886"
 
+babel-template@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-7.0.0-beta.0.tgz#85083cf9e4395d5e48bf5154d7a8d6991cafecfb"
+  dependencies:
+    babel-traverse "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    lodash "^4.2.0"
+
 babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-template/-/babel-template-6.26.0.tgz#de03e2d16396b069f46dd9fff8521fb1a0e35e02"
@@ -1840,6 +1798,20 @@ babel-template@^6.16.0, babel-template@^6.24.1, babel-template@^6.26.0:
     babel-types "^6.26.0"
     babylon "^6.18.0"
     lodash "^4.17.4"
+
+babel-traverse@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-traverse/-/babel-traverse-7.0.0-beta.0.tgz#da14be9b762f62a2f060db464eaafdd8cd072a41"
+  dependencies:
+    babel-code-frame "7.0.0-beta.0"
+    babel-helper-function-name "7.0.0-beta.0"
+    babel-messages "7.0.0-beta.0"
+    babel-types "7.0.0-beta.0"
+    babylon "7.0.0-beta.22"
+    debug "^3.0.1"
+    globals "^10.0.0"
+    invariant "^2.2.0"
+    lodash "^4.2.0"
 
 babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
   version "6.26.0"
@@ -1855,6 +1827,14 @@ babel-traverse@^6.18.0, babel-traverse@^6.24.1, babel-traverse@^6.26.0:
     invariant "^2.2.2"
     lodash "^4.17.4"
 
+babel-types@7.0.0-beta.0:
+  version "7.0.0-beta.0"
+  resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-7.0.0-beta.0.tgz#eb8b6e556470e6dcc4aef982d79ad229469b5169"
+  dependencies:
+    esutils "^2.0.2"
+    lodash "^4.2.0"
+    to-fast-properties "^2.0.0"
+
 babel-types@^6.18.0, babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-types/-/babel-types-6.26.0.tgz#a3b073f94ab49eb6fa55cd65227a334380632497"
@@ -1868,9 +1848,9 @@ babylon@7.0.0-beta.19:
   version "7.0.0-beta.19"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.19.tgz#e928c7e807e970e0536b078ab3e0c48f9e052503"
 
-babylon@7.0.0-beta.44:
-  version "7.0.0-beta.44"
-  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.44.tgz#89159e15e6e30c5096e22d738d8c0af8a0e8ca1d"
+babylon@7.0.0-beta.22:
+  version "7.0.0-beta.22"
+  resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.22.tgz#74f0ad82ed7c7c3cfeab74cf684f815104161b65"
 
 babylon@^6.18.0:
   version "6.18.0"
@@ -3445,7 +3425,7 @@ debug@2.6.9, debug@^2.0.0, debug@^2.1.0, debug@^2.1.1, debug@^2.2.0, debug@^2.3.
   dependencies:
     ms "2.0.0"
 
-debug@^3.1.0:
+debug@^3.0.1, debug@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-3.1.0.tgz#5bb5a0672628b64149566ba16819e61518c67261"
   dependencies:
@@ -4279,17 +4259,6 @@ eslint-plugin-react@^6.3.0:
     has "^1.0.1"
     jsx-ast-utils "^1.3.4"
     object.assign "^4.0.4"
-
-eslint-scope@~3.7.1:
-  version "3.7.1"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-3.7.1.tgz#3d63c3edfda02e06e01a452ad88caacc7cdcb6e8"
-  dependencies:
-    esrecurse "^4.1.0"
-    estraverse "^4.1.1"
-
-eslint-visitor-keys@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz#3f3180fb2e291017716acb4c9d6d5b5c34a6a81d"
 
 eslint@^2.7.0:
   version "2.13.1"
@@ -5327,9 +5296,9 @@ global@^4.3.2:
     min-document "^2.19.0"
     process "~0.5.1"
 
-globals@^11.1.0:
-  version "11.1.0"
-  resolved "https://registry.yarnpkg.com/globals/-/globals-11.1.0.tgz#632644457f5f0e3ae711807183700ebf2e4633e4"
+globals@^10.0.0:
+  version "10.4.0"
+  resolved "https://registry.yarnpkg.com/globals/-/globals-10.4.0.tgz#5c477388b128a9e4c5c5d01c7a2aca68c68b2da7"
 
 globals@^9.14.0, globals@^9.18.0, globals@^9.2.0:
   version "9.18.0"
@@ -7086,10 +7055,6 @@ jsdom@^9.12.0:
 jsesc@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-1.3.0.tgz#46c3fec8c1892b12b0833db9bc7622176dbab34b"
-
-jsesc@^2.5.1:
-  version "2.5.1"
-  resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.1.tgz#e421a2a8e20d6b0819df28908f782526b96dd1fe"
 
 jsesc@~0.5.0:
   version "0.5.0"
@@ -11173,7 +11138,7 @@ source-map-url@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
 
-source-map@0.5.x, source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
+source-map@0.5.x, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.0, source-map@~0.5.1, source-map@~0.5.6:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fully manage the calendar display dynamically.

**What is the chosen solution to this problem?**
Do some stuff and things with lots of date-fns magic.
- Throw the ingredients (props) needed to display the right calendar based on month and year previously cooked (selected)
- Achieve some black magic to invoke the right weeks
- Give back the selected/picked date as wanted

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
