### PR TITLE
feat(ActionsButton/ActionIconToggle): add aria attributes

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -155,6 +155,10 @@ export function ActionButton(props) {
 		ariaLabel = t('SKELETON_LOADING', { defaultValue: ' {{type}} (loading)', type: ariaLabel });
 	}
 
+	const hasPopup = !inProgress && overlayComponent;
+	if (hasPopup) {
+		buttonProps['aria-haspopup'] = true;
+	}
 	let btn = (
 		<Button
 			onMouseDown={!overlayComponent ? rMouseDown : null}
@@ -169,7 +173,7 @@ export function ActionButton(props) {
 			{buttonContent}
 		</Button>
 	);
-	if (!inProgress && overlayComponent) {
+	if (hasPopup) {
 		btn = (
 			<OverlayTrigger
 				onClick={rClick}

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -136,6 +136,7 @@ exports[`Action should render a button with a overlay component 1`] = `
 >
   <Button
     active={false}
+    aria-haspopup={true}
     aria-label="Click me"
     block={false}
     bsClass="btn"

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
@@ -37,6 +37,7 @@ function ActionIconToggle(props) {
 				className={cn}
 				bsStyle="link"
 				aria-label={label}
+				aria-pressed={active}
 			>
 				<Icon name={icon} />
 			</Button>
@@ -55,6 +56,7 @@ ActionIconToggle.propTypes = {
 };
 
 ActionIconToggle.defaultProps = {
+	active: false,
 	tooltipPlacement: 'top',
 };
 

--- a/packages/components/src/Actions/ActionIconToggle/__snapshots__/ActionIconToggle.component.test.js.snap
+++ b/packages/components/src/Actions/ActionIconToggle/__snapshots__/ActionIconToggle.component.test.js.snap
@@ -8,6 +8,7 @@ exports[`ActionIconToggle should render a button 1`] = `
   <Button
     active={false}
     aria-label="Click me, I'm inactive"
+    aria-pressed={false}
     block={false}
     bsClass="btn"
     bsStyle="link"
@@ -32,6 +33,7 @@ exports[`ActionIconToggle should render an active button 1`] = `
   <Button
     active={false}
     aria-label="Click me, I'm inactive"
+    aria-pressed={true}
     block={false}
     bsClass="btn"
     bsStyle="link"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
* ActionButton: there is no indication that is opens a popup
* ActionIconToggle: there is no indication that the button is active or not

**What is the chosen solution to this problem?**
* ActionButton: add `aria-haspopup` attribute
* ActionIconToggle: add `aria-pressed` attribute

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
