### PR TITLE
fix(List): cell title dropdown position

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -25,12 +25,22 @@ function getLargeDisplayActions(actions, getComponent) {
 		return null;
 	}
 
+	const adaptedActions = actions.map(actionDef => {
+		if (!isDropdown(actionDef)) {
+			return actionDef;
+		}
+		return {
+			...actionDef,
+			pullRight: true,
+		};
+	});
+
 	return (
 		<Actions
 			getComponent={getComponent}
 			className={classNames('cell-title-actions', theme['cell-title-actions'])}
 			key={'large-display-actions'}
-			actions={actions}
+			actions={adaptedActions}
 			hideLabel
 			link
 		/>

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -25,22 +25,12 @@ function getLargeDisplayActions(actions, getComponent) {
 		return null;
 	}
 
-	const adaptedActions = actions.map(actionDef => {
-		if (!isDropdown(actionDef)) {
-			return actionDef;
-		}
-		return {
-			...actionDef,
-			pullRight: true,
-		};
-	});
-
 	return (
 		<Actions
 			getComponent={getComponent}
 			className={classNames('cell-title-actions', theme['cell-title-actions'])}
 			key={'large-display-actions'}
-			actions={adaptedActions}
+			actions={actions}
 			hideLabel
 			link
 		/>

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -10,7 +10,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	position: relative;
 	right: 0;
 	top: 0;
-	height: 100%;
+	height: $btn-line-height;
 
 	.cell-title-actions {
 		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
@@ -75,6 +75,23 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 				transform: translateX(-50%);
 				color: white;
 				text-shadow: 0 2px 2px rgba(0, 0, 0, 0.175);
+			}
+		}
+	}
+}
+
+:global(.tc-list-large) .main-title-actions-group {
+	:global {
+		.dropup.btn-group > .dropdown-menu,
+		.btn-group > .dropdown-menu {
+			right: 0;
+			left: auto;
+			transform: none;
+
+			&:before {
+				left: auto;
+				right: $padding-normal;
+				transform: none;
 			}
 		}
 	}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -84,7 +84,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	:global {
 		.dropup.btn-group > .dropdown-menu,
 		.btn-group > .dropdown-menu {
-			right: 0;
+			//right: 0;
 			left: auto;
 			transform: none;
 

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -84,7 +84,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	:global {
 		.dropup.btn-group > .dropdown-menu,
 		.btn-group > .dropdown-menu {
-			//right: 0;
+			right: 0;
 			left: auto;
 			transform: none;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In List title actions dropdowns, when entries are long, it overflows on the right of the screen
<img width="288" alt="capture d ecran 2018-07-26 a 10 35 52" src="https://user-images.githubusercontent.com/10761073/43251315-df6fdece-90bf-11e8-8181-3022c99ffdfe.png">


**What is the chosen solution to this problem?**
Since the actions are on the right, let's aligne the dropdowns on the right in Large display
<img width="448" alt="capture d ecran 2018-07-26 a 10 36 09" src="https://user-images.githubusercontent.com/10761073/43251348-f1e20118-90bf-11e8-84bf-f70036385cfb.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
