### PR TITLE
fix(components): highlight the main title on the list 

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
@@ -44,6 +44,7 @@ function CellTitle({ cellData, columnData, getComponent, rowData, rowIndex, type
 				cellData={cellData}
 				className={classNames(theme['main-title'], {
 					[theme['tc-main-title-active']]: onClick,
+					'tc-main-title-active': onClick,
 				})}
 				displayMode={displayMode}
 				onClick={onClick}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
@@ -42,7 +42,9 @@ function CellTitle({ cellData, columnData, getComponent, rowData, rowIndex, type
 			<CellTitleSelector
 				id={titleId}
 				cellData={cellData}
-				className={theme['main-title']}
+				className={classNames(theme['main-title'], {
+					[theme['tc-main-title-active']]: onClick,
+				})}
 				displayMode={displayMode}
 				onClick={onClick}
 				onEditCancel={onEditCancel}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -56,12 +56,12 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 			text-decoration: none;
 		}
 	}
-}
 
-.tc-main-title-active {
 	&:hover,
 	&:focus {
-		color: $scooter;
+		.tc-main-title-active {
+			color: $scooter;
+		}
 	}
 }
 

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -58,6 +58,13 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 	}
 }
 
+.tc-main-title-active {
+	&:hover,
+	&:focus {
+		color: $scooter;
+	}
+}
+
 // manage actions display on row hover
 :global(.tc-list-large-row),
 :global(.ReactVirtualized__Table__row) {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
@@ -38,6 +38,36 @@ describe('CellTitle', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render without active class if no onClick on the title', () => {
+		// given
+		const columnData = {
+			id: 'my-title',
+			displayModeKey: 'displayMode',
+			onEditCancel: jest.fn(),
+			onEditSubmit: jest.fn(),
+		};
+		const rowData = {
+			id: 1,
+			displayMode: 'text',
+			icon: 'talend-file-o',
+			title: 'my awesome title',
+		};
+
+		// when
+		const wrapper = shallow(
+			<CellTitle
+				cellData={'my awesome title'}
+				columnData={columnData}
+				getComponent={jest.fn()}
+				rowData={rowData}
+				rowIndex={1}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	describe('icon', () => {
 		const rowData = {
 			id: 1,

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitle.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitle.test.js.snap
@@ -295,7 +295,7 @@ exports[`CellTitle should render title selector component 1`] = `
 >
   <CellTitleSelector
     cellData="my awesome title"
-    className="theme-main-title theme-tc-main-title-active"
+    className="theme-main-title theme-tc-main-title-active tc-main-title-active"
     columnData={Object {}}
     displayMode="text"
     id="my-title-1-title-cell"

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitle.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitle.test.js.snap
@@ -295,11 +295,53 @@ exports[`CellTitle should render title selector component 1`] = `
 >
   <CellTitleSelector
     cellData="my awesome title"
-    className="theme-main-title"
+    className="theme-main-title theme-tc-main-title-active"
     columnData={Object {}}
     displayMode="text"
     id="my-title-1-title-cell"
     onClick={[Function]}
+    onEditCancel={[Function]}
+    onEditSubmit={[Function]}
+    rowData={
+      Object {
+        "displayMode": "text",
+        "icon": "talend-file-o",
+        "id": 1,
+        "title": "my awesome title",
+      }
+    }
+  />
+  <Translate(VirtualizedList(CellTitleActions))
+    actionsKey={undefined}
+    displayMode="text"
+    getComponent={[Function]}
+    id="my-title-1-title-actions"
+    persistentActionsKey={undefined}
+    rowData={
+      Object {
+        "displayMode": "text",
+        "icon": "talend-file-o",
+        "id": 1,
+        "title": "my awesome title",
+      }
+    }
+    type={undefined}
+  />
+</div>
+`;
+
+exports[`CellTitle should render without active class if no onClick on the title 1`] = `
+<div
+  className="tc-list-title theme-tc-list-title"
+  id="my-title-1-title-cell"
+>
+  <CellTitleSelector
+    cellData="my awesome title"
+    className="theme-main-title"
+    columnData={Object {}}
+    displayMode="text"
+    id="my-title-1-title-cell"
+    onClick={undefined}
     onEditCancel={[Function]}
     onEditSubmit={[Function]}
     rowData={


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
update list with the guidines to hightlight the title when the user can interact with it.
https://company-57688.frontify.com/document/92132#/navigation-layout/list

no on the icon. we have issue https://github.com/Talend/ui/pull/1602

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
