### PR TITLE
fix(theme): buttons active state in some components

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -28,26 +28,30 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 	min-height: auto;
 	padding: 0;
 
-	&:hover,
-	&:active,
-	&:focus {
-		box-shadow: none;
-		background-color: $white;
-		border-color: $scooter;
-		color: $scooter;
+	&,
+	&:active{
+		&:hover,
+		&:focus {
+			background-color: $white;
+			border: 1px solid $scooter;
+			box-shadow: none;
+			color: $scooter;
+		}
 	}
 
 	&.active {
 		background-color: $brand-primary;
-		border-color: $brand-primary;
+		border: 1px solid $brand-primary;
 		color: $white;
 
-		&:hover,
-		&:active,
-		&:focus {
-			background-color: $scooter;
-			border-color: $scooter;
-			color: $white;
+		&,
+		&:active{
+			&:hover,
+			&:focus {
+				background-color: $scooter;
+				border: 1px solid $scooter;
+				color: $white;
+			}
 		}
 	}
 }

--- a/packages/theme/src/theme/_buttons.scss
+++ b/packages/theme/src/theme/_buttons.scss
@@ -73,11 +73,15 @@
 		font-weight: inherit;
 
 		&,
-		&:hover,
 		&:active {
-			background: none;
-			box-shadow: none;
-			border: none;
+			&,
+			&:hover,
+			&:focus {
+				background: none;
+				box-shadow: none;
+				border: none;
+				opacity: 1;
+			}
 		}
 	}
 

--- a/packages/theme/src/theme/_navs.scss
+++ b/packages/theme/src/theme/_navs.scss
@@ -1,14 +1,12 @@
 .nav {
 	.btn-link {
 		color: inherit;
-		border: none;
 		display: inline-block;
 
 		&:focus,
 		&:active,
 		&:hover {
 			text-decoration: none;
-			background: none;
 		}
 
 		> *,
@@ -29,8 +27,6 @@
 				margin: 0;
 			}
 
-			&:focus,
-			&:active,
 			&:hover,
 			&.active,
 			&.open {
@@ -40,7 +36,6 @@
 
 			&.disabled .btn {
 				&:focus,
-				&:active,
 				&:hover {
 					color: shade($navbar-inverse-color, 10);
 				}
@@ -57,6 +52,7 @@
 			white-space: nowrap;
 
 			&.dropdown-toggle {
+				background-color: transparent;
 				position: relative;
 				padding-right: 2 * $padding-large;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some active state make the buttons have a grey background (default buttons background).
It's not only on active, but bootstrap add styles on `.btn:active:hover` too for example.

**What is the chosen solution to this problem?**
Fix that

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
