### PR TITLE
fix(forms/rjsf): add support for modal and drawers

### DIFF
--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -3,8 +3,8 @@ import { configure } from '@storybook/react';
 import '@talend/bootstrap-theme/src/theme/theme.scss';
 
 function loadStories() {
-	require('../stories');
 	require('../stories-core');
+	require('../stories');
 }
 
 configure(loadStories, module);

--- a/packages/forms/src/Form.js
+++ b/packages/forms/src/Form.js
@@ -22,6 +22,8 @@ import CodeWidget from './widgets/CodeWidget';
 import ColumnsWidget from './widgets/ColumnsWidget';
 import ListViewWidget from './widgets/ListViewWidget/ListViewWidget';
 
+import theme from './Form.scss';
+
 /**
  * @type {string} After trigger name for field value has changed
  */
@@ -173,8 +175,10 @@ class Form extends React.Component {
 				}}
 			>
 				{this.props.children}
-				<div className={this.props.buttonBlockClass}>
-					{renderActions(this.props.actions, this.handleActionClick, this.props.getComponent)}
+				<div className={theme['form-actions']}>
+					<div className={`form-actions ${this.props.buttonBlockClass}`}>
+						{renderActions(this.props.actions, this.handleActionClick, this.props.getComponent)}
+					</div>
 				</div>
 			</RJSForm>
 		);

--- a/packages/forms/src/Form.scss
+++ b/packages/forms/src/Form.scss
@@ -4,23 +4,21 @@
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-        min-height: 0;
+		min-height: 0;
 
-        > :global(.form-group) {
-            flex-grow: 1;
-            min-height: 0;
-            overflow-y: auto;
-        }
+		> :global(.form-group) {
+			flex-grow: 1;
+			min-height: 0;
+			overflow-y: auto;
+		}
 	}
