### PR TITLE
feat(SidePanel): improve a11y

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.component.js
+++ b/packages/components/src/SidePanel/SidePanel.component.js
@@ -56,24 +56,23 @@ function SidePanel({
 		'nav-inverse': !reverse,
 	});
 
-	const expandLabel = t('SIDEPANEL_EXPAND', { defaultValue: 'Expand' });
-	const collapseTitle = t('SIDEPANEL_COLLAPSE', { defaultValue: 'Collapse' });
+	const expandLabel = t('SIDEPANEL_EXPAND', { defaultValue: 'Expand menu' });
+	const collapseTitle = t('SIDEPANEL_COLLAPSE', { defaultValue: 'Collapse menu' });
 	const toggleButtonTitle = docked ? expandLabel : collapseTitle;
 	const Components = Inject.getAll(getComponent, { Action, ActionList });
 	return (
 		<nav id={id} className={navCSS} role="navigation" aria-expanded={!(dockable && docked)}>
 			{dockable && (
-				<div
-					className={classNames(theme['toggle-btn'], 'tc-side-panel-toggle-btn')}
-					title={toggleButtonTitle}
-				>
+				<div className={classNames(theme['toggle-btn'], 'tc-side-panel-toggle-btn')}>
 					<Components.Action
 						id={id && `${id}-toggle-dock`}
 						bsStyle="link"
 						onClick={onToggleDock}
 						icon="talend-opener"
-						label=""
 						aria-controls={id}
+						label={toggleButtonTitle}
+						tooltipPlacement="right"
+						hideLabel
 					/>
 				</div>
 			)}

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -130,16 +130,17 @@ exports[`Storyshots SidePanel default 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Collapse"
     >
       <button
         aria-controls="context"
-        aria-label=""
+        aria-label="Collapse menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id="context-toggle-dock"
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -154,9 +155,6 @@ exports[`Storyshots SidePanel default 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -391,16 +389,17 @@ exports[`Storyshots SidePanel docked 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Expand"
     >
       <button
         aria-controls={undefined}
-        aria-label=""
+        aria-label="Expand menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id={undefined}
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -415,9 +414,6 @@ exports[`Storyshots SidePanel docked 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -652,16 +648,17 @@ exports[`Storyshots SidePanel large docked 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Expand"
     >
       <button
         aria-controls={undefined}
-        aria-label=""
+        aria-label="Expand menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id={undefined}
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -676,9 +673,6 @@ exports[`Storyshots SidePanel large docked 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -913,16 +907,17 @@ exports[`Storyshots SidePanel large reverse 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Collapse"
     >
       <button
         aria-controls={undefined}
-        aria-label=""
+        aria-label="Collapse menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id={undefined}
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -937,9 +932,6 @@ exports[`Storyshots SidePanel large reverse 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -1174,16 +1166,17 @@ exports[`Storyshots SidePanel links 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Collapse"
     >
       <button
         aria-controls="context"
-        aria-label=""
+        aria-label="Collapse menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id="context-toggle-dock"
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -1198,9 +1191,6 @@ exports[`Storyshots SidePanel links 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -1665,16 +1655,17 @@ exports[`Storyshots SidePanel reverse 1`] = `
   >
     <div
       className="theme-toggle-btn tc-side-panel-toggle-btn"
-      title="Collapse"
     >
       <button
         aria-controls={undefined}
-        aria-label=""
+        aria-label="Collapse menu"
         className="btn-icon-only btn btn-link"
         disabled={false}
         id={undefined}
         onClick={[Function]}
+        onFocus={[Function]}
         onMouseDown={[Function]}
+        onMouseOver={[Function]}
         role={null}
         type="button"
       >
@@ -1689,9 +1680,6 @@ exports[`Storyshots SidePanel reverse 1`] = `
             xlinkHref="#talend-opener"
           />
         </svg>
-        <span>
-          
-        </span>
       </button>
     </div>
     <ul
@@ -1936,16 +1924,17 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
         >
           <div
             className="theme-toggle-btn tc-side-panel-toggle-btn"
-            title="Collapse"
           >
             <button
               aria-controls={undefined}
-              aria-label=""
+              aria-label="Collapse menu"
               className="btn-icon-only btn btn-link"
               disabled={false}
               id={undefined}
               onClick={[Function]}
+              onFocus={[Function]}
               onMouseDown={[Function]}
+              onMouseOver={[Function]}
               role={null}
               type="button"
             >
@@ -1960,9 +1949,6 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
                   xlinkHref="#talend-opener"
                 />
               </svg>
-              <span>
-                
-              </span>
             </button>
           </div>
           <ul
@@ -2565,16 +2551,17 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
         >
           <div
             className="theme-toggle-btn tc-side-panel-toggle-btn"
-            title="Collapse"
           >
             <button
               aria-controls={undefined}
-              aria-label=""
+              aria-label="Collapse menu"
               className="btn-icon-only btn btn-link"
               disabled={false}
               id={undefined}
               onClick={[Function]}
+              onFocus={[Function]}
               onMouseDown={[Function]}
+              onMouseOver={[Function]}
               role={null}
               type="button"
             >
@@ -2589,9 +2576,6 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
                   xlinkHref="#talend-opener"
                 />
               </svg>
-              <span>
-                
-              </span>
             </button>
           </div>
           <ul
@@ -3195,16 +3179,17 @@ exports[`Storyshots SidePanel 🎨 [PORTAL] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -3219,9 +3204,6 @@ exports[`Storyshots SidePanel 🎨 [PORTAL] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -3469,16 +3451,17 @@ exports[`Storyshots SidePanel 🎨 [TDC] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -3493,9 +3476,6 @@ exports[`Storyshots SidePanel 🎨 [TDC] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -3743,16 +3723,17 @@ exports[`Storyshots SidePanel 🎨 [TDP] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -3767,9 +3748,6 @@ exports[`Storyshots SidePanel 🎨 [TDP] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -4017,16 +3995,17 @@ exports[`Storyshots SidePanel 🎨 [TDS] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -4041,9 +4020,6 @@ exports[`Storyshots SidePanel 🎨 [TDS] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -4291,16 +4267,17 @@ exports[`Storyshots SidePanel 🎨 [TFD] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -4315,9 +4292,6 @@ exports[`Storyshots SidePanel 🎨 [TFD] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -4565,16 +4539,17 @@ exports[`Storyshots SidePanel 🎨 [TIC] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -4589,9 +4564,6 @@ exports[`Storyshots SidePanel 🎨 [TIC] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul
@@ -4839,16 +4811,17 @@ exports[`Storyshots SidePanel 🎨 [TMC] SidePanel 1`] = `
       >
         <div
           className="theme-toggle-btn tc-side-panel-toggle-btn"
-          title="Collapse"
         >
           <button
             aria-controls="context"
-            aria-label=""
+            aria-label="Collapse menu"
             className="btn-icon-only btn btn-link"
             disabled={false}
             id="context-toggle-dock"
             onClick={[Function]}
+            onFocus={[Function]}
             onMouseDown={[Function]}
+            onMouseOver={[Function]}
             role={null}
             type="button"
           >
@@ -4863,9 +4836,6 @@ exports[`Storyshots SidePanel 🎨 [TMC] SidePanel 1`] = `
                 xlinkHref="#talend-opener"
               />
             </svg>
-            <span>
-              
-            </span>
           </button>
         </div>
         <ul


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- Collapse button has no text. Instead the meaningful text is on the container div

**What is the chosen solution to this problem?**
- Move the text to the button, hide it and make it appear as tooltip and aria-label.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
