### PR TITLE
feat(EditableText): improve a11y

### DIFF
--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -20,7 +20,7 @@ function PlainTextTitle({ onEdit, disabled, text, inProgress, t }) {
 			</span>
 			<Action
 				name="action-edit"
-				label={t('EDITABLE_TEXT_EDIT', { defaultValue: 'Edit' })}
+				label={t('MODIFY_TOOLTIP', { defaultValue: 'Edit' })}
 				icon="talend-pencil"
 				onClick={onEdit}
 				bsStyle="link"
@@ -49,7 +49,7 @@ function EditableText({ editMode, loading, inProgress, ...rest }) {
 	const allyProps = {};
 	if (inProgress) {
 		allyProps['aria-label'] = rest.t('EDITABLE_TEXT_IN_PROGRESS', {
-			defaultValue: 'Edition in progress',
+			defaultValue: 'Edit in progress',
 		});
 		allyProps['aria-busy'] = true;
 	}

--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -9,30 +9,22 @@ import theme from './EditableText.scss';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 
 function PlainTextTitle({ onEdit, disabled, text, inProgress, t }) {
+	const isDisabled = disabled || inProgress;
 	return (
-		<div>
-			<button
-				className={classNames(
-					theme['tc-editable-text-text-wording-button'],
-					'tc-editable-text-text-wording-button',
-					'btn',
-					'btn-link',
-				)}
-				onDoubleClick={onEdit}
-				disabled={disabled || inProgress}
+		<div className={theme['tc-editable-text-title']}>
+			<span
+				className={classNames(theme['tc-editable-text-wording'], 'tc-editable-text-wording')}
+				onDoubleClick={isDisabled ? undefined : onEdit}
 			>
 				{text}
-			</button>
+			</span>
 			<Action
 				name="action-edit"
-				label={t('MODIFY_TOOLTIP', { defaultValue: 'Edit' })}
+				label={t('EDITABLE_TEXT_EDIT', { defaultValue: 'Edit' })}
 				icon="talend-pencil"
 				onClick={onEdit}
 				bsStyle="link"
-				className={classNames(
-					theme['tc-editable-text-text-pencil'],
-					'tc-editable-text-text-pencil',
-				)}
+				className={classNames(theme['tc-editable-text-pencil'], 'tc-editable-text-pencil')}
 				disabled={disabled || inProgress}
 				hideLabel
 			/>
@@ -54,12 +46,20 @@ function EditableText({ editMode, loading, inProgress, ...rest }) {
 	}
 
 	const Component = editMode ? InlineForm : PlainTextTitle;
+	const allyProps = {};
+	if (inProgress) {
+		allyProps['aria-label'] = rest.t('EDITABLE_TEXT_IN_PROGRESS', {
+			defaultValue: 'Edition in progress',
+		});
+		allyProps['aria-busy'] = true;
+	}
 	return (
 		<div
 			className={classNames(theme['tc-editable-text'], 'tc-editable-text', {
 				[theme['tc-editable-text-blink']]: inProgress,
 				'tc-editable-text-blink': inProgress,
 			})}
+			{...allyProps}
 		>
 			<Component inProgress={inProgress} {...rest} />
 		</div>

--- a/packages/components/src/EditableText/EditableText.scss
+++ b/packages/components/src/EditableText/EditableText.scss
@@ -26,52 +26,32 @@ $tc-circle-editable-text-size: 16px !default;
 }
 
 .tc-editable-text {
-	display: flex;
-	margin: 0;
-	height: 100%;
-	position: relative;
+	margin: 0 110px 0 0;
+	max-width: 90rem;
 
-	& &-text {
-		flex-direction: column;
-		justify-content: center;
-		overflow: hidden;
-		flex: 1 auto;
-		margin-right: 110px;
-		max-width: 90rem;
-		display: inline-flex;
+	&-title {
+		display: flex;
 		align-items: center;
+		max-width: 90rem;
+	}
 
-		&-wording-button {
-			@include input-text($tc-input-editable-text-title-weight);
-			@include ellipsis;
-			text-transform: uppercase;
-			margin: 0;
-		}
+	&-wording {
+		@include input-text($tc-input-editable-text-title-weight);
+		@include ellipsis;
+		text-transform: uppercase;
+		flex: 0 1 auto;
+	}
 
-		&-wording-button {
-			padding: 0;
-			letter-spacing: inherit;
+	&-pencil {
+		padding-left: $padding-small;
+		padding-right: $padding-small;
+		flex: 0 0 auto;
 
-			&:global(.btn-link) {
-				color: $black;
-
-				&:focus,
-				&:hover,
-				&:active {
-					color: $black;
-				}
-			}
-		}
-
-		&-pencil {
-			padding-left: $padding-small;
-			padding-right: $padding-small;
-
-			&:global(.btn-link) {
-				color: $silver;
-			}
+		&:global(.btn-link) {
+			color: $silver;
 		}
 	}
+
 	& &-form {
 		width: 100%;
 		display: flex;

--- a/packages/components/src/Skeleton/Skeleton.component.js
+++ b/packages/components/src/Skeleton/Skeleton.component.js
@@ -58,7 +58,7 @@ function Skeleton({ heartbeat, type, size, width, height, name, className, t }) 
 	);
 
 	const ariaLabel = t('SKELETON_LOADING', {
-		defaultValue: ' {{type}} (loading)',
+		defaultValue: '{{type}} (loading)',
 		type: getTranslatedType(t, type),
 	});
 

--- a/packages/components/src/Skeleton/__snapshots__/Skeleton.test.js.snap
+++ b/packages/components/src/Skeleton/__snapshots__/Skeleton.test.js.snap
@@ -46,7 +46,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       small
     </div>
     <span
-      aria-label=" circle (loading)"
+      aria-label="circle (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-circle theme-tc-skeleton-circle-small tc-skeleton tc-skeleton-circle tc-skeleton-circle-small tc-skeleton-heartbeat"
       style={
         Object {
@@ -59,7 +59,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       medium
     </div>
     <span
-      aria-label=" circle (loading)"
+      aria-label="circle (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-circle theme-tc-skeleton-circle-medium tc-skeleton tc-skeleton-circle tc-skeleton-circle-medium tc-skeleton-heartbeat"
       style={
         Object {
@@ -72,7 +72,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       large
     </div>
     <span
-      aria-label=" circle (loading)"
+      aria-label="circle (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-circle theme-tc-skeleton-circle-large tc-skeleton tc-skeleton-circle tc-skeleton-circle-large tc-skeleton-heartbeat"
       style={
         Object {
@@ -85,7 +85,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       custom size override class definition 
     </div>
     <span
-      aria-label=" circle (loading)"
+      aria-label="circle (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-circle theme-tc-skeleton-circle-small tc-skeleton tc-skeleton-circle tc-skeleton-circle-small tc-skeleton-heartbeat"
       style={
         Object {
@@ -101,7 +101,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       small:
     </div>
     <span
-      aria-label=" text (loading)"
+      aria-label="text (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-text theme-tc-skeleton-text-small tc-skeleton tc-skeleton-text tc-skeleton-text-small tc-skeleton-heartbeat"
       style={
         Object {
@@ -114,7 +114,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       medium:
     </div>
     <span
-      aria-label=" text (loading)"
+      aria-label="text (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-text theme-tc-skeleton-text-medium tc-skeleton tc-skeleton-text tc-skeleton-text-medium tc-skeleton-heartbeat"
       style={
         Object {
@@ -127,7 +127,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       large:
     </div>
     <span
-      aria-label=" text (loading)"
+      aria-label="text (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-text theme-tc-skeleton-text-large tc-skeleton tc-skeleton-text tc-skeleton-text-large tc-skeleton-heartbeat"
       style={
         Object {
@@ -140,7 +140,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       extra-large:
     </div>
     <span
-      aria-label=" text (loading)"
+      aria-label="text (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-text theme-tc-skeleton-text-xlarge tc-skeleton tc-skeleton-text tc-skeleton-text-xlarge tc-skeleton-heartbeat"
       style={
         Object {
@@ -153,7 +153,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       custom width:
     </div>
     <span
-      aria-label=" text (loading)"
+      aria-label="text (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-text theme-tc-skeleton-text-small tc-skeleton tc-skeleton-text tc-skeleton-text-small tc-skeleton-heartbeat"
       style={
         Object {
@@ -166,7 +166,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
       Button: 
     </h4>
     <span
-      aria-label=" button (loading)"
+      aria-label="button (loading)"
       className="theme-tc-skeleton theme-tc-skeleton-button theme-tc-skeleton-button-medium tc-skeleton tc-skeleton-button tc-skeleton-button-medium tc-skeleton-heartbeat"
       style={
         Object {
@@ -180,7 +180,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
     </h4>
     <svg
       aria-hidden="true"
-      aria-label=" icon (loading)"
+      aria-label="icon (loading)"
       className="theme-tc-svg-icon tc-svg-icon theme-tc-skeleton theme-tc-skeleton-icon theme-tc-skeleton-icon-medium tc-skeleton tc-skeleton-icon tc-skeleton-icon-medium tc-skeleton-heartbeat"
       focusable="false"
       name="talend-locked"
@@ -195,7 +195,7 @@ exports[`Storyshots Translate(Skeleton) default 1`] = `
     </h4>
     <svg
       aria-hidden="true"
-      aria-label=" icon (loading)"
+      aria-label="icon (loading)"
       className="theme-tc-svg-icon tc-svg-icon theme-tc-skeleton theme-tc-skeleton-icon theme-tc-skeleton-icon-medium tc-skeleton tc-skeleton-icon tc-skeleton-icon-medium theme-skeleton-96x96 tc-skeleton-heartbeat"
       focusable="false"
       name="talend-table"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- inProgress: no text alternative of the visual heartbeat animation
- wording part is a button but handles only a double click. There is no possibility to perform a double click without a mouse. That is ok because we have the pencil but we end up with a button with no indication that does nothing with a keyboard.

**What is the chosen solution to this problem?**
- add aria attributes on inProgress state
- wording part is a span with double click
- removed a bunch of useless css and reshape the style

(Bonus)
- removed extra space in skeleton text alternative

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
