### PR TITLE
feat(Dialog): improve a11y

### DIFF
--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -7,7 +7,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
   bsSize="large"
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div
@@ -83,7 +83,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   bsSize="large"
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div
@@ -172,7 +172,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
   bsSize="small"
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div
@@ -248,7 +248,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
   bsSize={undefined}
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div
@@ -337,7 +337,7 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
   bsSize={undefined}
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div
@@ -412,7 +412,7 @@ exports[`ConfirmDialog should render without header 1`] = `
   bsSize={undefined}
   className="Modal"
   keyboard={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <div

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -3,7 +3,7 @@
 exports[`ConfirmDialog should render with a large container 1`] = `
 <div
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   bsSize="large"
   className="Modal"
   keyboard={true}
@@ -79,7 +79,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
 exports[`ConfirmDialog should render with a progress bar 1`] = `
 <div
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   bsSize="large"
   className="Modal"
   keyboard={true}
@@ -168,7 +168,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
 exports[`ConfirmDialog should render with a small container 1`] = `
 <div
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   bsSize="small"
   className="Modal"
   keyboard={true}
@@ -244,7 +244,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
 exports[`ConfirmDialog should render with additional actions 1`] = `
 <div
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   bsSize={undefined}
   className="Modal"
   keyboard={true}
@@ -333,7 +333,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
 exports[`ConfirmDialog should render with defaults values 1`] = `
 <div
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   bsSize={undefined}
   className="Modal"
   keyboard={true}
@@ -408,7 +408,8 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
 
 exports[`ConfirmDialog should render without header 1`] = `
 <div
-  aria-modal={true}
+  aria-labelledby={null}
+  aria-modal="true"
   bsSize={undefined}
   className="Modal"
   keyboard={true}

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -2,9 +2,12 @@
 
 exports[`ConfirmDialog should render with a large container 1`] = `
 <div
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   bsSize="large"
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div
@@ -13,6 +16,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
   >
     <div
       className="Title"
+      id="tc-dialog-header"
     >
       Hello world
     </div>
@@ -74,9 +78,12 @@ exports[`ConfirmDialog should render with a large container 1`] = `
 
 exports[`ConfirmDialog should render with a progress bar 1`] = `
 <div
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   bsSize="large"
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div
@@ -85,6 +92,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   >
     <div
       className="Title"
+      id="tc-dialog-header"
     >
       Hello world
     </div>
@@ -159,9 +167,12 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
 
 exports[`ConfirmDialog should render with a small container 1`] = `
 <div
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   bsSize="small"
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div
@@ -170,6 +181,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
   >
     <div
       className="Title"
+      id="tc-dialog-header"
     >
       Hello world
     </div>
@@ -231,9 +243,12 @@ exports[`ConfirmDialog should render with a small container 1`] = `
 
 exports[`ConfirmDialog should render with additional actions 1`] = `
 <div
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   bsSize={undefined}
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div
@@ -242,6 +257,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
   >
     <div
       className="Title"
+      id="tc-dialog-header"
     >
       Hello world
     </div>
@@ -316,9 +332,12 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
 
 exports[`ConfirmDialog should render with defaults values 1`] = `
 <div
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   bsSize={undefined}
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div
@@ -327,6 +346,7 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
   >
     <div
       className="Title"
+      id="tc-dialog-header"
     >
       Hello world
     </div>
@@ -388,9 +408,11 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
 
 exports[`ConfirmDialog should render without header 1`] = `
 <div
+  aria-modal={true}
   bsSize={undefined}
   className="Modal"
   keyboard={true}
+  role="modal"
   show={true}
 >
   <div

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -31,12 +31,23 @@ function Dialog({
 	});
 	const injected = Inject.all(getComponent, components);
 
+	const headerId = 'tc-dialog-header';
+	const a11yProps = {
+		role: 'modal',
+		'aria-modal': true,
+	};
+	if (header) {
+		a11yProps['aria-labelledby'] = headerId;
+	}
+
 	return (
-		<Modal bsSize={size} {...props}>
+		// we disable jsx-a11y/aria-props because the version we use does not consider it valid (bug)
+		// eslint-disable-next-line jsx-a11y/aria-props
+		<Modal bsSize={size} {...a11yProps} {...props}>
 			{injected('before-modal-header')}
 			{header && (
 				<Modal.Header closeButton={closeButton}>
-					<Modal.Title>{header}</Modal.Title>
+					<Modal.Title id={headerId}>{header}</Modal.Title>
 				</Modal.Header>
 			)}
 			{injected('after-modal-header')}

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -33,7 +33,7 @@ function Dialog({
 
 	const headerId = 'tc-dialog-header';
 	const a11yProps = {
-		role: 'modal',
+		role: 'dialog',
 		'aria-modal': true,
 	};
 	if (header) {

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -30,20 +30,18 @@ function Dialog({
 		Action,
 	});
 	const injected = Inject.all(getComponent, components);
-
 	const headerId = 'tc-dialog-header';
-	const a11yProps = {
-		role: 'dialog',
-		'aria-modal': true,
-	};
-	if (header) {
-		a11yProps['aria-labelledby'] = headerId;
-	}
 
 	return (
-		// we disable jsx-a11y/aria-props because the version we use does not consider it valid (bug)
-		// eslint-disable-next-line jsx-a11y/aria-props
-		<Modal bsSize={size} {...a11yProps} {...props}>
+		<Modal
+			bsSize={size}
+			role="dialog"
+			// we disable jsx-a11y/aria-props because the version we use does not consider it valid (bug)
+			// eslint-disable-next-line jsx-a11y/aria-props
+			aria-modal="true"
+			aria-labelledby={header ? headerId : null}
+			{...props}
+		>
 			{injected('before-modal-header')}
 			{header && (
 				<Modal.Header closeButton={closeButton}>

--- a/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
+++ b/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
@@ -3,6 +3,7 @@
 exports[`Dialog should render 1`] = `
 <Modal
   animation={true}
