### PR TITLE
fix(AppLoader): wrong a11y attributes

### DIFF
--- a/packages/components/src/AppLoader/AppLoader.component.js
+++ b/packages/components/src/AppLoader/AppLoader.component.js
@@ -8,9 +8,8 @@ export function AppLoaderComponent({ t }) {
 	return (
 		<div
 			className="tc-app-loader-container"
-			aria-atomic="true"
-			aria-busy="true"
 			aria-label={t('APP_LOADER_LOADING', { defaultValue: 'Loading application' })}
+			role="status"
 		>
 			<div className="tc-app-loader-icon">
 				<div className="tc-app-loader">

--- a/packages/components/src/AppLoader/__snapshots__/AppLoader.test.js.snap
+++ b/packages/components/src/AppLoader/__snapshots__/AppLoader.test.js.snap
@@ -2,10 +2,9 @@
 
 exports[`AppLoader should render 1`] = `
 <div
-  aria-atomic="true"
-  aria-busy="true"
   aria-label="Loading application"
   className="tc-app-loader-container"
+  role="status"
 >
   <div
     className="tc-app-loader-icon"

--- a/packages/components/src/AppLoader/constant.js
+++ b/packages/components/src/AppLoader/constant.js
@@ -170,7 +170,7 @@ body {
   }
 }`;
 
-const APP_LOADER = `<div class="tc-app-loader-container">
+const APP_LOADER = `<div class="tc-app-loader-container" aria-label="Loading application" role="status">
 	<div class="tc-app-loader-icon">
 		<div class="tc-app-loader" >
 			<div class="spinner-wrapper">


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
AppLoader has `aria-busy=true` and `aria-atomic=true`.
The first one is wrong because the component/container is not loading, it's the app that is loading, and will replace the current component/container.
The second one is wrong because nothing changes in it, so screen readers don't need it. So in fact it is useless.

**What is the chosen solution to this problem?**
Remove them, and add `role=status` instead. Coupled with the current aria-label, it's understandable that the app is loading.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
