### PR TITLE
fix(DeleteResource): missing blank space before question mark

### DIFF
--- a/packages/containers/src/DeleteResource/DeleteResource.container.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.container.js
@@ -112,6 +112,7 @@ export class DeleteResource extends React.Component {
 					})}
 					&nbsp;
 					<strong>{resourceInfo.label}</strong>
+					&nbsp;
 					{this.props.t('DELETE_RESOURCE_QUESTION_MARK', { defaultValue: '?' })}
 				</div>
 			</ConfirmDialog>

--- a/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
+++ b/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
@@ -47,6 +47,7 @@ exports[`Container DeleteResource should render with proper resourceInfo params 
     <strong>
       myLabel
     </strong>
+     
     ?
   </div>
 </ConfirmDialog>
@@ -97,6 +98,7 @@ exports[`Container DeleteResource should render with wrong resourceInfo params 1
     Are you sure you want to remove the unknownResourceType
      
     <strong />
+     
     ?
   </div>
 </ConfirmDialog>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
A blank space is missing before the question mark
**What is the chosen solution to this problem?**
Add it
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