+  aria-modal={true}
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -25,6 +26,7 @@ exports[`Dialog should render 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
+  role="modal"
   show={true}
 >
   <ModalBody
@@ -41,6 +43,8 @@ exports[`Dialog should render 1`] = `
 exports[`Dialog should render action 1`] = `
 <Modal
   animation={true}
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -63,6 +67,7 @@ exports[`Dialog should render action 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
+  role="modal"
   show={true}
 >
   <ModalHeader
@@ -73,6 +78,7 @@ exports[`Dialog should render action 1`] = `
     <ModalTitle
       bsClass="modal-title"
       componentClass="h4"
+      id="tc-dialog-header"
     >
       Hello world
     </ModalTitle>
@@ -100,6 +106,8 @@ exports[`Dialog should render action 1`] = `
 exports[`Dialog should render header 1`] = `
 <Modal
   animation={true}
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -122,6 +130,7 @@ exports[`Dialog should render header 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
+  role="modal"
   show={true}
 >
   <ModalHeader
@@ -132,6 +141,7 @@ exports[`Dialog should render header 1`] = `
     <ModalTitle
       bsClass="modal-title"
       componentClass="h4"
+      id="tc-dialog-header"
     >
       Hello world
     </ModalTitle>
@@ -150,6 +160,8 @@ exports[`Dialog should render header 1`] = `
 exports[`Dialog should render large 1`] = `
 <Modal
   animation={true}
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   autoFocus={true}
   backdrop={false}
   bsClass="modal"
@@ -173,6 +185,7 @@ exports[`Dialog should render large 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
+  role="modal"
   show={true}
 >
   <ModalHeader
@@ -183,6 +196,7 @@ exports[`Dialog should render large 1`] = `
     <ModalTitle
       bsClass="modal-title"
       componentClass="h4"
+      id="tc-dialog-header"
     >
       Hello world
     </ModalTitle>
@@ -210,6 +224,8 @@ exports[`Dialog should render large 1`] = `
 exports[`Dialog should render small 1`] = `
 <Modal
   animation={true}
+  aria-labelledby="tc-dialog-header"
+  aria-modal={true}
   autoFocus={true}
   backdrop={false}
   bsClass="modal"
@@ -233,6 +249,7 @@ exports[`Dialog should render small 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
+  role="modal"
   show={true}
 >
   <ModalHeader
@@ -243,6 +260,7 @@ exports[`Dialog should render small 1`] = `
     <ModalTitle
       bsClass="modal-title"
       componentClass="h4"
+      id="tc-dialog-header"
     >
       Hello world
     </ModalTitle>

--- a/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
+++ b/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
@@ -26,7 +26,7 @@ exports[`Dialog should render 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <ModalBody
@@ -67,7 +67,7 @@ exports[`Dialog should render action 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <ModalHeader
@@ -130,7 +130,7 @@ exports[`Dialog should render header 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <ModalHeader
@@ -185,7 +185,7 @@ exports[`Dialog should render large 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <ModalHeader
@@ -249,7 +249,7 @@ exports[`Dialog should render small 1`] = `
   onHide={[Function]}
   renderBackdrop={[Function]}
   restoreFocus={true}
-  role="modal"
+  role="dialog"
   show={true}
 >
   <ModalHeader

--- a/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
+++ b/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
@@ -3,7 +3,8 @@
 exports[`Dialog should render 1`] = `
 <Modal
   animation={true}
-  aria-modal={true}
+  aria-labelledby={null}
+  aria-modal="true"
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -44,7 +45,7 @@ exports[`Dialog should render action 1`] = `
 <Modal
   animation={true}
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -107,7 +108,7 @@ exports[`Dialog should render header 1`] = `
 <Modal
   animation={true}
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   autoFocus={true}
   backdrop={true}
   bsClass="modal"
@@ -161,7 +162,7 @@ exports[`Dialog should render large 1`] = `
 <Modal
   animation={true}
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   autoFocus={true}
   backdrop={false}
   bsClass="modal"
@@ -225,7 +226,7 @@ exports[`Dialog should render small 1`] = `
 <Modal
   animation={true}
   aria-labelledby="tc-dialog-header"
-  aria-modal={true}
+  aria-modal="true"
   autoFocus={true}
   backdrop={false}
   bsClass="modal"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dialog missing
* role
* aria-modal
* aria-labelledby
* aria-describedby

**What is the chosen solution to this problem?**
* role=dialog
* aria-modal=true
* if we have a header: aria-labelledby use the header id. We suppose we have only 1 modal at a time, so no id generation needed
* for `aria-labelledby` (in case of no header) and `aria-describedby`, we can't guess user input, but all rest props are spread to the modal. So the user must manage that in its project

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
