### PR TITLE
feat(components/ActionButton): prevent scrolling with the overflow

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -176,7 +176,6 @@ export function ActionButton(props) {
 	if (!inProgress && overlayComponent) {
 		btn = (
 			<ActionButtonOverlay
-				onClick={rClick}
 				overlayRef={overlayRef}
 				overlayId={overlayId}
 				overlayPlacement={overlayPlacement}

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { Button, OverlayTrigger, Popover } from 'react-bootstrap';
+import { Button, OverlayTrigger } from 'react-bootstrap';
 import { translate } from 'react-i18next';
 
 import TooltipTrigger from '../../TooltipTrigger';
@@ -12,6 +12,7 @@ import getPropsFrom from '../../utils/getPropsFrom';
 import theme from './ActionButton.scss';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
+import ActionButtonOverlay from './ActionButtonOverlay.component';
 
 const LEFT = 'left';
 const RIGHT = 'right';
@@ -174,18 +175,17 @@ export function ActionButton(props) {
 	);
 	if (!inProgress && overlayComponent) {
 		btn = (
-			// this span is here to allow the tooltip trigger to work
-			<span>
-				<OverlayTrigger
-					trigger="click"
-					ref={overlayRef}
-					rootClose
-					placement={overlayPlacement}
-					overlay={<Popover id={overlayId}>{overlayComponent}</Popover>}
-				>
-					{btn}
-				</OverlayTrigger>
-			</span>
+			<ActionButtonOverlay
+				onClick={rClick}
+				overlayRef={overlayRef}
+				overlayId={overlayId}
+				overlayPlacement={overlayPlacement}
+				overlayComponent={props.overlayComponent}
+				getComponent={props.getComponent}
+				preventScrolling={props.preventScrolling}
+			>
+				{btn}
+			</ActionButtonOverlay>
 		);
 	}
 	if (hideLabel || tooltip || tooltipLabel) {

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -162,7 +162,7 @@ describe('Action', () => {
 		const wrapper = shallow(<ActionButton {...props} />);
 
 		// then
-		expect(wrapper.find('OverlayTrigger').length).toBe(1);
+		expect(wrapper.find('ActionButtonOverlay').length).toBe(1);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 	it('should called ref method on overlay', () => {

--- a/packages/components/src/Actions/ActionButton/ActionButtonOverlay.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButtonOverlay.component.js
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { OverlayTrigger, Popover } from 'react-bootstrap';
+import classNames from 'classnames';
+import Inject from '../../Inject';
+
+import theme from './ActionButtonOverlay.scss';
+
+export default class ActionButtonOverlay extends React.Component {
+	static propTypes = {
+		children: PropTypes.element,
+		getComponent: PropTypes.func,
+		onClick: PropTypes.func,
+		overlayComponent: Inject.getReactElement.propTypes,
+		overlayId: PropTypes.string,
+		overlayPlacement: OverlayTrigger.propTypes.placement,
+		overlayRef: PropTypes.func,
+		preventScrolling: PropTypes.bool,
+	};
+
+	static defaultProps = {
+		preventScrolling: false,
+	};
+
+	render() {
+		const props = {};
+
+		if (this.props.preventScrolling) {
+			props.container = this;
+		}
+
+		return (
+			<span className={classNames(theme['tc-action-button-positionned'])}>
+				<OverlayTrigger
+					placement={this.props.overlayPlacement}
+					overlay={
+						<Popover id={this.props.overlayId}>
+							{Inject.getReactElement(this.props.getComponent, this.props.overlayComponent)}
+						</Popover>
+					}
+					onClick={this.props.onClick}
+					ref={this.props.overlayRef}
+					rootClose
+					trigger="click"
+					{...props}
+				>
+					{this.props.children}
+				</OverlayTrigger>
+			</span>
+		);
+	}
+}

--- a/packages/components/src/Actions/ActionButton/ActionButtonOverlay.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButtonOverlay.component.js
@@ -10,7 +10,6 @@ export default class ActionButtonOverlay extends React.Component {
 	static propTypes = {
 		children: PropTypes.element,
 		getComponent: PropTypes.func,
-		onClick: PropTypes.func,
 		overlayComponent: Inject.getReactElement.propTypes,
 		overlayId: PropTypes.string,
 		overlayPlacement: OverlayTrigger.propTypes.placement,
@@ -38,7 +37,6 @@ export default class ActionButtonOverlay extends React.Component {
 							{Inject.getReactElement(this.props.getComponent, this.props.overlayComponent)}
 						</Popover>
 					}
-					onClick={this.props.onClick}
 					ref={this.props.overlayRef}
 					rootClose
 					trigger="click"

--- a/packages/components/src/Actions/ActionButton/ActionButtonOverlay.scss
+++ b/packages/components/src/Actions/ActionButton/ActionButtonOverlay.scss
@@ -1,0 +1,4 @@
+.tc-action-button-positionned {
+	position: relative;
+	display: inline-block;
+}

--- a/packages/components/src/Actions/ActionButton/ActionButtonOverlay.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButtonOverlay.test.js
@@ -1,0 +1,43 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import ActionButtonOverlay from './ActionButtonOverlay.component';
+
+describe('ActionButtonOverlay', () => {
+	it('should wrap the children with an overlay', () => {
+		const Overlay = <div>Overlay</div>;
+		const wrapper = shallow(
+			<ActionButtonOverlay
+				overlayId="myId"
+				overlayRef={() => {}}
+				overlayComponent={Overlay}
+				overlayPlacement="top"
+			>
+				<div>wrap me</div>
+			</ActionButtonOverlay>,
+		);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should prevent the scrolling', () => {
+		const Overlay = <div>Overlay</div>;
+		const wrapper = shallow(
+			<ActionButtonOverlay overlayComponent={Overlay} preventScrolling>
+				<div>wrap me</div>
+			</ActionButtonOverlay>,
+		);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should inject the overlay', () => {
+		const Overlay = <div>Overlay</div>;
+		const wrapper = shallow(
+			<ActionButtonOverlay overlayComponent="Overlay" getComponent={() => Overlay}>
+				<div>wrap me</div>
+			</ActionButtonOverlay>,
+		);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -125,46 +125,37 @@ exports[`Action should render a button 1`] = `
 `;
 
 exports[`Action should render a button with a overlay component 1`] = `
-<span>
-  <OverlayTrigger
-    defaultOverlayShown={false}
-    overlay={
-      <Popover
-        bsClass="popover"
-        id="myOverlayId"
-        placement="right"
-      >
-        [Function]
-      </Popover>
-    }
-    placement="bottom"
-    rootClose={true}
-    trigger="click"
+<ActionButtonOverlay
+  getComponent={undefined}
+  overlayComponent={[Function]}
+  overlayId="myOverlayId"
+  overlayPlacement="bottom"
+  overlayRef={undefined}
+  preventScrolling={false}
+>
+  <Button
+    active={false}
+    aria-label="Click me"
+    block={false}
+    bsClass="btn"
+    bsStyle="default"
+    className=""
+    data-feature="action.feature"
+    disabled={false}
+    onClick={null}
+    onMouseDown={null}
+    role={null}
+    title="Title to describe click me button"
   >
-    <Button
-      active={false}
-      aria-label="Click me"
-      block={false}
-      bsClass="btn"
-      bsStyle="default"
-      className=""
-      data-feature="action.feature"
-      disabled={false}
-      onClick={null}
-      onMouseDown={null}
-      role={null}
-      title="Title to describe click me button"
-    >
-      <Icon
-        name="talend-caret-down"
-        transform={undefined}
-      />
-      <span>
-        Click me
-      </span>
-    </Button>
-  </OverlayTrigger>
-</span>
+    <Icon
+      name="talend-caret-down"
+      transform={undefined}
+    />
+    <span>
+      Click me
+    </span>
+  </Button>
+</ActionButtonOverlay>
 `;
 
 exports[`Action should render a button with loading state 1`] = `

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButtonOverlay.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButtonOverlay.test.js.snap
@@ -1,0 +1,151 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`ActionButtonOverlay should inject the overlay 1`] = `
+<span
+  className="theme-tc-action-button-positionned"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Popover
+        bsClass="popover"
+        id={undefined}
+        placement="right"
+      >
+        <Inject
+          component="Overlay"
+          getComponent={[Function]}
+        />
+      </Popover>
+    }
+    placement={undefined}
+    rootClose={true}
+    trigger="click"
+  >
+    <div>
+      wrap me
+    </div>
+  </OverlayTrigger>
+</span>
+`;
+
+exports[`ActionButtonOverlay should prevent the scrolling 1`] = `
+<span
+  className="theme-tc-action-button-positionned"
+>
+  <OverlayTrigger
+    container={
+      ActionButtonOverlay {
+        "context": Object {},
+        "props": Object {
+          "children": <div>
+            wrap me
+      </div>,
+          "overlayComponent": <div>
+            Overlay
+      </div>,
+          "preventScrolling": true,
+        },
+        "refs": Object {},
+        "state": null,
+        "updater": Updater {
+          "_callbacks": Array [],
+          "_renderer": ReactShallowRenderer {
+            "_context": Object {},
+            "_element": <ActionButtonOverlay
+              overlayComponent={
+                      <div>
+                              Overlay
+                      </div>
+              }
+              preventScrolling={true}
+      >
+              <div>
+                      wrap me
+              </div>
+      </ActionButtonOverlay>,
+            "_forcedUpdate": false,
+            "_instance": [Circular],
+            "_newState": null,
+            "_rendered": <span
+              className="theme-tc-action-button-positionned"
+      >
+              <OverlayTrigger
+                      container={[Circular]}
+                      defaultOverlayShown={false}
+                      overlay={
+                              <Popover
+                                      bsClass="popover"
+                                      id={undefined}
+                                      placement="right"
+                              >
+                                      <div>
+                                              Overlay
+                                      </div>
+                              </Popover>
+                      }
+                      placement={undefined}
+                      rootClose={true}
+                      trigger="click"
+              >
+                      <div>
+                              wrap me
+                      </div>
+              </OverlayTrigger>
+      </span>,
+            "_rendering": false,
+            "_updater": [Circular],
+          },
+        },
+      }
+    }
+    defaultOverlayShown={false}
+    overlay={
+      <Popover
+        bsClass="popover"
+        id={undefined}
+        placement="right"
+      >
+        <div>
+          Overlay
+        </div>
+      </Popover>
+    }
+    placement={undefined}
+    rootClose={true}
+    trigger="click"
+  >
+    <div>
+      wrap me
+    </div>
+  </OverlayTrigger>
+</span>
+`;
+
+exports[`ActionButtonOverlay should wrap the children with an overlay 1`] = `
+<span
+  className="theme-tc-action-button-positionned"
+>
+  <OverlayTrigger
+    defaultOverlayShown={false}
+    overlay={
+      <Popover
+        bsClass="popover"
+        id="myId"
+        placement="right"
+      >
+        <div>
+          Overlay
+        </div>
+      </Popover>
+    }
+    placement="top"
+    rootClose={true}
+    trigger="click"
+  >
+    <div>
+      wrap me
+    </div>
+  </OverlayTrigger>
+</span>
+`;

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -77,6 +77,42 @@ storiesOf('Action', module)
 				{...mouseDownAction}
 				hideLabel
 			/>
+			<h3>
+				Automatic Dropup : this is contained in a restricted ".tc-dropdown-container" element.
+			</h3>
+			<div
+				id="auto-dropup"
+				className={'tc-dropdown-container'}
+				style={{ border: '1px solid black', overflow: 'scroll', height: '300px' }}
+			>
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor<br />
+				ut labore et dolore magna aliqua.<br />
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco la<br />
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor<br />
+				ut labore et dolore magna aliqua.<br />
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco la<br />
+				<br />
+				<br />
+				<br />
+				<p>Scroll me to set overflow on top or down of the container, then open the dropdown.</p>
+				<Action
+					preventScrolling
+					overlayComponent={OverlayComponent}
+					overlayPlacement="top"
+					tooltipPlacement="right"
+					{...mouseDownAction}
+					hideLabel
+				/>
+				<br />
+				<br />
+				<br />
+				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor <br />
+				ut labore et dolore magna aliqua.<br />
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco la Lorem ipsum dolor sit amet,
+				consectetur adipiscing elit, sed do eiusmod tempor <br />
+				ut labore et dolore magna aliqua.<br />
+				Ut enim ad minim veniam, quis nostrud exercitation ullamco la
+			</div>
 		</div>
 	))
 	.addWithPropsCombinations('combinations', Action, {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The overlay is fixed with the body. If the overlay is in a list and when the user scrolls, the overflow don't follow the scroll.

**What is the chosen solution to this problem?**
fix that

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
