### PR TITLE
feat(ListView): Allow hiding header items count

### DIFF
--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -27,8 +27,8 @@ function ListView(props) {
 			{props.items && props.items.length ? (
 				<ItemsListView {...props} />
 			) : (
-					<span className={theme['empty-message']}>{label}</span>
-				)}
+				<span className={theme['empty-message']}>{label}</span>
+			)}
 		</div>
 	);
 }

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -27,8 +27,8 @@ function ListView(props) {
 			{props.items && props.items.length ? (
 				<ItemsListView {...props} />
 			) : (
-				<span className={theme['empty-message']}>{label}</span>
-			)}
+					<span className={theme['empty-message']}>{label}</span>
+				)}
 		</div>
 	);
 }
@@ -81,6 +81,7 @@ function HeaderListView(props) {
 		headerInput,
 		headerDefault,
 		headerLabel,
+		hideHeaderCount,
 		items,
 		required,
 		searchPlaceholder,
@@ -103,10 +104,14 @@ function HeaderListView(props) {
 				headerDefault,
 				headerLabel,
 				required,
-				nbItems: items.length,
-				nbItemsSelected: items.filter(item => !!item.checked).length,
 				t,
 			};
+
+			if (!hideHeaderCount) {
+				propsDefault.nbItems = items.length;
+				propsDefault.nbItemsSelected = items.filter(item => !!item.checked).length;
+			}
+
 			return <Header {...propsDefault} />;
 		}
 	}
@@ -122,6 +127,7 @@ HeaderListView.propTypes = {
 	headerDefault: PropTypes.arrayOf(PropTypes.object),
 	headerInput: PropTypes.arrayOf(PropTypes.object),
 	headerLabel: PropTypes.string,
+	hideHeaderCount: PropTypes.bool,
 	items: ListView.propTypes.items,
 	onInputChange: PropTypes.func,
 	onAddKeyDown: PropTypes.func,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
ListView's header items count is always shown
![image](https://user-images.githubusercontent.com/38908846/43845908-62af41ae-9b2d-11e8-9a50-3d789483bc3b.png)

**What is the chosen solution to this problem?**
Allow hiding this count by providing a new prop `hideHeaderCount`

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
