### PR TITLE
feat(Search): improve a11y

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -10,6 +10,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
 
+/home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
+  105:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role
+
 /home/travis/build/Talend/ui/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
   21:1  error  Line 21 exceeds the maximum line length of 100                                       max-len
   56:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
@@ -27,5 +30,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 11 problems (10 errors, 1 warning)
+✖ 12 problems (11 errors, 1 warning)
 

--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -27,11 +27,14 @@ src/theme/_forms.scss
 src/theme/_navbar.scss
   18:6  warning  Expected indentation of 4 tabs but found 5  indentation
 
+src/theme/_navbar.search.scss
+  7:11  error  A value of `0` is not allowed. `none` must be used  border-zero
+
 src/theme/_tables.scss
   21:2   warning  Vendor prefixes should not be used  no-vendor-prefixes
   23:29  error    !important not allowed              no-important
   29:26  error    !important not allowed              no-important
   34:25  error    !important not allowed              no-important
 
-✖ 20 problems (11 errors, 9 warnings)
+✖ 21 problems (12 errors, 9 warnings)
 

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -57,6 +57,7 @@ function FilterInput(props) {
 		onChange: event => onFilter(event, event.target.value),
 		onKeyDown: event => onKeyDown(event, onToggle, onBlur),
 		autoFocus,
+		role: 'searchbox',
 	};
 
 	if (debounceMinLength || debounceTimeout) {
@@ -146,6 +147,7 @@ export class FilterBarComponent extends React.Component {
 					icon="talend-search"
 					bsStyle="link"
 					tooltipPlacement={this.props.tooltipPlacement}
+					role="search"
 				/>
 			);
 		}

--- a/packages/components/src/FilterBar/__snapshots__/FilterBar.snapshot.test.js.snap
+++ b/packages/components/src/FilterBar/__snapshots__/FilterBar.snapshot.test.js.snap
@@ -9,6 +9,7 @@ exports[`Filter should render 1`] = `
   id={undefined}
   label="Toggle filter"
   onClick={[Function]}
+  role="search"
   tooltipPlacement={undefined}
 />
 `;
@@ -104,6 +105,7 @@ exports[`Filter should render highlighted filter 1`] = `
   id={undefined}
   label="Toggle filter"
   onClick={[Function]}
+  role="search"
   tooltipPlacement={undefined}
 />
 `;
@@ -117,6 +119,7 @@ exports[`Filter should render id if provided 1`] = `
   id="toolbar-filter"
   label="Toggle filter"
   onClick={[Function]}
+  role="search"
   tooltipPlacement={undefined}
 />
 `;
@@ -130,6 +133,7 @@ exports[`Filter should render only toggle icon 1`] = `
   id={undefined}
   label="Toggle filter"
   onClick={[Function]}
+  role="search"
   tooltipPlacement={undefined}
 />
 `;

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -87,7 +87,7 @@ function Environment({ getComponent, ...props }) {
 	);
 }
 
