### PR TITLE
fix(Date): locale with plurals

### DIFF
--- a/packages/components/src/DateFnsLocale/distanceInWords/distanceInWords.js
+++ b/packages/components/src/DateFnsLocale/distanceInWords/distanceInWords.js
@@ -1,0 +1,96 @@
+function buildDistanceInWords(t) {
+	return {
+		lessThanXSeconds: {
+			one: t('DATE_FNS_LESS_THAN_SECOND', { defaultValue: 'less than a second' }),
+			other: t('DATE_FNS_LESS_THAN_SECOND_plural', { defaultValue: 'less than [count] seconds' }),
+		},
+
+		xSeconds: {
+			one: t('DATE_FNS_SECOND', { defaultValue: '1 second' }),
+			other: t('DATE_FNS_SECOND_plural', { defaultValue: '[count] seconds' }),
+		},
+
+		halfAMinute: t('DATE_FNS_HALF_A_MINUTE', { defaultValue: 'half a minute' }),
+
+		lessThanXMinutes: {
+			one: t('DATE_FNS_LESS_THAN_MINUTE', { defaultValue: 'less than a minute' }),
+			other: t('DATE_FNS_LESS_THAN_MINUTE_plural', { defaultValue: 'less than [count] minutes' }),
+		},
+
+		xMinutes: {
+			one: t('DATE_FNS_MINUTE', { defaultValue: '1 minute' }),
+			other: t('DATE_FNS_MINUTE_plural', { defaultValue: '[count] minutes' }),
+		},
+
+		aboutXHours: {
+			one: t('DATE_FNS_ABOUT_HOUR', { defaultValue: 'about 1 hour' }),
+			other: t('DATE_FNS_ABOUT_HOUR_plural', { defaultValue: 'about [count] hours' }),
+		},
+
+		xHours: {
+			one: t('DATE_FNS_HOUR', { defaultValue: '1 hour' }),
+			other: t('DATE_FNS_HOUR_plural', { defaultValue: '[count] hours' }),
+		},
+
+		xDays: {
+			one: t('DATE_FNS_DAY', { defaultValue: '1 day' }),
+			other: t('DATE_FNS_DAY_plural', { defaultValue: '[count] days' }),
+		},
+
+		aboutXMonths: {
+			one: t('DATE_FNS_ABOUT_MONTH', { defaultValue: 'about 1 month' }),
+			other: t('DATE_FNS_ABOUT_MONTH_plural', { defaultValue: 'about [count] months' }),
+		},
+
+		xMonths: {
+			one: t('DATE_FNS_MONTH', { defaultValue: '1 month' }),
+			other: t('DATE_FNS_MONTH_plural', { defaultValue: '[count] months' }),
+		},
+
+		aboutXYears: {
+			one: t('DATE_FNS_ABOUT_YEAR', { defaultValue: 'about 1 year' }),
+			other: t('DATE_FNS_ABOUT_YEAR_plural', { defaultValue: 'about [count] years' }),
+		},
+
+		xYears: {
+			one: t('DATE_FNS_YEAR', { defaultValue: '1 year' }),
+			other: t('DATE_FNS_YEAR_plural', { defaultValue: '[count] years' }),
+		},
+
+		overXYears: {
+			one: t('DATE_FNS_OVER_YEAR', { defaultValue: 'over 1 year' }),
+			other: t('DATE_FNS_OVER_YEAR_plural', { defaultValue: 'over [count] years' }),
+		},
+
+		almostXYears: {
+			one: t('DATE_FNS_ALMOST_YEAR', { defaultValue: 'almost 1 year' }),
+			other: t('DATE_FNS_ALMOST_YEAR_plural', { defaultValue: 'almost [count] years' }),
+		},
+	};
+}
+
+export default function buildDistanceInWordsLocale(t) {
+	const distanceInWords = buildDistanceInWords(t);
+	function localize(token, count, options = {}) {
+		let result;
+		if (typeof distanceInWords[token] === 'string') {
+			result = distanceInWords[token];
+		} else if (count === 1) {
+			result = distanceInWords[token].one;
+		} else {
+			result = distanceInWords[token].other.replace('[count]', count);
+		}
+
+		if (options.addSuffix) {
+			if (options.comparison > 0) {
+				return t('DATE_FNS_IN', { defaultValue: 'in {{value}}', value: result });
+			}
+			return t('DATE_FNS_AGO', { defaultValue: '{{value}} ago', value: result });
+		}
+		return result;
+	}
+
+	return {
+		localize,
+	};
+}

