### PR TITLE
feat(Progress): improve a11y

### DIFF
--- a/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
@@ -36,6 +36,7 @@ function ConfirmDialog({
 	validateAction,
 	secondaryActions,
 	cancelAction,
+	progressLabel,
 	progressValue,
 	...props
 }) {
@@ -55,7 +56,7 @@ function ConfirmDialog({
 	}
 	let progress;
 	if (progressValue) {
-		progress = { percent: progressValue };
+		progress = { percent: progressValue, tooltip: progressLabel };
 	}
 	return (
 		<Dialog
@@ -82,6 +83,7 @@ ConfirmDialog.propTypes = {
 	cancelAction: PropTypes.shape(Action.propTypes).isRequired,
 	validateAction: PropTypes.shape(Action.propTypes).isRequired,
 	secondaryActions: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+	progressLabel: PropTypes.string,
 	progressValue: PropTypes.number,
 	bodyOverflow: PropTypes.bool,
 	getComponent: PropTypes.func,

--- a/packages/components/src/ConfirmDialog/ConfirmDialog.test.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.test.js
@@ -130,6 +130,7 @@ describe('ConfirmDialog', () => {
 			size: 'large',
 			validateAction,
 			cancelAction,
+			progressLabel: 'This is loading',
 			progressValue: 25,
 		};
 

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -98,8 +98,13 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
     </div>
   </div>
   <div
+    aria-label={undefined}
+    aria-valuemax={100}
+    aria-valuemin={0}
+    aria-valuenow={25}
     className="theme-progress"
     id={undefined}
+    role="progressbar"
   >
     <div
       className="theme-progress-percent"

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -98,7 +98,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
     </div>
   </div>
   <div
-    aria-label={undefined}
+    aria-label="This is loading"
     aria-valuemax={100}
     aria-valuemin={0}
     aria-valuenow={25}
@@ -108,6 +108,8 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   >
     <div
       className="theme-progress-percent"
+      onFocus={[Function]}
+      onMouseOver={[Function]}
       style={
         Object {
           "width": "25%",

--- a/packages/components/src/Progress/Progress.component.js
+++ b/packages/components/src/Progress/Progress.component.js
@@ -40,8 +40,23 @@ function Progress({ id, percent, tooltip, infinite, contained }) {
 		);
 	}
 
+	let a11yProps;
+	if (!infinite) {
+		a11yProps = {
+			role: 'progressbar',
+			'aria-valuenow': normalizedPercent,
+			'aria-valuemin': 0,
+			'aria-valuemax': 100,
+		};
+	} else {
+		a11yProps = {
+			role: 'status',
+			'aria-busy': true,
+		};
+	}
+
 	return (
-		<div id={id} className={rootClassNames}>
+		<div id={id} className={rootClassNames} aria-label={tooltip} {...a11yProps}>
 			{progress}
 		</div>
 	);

--- a/packages/components/src/Progress/Progress.component.js
+++ b/packages/components/src/Progress/Progress.component.js
@@ -67,7 +67,7 @@ Progress.displayName = 'Progress';
 Progress.propTypes = {
 	id: PropTypes.string,
 	percent: PropTypes.number,
-	tooltip: PropTypes.string,
+	tooltip: PropTypes.string.isRequired,
 	infinite: PropTypes.bool,
 	contained: PropTypes.bool,
 };

--- a/packages/components/src/Progress/Progress.test.js
+++ b/packages/components/src/Progress/Progress.test.js
@@ -9,6 +9,7 @@ describe('Progress', () => {
 		const props = {
 			id: 'my-progress',
 			percent: 0,
+			tooltip: 'loading',
 		};
 
 		// when
@@ -23,6 +24,7 @@ describe('Progress', () => {
 		const props = {
 			id: 'my-progress',
 			percent: 60,
+			tooltip: 'loading',
 		};
 
 		// when
@@ -37,6 +39,7 @@ describe('Progress', () => {
 		const props = {
 			id: 'my-progress',
 			percent: -20,
+			tooltip: 'loading',
 		};
 
 		// when
@@ -51,6 +54,7 @@ describe('Progress', () => {
 		const props = {
 			id: 'my-progress',
 			percent: 200,
+			tooltip: 'loading',
 		};
 
 		// when
@@ -60,22 +64,7 @@ describe('Progress', () => {
 		expect(wrapper).toMatchSnapshot();
 	});
 
-	it('should render progress with tooltip', () => {
-		// given
-		const props = {
-			id: 'my-progress',
-			percent: 60,
-			tooltip: 'Hey dude ! Progress: 60% !',
-		};
-
-		// when
-		const wrapper = renderer.create(<Progress {...props} />).toJSON();
-
-		// then
-		expect(wrapper).toMatchSnapshot();
-	});
-
-	it('should render an infinite progress with tooltip', () => {
+	it('should render an infinite progress', () => {
 		// given
 		const props = {
 			id: 'my-progress',
@@ -96,6 +85,7 @@ describe('Progress', () => {
 			id: 'my-progress',
 			contained: true,
 			percent: 60,
+			tooltip: 'loading',
 		};
 
 		// when

--- a/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Progress should normalize percent to 0 when prop is < 0 1`] = `
 <div
-  aria-label={undefined}
+  aria-label="loading"
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={0}
@@ -12,6 +12,8 @@ exports[`Progress should normalize percent to 0 when prop is < 0 1`] = `
 >
   <div
     className="theme-progress-percent"
+    onFocus={[Function]}
+    onMouseOver={[Function]}
     style={
       Object {
         "width": "0%",
@@ -23,7 +25,7 @@ exports[`Progress should normalize percent to 0 when prop is < 0 1`] = `
 
 exports[`Progress should normalize percent to 100 when prop is > 100 1`] = `
 <div
-  aria-label={undefined}
+  aria-label="loading"
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={100}
@@ -33,6 +35,8 @@ exports[`Progress should normalize percent to 100 when prop is > 100 1`] = `
 >
   <div
     className="theme-progress-percent"
+    onFocus={[Function]}
+    onMouseOver={[Function]}
     style={
       Object {
         "width": "100%",
@@ -44,7 +48,7 @@ exports[`Progress should normalize percent to 100 when prop is > 100 1`] = `
 
 exports[`Progress should render a contained progress 1`] = `
 <div
-  aria-label={undefined}
+  aria-label="loading"
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={60}
@@ -54,6 +58,8 @@ exports[`Progress should render a contained progress 1`] = `
 >
   <div
     className="theme-progress-percent"
+    onFocus={[Function]}
+    onMouseOver={[Function]}
     style={
       Object {
         "width": "60%",
@@ -63,7 +69,7 @@ exports[`Progress should render a contained progress 1`] = `
 </div>
 `;
 
-exports[`Progress should render an infinite progress with tooltip 1`] = `
+exports[`Progress should render an infinite progress 1`] = `
 <div
   aria-busy={true}
   aria-label="Hey dude !"
@@ -90,7 +96,7 @@ exports[`Progress should render an infinite progress with tooltip 1`] = `
 
 exports[`Progress should render hidden progress at 0% 1`] = `
 <div
-  aria-label={undefined}
+  aria-label="loading"
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={0}
@@ -100,6 +106,8 @@ exports[`Progress should render hidden progress at 0% 1`] = `
 >
   <div
     className="theme-progress-percent"
+    onFocus={[Function]}
+    onMouseOver={[Function]}
     style={
       Object {
         "width": "0%",
@@ -111,28 +119,7 @@ exports[`Progress should render hidden progress at 0% 1`] = `
 
 exports[`Progress should render progress with given percentage 1`] = `
 <div
-  aria-label={undefined}
-  aria-valuemax={100}
-  aria-valuemin={0}
-  aria-valuenow={60}
-  className="theme-progress theme-fixed"
-  id="my-progress"
-  role="progressbar"
->
-  <div
-    className="theme-progress-percent"
-    style={
-      Object {
-        "width": "60%",
-      }
-    }
-  />
-</div>
-`;
-
-exports[`Progress should render progress with tooltip 1`] = `
-<div
-  aria-label="Hey dude ! Progress: 60% !"
+  aria-label="loading"
   aria-valuemax={100}
   aria-valuemin={0}
   aria-valuenow={60}

--- a/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
+++ b/packages/components/src/Progress/__snapshots__/Progress.test.js.snap
@@ -2,8 +2,13 @@
 
 exports[`Progress should normalize percent to 0 when prop is < 0 1`] = `
 <div
+  aria-label={undefined}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={0}
   className="theme-progress theme-hidden theme-fixed"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"
@@ -18,8 +23,13 @@ exports[`Progress should normalize percent to 0 when prop is < 0 1`] = `
 
 exports[`Progress should normalize percent to 100 when prop is > 100 1`] = `
 <div
+  aria-label={undefined}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={100}
   className="theme-progress theme-fixed"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"
@@ -34,8 +44,13 @@ exports[`Progress should normalize percent to 100 when prop is > 100 1`] = `
 
 exports[`Progress should render a contained progress 1`] = `
 <div
+  aria-label={undefined}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={60}
   className="theme-progress"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"
@@ -50,8 +65,11 @@ exports[`Progress should render a contained progress 1`] = `
 
 exports[`Progress should render an infinite progress with tooltip 1`] = `
 <div
+  aria-busy={true}
+  aria-label="Hey dude !"
   className="theme-progress theme-fixed theme-infinite"
   id="my-progress"
+  role="status"
 >
   <div
     className="theme-progress-percent"
@@ -72,8 +90,13 @@ exports[`Progress should render an infinite progress with tooltip 1`] = `
 
 exports[`Progress should render hidden progress at 0% 1`] = `
 <div
+  aria-label={undefined}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={0}
   className="theme-progress theme-hidden theme-fixed"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"
@@ -88,8 +111,13 @@ exports[`Progress should render hidden progress at 0% 1`] = `
 
 exports[`Progress should render progress with given percentage 1`] = `
 <div
+  aria-label={undefined}
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={60}
   className="theme-progress theme-fixed"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"
@@ -104,8 +132,13 @@ exports[`Progress should render progress with given percentage 1`] = `
 
 exports[`Progress should render progress with tooltip 1`] = `
 <div
+  aria-label="Hey dude ! Progress: 60% !"
+  aria-valuemax={100}
+  aria-valuemin={0}
+  aria-valuenow={60}
   className="theme-progress theme-fixed"
   id="my-progress"
+  role="progressbar"
 >
   <div
     className="theme-progress-percent"

--- a/packages/components/stories/Progress.js
+++ b/packages/components/stories/Progress.js
@@ -10,29 +10,17 @@ const containerStyle = {
 	height: '200px',
 };
 
-
 storiesOf('Progress', module)
 	.addDecorator(checkA11y)
-	.addWithInfo('Without tooltip', () => (
+	.addWithInfo('Percent', () => (
 		<div>
 			<h1>Action</h1>
 			<h2>Definition</h2>
 			<p>
 				The component displays a progress bar at the top of the window.<br />
-				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">Spec</a>
-			</p>
-			<h2>Examples</h2>
-			Look above
-			<Progress id="my-progress" percent={60} />
-		</div>
-	))
-	.addWithInfo('With tooltip', () => (
-		<div>
-			<h1>Action</h1>
-			<h2>Definition</h2>
-			<p>
-				The component displays a progress bar at the top of the window.<br />
-				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">Spec</a>
+				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">
+					Spec
+				</a>
 			</p>
 			<h2>Examples</h2>
 			Look above and put the mouse on it
@@ -45,7 +33,9 @@ storiesOf('Progress', module)
 			<h2>Definition</h2>
 			<p>
 				The component displays an infinite progress bar at the top of the window.<br />
-				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">Spec</a>
+				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">
+					Spec
+				</a>
 			</p>
 			<h2>Examples</h2>
 			Look above and put the mouse on it
@@ -58,7 +48,9 @@ storiesOf('Progress', module)
 			<h2>Definition</h2>
 			<p>
 				The component displays an infinite progress bar at the top of the window.<br />
-				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">Spec</a>
+				<a href="http://guidelines.talend.com/document/92132#/messaging-communication/progress-bar-circle">
+					Spec
+				</a>
 			</p>
 
 			<div style={containerStyle}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Progress component doesn't implement aria.

**What is the chosen solution to this problem?**
* aria attributes on infinite progress (role=status + aria-busy)
* aria attributes on definite progress (role=progressbar + aria-(valuenow, valuemin, valuemax))
* make tooltip required to add it in aria-label
* ConfirmDialog accepts a props.progressLabel to be passed as tooltip

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
