### PR TITLE
feat(PieChart): improve a11y

### DIFF
--- a/packages/components/src/PieChart/PieChartIcon.component.js
+++ b/packages/components/src/PieChart/PieChartIcon.component.js
@@ -281,7 +281,11 @@ export function PieChartIconComponent({
 	const sizeObject = getDisplaySize(size, display);
 	if (loading) {
 		return (
-			<span className={classnames(theme['tc-pie-chart-loading'], 'tc-pie-chart-loading')}>
+			<span
+				className={classnames(theme['tc-pie-chart-loading'], 'tc-pie-chart-loading')}
+				aria-busy="true"
+				aria-label={t('PIE_CHART_LOADING', { defaultValue: 'Loading chart' })}
+			>
 				<Skeleton
 					type={Skeleton.TYPES.circle}
 					width={sizeObject.svgSize}
@@ -301,12 +305,13 @@ export function PieChartIconComponent({
 	// to keep only the event listener from the TooltipTrigger.
 	const omitI18N = omit(rest, ['i18n', 'tReady']);
 	return (
-		<span className={classnames(theme['tc-pie-chart-icon'], 'tc-pie-icon-chart')} {...omitI18N}>
+		<span className={classnames(theme['tc-pie-chart-icon'], 'tc-pie-icon-chart')}>
 			<svg
 				width={sizeObject.svgSize}
 				height={sizeObject.svgSize}
 				className={classnames(theme['tc-pie-chart-icon-graph'], 'tc-pie-chart-icon-graph')}
 				style={{ width: sizeObject.svgSize, height: sizeObject.svgSize }}
+				{...omitI18N}
 			>
 				{preparedValues.map((value, index) => getCircle(value, index, preparedValues, sizeObject))}
 				{getEmptyPartCircle(preparedValues, sizeObject, minimumPercentage)}

--- a/packages/components/src/PieChart/PieChartIcon.test.js
+++ b/packages/components/src/PieChart/PieChartIcon.test.js
@@ -44,6 +44,18 @@ describe('PieChart', () => {
 			const wrapper = shallow(<PieChartIconComponent display="small" model={pieChartData} />);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
+		it('should spread extra props on svg', () => {
+			// given
+			const ariaLabel = 'Invalid values: 50%. Empty values: 14%. Valid values: 36%';
+
+			// when
+			const wrapper = shallow(
+				<PieChartIconComponent model={pieChartData} aria-label={ariaLabel} />,
+			);
+
+			// then
+			expect(wrapper.find('svg').prop('aria-label')).toBe(ariaLabel);
+		});
 	});
 
 	describe('getCircle', () => {

--- a/packages/components/src/PieChart/__snapshots__/PieChartIcon.test.js.snap
+++ b/packages/components/src/PieChart/__snapshots__/PieChartIcon.test.js.snap
@@ -80,6 +80,8 @@ exports[`PieChart snapshots render should render a PieChart 1`] = `
 
 exports[`PieChart snapshots render should render a Skeleton when the state is loading 1`] = `
 <span
+  aria-busy="true"
+  aria-label="Loading chart"
   className="theme-tc-pie-chart-loading tc-pie-chart-loading"
 >
   <Translate(Skeleton)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- On loading state, no busy indication or text-alternative
- Svg chart has no way to accept text-alternative

**What is the chosen solution to this problem?**
- Add `aria-busy` and loading aria-label
- Spread extra props into svg instead of span container

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**
Extra props provided to the component are now spread on the svg element, not the span container.

Example:
```
import PieChart from '@talend/react-components/lib/PieChart';

<PieChart aria-label='My text alternative' />
```

Before
```
<span arial-label='My text alternative'>
    <svg></svg>
    <span></span>
</span>
```

After
```
<span>
    <svg arial-label='My text alternative'></svg>
    <span></span>
</span>
```

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
