### PR TITLE
fix(List): input size optimisation

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -13,9 +13,16 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 		width: $tc-list-title-icon-size;
 		vertical-align: middle;
 
-		+ form > input {
-			margin-left: $padding-normal;
-			width: auto;
+		+ .edit-form {
+			padding-left: $padding-normal;
+		}
+	}
+
+	.edit-form {
+		flex-grow: 1;
+
+		> input {
+			width: 100%;
 		}
 	}
 

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleInput.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleInput.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import keycode from 'keycode';
+import theme from './CellTitle.scss';
 
 /**
  * Title input mode.
@@ -39,7 +40,7 @@ export default class CellTitleInput extends React.Component {
 
 	render() {
 		return (
-			<form onSubmit={this.onSubmit}>
+			<form onSubmit={this.onSubmit} className={theme['edit-form']}>
 				<label aria-hidden="true" hidden className="sr-only" htmlFor={this.props.id}>
 					{this.props.label || 'title'}
 				</label>

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleInput.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleInput.test.js.snap
@@ -13,6 +13,7 @@ exports[`CellTitleInput should render the input 1`] = `
   }
 >
   <form
+    className="theme-edit-form"
     onSubmit={[Function]}
   >
     <label


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In List, with long item title, the edition is not optimised. Instead it becomes painful to use because the input doesn't take all the available space.

<img width="501" alt="capture d ecran 2018-07-23 a 11 40 34" src="https://user-images.githubusercontent.com/10761073/43069404-452aa7f8-8e6d-11e8-9a93-aafddbe8311f.png">


**What is the chosen solution to this problem?**
Make the input take all the available space.

<img width="498" alt="capture d ecran 2018-07-23 a 11 37 47" src="https://user-images.githubusercontent.com/10761073/43069453-669785d2-8e6d-11e8-847d-36e52e0c7f62.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
