### PR TITLE
fix(components): Add actionFile shadow and hover effects

### DIFF
--- a/packages/components/src/Actions/ActionFile/ActionFile.component.js
+++ b/packages/components/src/Actions/ActionFile/ActionFile.component.js
@@ -123,7 +123,7 @@ class ActionFile extends React.Component {
 		const localId = id || uuid.v4();
 		const buttonContent = getButtonContent(this.props);
 		const labelClasses = classNames(
-			'btn',
+			'btn btn-default',
 			theme['btn-file'],
 			(disabled || inProgress) && 'disabled',
 			(hideLabel || !label) && 'btn-icon-only',

--- a/packages/components/src/Actions/ActionFile/ActionFile.scss
+++ b/packages/components/src/Actions/ActionFile/ActionFile.scss
@@ -4,11 +4,6 @@ input[type='file'] {
 	}
 }
 
-.btn-file {
-	@include btn-colors;
-	@include btn-inverse-colors($btn-default-color);
-}
-
 .btn-file-disabled {
 	cursor: not-allowed;
 }

--- a/packages/components/src/Actions/ActionFile/ActionFile.scss
+++ b/packages/components/src/Actions/ActionFile/ActionFile.scss
@@ -5,8 +5,8 @@ input[type='file'] {
 }
 
 .btn-file {
-	color: $btn-default-color;
-	background-color: $btn-default-bg;
+	@include btn-colors;
+	@include btn-inverse-colors($btn-default-color);
 }
 
 .btn-file-disabled {

--- a/packages/components/src/Actions/ActionFile/__snapshots__/ActionFile.test.js.snap
+++ b/packages/components/src/Actions/ActionFile/__snapshots__/ActionFile.test.js.snap
@@ -13,7 +13,7 @@ exports[`ActionFile should apply transformation on icon 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <Icon
@@ -40,7 +40,7 @@ exports[`ActionFile should display a Progress indicator if set 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file disabled"
+    className="btn btn-default theme-btn-file disabled"
     htmlFor={42}
   >
     <Translate(CircularProgress)
@@ -66,7 +66,7 @@ exports[`ActionFile should display a disabled Icon 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file disabled"
+    className="btn btn-default theme-btn-file disabled"
     htmlFor={42}
   >
     <Icon
@@ -93,7 +93,7 @@ exports[`ActionFile should pass all props to the Button 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <Icon
@@ -120,7 +120,7 @@ exports[`ActionFile should render a div with a input[type="file"] and a label to
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <Icon
@@ -147,7 +147,7 @@ exports[`ActionFile should render a div with a input[type="file"] with some clas
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <Icon
@@ -174,7 +174,7 @@ exports[`ActionFile should render action with html property name = props.name if
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <Icon
@@ -201,7 +201,7 @@ exports[`ActionFile should reverse icon/label 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file"
+    className="btn btn-default theme-btn-file"
     htmlFor={42}
   >
     <span>

--- a/packages/containers/src/ActionFile/__snapshots__/ActionFile.test.js.snap
+++ b/packages/containers/src/ActionFile/__snapshots__/ActionFile.test.js.snap
@@ -13,7 +13,7 @@ exports[`Connected ActionFile should render 1`] = `
     type="file"
   />
   <label
-    className="btn theme-btn-file btn-icon-only"
+    className="btn btn-default theme-btn-file btn-icon-only"
     htmlFor="42"
   >
     <span />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
actionFile button does not have any box-shadow or hover effects

**What is the chosen solution to this problem?**
Use default btn style for actionFile. 

Before / after:
![actionfile-styles](https://user-images.githubusercontent.com/36537247/42943831-357a2448-8b64-11e8-8991-5c0f484e40a4.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