-
-
 }
 :global(.tc-drawer-container) {
 	:global(.rjsf) > :global(.form-group) {
 		padding: $padding-small;
 	}
 
-    .form-actions {
+	.form-actions {
 		background-color: $wild-sand;
 		padding: $padding-small;
 		width: 100%;
@@ -29,7 +27,7 @@
 
 @media screen and (min-width: $screen-xs-max) {
 	:global(.stacked) :global(.tc-drawer-container) {
-        :global(.rjsf) > :global(.form-group) {
+		:global(.rjsf) > :global(.form-group) {
 			width: 600px;
 			margin: 0 auto;
 		}

--- a/packages/forms/src/Form.scss
+++ b/packages/forms/src/Form.scss
@@ -1,23 +1,26 @@
 :global(.tc-drawer-container),
 :global(.modal-body) {
-	> .uiform {
+	> :global(.rjsf) {
 		display: flex;
 		flex-direction: column;
 		flex-grow: 1;
-		min-height: 0;
+        min-height: 0;
+
+        > :global(.form-group) {
+            flex-grow: 1;
+            min-height: 0;
+            overflow-y: auto;
+        }
 	}
 
-	.form-content {
-		flex-grow: 1;
-		min-height: 0;
-		overflow-y: auto;
-	}
+
 }
 :global(.tc-drawer-container) {
-	.form-content {
+	:global(.rjsf) > :global(.form-group) {
 		padding: $padding-small;
 	}
-	.form-actions {
+
+    .form-actions {
 		background-color: $wild-sand;
 		padding: $padding-small;
 		width: 100%;
@@ -26,7 +29,7 @@
 
 @media screen and (min-width: $screen-xs-max) {
 	:global(.stacked) :global(.tc-drawer-container) {
-		.form-content {
+        :global(.rjsf) > :global(.form-group) {
 			width: 600px;
 			margin: 0 auto;
 		}

--- a/packages/forms/src/__snapshots__/Form.test.js.snap
+++ b/packages/forms/src/__snapshots__/Form.test.js.snap
@@ -97,34 +97,38 @@ exports[`<Form/> actions should render form with custom css 1`] = `
     <div />
   </div>
   <div
-    className="buttons"
+    className="theme-form-actions"
   >
-    <button
-      aria-label="Submit"
-      className="theme-btn-disabled btn btn-primary"
-      disabled={true}
-      onClick={[Function]}
-      onMouseDown={[Function]}
-      role={null}
-      type="submit"
+    <div
+      className="form-actions buttons"
     >
-      <span>
-        Submit
-      </span>
-    </button>
-    <button
-      aria-label="Reset"
-      className="btn btn-link"
-      disabled={false}
-      onClick={[Function]}
-      onMouseDown={[Function]}
-      role={null}
-      type="reset"
-    >
-      <span>
-        Reset
-      </span>
-    </button>
+      <button
+        aria-label="Submit"
+        className="theme-btn-disabled btn btn-primary"
+        disabled={true}
+        onClick={[Function]}
+        onMouseDown={[Function]}
+        role={null}
+        type="submit"
+      >
+        <span>
+          Submit
+        </span>
+      </button>
+      <button
+        aria-label="Reset"
+        className="btn btn-link"
+        disabled={false}
+        onClick={[Function]}
+        onMouseDown={[Function]}
+        role={null}
+        type="reset"
+      >
+        <span>
+          Reset
+        </span>
+      </button>
+    </div>
   </div>
 </form>
 `;

--- a/packages/forms/stories-core/layouts.js
+++ b/packages/forms/stories-core/layouts.js
@@ -1,9 +1,30 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { HeaderBar, Layout, Dialog, Drawer } from '@talend/react-components';
+import { action } from '@storybook/addon-actions';
+
 import Form from '../src/index';
 
 const simple = require('./json/concepts/core-simple.json');
+const old = require('../stories/json/simple.json');
+
+const actions = [
+	{
+		name: 'cancel',
+		style: 'link',
+		onClick: action('CANCEL'),
+		type: 'button',
+		label: 'CANCEL',
+	},
+	{
+		style: 'primary',
+		type: 'submit',
+		label: 'SUBMIT',
+		disabled: true,
+		'data-feature': 'form.feature',
+		onClick: action('SUBMIT'),
+	},
+];
 
 function LayoutDrawer({ title, stacked, ...props }) {
 	const drawers = [
@@ -15,8 +36,8 @@ function LayoutDrawer({ title, stacked, ...props }) {
 		<Layout drawers={drawers} mode="TwoColumns" header={<HeaderBar />}>
 			<div style={{ margin: 10 }}>
 				<h1>{title}</h1>
-				<p>To use a UIForm in a drawer you just have to create your component this way:</p>
-				<code>{'<Drawer.Container><UIForm {...props} /></Drawer.Container>'}</code>
+				<p>To use a Form in a drawer you just have to create your component this way:</p>
+				<code>{'<Drawer.Container><Form {...props} /></Drawer.Container>'}</code>
 			</div>
 		</Layout>
 	);
@@ -36,15 +57,15 @@ export default [
 			</div>
 		),
 	},
-	{ name: 'drawer', story: () => <LayoutDrawer title="UIForm in a drawer" data={simple} /> },
+	{ name: 'drawer', story: () => <LayoutDrawer title="Form in a drawer" data={simple} /> },
 	{
 		name: 'drawer-stacked',
-		story: () => <LayoutDrawer title="UIForm in a drawer" data={simple} stacked />,
+		story: () => <LayoutDrawer title="Form in a drawer" data={simple} stacked />,
 	},
 	{
 		name: 'modal',
 		story: () => (
-			<Dialog header="UIForm in a Modal" flex show>
+			<Dialog header="Form in a Modal" flex show>
 				<Form data={simple} />
 			</Dialog>
 		),
@@ -60,5 +81,27 @@ export default [
 	{
 		name: 'skeleton-srawer-stacked',
 		story: () => <LayoutDrawer loading title="Form in loading in drawer" stacked />,
+	},
+	{
+		name: 'default-old',
+		story: () => (
+			<div>
+				<h1>Form (old) by default take 100% with of the container</h1>
+				<Form data={old} />
+			</div>
+		),
+	},
+	{ name: 'drawer-old', story: () => <LayoutDrawer title="Form (old) in a drawer" data={old} /> },
+	{
+		name: 'drawer-stacked-old',
+		story: () => <LayoutDrawer title="Form (old) in a drawer" data={old} actions={actions} stacked />,
+	},
+	{
+		name: 'modal-old',
+		story: () => (
+			<Dialog header="Form (old) in a Modal" flex show>
+				<Form data={simple} />
+			</Dialog>
+		),
 	},
 ];


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Old form docs is still the first documentation in surge.
Old form are broken in drawer.
Apps use custom css to make it look nice (but they don t follow the guideline).

**What is the chosen solution to this problem?**

Move `Form` doc in surge to the last one. Make core stories first. 
Make old form follow the guideline in modal and drawer

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
