### PR TITLE
fix(storybook) Typo in the widget name for listView storybook

### DIFF
--- a/packages/forms/stories/json/listView.json
+++ b/packages/forms/stories/json/listView.json
@@ -430,7 +430,7 @@
   },
   "uiSchema": {
     "documents": {
-      "ui:widget": "listview"
+      "ui:widget": "listView"
     }
   },
   "properties": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Migration > ListView in storybook is broken
![image](https://user-images.githubusercontent.com/38908846/43572193-24bf2802-963f-11e8-9819-4d626a7129ff.png)

**What is the chosen solution to this problem?**
Fix widget name

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