-function Search({ getComponent, ...props }) {
+function Search({ getComponent, icon, ...props }) {
 	const className = classNames(
 		theme['tc-header-bar-action'],
 		'tc-header-bar-action',
@@ -97,11 +97,12 @@ function Search({ getComponent, ...props }) {
 		theme.flex,
 	);
 	const Renderers = Inject.getAll(getComponent, { Typeahead });
+	const a11yIcon = icon && { ...icon, role: 'search' };
 
 	return (
 		<li role="presentation" className={className}>
-			<form className="navbar-form navbar-right" role="search">
-				<Renderers.Typeahead {...props} />
+			<form className="navbar-form navbar-right">
+				<Renderers.Typeahead {...props} role="searchbox" icon={a11yIcon} />
 			</form>
 		</li>
 	);

--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -132,21 +132,21 @@ $background-color-on-hover: shade($brand-primary, 30);
 	.tc-header-bar-search {
 		form {
 			height: $navbar-height;
-		}
 
-		[role='search'] > div > div:first-child {
-			margin-top: 0;
-			margin-bottom: 0;
+			:global(.tc-typeahead-container) > div:first-child {
+				margin-top: 0;
+				margin-bottom: 0;
 
-			padding-left: $padding-small;
-			padding-right: $padding-large;
-			height: $navbar-height;
-			background: $white;
+				padding-left: $padding-small;
+				padding-right: $padding-large;
+				height: $navbar-height;
+				background: $white;
 
-			:global(.form-control) {
-				font-style: italic;
-				animation: fadeIn 0.2s;
-				width: 400px;
+				:global(.form-control) {
+					font-style: italic;
+					animation: fadeIn 0.2s;
+					width: 400px;
+				}
 			}
 		}
 	}

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -798,7 +798,6 @@ exports[`Storyshots HeaderBar default 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -808,7 +807,7 @@ exports[`Storyshots HeaderBar default 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -1421,7 +1420,6 @@ exports[`Storyshots HeaderBar while searching 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <div
             aria-expanded={false}
@@ -1454,6 +1452,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
                 onKeyDown={undefined}
                 placeholder={undefined}
                 readOnly={false}
+                role="searchbox"
                 type="text"
                 value="le"
               />
@@ -2159,7 +2158,6 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -2169,7 +2167,7 @@ exports[`Storyshots HeaderBar with environment dropdown 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -2782,7 +2780,6 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -2792,7 +2789,7 @@ exports[`Storyshots HeaderBar with full logo 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -3405,7 +3402,6 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -3415,7 +3411,7 @@ exports[`Storyshots HeaderBar with help split dropdown 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -4028,7 +4024,6 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <div
             aria-expanded={false}
@@ -4061,6 +4056,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
                 onKeyDown={undefined}
                 placeholder={undefined}
                 readOnly={false}
+                role="searchbox"
                 type="text"
                 value="le"
               />
@@ -4679,7 +4675,6 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -4689,7 +4684,7 @@ exports[`Storyshots HeaderBar with read notifications 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -5330,7 +5325,6 @@ exports[`Storyshots HeaderBar with search input 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <div
             aria-expanded={false}
@@ -5363,6 +5357,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
                 onKeyDown={undefined}
                 placeholder="Search..."
                 readOnly={false}
+                role="searchbox"
                 type="text"
                 value={undefined}
               />
@@ -5975,7 +5970,6 @@ exports[`Storyshots HeaderBar with search results 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <div
             aria-expanded={true}
@@ -6008,6 +6002,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
                 onKeyDown={undefined}
                 placeholder={undefined}
                 readOnly={false}
+                role="searchbox"
                 type="text"
                 value="le"
               />
@@ -6959,7 +6954,6 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -6969,7 +6963,7 @@ exports[`Storyshots HeaderBar with unread notifications 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -7505,7 +7499,6 @@ exports[`Storyshots HeaderBar without products 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -7515,7 +7508,7 @@ exports[`Storyshots HeaderBar without products 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -8128,7 +8121,6 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
       >
         <form
           className="navbar-form navbar-right"
-          role="search"
         >
           <button
             aria-label="Search"
@@ -8138,7 +8130,7 @@ exports[`Storyshots HeaderBar without user and with information 1`] = `
             onFocus={[Function]}
             onMouseDown={[Function]}
             onMouseOver={[Function]}
-            role={null}
+            role="search"
             type="button"
           >
             <svg
@@ -8783,7 +8775,6 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -8793,7 +8784,7 @@ exports[`Storyshots HeaderBar 🎨 [PORTAL] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -9418,7 +9409,6 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -9428,7 +9418,7 @@ exports[`Storyshots HeaderBar 🎨 [TDC] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -10053,7 +10043,6 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -10063,7 +10052,7 @@ exports[`Storyshots HeaderBar 🎨 [TDP] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -10688,7 +10677,6 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -10698,7 +10686,7 @@ exports[`Storyshots HeaderBar 🎨 [TDS] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -11323,7 +11311,6 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -11333,7 +11320,7 @@ exports[`Storyshots HeaderBar 🎨 [TFD] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -11958,7 +11945,6 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -11968,7 +11954,7 @@ exports[`Storyshots HeaderBar 🎨 [TIC] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg
@@ -12593,7 +12579,6 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
             >
               <form
                 className="navbar-form navbar-right"
-                role="search"
               >
                 <button
                   aria-label="Search"
@@ -12603,7 +12588,7 @@ exports[`Storyshots HeaderBar 🎨 [TMC] HeaderBar 1`] = `
                   onFocus={[Function]}
                   onMouseDown={[Function]}
                   onMouseOver={[Function]}
-                  role={null}
+                  role="search"
                   type="button"
                 >
                   <svg

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -235,7 +235,7 @@ exports[`Toolbar should render filter form 1`] = `
         onFocus={[Function]}
         onMouseDown={[Function]}
         onMouseOver={[Function]}
-        role={null}
+        role="search"
         type="button"
       >
         <svg

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -1743,6 +1743,7 @@ exports[`List should render 1`] = `
                               icon="talend-search"
                               label="Toggle filter"
                               onClick={[Function]}
+                              role="search"
                             >
                               <Translate(ActionButton)
                                 bsStyle="link"
@@ -1751,6 +1752,7 @@ exports[`List should render 1`] = `
                                 icon="talend-search"
                                 label="Toggle filter"
                                 onClick={[Function]}
+                                role="search"
                               >
                                 <I18n
                                   bindI18n="languageChanged loaded"
@@ -1768,6 +1770,7 @@ exports[`List should render 1`] = `
                                   }
                                   nsMode="default"
                                   onClick={[Function]}
+                                  role="search"
                                   translateFuncName="t"
                                   usePureComponent={false}
                                   wait={false}
@@ -1785,6 +1788,7 @@ exports[`List should render 1`] = `
                                     label="Toggle filter"
                                     loading={false}
                                     onClick={[Function]}
+                                    role="search"
                                     t={[Function]}
                                     tReady={false}
                                     tooltipPlacement="top"
@@ -1805,7 +1809,7 @@ exports[`List should render 1`] = `
                                         onFocus={[Function]}
                                         onMouseDown={[Function]}
                                         onMouseOver={[Function]}
-                                        role={null}
+                                        role="search"
                                       >
                                         <button
                                           aria-label="Toggle filter"
@@ -1815,7 +1819,7 @@ exports[`List should render 1`] = `
                                           onFocus={[Function]}
                                           onMouseDown={[Function]}
                                           onMouseOver={[Function]}
-                                          role={null}
+                                          role="search"
                                           type="button"
                                         >
                                           <Icon
@@ -3601,6 +3605,7 @@ exports[`List should render id if provided 1`] = `
                               id="context-filter"
                               label="Toggle filter"
                               onClick={[Function]}
+                              role="search"
                             >
                               <Translate(ActionButton)
                                 bsStyle="link"
@@ -3610,6 +3615,7 @@ exports[`List should render id if provided 1`] = `
                                 id="context-filter"
                                 label="Toggle filter"
                                 onClick={[Function]}
+                                role="search"
                               >
                                 <I18n
                                   bindI18n="languageChanged loaded"
@@ -3628,6 +3634,7 @@ exports[`List should render id if provided 1`] = `
                                   }
                                   nsMode="default"
                                   onClick={[Function]}
+                                  role="search"
                                   translateFuncName="t"
                                   usePureComponent={false}
                                   wait={false}
@@ -3646,6 +3653,7 @@ exports[`List should render id if provided 1`] = `
                                     label="Toggle filter"
                                     loading={false}
                                     onClick={[Function]}
+                                    role="search"
                                     t={[Function]}
                                     tReady={false}
                                     tooltipPlacement="top"
@@ -3667,7 +3675,7 @@ exports[`List should render id if provided 1`] = `
                                         onFocus={[Function]}
                                         onMouseDown={[Function]}
                                         onMouseOver={[Function]}
-                                        role={null}
+                                        role="search"
                                       >
                                         <button
                                           aria-label="Toggle filter"
@@ -3678,7 +3686,7 @@ exports[`List should render id if provided 1`] = `
                                           onFocus={[Function]}
                                           onMouseDown={[Function]}
                                           onMouseOver={[Function]}
-                                          role={null}
+                                          role="search"
                                           type="button"
                                         >
                                           <Icon

--- a/packages/components/src/Table/Filters/__snapshots__/FiltersBar.test.js.snap
+++ b/packages/components/src/Table/Filters/__snapshots__/FiltersBar.test.js.snap
@@ -13,7 +13,7 @@ exports[`two-filters 1`] = `
     onFocus={[Function]}
     onMouseDown={[Function]}
     onMouseOver={[Function]}
-    role={null}
+    role="search"
     type="button"
   >
     <svg

--- a/packages/components/src/Table/TitleBar/__snapshots__/TitleBar.test.js.snap
+++ b/packages/components/src/Table/TitleBar/__snapshots__/TitleBar.test.js.snap
@@ -21,7 +21,7 @@ exports[`title-bar 1`] = `
       onFocus={[Function]}
       onMouseDown={[Function]}
       onMouseOver={[Function]}
-      role={null}
+      role="search"
       type="button"
     >
       <svg

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -29,6 +29,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 				icon={icon.name}
 				bsStyle={icon.bsStyle}
 				className={classNames(theme['only-icon-cls'], 'tc-typeahead-toggle')}
+				role={icon.role}
 				tooltipPlacement={icon.tooltipPlacement}
 			/>
 		);
@@ -80,6 +81,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			value: rest.value,
 			icon,
 			caret: rest.caret,
+			role: rest.role,
 		},
 	};
 
@@ -150,6 +152,7 @@ Typeahead.propTypes = {
 		name: PropTypes.string,
 		title: PropTypes.string,
 		bsStyle: PropTypes.string,
+		role: PropTypes.string,
 	}),
 
 	// input

--- a/packages/components/src/Typeahead/Typeahead.snapshot.test.js
+++ b/packages/components/src/Typeahead/Typeahead.snapshot.test.js
@@ -8,6 +8,7 @@ const itemsObject = [
 		icon: {
 			name: 'fa fa-filter',
 			title: 'icon',
+			role: 'search',
 		},
 		suggestions: [
 			{
@@ -69,6 +70,7 @@ describe('Typeahead', () => {
 			const props = {
 				id: 'my-search',
 				position: 'right',
+				role: 'searchbox',
 			};
 
 			// when

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -32,6 +32,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role={undefined}
       type="text"
       value="le"
     />
@@ -276,6 +277,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role={undefined}
       type="text"
       value={undefined}
     />
@@ -330,6 +332,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role={undefined}
       type="text"
       value={undefined}
     />
@@ -516,6 +519,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role={undefined}
       type="text"
       value={undefined}
     />
@@ -610,6 +614,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role={undefined}
       type="text"
       value={undefined}
     />
@@ -664,6 +669,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       onKeyDown={undefined}
       placeholder={undefined}
       readOnly={false}
+      role="searchbox"
       type="text"
       value={undefined}
     />
@@ -689,7 +695,7 @@ exports[`Typeahead with toggle should render button 1`] = `
   onFocus={[Function]}
   onMouseDown={[Function]}
   onMouseOver={[Function]}
-  role={null}
+  role={undefined}
   type="button"
 >
   <i

--- a/packages/components/stories/Typeahead.js
+++ b/packages/components/stories/Typeahead.js
@@ -15,11 +15,13 @@ const items = [
 		suggestions: [
 			{
 				title: 'le title 1',
-				description: 'description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.',
+				description:
+					'description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.',
 			},
 			{
 				title: 'title 2 Les elephants elementaires ont des aile ',
-				description: 'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
+				description:
+					'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
 			},
 		],
 	},
@@ -32,7 +34,8 @@ const items = [
 		suggestions: [
 			{
 				title: 'title 3',
-				description: 'description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.',
+				description:
+					'description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.',
 			},
 		],
 	},
@@ -45,15 +48,18 @@ const items = [
 		suggestions: [
 			{
 				title: 'title 4',
-				description: 'description: Praesentibus genero ne in Africani mandavi saepius ipsam C in libro et hoc Laeli cum.',
+				description:
+					'description: Praesentibus genero ne in Africani mandavi saepius ipsam C in libro et hoc Laeli cum.',
 			},
 			{
 				title: 'title 5',
-				description: 'description: Feceris unde tot illo tot clientes dederis numerando et indiscretus cum paria et unde ubi.',
+				description:
+					'description: Feceris unde tot illo tot clientes dederis numerando et indiscretus cum paria et unde ubi.',
 			},
 			{
 				title: 'title 6',
-				description: 'description: Gradu quos cedentium sunt appeterent ita ancoralia instar luna sunt etiam ubi incendente nihil observabant.',
+				description:
+					'description: Gradu quos cedentium sunt appeterent ita ancoralia instar luna sunt etiam ubi incendente nihil observabant.',
 			},
 			{
 				title: 'without description',
@@ -98,10 +104,9 @@ decoratedStories
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			debounceTimeout: 300,
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('searching', () => {
 		const props = {
@@ -109,10 +114,9 @@ decoratedStories
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			searching: true,
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('with results', () => {
 		const props = {
@@ -121,10 +125,9 @@ decoratedStories
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			onSelect: action('onSelect'),
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('without results', () => {
 		const props = {
@@ -132,10 +135,9 @@ decoratedStories
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			items: [],
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('on the right', () => {
 		const props = {
@@ -145,10 +147,9 @@ decoratedStories
 			onChange: action('onChange'),
 			onSelect: action('onSelect'),
 			position: 'right',
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('with toggle button', () => {
 		const props = {
@@ -156,13 +157,12 @@ decoratedStories
 				name: 'talend-search',
 				title: 'Toggle search input',
 				bsStyle: 'link',
+				role: 'search',
 			},
 			onToggle: action('onToggle'),
 			docked: true,
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('with focused item', () => {
 		const props = {
@@ -175,20 +175,18 @@ decoratedStories
 			items,
 			focusedSectionIndex: 1,
 			focusedItemIndex: 0,
+			role: 'searchbox',
 		};
-		return (
-			<Typeahead {...props} />
-		);
+		return <Typeahead {...props} />;
 	})
 	.addWithInfo('without section header', () => {
-	const props = {
-		value: 'le',
-		items: noHeaderItems,
-		onBlur: action('onBlur'),
-		onChange: action('onChange'),
-		onSelect: action('onSelect'),
-	};
-	return (
-		<Typeahead {...props} />
-	);
-});
+		const props = {
+			value: 'le',
+			items: noHeaderItems,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			role: 'searchbox',
+		};
+		return <Typeahead {...props} />;
+	});

--- a/packages/theme/src/theme/_navbar.scss
+++ b/packages/theme/src/theme/_navbar.scss
@@ -21,11 +21,6 @@
 		}
 	}
 
-	&-form {
-		margin-top: $navbar-form-margin;
-		margin-bottom: $navbar-form-margin;
-	}
-
 	&-nav {
 		display: flex;
 

--- a/packages/theme/src/theme/_navbar.search.scss
+++ b/packages/theme/src/theme/_navbar.search.scss
@@ -1,16 +1,12 @@
 
 .navbar {
-	[role='search'] {
-		display: flex;
-
-		.form-control {
-			font-style: italic;
-			color: $navbar-search-btn-color;
-			border-radius: 0;
-		}
-	}
-
 	.navbar-form {
+		margin-top: $navbar-form-margin;
+		margin-bottom: $navbar-form-margin;
+		padding-top: 0;
+		padding-bottom: 0;
+		border: 0;
+
 		.form-group {
 			padding: $padding-small $padding-small $padding-smaller;
 			min-height: $navbar-height;

--- a/packages/theme/src/theme/_navbar.search.scss
+++ b/packages/theme/src/theme/_navbar.search.scss
@@ -1,4 +1,3 @@
-
 .navbar {
 	.navbar-form {
 		margin-top: $navbar-form-margin;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
* FilterBar: missing search roles
* HeaderBar > search: role=search on form, which is wrong. We should not override form implicit role, and search role should be on button/input
* Typeahead: no roles props

**What is the chosen solution to this problem?**
* Typeahead: allow to pass roles on input and toggle button
* FilterBar and HeaderBar: set role=search on toggle button and role=searchbox
* HeaderBar: remove role from form and fix style

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
