### PR TITLE
fix(storybook): restore scroll

### DIFF
--- a/packages/components/.storybook/preview-head.html
+++ b/packages/components/.storybook/preview-head.html
@@ -6,7 +6,11 @@
 	}
 
     body {
-        min-height: 100vh;
+        min-height: 70vh;
+
+        /* Layout set style on body that disable the scroll. This restore the default so we can scroll in the story */
+        overflow: visible !important;
+        width: auto !important;
     }
 
 	.tc-drawer.drawer-custom {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
It's not possible to scroll in the stories anymore.
Regression du to wrong cleanup in stories style, so Layout style `<body>` making it impossible to scroll.

**What is the chosen solution to this problem?**
Restore scroll

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
