### PR TITLE
fix(Forms): FormSwitcher has the same api as underlying forms

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -179,7 +179,6 @@ export class TCompForm extends React.Component {
 		const props = {
 			...omit(this.props, cmfConnect.INJECTED_PROPS),
 			data: uiSpecs,
-			properties: this.state.properties,
 			onTrigger: this.onTrigger,
 			onChange: this.onChange,
 			onSubmit: this.onSubmit,

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -178,7 +178,7 @@ export class TCompForm extends React.Component {
 
 		const props = {
 			...omit(this.props, cmfConnect.INJECTED_PROPS),
-			...uiSpecs,
+			data: uiSpecs,
 			properties: this.state.properties,
 			onTrigger: this.onTrigger,
 			onChange: this.onChange,

--- a/packages/containers/src/ComponentForm/__snapshots__/ComponentForm.test.js.snap
+++ b/packages/containers/src/ComponentForm/__snapshots__/ComponentForm.test.js.snap
@@ -8,97 +8,98 @@ exports[`ComponentForm #render should render a CircularProgress when we don't ha
 
 exports[`ComponentForm #render should render a UIForm 1`] = `
 <FormSwitcher
+  data={
+    Object {
+      "jsonSchema": Object {
+        "properties": Object {
+          "_datasetMetadata": Object {
+            "properties": Object {
+              "description": Object {
+                "title": "Description",
+                "type": "string",
+              },
+              "name": Object {
+                "title": "Name",
+                "type": "string",
+              },
+              "type": Object {
+                "title": "Types",
+                "type": "string",
+              },
+            },
+            "required": Array [],
+            "type": "object",
+          },
+        },
+        "required": Array [],
+        "title": "datastore",
+        "type": "object",
+      },
+      "properties": undefined,
+      "uiSchema": Array [
+        Object {
+          "conditions": Array [],
+          "items": Array [
+            Object {
+              "conditions": Array [],
+              "key": "_datasetMetadata.name",
+              "title": "Name",
+              "widget": "text",
+            },
+            Object {
+              "conditions": Array [],
+              "key": "_datasetMetadata.type",
+              "schema": Object {
+                "enum": Array [
+                  "U2VydmljZU5vdyNkYXRhc3RvcmUjYmFzaWNBdXRo",
+                ],
+                "type": "string",
+              },
+              "title": "Types",
+              "titleMap": Array [
+                Object {
+                  "name": "Basic Auth",
+                  "value": "U2VydmljZU5vdyNkYXRhc3RvcmUjYmFzaWNBdXRo",
+                },
+              ],
+              "triggers": Array [
+                Object {
+                  "action": "builtin::root::reloadFromId",
+                  "event": "focus",
+                  "family": "builtin::family",
+                  "parameters": Array [
+                    Object {
+                      "key": "id",
+                      "path": "_datasetMetadata.type",
+                    },
+                  ],
+                  "type": "reloadForm",
+                },
+              ],
+              "widget": "datalist",
+            },
+            Object {
+              "conditions": Array [],
+              "key": "_datasetMetadata.description",
+              "title": "Description",
+              "widget": "textarea",
+            },
+          ],
+          "title": "Metadata",
+          "widget": "fieldset",
+        },
+      ],
+    }
+  }
   errors={
     Object {
       "key": "This is wrong",
-    }
-  }
-  jsonSchema={
-    Object {
-      "properties": Object {
-        "_datasetMetadata": Object {
-          "properties": Object {
-            "description": Object {
-              "title": "Description",
-              "type": "string",
-            },
-            "name": Object {
-              "title": "Name",
-              "type": "string",
-            },
-            "type": Object {
-              "title": "Types",
-              "type": "string",
-            },
-          },
-          "required": Array [],
-          "type": "object",
-        },
-      },
-      "required": Array [],
-      "title": "datastore",
-      "type": "object",
     }
   }
   onChange={[Function]}
   onSubmit={[Function]}
   onTrigger={[Function]}
   properties={undefined}
-  uiSchema={
-    Array [
-      Object {
-        "conditions": Array [],
-        "items": Array [
-          Object {
-            "conditions": Array [],
-            "key": "_datasetMetadata.name",
-            "title": "Name",
-            "widget": "text",
-          },
-          Object {
-            "conditions": Array [],
-            "key": "_datasetMetadata.type",
-            "schema": Object {
-              "enum": Array [
-                "U2VydmljZU5vdyNkYXRhc3RvcmUjYmFzaWNBdXRo",
-              ],
-              "type": "string",
-            },
-            "title": "Types",
-            "titleMap": Array [
-              Object {
-                "name": "Basic Auth",
-                "value": "U2VydmljZU5vdyNkYXRhc3RvcmUjYmFzaWNBdXRo",
-              },
-            ],
-            "triggers": Array [
-              Object {
-                "action": "builtin::root::reloadFromId",
-                "event": "focus",
-                "family": "builtin::family",
-                "parameters": Array [
-                  Object {
-                    "key": "id",
-                    "path": "_datasetMetadata.type",
-                  },
-                ],
-                "type": "reloadForm",
-              },
-            ],
-            "widget": "datalist",
-          },
-          Object {
-            "conditions": Array [],
-            "key": "_datasetMetadata.description",
-            "title": "Description",
-            "widget": "textarea",
-          },
-        ],
-        "title": "Metadata",
-        "widget": "fieldset",
-      },
-    ]
-  }
   uiform={true}
   widgets={
     Object {

--- a/packages/containers/src/ComponentForm/__snapshots__/ComponentForm.test.js.snap
+++ b/packages/containers/src/ComponentForm/__snapshots__/ComponentForm.test.js.snap
@@ -99,7 +99,6 @@ exports[`ComponentForm #render should render a UIForm 1`] = `
   onChange={[Function]}
   onSubmit={[Function]}
   onTrigger={[Function]}
-  properties={undefined}
   uiform={true}
   widgets={
     Object {

--- a/packages/containers/src/Form/Form.test.js
+++ b/packages/containers/src/Form/Form.test.js
@@ -44,7 +44,7 @@ describe('Container(Form)', () => {
 
 	it('should render with prop uiform = true : UIForm', () => {
 		const wrapper = mount(<Container jsonSchema={{}} uiSchema={{}} uiform />);
-		expect(wrapper.find('TalendForm').length).toBe(0);
+		expect(wrapper.find('TalendForm').length).toBe(1);
 		expect(wrapper.find('TalendUIForm').length).toBe(1);
 	});
 

--- a/packages/containers/src/Form/Form.test.js
+++ b/packages/containers/src/Form/Form.test.js
@@ -43,8 +43,8 @@ describe('Container(Form)', () => {
 	});
 
 	it('should render with prop uiform = true : UIForm', () => {
-		const wrapper = mount(<Container jsonSchema={{}} uiSchema={[]} uiform />);
-		expect(wrapper.find('TalendForm').length).toBe(1);
+		const wrapper = mount(<Container jsonSchema={{}} uiSchema={{}} uiform />);
+		expect(wrapper.find('TalendForm').length).toBe(0);
 		expect(wrapper.find('TalendUIForm').length).toBe(1);
 	});
 

--- a/packages/forms/src/FormSwitcher.js
+++ b/packages/forms/src/FormSwitcher.js
@@ -8,7 +8,7 @@ export default function FormSwitcher(props) {
 	if (props.loading) {
 		return <FormSkeleton />;
 	}
-	if (Array.isArray(props.uiSchema)) {
+	if (props.data && Array.isArray(props.data.uiSchema)) {
 		return <UIForm {...props} />;
 	}
 	return <Form {...props} />;
@@ -16,5 +16,7 @@ export default function FormSwitcher(props) {
 
 FormSwitcher.propTypes = {
 	loading: PropTypes.bool,
-	uiSchema: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+	data: PropTypes.shape({
+		uiSchema: PropTypes.oneOfType([PropTypes.array, PropTypes.object]),
+	}),
 };

--- a/packages/forms/src/FormSwitcher.test.js
+++ b/packages/forms/src/FormSwitcher.test.js
@@ -7,4 +7,16 @@ describe('FormSwitcher', () => {
 		const wrapper = shallow(<FormSwitcher loading />);
 		expect(wrapper.find('FormSkeleton').length).toBe(1);
 	});
+
+	it('should render UIForm when uiSchema is an array', () => {
+		const wrapper = shallow(<FormSwitcher data={{ uiSchema: [] }} />);
+		expect(wrapper.find('Form').length).toBe(0);
+		expect(wrapper.find('UIForm').length).toBe(1);
+	});
+
+	it('should render old RFSJ when uiSchema is an object', () => {
+		const wrapper = shallow(<FormSwitcher data={{ uiSchema: {} }} />);
+		expect(wrapper.find('Form').length).toBe(1);
+		expect(wrapper.find('UIForm').length).toBe(0);
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
FormSwitcher is ineffective because its api is not the same as Form component which was the previous form entry point. It means that it introduces a breaking change.

**What is the chosen solution to this problem?**
Align api with old entry point, so switcher works with old props shape

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