--- a/packages/components/src/DateFnsLocale/distanceInWords/distanceInWords.test.js
+++ b/packages/components/src/DateFnsLocale/distanceInWords/distanceInWords.test.js
@@ -1,0 +1,157 @@
+import getDefaultT from '../../translate';
+import buildDistanceInWordsLocale from './distanceInWords';
+
+describe('distanceInWords', () => {
+	it('should return the formatDistance with ', () => {
+		const distanceInWords = buildDistanceInWordsLocale(getDefaultT());
+		expect(
+			distanceInWords.localize('lessThanXSeconds', 5, {
+				addSuffix: true,
+			}),
+		).toBe('less than 5 seconds ago');
+		expect(
+			distanceInWords.localize('lessThanXSeconds', 1, {
+				addSuffix: true,
+			}),
+		).toBe('less than a second ago');
+		expect(
+			distanceInWords.localize('xSeconds', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 seconds ago');
+		expect(
+			distanceInWords.localize('xSeconds', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 second ago');
+		expect(
+			distanceInWords.localize('halfAMinute', null, {
+				addSuffix: true,
+			}),
+		).toBe('half a minute ago');
+		expect(
+			distanceInWords.localize('lessThanXMinutes', 5, {
+				addSuffix: true,
+			}),
+		).toBe('less than 5 minutes ago');
+		expect(
+			distanceInWords.localize('lessThanXMinutes', 1, {
+				addSuffix: true,
+			}),
+		).toBe('less than a minute ago');
+		expect(
+			distanceInWords.localize('xMinutes', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 minutes ago');
+		expect(
+			distanceInWords.localize('xMinutes', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 minute ago');
+		expect(
+			distanceInWords.localize('aboutXHours', 5, {
+				addSuffix: true,
+			}),
+		).toBe('about 5 hours ago');
+		expect(
+			distanceInWords.localize('aboutXHours', 1, {
+				addSuffix: true,
+			}),
+		).toBe('about 1 hour ago');
+		expect(
+			distanceInWords.localize('xHours', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 hours ago');
+		expect(
+			distanceInWords.localize('xHours', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 hour ago');
+		expect(
+			distanceInWords.localize('xDays', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 days ago');
+		expect(
+			distanceInWords.localize('xDays', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 day ago');
+		expect(
+			distanceInWords.localize('aboutXMonths', 5, {
+				addSuffix: true,
+			}),
+		).toBe('about 5 months ago');
+		expect(
+			distanceInWords.localize('aboutXMonths', 1, {
+				addSuffix: true,
+			}),
+		).toBe('about 1 month ago');
+		expect(
+			distanceInWords.localize('xMonths', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 months ago');
+		expect(
+			distanceInWords.localize('xMonths', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 month ago');
+		expect(
+			distanceInWords.localize('aboutXYears', 5, {
+				addSuffix: true,
+			}),
+		).toBe('about 5 years ago');
+		expect(
+			distanceInWords.localize('aboutXYears', 1, {
+				addSuffix: true,
+			}),
+		).toBe('about 1 year ago');
+		expect(
+			distanceInWords.localize('xYears', 5, {
+				addSuffix: true,
+			}),
+		).toBe('5 years ago');
+		expect(
+			distanceInWords.localize('xYears', 1, {
+				addSuffix: true,
+			}),
+		).toBe('1 year ago');
+		expect(
+			distanceInWords.localize('overXYears', 5, {
+				addSuffix: true,
+			}),
+		).toBe('over 5 years ago');
+		expect(
+			distanceInWords.localize('overXYears', 1, {
+				addSuffix: true,
+			}),
+		).toBe('over 1 year ago');
+		expect(
+			distanceInWords.localize('almostXYears', 5, {
+				addSuffix: true,
+			}),
+		).toBe('almost 5 years ago');
+		expect(
+			distanceInWords.localize('almostXYears', 1, {
+				addSuffix: true,
+			}),
+		).toBe('almost 1 year ago');
+		expect(
+			distanceInWords.localize('lessThanXSeconds', 5, {
+				addSuffix: true,
+				comparison: 1,
+			}),
+		).toBe('in less than 5 seconds');
+		expect(
+			distanceInWords.localize('lessThanXSeconds', 1, {
+				addSuffix: true,
+				comparison: 1,
+			}),
+		).toBe('in less than a second');
+		expect(distanceInWords.localize('lessThanXSeconds', 5)).toBe('less than 5 seconds');
+		expect(distanceInWords.localize('lessThanXSeconds', 1)).toBe('less than a second');
+	});
+});

--- a/packages/components/src/DateFnsLocale/distanceInWords/index.js
+++ b/packages/components/src/DateFnsLocale/distanceInWords/index.js
@@ -1,0 +1,3 @@
+import distanceInWords from './distanceInWords';
+
+export default distanceInWords;

--- a/packages/components/src/DateFnsLocale/locale.js
+++ b/packages/components/src/DateFnsLocale/locale.js
@@ -1,47 +1,5 @@
+import buildDistanceInWordsLocale from './distanceInWords';
 import { getCurrentLanguage } from '../translate';
-
-export function buildDistanceInWordsLocale(t) {
-	function localize(token, count, options = {}) {
-		const distanceInWordsLocale = {
-			lessThanXSeconds: t('DATE_FNS_LESS_THAN_SECONDS', {
-				defaultValue: 'less than {{count}} seconds',
-				count,
-			}),
-			xSeconds: t('DATE_FNS_SECOND', { defaultValue: '{{count}} seconds', count }),
-			halfAMinute: t('DATE_FNS_HALF_A_MINUTE', { defaultValue: 'half a minute' }),
-			lessThanXMinutes: t('DATE_FNS_LESS_THAN_MINUTES', {
-				defaultValue: 'less than {{count}} minutes',
-				count,
-			}),
-			xMinutes: t('DATE_FNS_ABOUT_MINUTE', { defaultValue: '{{count}} minutes', count }),
-			aboutXHours: t('DATE_FNS_ABOUT_HOUR', { defaultValue: 'about {{count}} hours', count }),
-			xHours: t('DATE_FNS_HOUR', { defaultValue: '{{count}} hours', count }),
-			xDays: t('DATE_FNS_DAY', { defaultValue: '{{count}} days', count }),
-			aboutXMonths: t('DATE_FNS_ABOUT_MONTH', { defaultValue: 'about {{count}} months', count }),
-			xMonths: t('DATE_FNS_MONTH', { defaultValue: '{{count}} months', count }),
-			aboutXYears: t('DATE_FNS_ABOUT_YEAR', { defaultValue: 'about {{count}} years', count }),
-			xYears: t('DATE_FNS_YEAR', { defaultValue: '{{count}} years', count }),
-			overXYears: t('DATE_FNS_OVER_YEAR', { defaultValue: 'over {{count}} years', count }),
-			almostXYears: t('DATE_FNS_ALMOST_YEAR', { defaultValue: 'almost {{count}} years', count }),
-		};
-
-		const result = distanceInWordsLocale[token];
-
-		if (!options.addSuffix) {
-			return result;
-		}
-
-		if (options.comparison > 0) {
-			return t('DATE_FNS_IN', { defaultValue: 'in {{value}}', value: result });
-		}
-
-		return t('DATE_FNS_AGO', { defaultValue: '{{value}} ago', value: result });
-	}
-
-	return {
-		localize,
-	};
-}
 
 let language;
 let locale;

--- a/packages/components/src/DateFnsLocale/locale.test.js
+++ b/packages/components/src/DateFnsLocale/locale.test.js
@@ -1,101 +1,15 @@
 import i18next from 'i18next';
 import getDefaultT from '../translate';
-import getLocale, { buildDistanceInWordsLocale } from './locale';
-
-describe('buildDistanceInWordsLocale', () => {
-	it('should return the formatDistance with ', () => {
-		const distanceInWords = buildDistanceInWordsLocale(getDefaultT());
-		expect(
-			distanceInWords.localize('lessThanXSeconds', 5, {
-				addSuffix: true,
-			}),
-		).toBe('less than 5 seconds ago');
-		expect(
-			distanceInWords.localize('xSeconds', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 seconds ago');
-		expect(
-			distanceInWords.localize('halfAMinute', 5, {
-				addSuffix: true,
-			}),
-		).toBe('half a minute ago');
-		expect(
-			distanceInWords.localize('lessThanXMinutes', 5, {
-				addSuffix: true,
-			}),
-		).toBe('less than 5 minutes ago');
-		expect(
-			distanceInWords.localize('xMinutes', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 minutes ago');
-		expect(
-			distanceInWords.localize('aboutXHours', 5, {
-				addSuffix: true,
-			}),
-		).toBe('about 5 hours ago');
-		expect(
-			distanceInWords.localize('xHours', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 hours ago');
-		expect(
-			distanceInWords.localize('xDays', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 days ago');
-		expect(
-			distanceInWords.localize('aboutXMonths', 5, {
-				addSuffix: true,
-			}),
-		).toBe('about 5 months ago');
-		expect(
-			distanceInWords.localize('xMonths', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 months ago');
-		expect(
-			distanceInWords.localize('aboutXYears', 5, {
-				addSuffix: true,
-			}),
-		).toBe('about 5 years ago');
-		expect(
-			distanceInWords.localize('xYears', 5, {
-				addSuffix: true,
-			}),
-		).toBe('5 years ago');
-		expect(
-			distanceInWords.localize('overXYears', 5, {
-				addSuffix: true,
-			}),
-		).toBe('over 5 years ago');
-		expect(
-			distanceInWords.localize('almostXYears', 5, {
-				addSuffix: true,
-			}),
-		).toBe('almost 5 years ago');
-		expect(
-			distanceInWords.localize('lessThanXSeconds', 5, {
-				addSuffix: true,
-				comparison: 1,
-			}),
-		).toBe('in less than 5 seconds');
-
-		expect(distanceInWords.localize('lessThanXSeconds', 5)).toBe('less than 5 seconds');
-	});
-});
+import getLocale from './locale';
 
 describe('getLocale', () => {
 	afterEach(() => {
 		i18next.language = undefined;
 	});
+
 	it('should return the locale', () => {
 		const locale = getLocale(getDefaultT());
-
 		expect(locale.distanceInWords).toBeDefined();
-		expect(locale.distanceInWords.localize).toBeDefined();
-		expect(locale.distanceInWords.localize('lessThanXSeconds', 2)).toBe('less than 2 seconds');
 	});
 
 	it('should return a locale different when we change the i18next language', () => {

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -13,13 +13,15 @@ const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
 export function computeValue(cellData, columnData, t) {
 	try {
-		if (columnData.mode === 'ago') {
-			return distanceInWordsToNow(cellData, {
-				addSuffix: true,
-				locale: getLocale(t),
-			});
-		} else if (columnData.mode === 'format') {
-			return format(cellData, columnData.pattern || DATE_TIME_FORMAT);
+		if (cellData !== undefined) {
+			if (columnData.mode === 'ago') {
+				return distanceInWordsToNow(cellData, {
+					addSuffix: true,
+					locale: getLocale(t),
+				});
+			} else if (columnData.mode === 'format') {
+				return format(cellData, columnData.pattern || DATE_TIME_FORMAT);
+			}
 		}
 	} catch (e) {
 		invariant(true, 'Conversion error in list cell ', columnData);

--- a/packages/components/stories/VirtualizedList.js
+++ b/packages/components/stories/VirtualizedList.js
@@ -8,6 +8,7 @@ import { IconsProvider } from '../src/index';
 import VirtualizedList, { listTypes } from '../src/VirtualizedList';
 import CellTitle from '../src/VirtualizedList/CellTitle';
 import CellBadge from '../src/VirtualizedList/CellBadge';
+import CellDateTime from '../src/VirtualizedList/CellDatetime';
 
 function NoRowsRenderer() {
 	return (
@@ -66,7 +67,7 @@ const fewTitleActions = [
 		icon: 'talend-trash',
 		onClick: action('onDelete'),
 		hideLabel: true,
-	}
+	},
 ];
 
 const lotOfTitleActions = [
@@ -179,6 +180,7 @@ const collection = [
 		display: 'text',
 		className: 'item-0-class',
 		titleActions: fewTitleActions,
+		subscription: new Date(2017, 1, 21),
 	},
 	{
 		id: 1,
@@ -191,6 +193,7 @@ const collection = [
 		display: 'text',
 		className: 'item-1-class',
 		titleActions: lotOfTitleActions,
+		subscription: new Date(2016, 1, 21),
 	},
 	{
 		id: 2,
@@ -203,6 +206,7 @@ const collection = [
 		display: 'text',
 		className: 'item-2-class',
 		persistentActions,
+		subscription: new Date(2018, 6, 10),
 	},
 	{
 		id: 3,
@@ -215,6 +219,7 @@ const collection = [
 		icon: 'talend-file-xls-o',
 		display: 'text',
 		className: 'item-3-class',
+		subscription: new Date(2018, 5, 1),
 	},
 	{
 		id: 4,
@@ -227,6 +232,7 @@ const collection = [
 		icon: 'talend-file-json-o',
 		display: 'input',
 		className: 'item-4-class',
+		subscription: new Date(2016, 5, 1),
 	},
 	{
 		id: 5,
@@ -239,6 +245,7 @@ const collection = [
 			'Jean-Pierre DUPONT with super super super super super super super super super super super super long name, but there was not enough long text',
 		icon: 'talend-file-json-o',
 		className: 'item-5-class',
+		subscription: new Date(2018, 7, 1),
 	},
 ];
 
@@ -301,6 +308,12 @@ storiesOf('Virtualized List', module)
 					<VirtualizedList.Content label="Author" dataKey="author" />
 					<VirtualizedList.Content label="Created" dataKey="created" />
 					<VirtualizedList.Content label="Modified" dataKey="modified" />
+					<VirtualizedList.Content
+						label="Member since"
+						dataKey="subscription"
+						columnData={{ mode: 'ago' }}
+						{...CellDateTime}
+					/>
 				</VirtualizedList>
 			</section>
 		</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Talend/ui contains a date-fns local plugged on our translation system.
But it doesn't support plurals. 

**What is the chosen solution to this problem?**
Support plurals

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
