### PR TITLE
fix(forms): CustomFormat - simplify the regex to manage majority of cases

### DIFF
--- a/packages/forms/src/UIForm/customFormats.js
+++ b/packages/forms/src/UIForm/customFormats.js
@@ -1,14 +1,14 @@
 const emailRegExp = /^[a-zA-Z][a-zA-Z0-9-.]+@[a-zA-Z-]+\.[a-zA-Z-]+$/;
 const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_]+)?$/;
 /* eslint-disable max-len */
-// Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_]+[^.git])(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
-const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_]+[^.git])(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~]+[^.git])(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+[^.git])(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~]+[^.git])(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~]+[^.git])(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~]+[^.git])(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
-const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+[^.git])(\.git)?(\/)?$/;
+// Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_]+)(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
+const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_]+)(\.git)?(\/)?$/;
+// Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
+const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
+// Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
+const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
+// Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
+const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
 /* eslint-disable max-len */
 
 const urlGit = new RegExp(
@@ -40,7 +40,7 @@ const customFormats = t => ({
 		if (typeof fieldData === 'string' && !urlGit.test(fieldData)) {
 			return t('FORMAT_URL_GIT', {
 				defaultValue:
-					'must be a valid url HTTP (e.g.: http(s)://host[:port]/my-repo[.git]), SSH (e.g. ssh://[user@]host:[port/]my-repo.git) or GIT (e.g git://host[:port]/my-repo.git)',
+					'must be a valid HTTP URL (e.g.: http(s)://host[:port]/my-repo[.git]), SSH URL (e.g.: [ssh://][user@]host:[port/]my-repo[.git]) or GIT URL (e.g.: git://host[:port]/my-repo[.git])',
 			});
 		}
 		return null;

--- a/packages/forms/src/UIForm/customFormats.test.js
+++ b/packages/forms/src/UIForm/customFormats.test.js
@@ -162,23 +162,14 @@ describe('custom formats', () => {
 		const gitResultSshKO3 = customValidation['url-git']('ssh://host.xz.git');
 		expect(gitResultSshKO3).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultSshKO4 = customValidation['url-git']('ssh://host.xz/.git');
+		const gitResultSshKO4 = customValidation['url-git']('ssh://1.1.1.1.xz:999.git');
 		expect(gitResultSshKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultSshKO5 = customValidation['url-git']('ssh://1.1.1.1.xz:999.git');
+		const gitResultSshKO5 = customValidation['url-git']('ssh://user@1.1.1.1:/path/to/repo.git');
 		expect(gitResultSshKO5).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultSshKO6 = customValidation['url-git']('ssh://host.xz/~/path/to/repo.git/test');
+		const gitResultSshKO6 = customValidation['url-git']('ssh://user@host.xz:999path/to/repo.git/');
 		expect(gitResultSshKO6).toBe(mockedTranslation.FORMAT_URL_GIT);
-
-		const gitResultSshKO7 = customValidation['url-git']('ssh://host.xz/~/path/to/repo.gittest');
-		expect(gitResultSshKO7).toBe(mockedTranslation.FORMAT_URL_GIT);
-
-		const gitResultSshKO8 = customValidation['url-git']('ssh://user@1.1.1.1:/path/to/repo.git');
-		expect(gitResultSshKO8).toBe(mockedTranslation.FORMAT_URL_GIT);
-
-		const gitResultSshKO9 = customValidation['url-git']('ssh://user@host.xz:999path/to/repo.git/');
-		expect(gitResultSshKO9).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate a git url ssh 2', () => {
@@ -239,17 +230,14 @@ describe('custom formats', () => {
 		const gitResultGitKO1 = customValidation['url-git']('git://host.xz.git/');
 		expect(gitResultGitKO1).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultGitKO2 = customValidation['url-git']('git://host.xz/.git');
+		const gitResultGitKO2 = customValidation['url-git']('git://host~s.xz:999.git');
 		expect(gitResultGitKO2).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultGitKO3 = customValidation['url-git']('git://host~s.xz:999.git');
+		const gitResultGitKO3 = customValidation['url-git']('git://user@host.xz:999/test.git');
 		expect(gitResultGitKO3).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultGitKO4 = customValidation['url-git']('git://user@host.xz:999/test.git');
+		const gitResultGitKO4 = customValidation['url-git']('git://user@1.1.1.1:9999/path/to/repo.git');
 		expect(gitResultGitKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
-
-		const gitResultGitKO5 = customValidation['url-git']('git://user@1.1.1.1:9999/path/to/repo.git');
-		expect(gitResultGitKO5).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate string with no leading and trailing space', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The exclusion of ".git" in the regex cause some false errors
**What is the chosen solution to this problem?**
revert this exclusion

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
