### PR TITLE
 fix(containers): DeleteResource confirmDialog cancel button style

### DIFF
--- a/packages/components/stories/ConfirmDialog.js
+++ b/packages/components/stories/ConfirmDialog.js
@@ -39,6 +39,7 @@ const defaultProps = {
 	cancelAction: {
 		label: 'CANCEL',
 		onClick: action('cancel'),
+		className: 'btn-inverse',
 	},
 };
 
@@ -53,6 +54,7 @@ const propsWithoutHeader = {
 	cancelAction: {
 		label: 'CANCEL',
 		onClick: action('cancel'),
+		className: 'btn-inverse',
 	},
 };
 
@@ -68,6 +70,7 @@ const smallProps = {
 	cancelAction: {
 		label: 'CANCEL',
 		onClick: action('cancel'),
+		className: 'btn-inverse',
 	},
 };
 const largeProps = {
@@ -82,6 +85,7 @@ const largeProps = {
 	cancelAction: {
 		label: 'CANCEL',
 		onClick: action('cancel'),
+		className: 'btn-inverse',
 	},
 };
 
@@ -97,6 +101,7 @@ const withProgressBarProps = {
 	cancelAction: {
 		label: 'CANCEL',
 		onClick: action('cancel'),
+		className: 'btn-inverse',
 	},
 	progressValue: 66,
 };
@@ -214,11 +219,11 @@ storiesOf('ConfirmDialog', module)
 			displayMode: 'table',
 			list: {
 				columns: [
-			{ key: 'id', label: 'Id' },
-			{ key: 'name', label: 'Name' },
-			{ key: 'author', label: 'Author' },
-			{ key: 'created', label: 'Created' },
-			{ key: 'modified', label: 'Modified' },
+					{ key: 'id', label: 'Id' },
+					{ key: 'name', label: 'Name' },
+					{ key: 'author', label: 'Author' },
+					{ key: 'created', label: 'Created' },
+					{ key: 'modified', label: 'Modified' },
 				],
 				items,
 				titleProps: {
@@ -274,8 +279,8 @@ storiesOf('ConfirmDialog', module)
 					field: 'name',
 					onChange: action('sort.onChange'),
 					options: [
-				{ id: 'id', name: 'Id' },
-				{ id: 'name', name: 'Name' },
+						{ id: 'id', name: 'Id' },
+						{ id: 'name', name: 'Name' },
 					],
 				},
 				pagination: {

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -403,6 +403,7 @@ function loadStories() {
 		actions['dialog:delete:cancel'] = {
 			id: 'dialog:delete:cancel',
 			label: 'No',
+			className: 'btn-inverse',
 			actionCreator: 'cancel:hide:dialog',
 		};
 		actions['action:overlay:component'] = {

--- a/packages/containers/src/DeleteResource/DeleteResource.container.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.container.js
@@ -94,6 +94,7 @@ export class DeleteResource extends React.Component {
 			componentId: this.props[CONSTANTS.CANCEL_ACTION],
 			model: resourceInfo,
 			label: this.props.t('DELETE_RESOURCE_NO', { defaultValue: 'CANCEL' }),
+			className: 'btn-inverse',
 			onClickActionCreator: 'DeleteResource#cancel',
 		};
 		return (

--- a/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
+++ b/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
@@ -4,6 +4,7 @@ exports[`Container DeleteResource should render with proper resourceInfo params 
 <ConfirmDialog
   cancelAction={
     Object {
+      "className": "btn-inverse",
       "componentId": "dialog:delete:cancel",
       "label": "CANCEL",
       "model": Object {
@@ -56,6 +57,7 @@ exports[`Container DeleteResource should render with wrong resourceInfo params 1
 <ConfirmDialog
   cancelAction={
     Object {
+      "className": "btn-inverse",
       "componentId": "dialog:delete:cancel",
       "label": "CANCEL",
       "model": Object {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
DeleteResource is using the wrong cancelAction style.
Before:
![deleteresource-before](https://user-images.githubusercontent.com/36537247/43709996-a2a8ead2-996e-11e8-8a8b-3fa2cf0f96cf.png)


**What is the chosen solution to this problem?**
Make the cancelAction use default inverse style, and update stories on confirmdialog to also use the same style
After:
![deleteresource-after](https://user-images.githubusercontent.com/36537247/43710003-a8a94080-996e-11e8-9f0d-5b1acbc56812.png)




**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
