### PR TITLE
chore(datalist/liveupdate): Adding onLiveUpdate on Datalist

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -10,6 +10,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   113:8  error  'isDropup' is assigned a value but never used    no-unused-vars
   114:8  error  'isDropdown' is assigned a value but never used  no-unused-vars
 
+/home/travis/build/Talend/ui/packages/components/src/Datalist/Datalist.component.js
+  173:74  error  Expected '!==' and instead saw '!='  eqeqeq
+
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/__snapshots__/config.js
   1:1  error  '@storybook/react' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
   4:2  error  Unexpected require()                                                                    global-require
@@ -34,5 +37,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 14 problems (13 errors, 1 warning)
+✖ 15 problems (14 errors, 1 warning)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -17,6 +17,13 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
   9:4  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+  38:2  error  getSchema should be placed after onLiveChange  react/sort-comp
+
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+  51:10  error  'schema' is already declared in the upper scope  no-shadow
+  64:36  error  'reject' is defined but never used               no-unused-vars
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
   6:8  error  'Icon' is defined but never used  no-unused-vars
 
@@ -30,5 +37,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:8  error  Expected indentation of 6 tab characters but found 7  react/jsx-indent
   78:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
-✖ 12 problems (12 errors, 0 warnings)
+✖ 15 problems (15 errors, 0 warnings)
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
+    "test:updateSnapshot": "jest --updateSnapshot",
     "test:slimerjs": "slimerjs stories/slimer.js",
     "test:demo": "build-storybook",
     "lint:style": "sass-lint -v -q",

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -18,6 +18,7 @@ class Datalist extends Component {
 		super(props);
 		this.onBlur = this.onBlur.bind(this);
 		this.onChange = this.onChange.bind(this);
+		this.onLiveChange = this.onLiveChange.bind(this);
 		this.onFocus = this.onFocus.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onSelect = this.onSelect.bind(this);
@@ -77,6 +78,20 @@ class Datalist extends Component {
 		this.updateValue(event, value, false);
 		// resetting selection here in order to reinit the section + item indexes
 		this.resetSelection();
+	}
+
+	/**
+	 * Update value (non persistent) on input value change and update the suggestions.
+	 * Compare to onChange, it is systematically triggered but only for temporary
+	 * values, i.e. the final value will go through onChange and not onLiveChange.
+	 *
+	 * @param event the change event
+	 * @param payload the event data, it contains <em>value</em>.
+	 */
+	onLiveChange(event, payload) {
+		if (this.props.onLiveChange) {
+			this.props.onLiveChange(event, payload);
+		}
 	}
 
 	/**
@@ -155,6 +170,9 @@ class Datalist extends Component {
 				});
 				break;
 			default:
+				if (!event.ctrlKey && !event.metaKey && !event.altKey && event.which != 8) {
+					this.onLiveChange(event, { value: this.state.value + (event.key || '') });
+				}
 				break;
 		}
 	}
@@ -273,6 +291,8 @@ class Datalist extends Component {
 			} else {
 				this.resetValue();
 			}
+		} else {
+			this.onLiveChange(event, { value });
 		}
 	}
 
@@ -382,6 +402,7 @@ Datalist.defaultProps = {
 if (process.env.NODE_ENV !== 'production') {
 	Datalist.propTypes = {
 		onChange: PropTypes.func.isRequired,
+		onLiveChange: PropTypes.func,
 		onFocus: PropTypes.func,
 		disabled: PropTypes.bool,
 		multiSection: PropTypes.bool.isRequired,

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -536,7 +536,7 @@ describe('Datalist component', () => {
 		const input = wrapper.find('input').at(0);
 
 		// when
-		input.simulate('change', { target: { value: 'foob' }});
+		input.simulate('change', { target: { value: 'foob' } });
 
 		// then
 		expect(onLiveChange).toBeCalledWith(expect.anything(), { value: 'foob' });

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -521,4 +521,25 @@ describe('Datalist component', () => {
 		expect(instance.updateSuggestions).toHaveBeenCalled();
 		expect(instance.updateSelectedIndexes).toHaveBeenCalled();
 	});
+
+	it('should call onLiveChange for temporary values', () => {
+		// given
+		const onLiveChange = jest.fn();
+		const wrapper = mount(
+			<Datalist
+				multiSection={false}
+				onChange={jest.fn()}
+				onLiveChange={onLiveChange}
+				value={'foo'}
+			/>,
+		);
+		const input = wrapper.find('input').at(0);
+
+		// when
+		input.simulate('change', { target: { value: 'foob' }});
+
+		// then
+		expect(onLiveChange).toBeCalledWith(expect.anything(), { value: 'foob' });
+		expect(wrapper.props().value).toBe('foo');
+	});
 });

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "prepublish": "rimraf lib && babel -d lib ./src/ && cpx -v \"./src/**/*.scss\" lib",
     "test": "jest",
+    "test:updateSnapshot": "jest --updateSnapshot",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
     "test:demo": "build-storybook",

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -31,6 +31,7 @@ export class UIFormComponent extends React.Component {
 		this.state = state;
 
 		this.onChange = this.onChange.bind(this);
+		this.onLiveChange = this.onLiveChange.bind(this);
 		this.onFinish = this.onFinish.bind(this);
 		this.onSubmit = this.onSubmit.bind(this);
 		this.onTrigger = this.onTrigger.bind(this);
@@ -90,6 +91,23 @@ export class UIFormComponent extends React.Component {
 			oldProperties: this.props.properties,
 			properties: newProperties,
 			formData: newProperties,
+		});
+	}
+
+	/**
+	 * Fire onLiveChange callback while interacting with form fields
+	 * @param event The event that triggered the callback
+	 * @param schema The payload field schema
+	 * @param value The payload new value, it contains the schema, value and properties.
+	 */
+	onLiveChange(event, { schema, value }) {
+		if (!this.props.onLiveChange) {
+			return;
+		}
+		this.props.onLiveChange(event, {
+			schema,
+			value,
+			properties: this.props.properties,
 		});
 	}
 
