### PR TITLE
fix(datagrid): fix redrawsRows when the datagrid is not showed

### DIFF
--- a/packages/datagrid/README.md
+++ b/packages/datagrid/README.md
@@ -69,6 +69,7 @@ In entry, the datagrid component waits a sample of dataset. By default, the data
 | --------------------- | ------------------------------------------------------ | -------- | ------------------------ |
 | avroRenderer          | list of components to inject to the avro renderer      | object   |                          |
 | cellRenderer          | cell component to inject                               | string   | DefaultCellRenderer      |
+| forceRedrawRows          | function called when the component updated to know if ag-grid have to redraw the grid     . should return true or false                         | function   | null      |
 | getComponent          | method to provide the injected components              | function | cellRenderer             |
 | getPinnedColumnDefsFn | method to provide the definition of the pinned columns | function | dataset serializer       |
 | getColumnDefsFn       | method to provide the definition of the columns        | function | dataset serializer       |

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -80,6 +80,30 @@ export function getRowDataInfos(rowData) {
 	);
 }
 
+/**
+ * redrawRows - call redrawRows only if necessary. (improve ag-grid performance)
+ *
+ * @param  {object} props     component props
+ * @param  {object} gridAPI   ag-grid api
+ * @param  {object} prevProps previous component prop
+ */
+export function redrawRows(props, gridAPI, prevProps) {
+	if (props.loading || !gridAPI) {
+		return;
+	}
+
+	const prevInfos = getRowDataInfos(prevProps.rowData);
+	const currentInfos = getRowDataInfos(props.rowData);
+
+	if (
+		prevInfos.loaded !== currentInfos.loaded ||
+		prevInfos.loading !== currentInfos.loading ||
+		prevInfos.notLoaded !== currentInfos.notLoaded
+	) {
+		gridAPI.redrawRows();
+	}
+}
+
 export default class DataGrid extends React.Component {
 	static defaultProps = {
 		cellRenderer: 'DefaultCellRenderer',
@@ -116,16 +140,7 @@ export default class DataGrid extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		const prevInfos = getRowDataInfos(prevProps.rowData);
-		const currentInfos = getRowDataInfos(this.props.rowData);
-		if (
-			this.gridAPI &&
-			(prevInfos.loaded !== currentInfos.loaded ||
-				prevInfos.loading !== currentInfos.loading ||
-				prevInfos.notLoaded !== currentInfos.notLoaded)
-		) {
-			this.gridAPI.redrawRows();
-		}
+		redrawRows(this.props, this.gridAPI, prevProps);
 	}
 
 	onGridReady({ api }) {

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -93,7 +93,7 @@ export default class DataGrid extends React.Component {
 			return;
 		}
 
-		if (this.props.forceRedrawRowsFn && this.props.forceRedrawRowsFn(this.props, prevProps)) {
+		if (this.props.forceRedrawRows && this.props.forceRedrawRows(this.props, prevProps)) {
 			this.gridAPI.redrawRows();
 		}
 	}

--- a/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
@@ -31,6 +31,7 @@ const DATAGRID_PROPTYPES = {
 	deltaRowDataMode: PropTypes.bool,
 	rowBuffer: PropTypes.number,
 	rowNodeIdentifier: PropTypes.string,
+	forceRedrawRowsFn: PropTypes.func,
 };
 
 export default DATAGRID_PROPTYPES;

--- a/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
@@ -12,6 +12,7 @@ const DATAGRID_PROPTYPES = {
 	loading: PropTypes.bool,
 	enableColResize: PropTypes.bool,
 	columnMinWidth: PropTypes.number,
+	forceRedrawRows: PropTypes.func,
 	getComponent: PropTypes.func,
 	getPinnedColumnDefsFn: PropTypes.func,
 	getColumnDefsFn: PropTypes.func,
@@ -31,7 +32,6 @@ const DATAGRID_PROPTYPES = {
 	deltaRowDataMode: PropTypes.bool,
 	rowBuffer: PropTypes.number,
 	rowNodeIdentifier: PropTypes.string,
-	forceRedrawRowsFn: PropTypes.func,
 };
 
 export default DATAGRID_PROPTYPES;

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -173,31 +173,31 @@ describe('#DataGrid', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should not call forceRedrawRowsFn when the DataGrid is loading', () => {
-		const forceRedrawRowsFn = jest.fn(() => true);
+	it('should not call forceRedrawRows when the DataGrid is loading', () => {
+		const forceRedrawRows = jest.fn(() => true);
 		const wrapper = shallow(
-			<DataGrid getComponent={getComponent} forceRedrawRowsFn={forceRedrawRowsFn} loading />,
+			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} loading />,
 		);
 
 		wrapper.instance().componentDidUpdate();
-		expect(forceRedrawRowsFn).not.toHaveBeenCalled();
+		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
-	it('should not call forceRedrawRowsFn when the DataGrid is not ready', () => {
-		const forceRedrawRowsFn = jest.fn(() => true);
+	it('should not call forceRedrawRows when the DataGrid is not ready', () => {
+		const forceRedrawRows = jest.fn(() => true);
 		const wrapper = shallow(
-			<DataGrid getComponent={getComponent} forceRedrawRowsFn={forceRedrawRowsFn} />,
+			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} />,
 		);
 
 		wrapper.instance().componentDidUpdate();
-		expect(forceRedrawRowsFn).not.toHaveBeenCalled();
+		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
-	it('should call redrawRows when forceRedrawRowsFn return true', () => {
-		const forceRedrawRowsFn = jest.fn(() => true);
+	it('should call redrawRows when forceRedrawRows return true', () => {
+		const forceRedrawRows = jest.fn(() => true);
 		const redrawRows = jest.fn();
 		const wrapper = shallow(
-			<DataGrid getComponent={getComponent} forceRedrawRowsFn={forceRedrawRowsFn} rowData={[]} />,
+			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} rowData={[]} />,
 		);
 
 		wrapper.instance().onGridReady({
@@ -207,15 +207,15 @@ describe('#DataGrid', () => {
 		});
 		wrapper.instance().componentDidUpdate();
 
-		expect(forceRedrawRowsFn).toHaveBeenCalled();
+		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).toHaveBeenCalled();
 	});
 
-	it('should not call redrawRows when forceRedrawRowsFn return false', () => {
-		const forceRedrawRowsFn = jest.fn(() => false);
+	it('should not call redrawRows when forceRedrawRows return false', () => {
+		const forceRedrawRows = jest.fn(() => false);
 		const redrawRows = jest.fn();
 		const wrapper = shallow(
-			<DataGrid getComponent={getComponent} forceRedrawRowsFn={forceRedrawRowsFn} rowData={[]} />,
+			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} rowData={[]} />,
 		);
 
 		wrapper.instance().onGridReady({
@@ -225,7 +225,7 @@ describe('#DataGrid', () => {
 		});
 		wrapper.instance().componentDidUpdate();
 
-		expect(forceRedrawRowsFn).toHaveBeenCalled();
+		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).not.toHaveBeenCalled();
 	});
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -10,6 +10,7 @@ import DataGrid, {
 	injectedHeaderRenderer,
 	AG_GRID,
 	getRowDataInfos,
+	redrawRows,
 } from './DataGrid.component';
 
 function PinHeaderRenderer() {}
@@ -762,5 +763,87 @@ describe('getRowDataInfos', () => {
 			loading: 1,
 			loaded: 3,
 		});
+	});
+});
+
+describe('redrawRows', () => {
+	it('should not call redrawRows when the component is loading', () => {
+		const redrawRowsFn = jest.fn();
+
+		redrawRows(
+			{
+				loading: true,
+			},
+			{ redrawRows: redrawRowsFn },
+			{
+				rowData: [{ loading: true }],
+			},
+		);
+
+		expect(redrawRowsFn).not.toHaveBeenCalled();
+	});
+
+	it('should not call redrawRows when the component has not gridAPI', () => {
+		const redrawRowsFn = jest.fn();
+
+		redrawRows(
+			{
+				rowData: [{ loading: false }],
+			},
+			null,
+			{
+				rowData: [],
+			},
+		);
+
+		expect(redrawRowsFn).not.toHaveBeenCalled();
+	});
+
+	it('should call redrawRows when loading state change', () => {
+		const redrawRowsFn = jest.fn();
+
+		redrawRows(
+			{
+				rowData: [{ loading: false }],
+			},
+			{ redrawRows: redrawRowsFn },
+			{
+				rowData: [],
+			},
+		);
+
+		expect(redrawRowsFn).toHaveBeenCalled();
+	});
+
+	it('should call redrawRows when loaded state change', () => {
+		const redrawRowsFn = jest.fn();
+
+		redrawRows(
+			{
+				rowData: [{}],
+			},
+			{ redrawRows: redrawRowsFn },
+			{
+				rowData: [],
+			},
+		);
+
+		expect(redrawRowsFn).toHaveBeenCalled();
+	});
+
+	it('should call redrawRows when notLoaded state change', () => {
+		const redrawRowsFn = jest.fn();
+
+		redrawRows(
+			{
+				rowData: [{ loading: false, 'indexes.index': 1 }],
+			},
+			{ redrawRows: redrawRowsFn },
+			{
+				rowData: [],
+			},
+		);
+
+		expect(redrawRowsFn).toHaveBeenCalled();
 	});
 });

--- a/packages/datagrid/stories/datagrid.component.js
+++ b/packages/datagrid/stories/datagrid.component.js
@@ -9,6 +9,10 @@ import sample from './sample.json';
 import sample2 from './sample2.json';
 import sample3 from './sample3.json';
 
+function forceRedrawRowsFn(props, oldProps) {
+	return props.rowData[0].loading !== oldProps.rowData[0].loading;
+}
+
 sample.data[0].value.field0.value = `﻿﻿﻿﻿﻿﻿﻿  loreum lo
 psum	 	 `;
 
@@ -100,24 +104,26 @@ storiesOf('Component Datagrid')
 			render() {
 				const currentSample = this.state.firstSample ? sample : sample2;
 				return (
-					<div style={{ height: '100vh' }}>
+					<div>
 						<input type="button" value="changestatus" onClick={this.changeState} />
 						Number of fields : {currentSample.schema.fields.length}
 						<IconsProvider />
-						<DataGrid
-							data={currentSample}
-							onFocusedCell={event => console.log(event)}
-							onFocusedColumn={event => console.log(event)}
-							onVerticalScroll={event => console.log(event)}
-							rowSelection="multiple"
-						/>
+						<div style={{ height: '200px' }}>
+							<DataGrid
+								data={currentSample}
+								onFocusedCell={event => console.log(event)}
+								onFocusedColumn={event => console.log(event)}
+								onVerticalScroll={event => console.log(event)}
+								rowSelection="multiple"
+							/>
+						</div>
 					</div>
 				);
 			}
 		}
 		return <WithLayout />;
 	})
-	.add('dynamic add data', () => {
+	.add('dynamic change data', () => {
 		class WithLayout extends React.Component {
 			constructor() {
 				super();
@@ -125,49 +131,8 @@ storiesOf('Component Datagrid')
 				const datagridSample = Object.assign({}, sample);
 				datagridSample.data = [
 					{
-						value: {
-							field2: {
-								value: '95716',
-								quality: 1,
-							},
-							field8: {
-								value: '10771660',
-								quality: 0,
-							},
-							field5: {
-								value: '33929307',
-								quality: -1,
-							},
-							field4: {
-								value: '10748798',
-								quality: 1,
-							},
-							field7: {
-								value: '11030795',
-								quality: 1,
-							},
-							field3: {
-								value: '',
-								quality: 1,
-							},
-							field1: {
-								value: ' 271494',
-								quality: 1,
-							},
-							field0: {
-								value: 'Aéroport Charles de Gaulle 2 TGV',
-								quality: 1,
-							},
-							field9: {
-								value: '10880464',
-								quality: 1,
-							},
-							field6: {
-								value: '10920487',
-								quality: 1,
-							},
-						},
-						quality: 1,
+						value: {},
+						loading: true,
 					},
 				];
 				this.state = { sample: datagridSample };
@@ -175,53 +140,7 @@ storiesOf('Component Datagrid')
 
 			changeState() {
 				const datagridSample = Object.assign({}, this.state.sample);
-				datagridSample.data = datagridSample.data.concat([
-					{
-						value: {
-							field2: {
-								value: 'new',
-								quality: 1,
-							},
-							field8: {
-								value: 'new',
-								quality: 0,
-							},
-							field5: {
-								value: 'new',
-								quality: -1,
-							},
-							field4: {
-								value: 'new',
-								quality: 1,
-							},
-							field7: {
-								value: 'new',
-								quality: 1,
-							},
-							field3: {
-								value: '',
-								quality: 1,
-							},
-							field1: {
-								value: 'new',
-								quality: 1,
-							},
-							field0: {
-								value: 'Aéroport Charles de Gaulle 2 TGV-1',
-								quality: 1,
-							},
-							field9: {
-								value: 'new',
-								quality: 1,
-							},
-							field6: {
-								value: 'new',
-								quality: 1,
-							},
-						},
-						quality: 1,
-					},
-				]);
+				datagridSample.data[0] = sample.data[0];
 
 				this.setState({
 					sample: datagridSample,
@@ -238,6 +157,7 @@ storiesOf('Component Datagrid')
 							data={this.state.sample}
 							rowData={serializer.getRowData(this.state.sample)}
 							rowSelection="multiple"
+							forceRedrawRowsFn={forceRedrawRowsFn}
 						/>
 					</div>
 				);

--- a/packages/datagrid/stories/datagrid.component.js
+++ b/packages/datagrid/stories/datagrid.component.js
@@ -9,7 +9,7 @@ import sample from './sample.json';
 import sample2 from './sample2.json';
 import sample3 from './sample3.json';
 
-function forceRedrawRowsFn(props, oldProps) {
+function forceRedrawRows(props, oldProps) {
 	return props.rowData[0].loading !== oldProps.rowData[0].loading;
 }
 
@@ -157,7 +157,7 @@ storiesOf('Component Datagrid')
 							data={this.state.sample}
 							rowData={serializer.getRowData(this.state.sample)}
 							rowSelection="multiple"
-							forceRedrawRowsFn={forceRedrawRowsFn}
+							forceRedrawRows={forceRedrawRows}
 						/>
 					</div>
 				);

--- a/packages/datagrid/stories/datagrid.component.js
+++ b/packages/datagrid/stories/datagrid.component.js
@@ -4,6 +4,7 @@ import { checkA11y } from '@storybook/addon-a11y';
 import { IconsProvider } from '@talend/react-components';
 
 import DataGrid from '../src/components/';
+import serializer from '../src/components/DatasetSerializer';
 import sample from './sample.json';
 import sample2 from './sample2.json';
 import sample3 from './sample3.json';
@@ -108,6 +109,134 @@ storiesOf('Component Datagrid')
 							onFocusedCell={event => console.log(event)}
 							onFocusedColumn={event => console.log(event)}
 							onVerticalScroll={event => console.log(event)}
+							rowSelection="multiple"
+						/>
+					</div>
+				);
+			}
+		}
+		return <WithLayout />;
+	})
+	.add('dynamic add data', () => {
+		class WithLayout extends React.Component {
+			constructor() {
+				super();
+				this.changeState = this.changeState.bind(this);
+				const datagridSample = Object.assign({}, sample);
+				datagridSample.data = [
+					{
+						value: {
+							field2: {
+								value: '95716',
+								quality: 1,
+							},
+							field8: {
+								value: '10771660',
+								quality: 0,
+							},
+							field5: {
+								value: '33929307',
+								quality: -1,
+							},
+							field4: {
+								value: '10748798',
+								quality: 1,
+							},
+							field7: {
+								value: '11030795',
+								quality: 1,
+							},
+							field3: {
+								value: '',
+								quality: 1,
+							},
+							field1: {
+								value: ' 271494',
+								quality: 1,
+							},
+							field0: {
+								value: 'Aéroport Charles de Gaulle 2 TGV',
+								quality: 1,
+							},
+							field9: {
+								value: '10880464',
+								quality: 1,
+							},
+							field6: {
+								value: '10920487',
+								quality: 1,
+							},
+						},
+						quality: 1,
+					},
+				];
+				this.state = { sample: datagridSample };
+			}
+
+			changeState() {
+				const datagridSample = Object.assign({}, this.state.sample);
+				datagridSample.data = datagridSample.data.concat([
+					{
+						value: {
+							field2: {
+								value: 'new',
+								quality: 1,
+							},
+							field8: {
+								value: 'new',
+								quality: 0,
+							},
+							field5: {
+								value: 'new',
+								quality: -1,
+							},
+							field4: {
+								value: 'new',
+								quality: 1,
+							},
+							field7: {
+								value: 'new',
+								quality: 1,
+							},
+							field3: {
+								value: '',
+								quality: 1,
+							},
+							field1: {
+								value: 'new',
+								quality: 1,
+							},
+							field0: {
+								value: 'Aéroport Charles de Gaulle 2 TGV-1',
+								quality: 1,
+							},
+							field9: {
+								value: 'new',
+								quality: 1,
+							},
+							field6: {
+								value: 'new',
+								quality: 1,
+							},
+						},
+						quality: 1,
+					},
+				]);
+
+				this.setState({
+					sample: datagridSample,
+				});
+			}
+
+			render() {
+				return (
+					<div style={{ height: '100vh' }}>
+						<input type="button" value="changestatus" onClick={this.changeState} />
+						Number of data : {this.state.sample.data.length}
+						<IconsProvider />
+						<DataGrid
+							data={this.state.sample}
+							rowData={serializer.getRowData(this.state.sample)}
 							rowSelection="multiple"
 						/>
 					</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- javascript error when props loading is true because ag-grid is not loaded
- custom function to force the redrawRows

**What is the chosen solution to this problem?**

fix that

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

after
```javascript
<DataGrid forceRedrawRows={
     (props, prevProps) => 
        // add your condition to force the redrawsRows when componentDidUpdate is called
       return true;
   } 
/>
```

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
