### PR TITLE
fix(ListView) ListView behavior when quickly pressing escape

### DIFF
--- a/packages/forms/src/UIForm/fields/ListView/ListView.component.js
+++ b/packages/forms/src/UIForm/fields/ListView/ListView.component.js
@@ -94,6 +94,7 @@ class ListViewWidget extends React.Component {
 			event.stopPropagation();
 			event.preventDefault();
 		} else if (event.keyCode === keycode('escape')) {
+			clearTimeout(this.timerSearch);
 			event.stopPropagation();
 			event.preventDefault();
 			this.switchToDefaultMode();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When using the search field of the ListView form field, available options can disappear when quickly pressing "Escape" key after typing a search value (debounce timeout is not cleared so search is performed).
![image](https://user-images.githubusercontent.com/38908846/43836696-7592a868-9b16-11e8-8358-fcacfa374545.png)

**What is the chosen solution to this problem?**
Clear debounce timeout when pressing "Escape" key

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
