### PR TITLE
feat(components/SubHeaderBar): make the title/left part extend to full width when no center/right actions

### DIFF
--- a/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/InputTitleSubHeader/InputTitleSubHeader.scss
@@ -43,7 +43,7 @@ $tc-input-subheader-sub-title-weight: 300 !default;
 		overflow: hidden;
 		flex: 1 auto;
 		margin-right: 110px;
-		max-width: 45rem;
+		max-width: 90rem;
 
 		&-title {
 			display: inline-flex;

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.scss
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.scss
@@ -41,6 +41,10 @@ $tc-svg-icon-size: $padding-large !default;
 			display: flex;
 		}
 
+		&-left {
+			flex: 1;
+		}
+
 		&-right {
 			margin-left: $padding-normal;
 			justify-content: flex-end;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in TMC UI -> Add new engine page, where we use the SubHeaderBar component, the sub title text has been truncated whereas enough space on the right side.
related jira: https://jira.talendforge.org/browse/TMC-12988
**What is the chosen solution to this problem?**
make the title/left part extend to full width when there's no center or right actions.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
