### PR TITLE
feat(Forms): text display mode

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -23,6 +23,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   24:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
+  21:7  error  'formTemplates' is assigned a value but never used  no-unused-vars
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/templates.js
   1:8  error  Using exported name 'DefaultArrayTemplate' as identifier for default export  import/no-named-as-default
 
@@ -30,5 +33,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:8  error  Expected indentation of 6 tab characters but found 7  react/jsx-indent
   78:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
-✖ 12 problems (12 errors, 0 warnings)
+✖ 13 problems (13 errors, 0 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -23,9 +23,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   24:7  error  Form controls using a label to identify them must be programmatically associated with the control using htmlFor  jsx-a11y/label-has-for
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
-  21:7  error  'formTemplates' is assigned a value but never used  no-unused-vars
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/templates.js
   1:8  error  Using exported name 'DefaultArrayTemplate' as identifier for default export  import/no-named-as-default
 
@@ -33,5 +30,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   68:8  error  Expected indentation of 6 tab characters but found 7  react/jsx-indent
   78:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
-✖ 13 problems (13 errors, 0 warnings)
+✖ 12 problems (12 errors, 0 warnings)
 

--- a/packages/forms/.storybook/preview-head.html
+++ b/packages/forms/.storybook/preview-head.html
@@ -1,8 +1,12 @@
 <style>
-		body {
-			overflow: auto !important;
-		}
-		.wrapper {
+    body {
+        min-height: 70vh;
+
+        /* Layout set style on body that disable the scroll. This restore the default so we can scroll in the story */
+        overflow: visible !important;
+        width: auto !important;
+    }
+    .wrapper {
         display: flex;
         flex-direction: column;
         height: 100vh;

--- a/packages/forms/src/UIForm/FormTemplate/DefaultFormTemplate.component.js
+++ b/packages/forms/src/UIForm/FormTemplate/DefaultFormTemplate.component.js
@@ -1,0 +1,10 @@
+import React from 'react';
+import theme from '../UIForm.scss';
+
+export default function DefaultFormTemplate({ widgetsRenderer, buttonsRenderer, children }) {
+	return [
+		<div className={theme['form-content']}>{widgetsRenderer()}</div>,
+		children,
+		buttonsRenderer(),
+	];
+}

--- a/packages/forms/src/UIForm/FormTemplate/TextModeFormTemplate.component.js
+++ b/packages/forms/src/UIForm/FormTemplate/TextModeFormTemplate.component.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import theme from '../UIForm.scss';
+
+export default function TextModeFormTemplate({ widgetsRenderer, children }) {
+	return [<dl className={theme['form-content']}>{widgetsRenderer()}</dl>, children];
+}

--- a/packages/forms/src/UIForm/FormTemplate/index.js
+++ b/packages/forms/src/UIForm/FormTemplate/index.js
@@ -1,0 +1,4 @@
+import DefaultFormTemplate from './DefaultFormTemplate.component';
+import TextModeFormTemplate from './TextModeFormTemplate.component';
+
+export { DefaultFormTemplate, TextModeFormTemplate };

--- a/packages/forms/src/UIForm/README.md
+++ b/packages/forms/src/UIForm/README.md
@@ -282,7 +282,7 @@ Those validations change the `errors` object accordingly.
 
 ### Conditional rendering
 
-It is possible to render parts of the forms defined in uiSchema, depending on properties values.  
+It is possible to render parts of the forms defined in uiSchema, depending on properties values.
 The uiSchema accepts a `conditions` property, which define all conditions to match to be rendered.
 
 | UISchema conditions property | Description |
@@ -291,7 +291,7 @@ The uiSchema accepts a `conditions` property, which define all conditions to mat
 | conditions[].path | Define the path of the formData to test. This supports json path, dot notation, of an array of key. |
 | conditions[].values | Defines all the possible values. If the formData to test is equals to one of those, the condition is met. |
 
-Let's take this example: 
+Let's take this example:
 ```json
 {
   "jsonSchema": {
@@ -322,7 +322,7 @@ Let's take this example:
 }
 ```
 
-We want 
+We want
 * `civility` to appear only for humans
 * `lastname` and `firstname` to appear only for humans and animals
 
@@ -375,19 +375,19 @@ class MyComponent extends React.Component {
 	}
 
 	onChange(event, { schema, value, oldProperties, properties }) {
-		
+
 	}
-	
+
 	onErrors(event, errors) {
-		
+
 	}
 
 	onTrigger(event, { trigger, schema, properties }) {
-		
+
 	}
-	
+
 	onSubmit(event, properties) {
-		
+
 	}
 
 	render() {
@@ -415,7 +415,7 @@ class MyComponent extends React.Component {
 	onChange(event, { schema, value, oldProperties, properties }) {
 		// save properties in your app state
 	}
-	
+
 	onErrors(event, errors) {
 		// save errors in your app state
 	}
@@ -425,7 +425,7 @@ class MyComponent extends React.Component {
 		// inject them back to the forms
 		const properties = myAppState.properties;
 		const errors = myAppState.errors;
-		
+
 		return (<UIForm
 		    {...props}
 		    id={'my-unique-form-id'}
@@ -440,3 +440,116 @@ class MyComponent extends React.Component {
 Changing UIForm's `props.data` will replace the existing pieces in the form.
 
 So you need to synchronize the UIForm's state with your own stat system
+
+### Custom widgets
+
+You can add new widgets, or override an existing widget by passing a widget dictionary to the form.
+
+```
+import React from 'react';
+import { UIForm } from '@talend/react-forms/lib/UIForm';
+
+function MyComponent(props) {
+	const customWidgets = {
+		text: MyCustomIText, // this overrides the default text input widget
+		fancyInput: MyFancyInput, // this adds a new widget, with "fancyInput" name
+	};
+
+	return (<UIForm
+		{...props}
+		widgets={customWidgets}
+	/>);
+}
+```
+
+To develop a custom widget, you can use the following template
+
+```
+import PropTypes from 'prop-types';
+import React from 'react';
+import FieldTemplate from '@talend/react-forms/lib/UIForm/FieldTemplate';
+
+export default function MyWidget(props) {
+	const { id, isValid, errorMessage, onChange, onFinish, schema, value } = props;
+	const {
+		autoFocus,
+		description,
+		disabled,
+		placeholder,
+		readOnly,
+		title,
+		type,
+	} = schema;
+
+	return (
+		<FieldTemplate
+			description={description}
+			errorMessage={errorMessage}
+			id={id}
+			isValid={isValid}
+			label={title}
+			labelAfter
+			required={schema.required}
+		>
+			{// do whatever you want here}
+		</FieldTemplate>
+	);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	Text.propTypes = {
+		id: PropTypes.string,
+		isValid: PropTypes.bool,
+		errorMessage: PropTypes.string,
+		onChange: PropTypes.func.isRequired,
+		onFinish: PropTypes.func.isRequired,
+		schema: PropTypes.shape({
+			autoFocus: PropTypes.bool,
+			description: PropTypes.string,
+			disabled: PropTypes.bool,
+			placeholder: PropTypes.string,
+			readOnly: PropTypes.bool,
+			title: PropTypes.string,
+			type: PropTypes.string,
+		}),
+		value: PropTypes.any,
+	};
+}
+
+Text.defaultProps = {
+	isValid: true,
+	schema: {},
+	value: '',
+};
+```
+
+| Props | Type | Description |
+|---|---|
+| id | `string` | This is your widget id, you want use it as it is without any modification. |
+| isValid | `boolean` | If the field is valid (used by FieldTemplate). |
+| errorMessage | `string` | The error to display if the field is not valid (used by FieldTemplate). |
+| onChange | `function` | Call this when the value is supposed to be edited. |
+| onFinish | `function` | Call this when your value edition is finished. It triggers validation. |
+| schema | `object` | The merged json/ui schema. |
+| value | `any` | The value your widget handle. |
+
+
+### Display mode
+
+UIForm accept a `displayMode` props. The value `text` will switch display to a definition list, following the ui specs.
+
+```
+import React from 'react';
+import { UIForm } from '@talend/react-forms/lib/UIForm';
+
+function MyComponent(props) {
+	return (<UIForm
+		{...props}
+		displayMode="text"
+	/>);
+}
+```
+
+The rendered widgets will be selected with the name `${widgetId}_${displayMode}`.
+For example, the textarea will be the one registered under `textarea_text` id.
+You can pass custom widgets for text mode with the `widgets` props.

--- a/packages/forms/src/UIForm/README.md
+++ b/packages/forms/src/UIForm/README.md
@@ -524,7 +524,7 @@ Text.defaultProps = {
 ```
 
 | Props | Type | Description |
-|---|---|
+|---|---|---|
 | id | `string` | This is your widget id, you want use it as it is without any modification. |
 | isValid | `boolean` | If the field is valid (used by FieldTemplate). |
 | errorMessage | `string` | The error to display if the field is not valid (used by FieldTemplate). |

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import tv4 from 'tv4';
 import { translate } from 'react-i18next';
 
+import { DefaultFormTemplate, TextModeFormTemplate } from './FormTemplate';
 import merge from './merge';
 import { formPropTypes } from './utils/propTypes';
 import { validateSingle, validateAll } from './utils/validation';
@@ -16,6 +17,8 @@ import customFormats from './customFormats';
 import { I18N_DOMAIN_FORMS } from '../constants';
 import '../translate';
 import theme from './UIForm.scss';
+
+const formTemplates = { text: TextModeFormTemplate };
 
 export class UIFormComponent extends React.Component {
 	static displayName = 'TalendUIForm';
@@ -240,6 +243,38 @@ export class UIFormComponent extends React.Component {
 		if (!this.state.mergedSchema) {
 			return null;
 		}
+
+		const formTemplate =
+			this.props.displayMode === 'text' ? TextModeFormTemplate : DefaultFormTemplate;
+		const widgetsRenderer = () =>
+			this.state.mergedSchema.map((nextSchema, index) => (
+				<Widget
+					id={this.props.id}
+					key={index}
+					onChange={this.onChange}
+					onFinish={this.onFinish}
+					onTrigger={this.onTrigger}
+					schema={nextSchema}
+					properties={this.props.properties}
+					errors={this.props.errors}
+					templates={this.props.templates}
+					widgets={this.state.widgets}
+					displayMode={this.props.displayMode}
+				/>
+			));
+		const buttonsRenderer = () => (
+			<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')}>
+				<Buttons
+					id={`${this.props.id}-${this.props.id}-actions`}
+					onTrigger={this.onTrigger}
+					className={this.props.buttonBlockClass}
+					schema={{ items: actions }}
+					onClick={this.onActionClick}
+					getComponent={this.props.getComponent}
+				/>
+			</div>
+		);
+
 		return (
 			<form
 				acceptCharset={this.props.acceptCharset}
@@ -255,36 +290,7 @@ export class UIFormComponent extends React.Component {
 				onSubmit={this.onSubmit}
 				target={this.props.target}
 			>
-				<div className={theme['form-content']}>
-					{this.state.mergedSchema.map((nextSchema, index) => (
-						<Widget
-							id={this.props.id}
-							key={index}
-							onChange={this.onChange}
-							onFinish={this.onFinish}
-							onTrigger={this.onTrigger}
-							schema={nextSchema}
-							properties={this.props.properties}
-							errors={this.props.errors}
-							templates={this.props.templates}
-							widgets={this.state.widgets}
-							displayMode={this.props.displayMode}
-						/>
-					))}
-				</div>
-				{this.props.children}
-				{this.props.displayMode !== 'text' ? (
-					<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')}>
-						<Buttons
-							id={`${this.props.id}-${this.props.id}-actions`}
-							onTrigger={this.onTrigger}
-							className={this.props.buttonBlockClass}
-							schema={{ items: actions }}
-							onClick={this.onActionClick}
-							getComponent={this.props.getComponent}
-						/>
-					</div>
-				) : null}
+				{formTemplate({ children: this.props.children, widgetsRenderer, buttonsRenderer })}
 			</form>
 		);
 	}

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -268,20 +268,23 @@ export class UIFormComponent extends React.Component {
 							errors={this.props.errors}
 							templates={this.props.templates}
 							widgets={this.state.widgets}
+							displayMode={this.props.displayMode}
 						/>
 					))}
 				</div>
 				{this.props.children}
-				<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')}>
-					<Buttons
-						id={`${this.props.id}-${this.props.id}-actions`}
-						onTrigger={this.onTrigger}
-						className={this.props.buttonBlockClass}
-						schema={{ items: actions }}
-						onClick={this.onActionClick}
-						getComponent={this.props.getComponent}
-					/>
-				</div>
+				{this.props.displayMode !== 'text' ? (
+					<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')}>
+						<Buttons
+							id={`${this.props.id}-${this.props.id}-actions`}
+							onTrigger={this.onTrigger}
+							className={this.props.buttonBlockClass}
+							schema={{ items: actions }}
+							onClick={this.onActionClick}
+							getComponent={this.props.getComponent}
+						/>
+					</div>
+				) : null}
 			</form>
 		);
 	}
@@ -328,7 +331,11 @@ if (process.env.NODE_ENV !== 'production') {
 		/** Custom templates */
 		templates: PropTypes.object,
 		/** Custom widgets */
-		widgets: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+		widgets: PropTypes.object,
+		/**
+		 * Display mode: example 'text'
+		 */
+		displayMode: PropTypes.string,
 
 		/** State management impl: The change callback */
 		onChange: PropTypes.func.isRequired,

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -18,8 +18,6 @@ import { I18N_DOMAIN_FORMS } from '../constants';
 import '../translate';
 import theme from './UIForm.scss';
 
-const formTemplates = { text: TextModeFormTemplate };
-
 export class UIFormComponent extends React.Component {
 	static displayName = 'TalendUIForm';
 	constructor(props) {

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -332,9 +332,7 @@ if (process.env.NODE_ENV !== 'production') {
 		templates: PropTypes.object,
 		/** Custom widgets */
 		widgets: PropTypes.object,
-		/**
-		 * Display mode: example 'text'
-		 */
+		/** Display mode: example 'text' */
 		displayMode: PropTypes.string,
 
 		/** State management impl: The change callback */

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -24,6 +24,14 @@ describe('UIForm component', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render form in text display mode', () => {
+		// when
+		const wrapper = shallow(<UIFormComponent {...data} {...props} displayMode="text" />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	it('should render provided actions', () => {
 		// when
 		const wrapper = shallow(<UIFormComponent {...data} {...props} actions={actions} />);

--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -127,5 +127,7 @@ if (process.env.NODE_ENV !== 'production') {
 		templates: PropTypes.object,
 		/** Custom widgets */
 		widgets: PropTypes.object,
+		/** Display mode: example 'text' */
+		displayMode: PropTypes.string,
 	};
 }

--- a/packages/forms/src/UIForm/UIForm.scss
+++ b/packages/forms/src/UIForm/UIForm.scss
@@ -1,3 +1,7 @@
+.uiform {
+	font-size: 1.6rem;
+}
+
 :global(.tc-drawer-container),
 :global(.modal-body) {
 	> .uiform {

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -55,7 +55,7 @@ export default function Widget(props) {
 
 if (process.env.NODE_ENV !== 'production') {
 	Widget.propTypes = {
-		errors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+		errors: PropTypes.object,
 		id: PropTypes.string,
 		schema: PropTypes.shape({
 			conditions: PropTypes.arrayOf(

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -9,10 +9,7 @@ import shouldRender from './condition';
 
 function getWidget(displayMode, widgetId, customWidgets) {
 	// resolve the widget id depending on the display mode
-	let id = widgetId;
-	if (displayMode) {
-		id = `${widgetId}_${displayMode}`;
-	}
+	const id = displayMode ? `${widgetId}_${displayMode}` : widgetId;
 
 	// Get the widget and fallback to default mode widget if not found
 	let widget = customWidgets[id] || defaultWidgets[id];

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -7,15 +7,31 @@ import { getError } from '../utils/errors';
 import { getValue } from '../utils/properties';
 import shouldRender from './condition';
 
+function getWidget(displayMode, widgetId, customWidgets) {
+	// resolve the widget id depending on the display mode
+	let id = widgetId;
+	if (displayMode) {
+		id = `${widgetId}_${displayMode}`;
+	}
+
+	// Get the widget and fallback to default mode widget if not found
+	let widget = customWidgets[id] || defaultWidgets[id];
+	if (!widget) {
+		widget = customWidgets[widgetId] || defaultWidgets[widgetId];
+	}
+
+	return widget;
+}
+
 export default function Widget(props) {
-	const { conditions, key, options, type, validationMessage, widget } = props.schema;
+	const { conditions, key, options, type, validationMessage, widget, displayMode } = props.schema;
 	const widgetId = widget || type;
 
 	if (widgetId === 'hidden' || !shouldRender(conditions, props.properties)) {
 		return null;
 	}
 
-	const WidgetImpl = props.widgets[widgetId] || defaultWidgets[widgetId];
+	const WidgetImpl = getWidget(props.displayMode || displayMode, widgetId, props.widgets);
 
 	if (!WidgetImpl) {
 		return <p className="text-danger">Widget not found {widgetId}</p>;
@@ -56,8 +72,9 @@ if (process.env.NODE_ENV !== 'production') {
 			validationMessage: PropTypes.string,
 			widget: PropTypes.string,
 		}).isRequired,
-		properties: PropTypes.object, // eslint-disable-line react/forbid-prop-types
-		widgets: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+		properties: PropTypes.object,
+		displayMode: PropTypes.string,
+		widgets: PropTypes.object,
 	};
 }
 

--- a/packages/forms/src/UIForm/Widget/Widget.component.test.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.test.js
@@ -18,6 +18,10 @@ describe('Widget component', () => {
 		},
 		comment: '',
 	};
+	const customWidgets = {
+		customWidget: () => <div>my widget</div>,
+		customWidget_text: () => <div>my widget in text display mode</div>,
+	};
 
 	it('should render widget', () => {
 		// when
@@ -30,6 +34,25 @@ describe('Widget component', () => {
 				properties={properties}
 				schema={schema}
 				errors={errors}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render widget with the specific displayMode', () => {
+		// when
+		const wrapper = shallow(
+			<Widget
+				id={'myForm'}
+				onChange={jest.fn('onChange')}
+				onFinish={jest.fn('onFinish')}
+				onTrigger={jest.fn('onTrigger')}
+				properties={properties}
+				schema={schema}
+				errors={errors}
+				displayMode={'text'}
 			/>,
 		);
 
@@ -55,11 +78,6 @@ describe('Widget component', () => {
 
 	it('should render custom widget', () => {
 		// given
-		const widgets = {
-			customWidget() {
-				return <div>my widget</div>;
-			},
-		};
 		const customWidgetSchema = {
 			...schema,
 			type: 'customWidget',
@@ -74,7 +92,32 @@ describe('Widget component', () => {
 				properties={properties}
 				schema={customWidgetSchema}
 				errors={errors}
-				widgets={widgets}
+				widgets={customWidgets}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render custom widget in specific display mode', () => {
+		// given
+		const customWidgetSchema = {
+			...schema,
+			type: 'customWidget',
+		};
+
+		// when
+		const wrapper = shallow(
+			<Widget
+				id={'myForm'}
+				onChange={jest.fn('onChange')}
+				onTrigger={jest.fn('onTrigger')}
+				properties={properties}
+				schema={customWidgetSchema}
+				errors={errors}
+				widgets={customWidgets}
+				displayMode={'text'}
 			/>,
 		);
 

--- a/packages/forms/src/UIForm/Widget/__snapshots__/Widget.component.test.js.snap
+++ b/packages/forms/src/UIForm/Widget/__snapshots__/Widget.component.test.js.snap
@@ -35,6 +35,49 @@ exports[`Widget component should render custom widget 1`] = `
   widgets={
     Object {
       "customWidget": [Function],
+      "customWidget_text": [Function],
+    }
+  }
+/>
+`;
+
+exports[`Widget component should render custom widget in specific display mode 1`] = `
+<customWidget_text
+  displayMode="text"
+  errorMessage="This is not ok"
+  errors={
+    Object {
+      "user,firstname": "This is not ok",
+    }
+  }
+  id="myForm_user_firstname"
+  isValid={false}
+  onChange={[Function]}
+  onTrigger={[Function]}
+  options={undefined}
+  properties={
+    Object {
+      "comment": "",
+      "user": Object {
+        "firstname": "my firstname",
+        "lastname": "my lastname",
+      },
+    }
+  }
+  schema={
+    Object {
+      "key": Array [
+        "user",
+        "firstname",
+      ],
+      "type": "customWidget",
+    }
+  }
+  value="my firstname"
+  widgets={
+    Object {
+      "customWidget": [Function],
+      "customWidget_text": [Function],
     }
   }
 />
@@ -51,6 +94,44 @@ exports[`Widget component should render nothing if widget does not exist 1`] = `
 
 exports[`Widget component should render widget 1`] = `
 <Text
+  errorMessage="This is not ok"
+  errors={
+    Object {
+      "user,firstname": "This is not ok",
+    }
+  }
+  id="myForm_user_firstname"
+  isValid={false}
+  onChange={[Function]}
+  onFinish={[Function]}
+  onTrigger={[Function]}
+  options={undefined}
+  properties={
+    Object {
+      "comment": "",
+      "user": Object {
+        "firstname": "my firstname",
+        "lastname": "my lastname",
+      },
+    }
+  }
+  schema={
+    Object {
+      "key": Array [
+        "user",
+        "firstname",
+      ],
+      "type": "text",
+    }
+  }
+  value="my firstname"
+  widgets={Object {}}
+/>
+`;
+
+exports[`Widget component should render widget with the specific displayMode 1`] = `
+<TextMode
+  displayMode="text"
   errorMessage="This is not ok"
   errors={
     Object {

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -138,6 +138,120 @@ exports[`UIForm component should render form 1`] = `
 </form>
 `;
 
+exports[`UIForm component should render form in text display mode 1`] = `
+<form
+  acceptCharset={undefined}
+  action={undefined}
+  autoComplete="off"
+  className="tf-uiform theme-uiform my-form-class"
+  encType={undefined}
+  id="myFormId"
+  method={undefined}
+  name={undefined}
+  noValidate={true}
+  onReset={[Function]}
+  onSubmit={[Function]}
+  target={undefined}
+>
+  <dl
+    className="theme-form-content"
+  >
+    <Widget
+      displayMode="text"
+      errors={Object {}}
+      id="myFormId"
+      onChange={[Function]}
+      onFinish={[Function]}
+      onTrigger={[Function]}
+      properties={Object {}}
+      schema={
+        Object {
+          "autoFocus": true,
+          "description": "Hint: this is the last name",
+          "key": Array [
+            "lastname",
+          ],
+          "minlength": 10,
+          "ngModelOptions": Object {},
+          "schema": Object {
+            "minLength": 10,
+            "type": "string",
+          },
+          "title": "Last Name (with description)",
+          "type": "text",
+        }
+      }
+      templates={undefined}
+      widgets={
+        Object {
+          "custom": [Function],
+        }
+      }
+    />
+    <Widget
+      displayMode="text"
+      errors={Object {}}
+      id="myFormId"
+      onChange={[Function]}
+      onFinish={[Function]}
+      onTrigger={[Function]}
+      properties={Object {}}
+      schema={
+        Object {
+          "key": Array [
+            "firstname",
+          ],
+          "ngModelOptions": Object {},
+          "placeholder": "Enter your firstname here",
+          "required": true,
+          "schema": Object {
+            "type": "string",
+          },
+          "title": "First Name (with placeholder)",
+          "triggers": Array [
+            "after",
+          ],
+          "type": "text",
+        }
+      }
+      templates={undefined}
+      widgets={
+        Object {
+          "custom": [Function],
+        }
+      }
+    />
+    <Widget
+      displayMode="text"
+      errors={Object {}}
+      id="myFormId"
+      onChange={[Function]}
+      onFinish={[Function]}
+      onTrigger={[Function]}
+      properties={Object {}}
+      schema={
+        Object {
+          "key": Array [
+            "check",
+          ],
+          "title": "Check the thing",
+          "triggers": Array [
+            "after",
+          ],
+          "widget": "button",
+        }
+      }
+      templates={undefined}
+      widgets={
+        Object {
+          "custom": [Function],
+        }
+      }
+    />
+  </dl>
+</form>
+`;
+
 exports[`UIForm component should render provided actions 1`] = `
 <form
   acceptCharset={undefined}

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -19,6 +19,7 @@ exports[`UIForm component should render form 1`] = `
     className="theme-form-content"
   >
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}
@@ -50,6 +51,7 @@ exports[`UIForm component should render form 1`] = `
       }
     />
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}
@@ -82,6 +84,7 @@ exports[`UIForm component should render form 1`] = `
       }
     />
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}
@@ -154,6 +157,7 @@ exports[`UIForm component should render provided actions 1`] = `
     className="theme-form-content"
   >
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}
@@ -185,6 +189,7 @@ exports[`UIForm component should render provided actions 1`] = `
       }
     />
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}
@@ -217,6 +222,7 @@ exports[`UIForm component should render provided actions 1`] = `
       }
     />
     <Widget
+      displayMode={undefined}
       errors={Object {}}
       id="myFormId"
       onChange={[Function]}

--- a/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/TextMode.component.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+function FieldTemplate(props) {
+	return (
+		<div className="form-group">
+			<dt>
+				<label htmlFor={props.id} className="control-label">
+					{props.label}
+				</label>
+			</dt>
+			<dd id={props.id}>{props.children}</dd>
+		</div>
+	);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	FieldTemplate.propTypes = {
+		children: PropTypes.node,
+		id: PropTypes.string,
+		label: PropTypes.string,
+	};
+}
+FieldTemplate.displayName = 'FieldTemplate';
+
+export default FieldTemplate;

--- a/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/TextMode.component.test.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/TextMode.component.test.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TextModeFieldTemplate from './TextMode.component';
+
+describe('FieldTemplate in text display mode', () => {
+	it('should render dt/dd', () => {
+		// when
+		const wrapper = shallow(
+			<TextModeFieldTemplate id={'myAwesomeField'} label={'My awesome label'}>
+				My value as chrildren
+			</TextModeFieldTemplate>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FieldTemplate in text display mode should render dt/dd 1`] = `
+<div
+  className="form-group"
+>
+  <dt>
+    <label
+      className="control-label"
+      htmlFor="myAwesomeField"
+    >
+      My awesome label
+    </label>
+  </dt>
+  <dd
+    id="myAwesomeField"
+  >
+    My value as chrildren
+  </dd>
+</div>
+`;

--- a/packages/forms/src/UIForm/fields/FieldTemplate/index.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/index.js
@@ -1,3 +1,5 @@
 import FieldTemplate from './FieldTemplate.component';
+import TextMode from './displayMode/TextMode.component';
 
+export { TextMode };
 export default FieldTemplate;

--- a/packages/forms/src/UIForm/fields/Text/TextTextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Text/TextTextMode.component.js
@@ -1,0 +1,31 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import FieldTemplate from '../FieldTemplate';
+
+export default function TextTextMode(props) {
+	const { id, schema, value } = props;
+	const { title, type } = schema;
+
+	return (
+		<FieldTemplate id={id} label={title}>
+			<div>{type === 'password' && value ? '**********' : value}</div>
+		</FieldTemplate>
+	);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	TextTextMode.propTypes = {
+		id: PropTypes.string,
+		schema: PropTypes.shape({
+			title: PropTypes.string,
+			type: PropTypes.string,
+		}),
+		value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	};
+}
+
+TextTextMode.defaultProps = {
+	isValid: true,
+	schema: {},
+	value: '',
+};

--- a/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.js
@@ -1,8 +1,8 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import FieldTemplate from '../FieldTemplate';
+import FieldTemplate from '../../FieldTemplate';
 
-export default function TextTextMode(props) {
+export default function TextMode(props) {
 	const { id, schema, value } = props;
 	const { title, type } = schema;
 
@@ -14,7 +14,7 @@ export default function TextTextMode(props) {
 }
 
 if (process.env.NODE_ENV !== 'production') {
-	TextTextMode.propTypes = {
+	TextMode.propTypes = {
 		id: PropTypes.string,
 		schema: PropTypes.shape({
 			title: PropTypes.string,
@@ -24,8 +24,7 @@ if (process.env.NODE_ENV !== 'production') {
 	};
 }
 
-TextTextMode.defaultProps = {
-	isValid: true,
+TextMode.defaultProps = {
 	schema: {},
 	value: '',
 };

--- a/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import FieldTemplate from '../../FieldTemplate';
+import { TextMode as FieldTemplate } from '../../FieldTemplate';
 
 export default function TextMode(props) {
 	const { id, schema, value } = props;
@@ -8,7 +8,7 @@ export default function TextMode(props) {
 
 	return (
 		<FieldTemplate id={id} label={title}>
-			<div>{type === 'password' && value ? '**********' : value}</div>
+			{type === 'password' && value ? '**********' : value}
 		</FieldTemplate>
 	);
 }

--- a/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/displayMode/TextMode.component.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TextMode from './TextMode.component';
+
+describe('Text field text display mode', () => {
+	const schema = {
+		title: 'My input title',
+		type: 'text',
+	};
+
+	it('should render input', () => {
+		// when
+		const wrapper = shallow(<TextMode id={'myForm'} schema={schema} value={'toto'} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render password input', () => {
+		// when
+		const wrapper = shallow(
+			<TextMode id={'myForm'} schema={{ ...schema, type: 'password' }} value={'toto'} />,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/forms/src/UIForm/fields/Text/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Text/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text field text display mode should render input 1`] = `
+<FieldTemplate
+  id="myForm"
+  isValid={true}
+  label="My input title"
+>
+  <div>
+    toto
+  </div>
+</FieldTemplate>
+`;
+
+exports[`Text field text display mode should render password input 1`] = `
+<FieldTemplate
+  id="myForm"
+  isValid={true}
+  label="My input title"
+>
+  <div>
+    **********
+  </div>
+</FieldTemplate>
+`;

--- a/packages/forms/src/UIForm/fields/Text/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Text/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -3,23 +3,17 @@
 exports[`Text field text display mode should render input 1`] = `
 <FieldTemplate
   id="myForm"
-  isValid={true}
   label="My input title"
 >
-  <div>
-    toto
-  </div>
+  toto
 </FieldTemplate>
 `;
 
 exports[`Text field text display mode should render password input 1`] = `
 <FieldTemplate
   id="myForm"
-  isValid={true}
   label="My input title"
 >
-  <div>
-    **********
-  </div>
+  **********
 </FieldTemplate>
 `;

--- a/packages/forms/src/UIForm/fields/Text/index.js
+++ b/packages/forms/src/UIForm/fields/Text/index.js
@@ -1,3 +1,5 @@
 import Text from './Text.component';
+import TextTextMode from './TextTextMode.component';
 
+export { TextTextMode };
 export default Text;

--- a/packages/forms/src/UIForm/fields/Text/index.js
+++ b/packages/forms/src/UIForm/fields/Text/index.js
@@ -1,5 +1,5 @@
 import Text from './Text.component';
-import TextTextMode from './TextTextMode.component';
+import TextTextMode from './displayMode/TextMode.component';
 
 export { TextTextMode };
 export default Text;

--- a/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import FieldTemplate from '../../FieldTemplate';
+import { TextMode as FieldTemplate } from '../../FieldTemplate';
 
 export default function TextMode({ id, schema, value }) {
 	const { rows = 5, title } = schema;

--- a/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.js
@@ -1,0 +1,29 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import FieldTemplate from '../../FieldTemplate';
+
+export default function TextMode({ id, schema, value }) {
+	const { rows = 5, title } = schema;
+
+	return (
+		<FieldTemplate id={id} label={title}>
+			<pre style={{ height: `${rows * 2}rem`, fontSize: 'inherit' }}>{value}</pre>
+		</FieldTemplate>
+	);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	TextMode.propTypes = {
+		id: PropTypes.string,
+		schema: PropTypes.shape({
+			rows: PropTypes.number,
+			title: PropTypes.string,
+		}),
+		value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	};
+}
+
+TextMode.defaultProps = {
+	schema: {},
+	value: '',
+};

--- a/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.test.js
+++ b/packages/forms/src/UIForm/fields/TextArea/displayMode/TextMode.component.test.js
@@ -1,0 +1,32 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TextArea from './TextMode.component';
+
+describe('TextArea field text display mode', () => {
+	const schema = {
+		title: 'My input title',
+	};
+
+	it('should render textarea', () => {
+		// when
+		const wrapper = shallow(<TextArea id={'myForm'} schema={schema} value={'toto'} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render provided rows', () => {
+		// given
+		const schemaWithRows = {
+			...schema,
+			rows: 10,
+		};
+
+		// when
+		const wrapper = shallow(<TextArea id={'myForm'} schema={schemaWithRows} value={'toto'} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/forms/src/UIForm/fields/TextArea/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/TextArea/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -1,0 +1,39 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TextArea field text display mode should render provided rows 1`] = `
+<FieldTemplate
+  id="myForm"
+  isValid={true}
+  label="My input title"
+>
+  <pre
+    style={
+      Object {
+        "fontSize": "inherit",
+        "height": "20rem",
+      }
+    }
+  >
+    toto
+  </pre>
+</FieldTemplate>
+`;
+
+exports[`TextArea field text display mode should render textarea 1`] = `
+<FieldTemplate
+  id="myForm"
+  isValid={true}
+  label="My input title"
+>
+  <pre
+    style={
+      Object {
+        "fontSize": "inherit",
+        "height": "10rem",
+      }
+    }
+  >
+    toto
+  </pre>
+</FieldTemplate>
+`;

--- a/packages/forms/src/UIForm/fields/TextArea/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/TextArea/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -3,7 +3,6 @@
 exports[`TextArea field text display mode should render provided rows 1`] = `
 <FieldTemplate
   id="myForm"
-  isValid={true}
   label="My input title"
 >
   <pre
@@ -22,7 +21,6 @@ exports[`TextArea field text display mode should render provided rows 1`] = `
 exports[`TextArea field text display mode should render textarea 1`] = `
 <FieldTemplate
   id="myForm"
-  isValid={true}
   label="My input title"
 >
   <pre

--- a/packages/forms/src/UIForm/fields/TextArea/index.js
+++ b/packages/forms/src/UIForm/fields/TextArea/index.js
@@ -1,3 +1,5 @@
 import TextArea from './TextArea.component';
+import TextAreaTextMode from './displayMode/TextMode.component';
 
+export { TextAreaTextMode };
 export default TextArea;

--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -14,7 +14,7 @@ import MultiSelectTag from '../fields/MultiSelectTag';
 import Radios from '../fields/Radios';
 import RadioOrSelect from '../fields/RadioOrSelect';
 import Select from '../fields/Select';
-import Text from '../fields/Text';
+import Text, { TextTextMode } from '../fields/Text';
 import TextArea from '../fields/TextArea';
 import Toggle from '../fields/Toggle';
 
@@ -37,6 +37,11 @@ const widgets = {
 	submit: Button,
 	text: Text,
 	textarea: TextArea,
+
+	// fields: text mode
+	number_text: TextTextMode,
+	password_text: TextTextMode,
+	text_text: TextTextMode,
 
 	// widgets
 	buttons: Buttons,

--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -15,7 +15,7 @@ import Radios from '../fields/Radios';
 import RadioOrSelect from '../fields/RadioOrSelect';
 import Select from '../fields/Select';
 import Text, { TextTextMode } from '../fields/Text';
-import TextArea from '../fields/TextArea';
+import TextArea, { TextAreaTextMode } from '../fields/TextArea';
 import Toggle from '../fields/Toggle';
 
 const widgets = {
@@ -42,6 +42,7 @@ const widgets = {
 	number_text: TextTextMode,
 	password_text: TextTextMode,
 	text_text: TextTextMode,
+	textarea_text: TextAreaTextMode,
 
 	// widgets
 	buttons: Buttons,

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { action } from '@storybook/addon-actions';
 import { object } from '@storybook/addon-knobs';
 import IconsProvider from '@talend/react-components/lib/IconsProvider';
@@ -59,6 +60,11 @@ function createCommonProps(tab) {
 }
 
 class DisplayModeForm extends React.Component {
+	static propTypes = {
+		category: PropTypes.string,
+		doc: PropTypes.string,
+	};
+
 	constructor(props) {
 		super(props);
 		this.state = {};
@@ -71,7 +77,19 @@ class DisplayModeForm extends React.Component {
 
 	render() {
 		return (
-			<div>
+			<section>
+				<IconsProvider />
+				{this.props.doc && (
+					<a
+						href={`https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/${
+							this.props.category
+						}/${this.props.doc}`}
+						target="_blank"
+						rel="noopener noreferrer"
+					>
+						Documentation
+					</a>
+				)}
 				<form>
 					<div className="form-group">
 						<div className="checkbox">
@@ -90,7 +108,7 @@ class DisplayModeForm extends React.Component {
 				<hr style={{ borderColor: 'black' }} />
 
 				<UIForm {...this.props} displayMode={this.state.displayMode} />
-			</div>
+			</section>
 		);
 	}
 }
@@ -106,19 +124,12 @@ function createStory(category, sampleFilenames, filename) {
 		story() {
 			const { doc, ...data } = object(name, sampleFilenames(filename));
 			return (
-				<section>
-					<IconsProvider />
-					{doc && (
-						<a
-							href={`https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/${category}/${doc}`}
-							target="_blank"
-							rel="noopener noreferrer"
-						>
-							Documentation
-						</a>
-					)}
-					<DisplayModeForm {...createCommonProps('state')} data={data} />
-				</section>
+				<DisplayModeForm
+					{...createCommonProps('state')}
+					data={data}
+					doc={doc}
+					category={category}
+				/>
 			);
 		},
 	};

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -58,6 +58,43 @@ function createCommonProps(tab) {
 	};
 }
 
+class DisplayModeForm extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = {};
+		this.toggleDisplayModeText = this.toggleDisplayModeText.bind(this);
+	}
+
+	toggleDisplayModeText(event) {
+		this.setState({ displayMode: event.target.checked ? 'text' : undefined });
+	}
+
+	render() {
+		return (
+			<div>
+				<form>
+					<div className="form-group">
+						<div className="checkbox">
+							<label>
+								<input
+									type="checkbox"
+									checked={this.state.displayMode === 'text'}
+									onChange={this.toggleDisplayModeText}
+								/>
+								Text mode
+							</label>
+						</div>
+					</div>
+				</form>
+
+				<hr style={{ borderColor: 'black' }} />
+
+				<UIForm {...this.props} displayMode={this.state.displayMode} />
+			</div>
+		);
+	}
+}
+
 function createStory(category, sampleFilenames, filename) {
 	const sampleNameMatches = filename.match(sampleFilenameRegex);
 	const sampleName = sampleNameMatches[sampleNameMatches.length - 1];
@@ -80,7 +117,7 @@ function createStory(category, sampleFilenames, filename) {
 							Documentation
 						</a>
 					)}
-					<UIForm {...createCommonProps('state')} data={data} />
+					<DisplayModeForm {...createCommonProps('state')} data={data} />
 				</section>
 			);
 		},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With old forms, to display the info in text format we had JSONSchemaRenderer component.
Adapting JSONSchemaRenderer to the new format is not a good solution as fieldsets widgets (tabs, arrays, etc) would have to be implemented again, even if we have common styles with the form.

**What is the chosen solution to this problem?**
The approach here is to introduce display mode.
- to provide specific implementations of each widgets for a `text` display mode.
- they are registered in the widget dictionary with the key `{widgetId}_{displayMode)`. Example `checkbox_text` for text display mode.
- UIForm will select the right widget based on a `props.displayMode` (form global mode) or `uiSchema.displayMode` (property specific mode)
- storybook has now a checkbox to switch from classical and text display mode

For info : 
- [dl MDN page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/dl)
- [dt MDN page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/dt)
- [dd MDN page](https://developer.mozilla.org/fr/docs/Web/HTML/Element/dd)

Our structure is correct, event if the storybook a11y check returns an error. Plus, I tested with a screen reader
```
<dl>
    <div>
        <dt></dt>
        <dd></dd>
    <</div>
</dl>
```

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