@@ -332,6 +350,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 		/** State management impl: The change callback */
 		onChange: PropTypes.func.isRequired,
+		onLiveChange: PropTypes.func,
 		/** State management impl: Set All fields validations errors */
 		setErrors: PropTypes.func,
 		getComponent: PropTypes.func,

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -51,7 +51,7 @@ class Datalist extends Component {
 			};
 		}
 
-		return schema
+		return schema;
 	}
 
 	/**

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Datalist from './Datalist.component';
 
 const schema = {
@@ -39,6 +39,47 @@ describe('Datalist component', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+
+
+	describe('onLiveChange', () => {
+		it('should call triggers onLiveChange', () => {
+			// given
+			const onEvent = 'change';
+			const trigger = {
+				onEvent,
+			};
+			const schema = {
+				type: 'string',
+				schema: {
+					type: 'string',
+				},
+				triggers: [
+					trigger,
+				],
+			};
+			const onTrigger = jest.fn();
+			const input = mount(<Datalist
+				onChange={jest.fn()}
+				onTrigger={(e, p) => {
+					onTrigger(e, p); // ensure we capture it
+					return new Promise((resolve, reject) => resolve({}));
+				}}
+				onFinish={jest.fn()}
+				schema={schema}
+			/>).find('input').at(0);
+
+			// when
+			input.simulate('change', { target: { value: 'x' }});
+
+			// then
+			expect(onTrigger).toHaveBeenCalledWith(expect.anything(), {
+				schema,
+				trigger,
+				properties: 'x', // no form so it ends up like that
+			});
+		});
 	});
 
 	describe('onChange', () => {

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
@@ -41,8 +41,6 @@ describe('Datalist component', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-
-
 	describe('onLiveChange', () => {
 		it('should call triggers onLiveChange', () => {
 			// given
@@ -55,23 +53,25 @@ describe('Datalist component', () => {
 				schema: {
 					type: 'string',
 				},
-				triggers: [
-					trigger,
-				],
+				triggers: [trigger],
 			};
 			const onTrigger = jest.fn();
-			const input = mount(<Datalist
-				onChange={jest.fn()}
-				onTrigger={(e, p) => {
-					onTrigger(e, p); // ensure we capture it
-					return new Promise((resolve, reject) => resolve({}));
-				}}
-				onFinish={jest.fn()}
-				schema={schema}
-			/>).find('input').at(0);
+			const input = mount(
+				<Datalist
+					onChange={jest.fn()}
+					onTrigger={(e, p) => {
+						onTrigger(e, p); // ensure we capture it
+						return new Promise((resolve, reject) => resolve({}));
+					}}
+					onFinish={jest.fn()}
+					schema={schema}
+				/>,
+			)
+				.find('input')
+				.at(0);
 
 			// when
-			input.simulate('change', { target: { value: 'x' }});
+			input.simulate('change', { target: { value: 'x' } });
 
 			// then
 			expect(onTrigger).toHaveBeenCalledWith(expect.anything(), {

--- a/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -16,6 +16,7 @@ exports[`Datalist component should render 1`] = `
     multiSection={false}
     onChange={[Function]}
     onFocus={[Function]}
+    onLiveChange={[Function]}
     placeholder="Type here"
     readOnly={false}
     restricted={false}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

No way to implement dynamic suggestions with current Datalist API.

**What is the chosen solution to this problem?**

- Add a onLiveChange which is like onChange but called even on not data update (volatile)
- Use that in the form datalist field and call triggers (which are filtered by "onEvent" so user has to set onEvent=change to have this feature)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
