### PR TITLE
feat(Container): Add a Breadcrumbs Container

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,10 +2,6 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
-  5:1   error  Expected empty line after import statement not followed by another import  import/newline-after-import
-  9:22  error  'state' is missing in props validation                                     react/prop-types
-
 /home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/createTriggers.js
   18:8  error  'get' is defined but never used  no-unused-vars
 
@@ -18,5 +14,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
   3:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 4 problems (4 errors, 0 warnings)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,6 +2,10 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
+  5:1   error  Expected empty line after import statement not followed by another import  import/newline-after-import
+  9:22  error  'state' is missing in props validation                                     react/prop-types
+
 /home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/createTriggers.js
   18:8  error  'get' is defined but never used  no-unused-vars
 
@@ -14,5 +18,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
   3:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
 
-✖ 4 problems (4 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 

--- a/packages/containers/examples/ExampleBreadcrumbs.js
+++ b/packages/containers/examples/ExampleBreadcrumbs.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import api from '@talend/react-cmf';
+import { Map } from 'immutable';
+import { Breadcrumbs } from '../src';
+import { action } from '@storybook/addon-actions';
+
+const initialState = new Map({
+	items: [
+		{ text: 'Text A', title: 'Text title A', actionCreator: 'folder:openA', },
+		{ text: 'Text B', title: 'Text title B', actionCreator: 'folder:openB', },
+		{ text: 'text c in lower case', title: 'Text title C', actionCreator: 'folder:openC', },
+	],
+	maxItems: 3,
+});
+
+api.actionCreator.register('folder:openA',  action('click on A'));
+api.actionCreator.register('folder:openB',  action('click on B'));
+api.actionCreator.register('folder:openC',  action('click on C'));
+
+export default function ExampleBreadcrumbs() {
+	return (
+		<div>
+			<Breadcrumbs initialState={initialState} />
+		</div>
+	);
+}

--- a/packages/containers/examples/index.js
+++ b/packages/containers/examples/index.js
@@ -5,6 +5,7 @@ import ActionIconToggle from './ExampleActionIconToggle';
 import ActionSplitDropdown from './ExampleActionSplitDropdown';
 import ActionsExample from './ExampleActions';
 import AppLoader from './ExampleAppLoader';
+import Breadcrumbs from './ExampleBreadcrumbs';
 import DeleteResource from './ExampleDeleteResource';
 import ConfirmDialogExample from './ExampleConfirmDialog';
 import FormExample from './ExampleForm';
@@ -31,6 +32,7 @@ export default {
 	ActionSplitDropdown,
 	ActionsExample,
 	AppLoader,
+	Breadcrumbs,
 	ConfirmDialogExample,
 	DeleteResource,
 	FilterBarExample,

--- a/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
+++ b/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { cmfConnect } from '@talend/react-cmf';
+import { Map } from 'immutable';
+import { Breadcrumbs } from '@talend/react-components';
+export const DEFAULT_STATE = new Map();
+
+export function ContainerBreadcrumbs(props) {
+	const state = props.state || DEFAULT_STATE;
+	const items = state.get('items', props.items);
+	const newProps = {
+		items: items.map(item => ({ ...item, onClick: (event, data) => props.dispatchActionCreator(item.actionCreator, event, data) })),
+		maxItems: state.get('maxItems', props.maxItems),
+	};
+
+	return <Breadcrumbs {...newProps} />;
+}
+
+ContainerBreadcrumbs.displayName = 'Breadcrumbs';
+ContainerBreadcrumbs.propTypes = {
+	items: PropTypes.arrayOf(PropTypes.object),
+	maxItems: PropTypes.number,
+};
+
+export default cmfConnect({
+	defaultState: new Map({ items: [], maxItems: 10 }),
+})(ContainerBreadcrumbs);

--- a/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
+++ b/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
@@ -9,7 +9,10 @@ export function ContainerBreadcrumbs(props) {
 	const state = props.state || DEFAULT_STATE;
 	const items = state.get('items', props.items);
 	const newProps = {
-		items: items.map(item => ({ ...item, onClick: (event, data) => props.dispatchActionCreator(item.actionCreator, event, data) })),
+		items: items.map(item => ({
+			...item,
+			onClick: (event, data) => props.dispatchActionCreator(item.actionCreator, event, data),
+		})),
 		maxItems: state.get('maxItems', props.maxItems),
 	};
 

--- a/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
+++ b/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
@@ -1,8 +1,8 @@
 import React from 'react';
-import PropTypes from 'prop-types';
 import { cmfConnect } from '@talend/react-cmf';
 import { Map } from 'immutable';
 import { Breadcrumbs } from '@talend/react-components';
+
 export const DEFAULT_STATE = new Map();
 
 export function ContainerBreadcrumbs(props) {
@@ -21,8 +21,7 @@ export function ContainerBreadcrumbs(props) {
 
 ContainerBreadcrumbs.displayName = 'Breadcrumbs';
 ContainerBreadcrumbs.propTypes = {
-	items: PropTypes.arrayOf(PropTypes.object),
-	maxItems: PropTypes.number,
+	...cmfConnect.propTypes,
 };
 
 export default cmfConnect({

--- a/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
+++ b/packages/containers/src/Breadcrumbs/Breadcrumbs.connect.js
@@ -3,7 +3,7 @@ import { cmfConnect } from '@talend/react-cmf';
 import { Map } from 'immutable';
 import { Breadcrumbs } from '@talend/react-components';
 
-export const DEFAULT_STATE = new Map();
+const DEFAULT_STATE = new Map();
 
 export function ContainerBreadcrumbs(props) {
 	const state = props.state || DEFAULT_STATE;

--- a/packages/containers/src/Breadcrumbs/Breadcrumbs.test.js
+++ b/packages/containers/src/Breadcrumbs/Breadcrumbs.test.js
@@ -1,0 +1,8 @@
+import Connected, { ContainerBreadcrumbs } from './Breadcrumbs.connect';
+
+describe('Connected Breadcrumbs', () => {
+	it('should connect Breadcrumbs', () => {
+		expect(Connected.displayName).toBe(`Connect(CMF(${ContainerBreadcrumbs.displayName}))`);
+		expect(Connected.WrappedComponent).toBe(ContainerBreadcrumbs);
+	});
+});

--- a/packages/containers/src/Breadcrumbs/index.js
+++ b/packages/containers/src/Breadcrumbs/index.js
@@ -1,0 +1,3 @@
+import Breadcrumbs from './Breadcrumbs.connect';
+
+export default Breadcrumbs;

--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -1,5 +1,4 @@
 import {
-	Breadcrumbs,
 	CircularProgress,
 	Drawer,
 	Icon,
@@ -20,6 +19,7 @@ import Actions from './Actions';
 import ActionSplitDropdown from './ActionSplitDropdown';
 import AppLoader from './AppLoader';
 import Badge from './Badge';
+import Breadcrumbs from './Breadcrumbs';
 import ConfirmDialog from './ConfirmDialog';
 import FilterBar from './FilterBar';
 import HeaderBar from './HeaderBar';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TDP-5280
We need a container Breadcrumbs to order to be able to dispatch an actionCreator when clicking on an item of the Breadcrumbs
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
