### PR TITLE
fix(eslint-config): update link in API team's test configs

### DIFF
--- a/packages/eslint-config/README.md
+++ b/packages/eslint-config/README.md
@@ -39,6 +39,7 @@ Create an `.eslintrc` file in the folder you need to lint.
 
 ## Changelog
 
+* __2.0.1:__ Fix broken link between API team's `jasmine` and `generic` test configs
 * __2.0.0:__
 	* CodeceptJS config removed, the tests should be run with `noGlobals` attribute, the globals are no longer required
 	* The file `api-test-e2e` was removed, the file `api-test` is now generic, the file `api-test-jasmine` replaces the previous `api-test` file with Jasmine conf

--- a/packages/eslint-config/api-test-jasmine.yaml
+++ b/packages/eslint-config/api-test-jasmine.yaml
@@ -1,5 +1,5 @@
 extends:
-  - ./eslintrc-test.yaml
+  - ./api-test.yaml
   - 'plugin:jasmine/recommended'
 env:
   phantomjs: true

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/eslint-config",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Tools configurations",
   "author": "Talend Frontend <frontend@talend.com>",
   "main": "index.js",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The jasmine config's `extends` attribute has a faulty path.

**What is the chosen solution to this problem?**

Fix the path, duh.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
