### PR TITLE
chore(components/breadcrumb): a11y

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -6,10 +6,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
 
-/home/travis/build/Talend/ui/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
-   95:4  error  Function 'renderBreadcrumbItem' expected no return value  consistent-return
-  111:3  error  Function 'renderBreadcrumbItem' expected no return value  consistent-return
-
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/__snapshots__/config.js
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
@@ -31,5 +27,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 13 problems (12 errors, 1 warning)
+✖ 11 problems (10 errors, 1 warning)
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -6,6 +6,10 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
 
+/home/travis/build/Talend/ui/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+   95:4  error  Function 'renderBreadcrumbItem' expected no return value  consistent-return
+  111:3  error  Function 'renderBreadcrumbItem' expected no return value  consistent-return
+
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/__snapshots__/config.js
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
@@ -27,5 +31,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 11 problems (10 errors, 1 warning)
+✖ 13 problems (12 errors, 1 warning)
 

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -89,18 +89,11 @@ export function BreadcrumbsComponent(props) {
 			);
 		}
 		if (maxItemsReached && index < ellipsisIndex) {
-			return (
-				<li className="sr-only" key={index}>
-					{getItemContent()}
-				</li>
-			);
+			return;
 		}
 		if (maxItemsReached && index === ellipsisIndex) {
 			return [
-				<li className="sr-only" key={index + 0.1}>
-					{getItemContent()}
-				</li>,
-				<li className="tc-breadcrumb-menu" key={index + 0.2} aria-hidden="true">
+				<li className="tc-breadcrumb-menu" key={index + 0.1}>
 					<ActionDropdown
 						id={`${props.id}-ellipsis`}
 						items={hiddenItems}

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -89,7 +89,7 @@ export function BreadcrumbsComponent(props) {
 			);
 		}
 		if (maxItemsReached && index < ellipsisIndex) {
-			return;
+			return undefined;
 		}
 		if (maxItemsReached && index === ellipsisIndex) {
 			return [

--- a/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
+++ b/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
@@ -125,40 +125,6 @@ exports[`Breadcrumbs should render dropdown containing 3 items 1`] = `
     id="42"
   >
     <li
-      className="sr-only"
-    >
-      <span
-        aria-current={undefined}
-        id="42-item-0"
-        title={undefined}
-      >
-        Text A
-      </span>
-    </li>
-    <li
-      className="sr-only"
-    >
-      <span
-        aria-current={undefined}
-        id="42-item-1"
-        title={undefined}
-      >
-        Text B
-      </span>
-    </li>
-    <li
-      className="sr-only"
-    >
-      <span
-        aria-current={undefined}
-        id="42-item-2"
-        title={undefined}
-      >
-        Text C
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
       className="tc-breadcrumb-menu"
     >
       <ActionDropdown
@@ -246,18 +212,6 @@ exports[`Breadcrumbs should render items ids when provided 1`] = `
     id="my-breadcrumb"
   >
     <li
-      className="sr-only"
-    >
-      <span
-        aria-current={undefined}
-        id="my-breadcrumb-item-0"
-        title="Go to Page Text A"
-      >
-        Text A
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
       className="tc-breadcrumb-menu"
     >
       <ActionDropdown
@@ -353,18 +307,6 @@ exports[`Breadcrumbs should render items with ellipsis and 3 visible items by de
     id="42"
   >
     <li
-      className="sr-only"
-    >
-      <span
-        aria-current={undefined}
-        id="42-item-0"
-        title="Go to Page Text A"
-      >
-        Text A
-      </span>
-    </li>
-    <li
-      aria-hidden="true"
       className="tc-breadcrumb-menu"
     >
       <ActionDropdown


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There were duplicate contents and some non-accessible buttons

**What is the chosen solution to this problem?**
Fix #1558 according to https://w3c.github.io/aria-practices/#breadcrumb

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
