### PR TITLE
fix(Components) Badge and Typeahead whitespaces

### DIFF
--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -38,7 +38,7 @@ $tc-badge-margin: $padding-smaller !default;
 
 			overflow: hidden;
 			text-overflow: ellipsis;
-			white-space: nowrap;
+			white-space: pre;
 		}
 
 		&:hover {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -155,6 +155,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 	margin-bottom: 0;
 	padding: $padding-normal;
 	cursor: pointer;
+	white-space: pre;
 
 	&-description {
 		margin-bottom: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
White spaces are gathered in Badge and Typeahead components. 
We need them to be showing up https://jira.talendforge.org/browse/TPSVC-5309

**What is the chosen solution to this problem?**
Use CSS `white-space: pre` on the text elements

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
