### PR TITLE
chore(cmf/middleware): passing headers to onActionresponse

### DIFF
--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -8,9 +8,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/Inject.component.js
   23:2  warning  Unexpected console statement  no-console
 
-/home/travis/build/Talend/ui/packages/cmf/src/middlewares/http/middleware.js
-  166:39  error  Unexpected block statement surrounding arrow body  arrow-body-style
-
 /home/travis/build/Talend/ui/packages/cmf/src/sagaRouter/router.js
   158:2   warning  Unexpected constant condition                no-constant-condition
   163:54  error    There should be no spaces inside this paren  space-in-parens
@@ -19,5 +16,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/sagas/collection.js
   10:1  error  Prefer default export  import/prefer-default-export
 
-✖ 7 problems (4 errors, 3 warnings)
+✖ 6 problems (3 errors, 3 warnings)
 

--- a/output/cmf.eslint.txt
+++ b/output/cmf.eslint.txt
@@ -8,6 +8,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/Inject.component.js
   23:2  warning  Unexpected console statement  no-console
 
+/home/travis/build/Talend/ui/packages/cmf/src/middlewares/http/middleware.js
+  166:39  error  Unexpected block statement surrounding arrow body  arrow-body-style
+
 /home/travis/build/Talend/ui/packages/cmf/src/sagaRouter/router.js
   158:2   warning  Unexpected constant condition                no-constant-condition
   163:54  error    There should be no spaces inside this paren  space-in-parens
@@ -16,5 +19,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/cmf/src/sagas/collection.js
   10:1  error  Prefer default export  import/prefer-default-export
 
-✖ 6 problems (3 errors, 3 warnings)
+✖ 7 problems (4 errors, 3 warnings)
 

--- a/packages/cmf/__tests__/actions/http.test.js
+++ b/packages/cmf/__tests__/actions/http.test.js
@@ -119,13 +119,18 @@ describe('actions.http', () => {
 			type: 'DONT_CARE',
 			onResponse: 'CALL_ME_BACK',
 		};
-		const newAction = http.onActionResponse(action, response);
+		const headers = {
+			'content-type': 'application/json'
+		};
+		const newAction = http.onActionResponse(action, response, headers);
 		expect(newAction.type).toBe('CALL_ME_BACK');
 		expect(newAction.response).toBe(response);
+		expect(newAction.headers).toBe(headers);
 
 		action.onResponse = jest.fn();
-		http.onActionResponse(action, response);
+		http.onActionResponse(action, response, headers);
 		expect(action.onResponse.mock.calls.length).toBe(1);
 		expect(action.onResponse.mock.calls[0][0]).toBe(response);
+		expect(action.onResponse.mock.calls[0][1]).toBe(headers);
 	});
 });

--- a/packages/cmf/__tests__/middlewares/__snapshots__/http.test.js.snap
+++ b/packages/cmf/__tests__/middlewares/__snapshots__/http.test.js.snap
@@ -31,7 +31,12 @@ Object {
 
 exports[`json function should resolve if attr json is on response 1`] = `
 Object {
-  "foo": "bar",
+  "data": Object {
+    "foo": "bar",
+  },
+  "headers": Object {
+    "content-type": "application/json",
+  },
 }
 `;
 

--- a/packages/cmf/__tests__/middlewares/http.test.js
+++ b/packages/cmf/__tests__/middlewares/http.test.js
@@ -431,6 +431,9 @@ describe('json function', () => {
 	it('should resolve if attr json is on response', () => {
 		const response = {
 			status: HTTP_STATUS.OK,
+			headers: {
+				'content-type': 'application/json',
+			},
 			json: () => new Promise(resolve => resolve({ foo: 'bar' })),
 		};
 		return handleResponse(response).then(r => {

--- a/packages/cmf/src/actions/http.js
+++ b/packages/cmf/src/actions/http.js
@@ -42,13 +42,14 @@ function onResponse(response) {
 	};
 }
 
-function onActionResponse(action, response) {
+function onActionResponse(action, response, headers) {
 	if (typeof action.onResponse === 'function') {
-		return action.onResponse(response);
+		return action.onResponse(response, headers);
 	}
 	return {
 		type: action.onResponse,
 		response,
+		headers,
 	};
 }
 

--- a/packages/cmf/src/middlewares/http/middleware.js
+++ b/packages/cmf/src/middlewares/http/middleware.js
@@ -163,8 +163,7 @@ export function handleResponse(response) {
 		return Promise.resolve({});
 	}
 	if (response.json) {
-		return response.json()
-			.then(json => ({ data: json, headers: response.headers }));
+		return response.json().then(json => ({ data: json, headers: response.headers }));
 	}
 	return Promise.reject(new HTTPError(response));
 }

--- a/packages/cmf/src/middlewares/http/middleware.js
+++ b/packages/cmf/src/middlewares/http/middleware.js
@@ -163,7 +163,10 @@ export function handleResponse(response) {
 		return Promise.resolve({});
 	}
 	if (response.json) {
-		return response.json();
+		return response.json()
+			.then((json) => {
+				return Promise.resolve({ data: json, headers: response.headers });
+			});
 	}
 	return Promise.reject(new HTTPError(response));
 }
@@ -238,14 +241,14 @@ export const httpMiddleware = (middlewareDefaultConfig = {}) => ({
 		.then(handleResponse)
 		.then(response => {
 			const newAction = Object.assign({}, action);
-			dispatch(http.onResponse(response));
+			dispatch(http.onResponse(response.data));
 			if (newAction.transform) {
-				newAction.response = newAction.transform(response);
+				newAction.response = newAction.transform(response.data);
 			} else {
-				newAction.response = response;
+				newAction.response = response.data;
 			}
 			if (newAction.onResponse) {
-				dispatch(http.onActionResponse(newAction, newAction.response));
+				dispatch(http.onActionResponse(newAction, newAction.response, response.headers));
 			}
 			return next(newAction);
 		})

--- a/packages/cmf/src/middlewares/http/middleware.js
+++ b/packages/cmf/src/middlewares/http/middleware.js
@@ -163,10 +163,9 @@ export function handleResponse(response) {
 		return Promise.resolve({});
 	}
 	if (response.json) {
-		return response.json()
-			.then((json) => {
-				return Promise.resolve({ data: json, headers: response.headers });
-			});
+		return response.json().then(json => {
+			return Promise.resolve({ data: json, headers: response.headers });
+		});
 	}
 	return Promise.reject(new HTTPError(response));
 }

--- a/packages/cmf/src/middlewares/http/middleware.js
+++ b/packages/cmf/src/middlewares/http/middleware.js
@@ -163,9 +163,8 @@ export function handleResponse(response) {
 		return Promise.resolve({});
 	}
 	if (response.json) {
-		return response.json().then(json => {
-			return Promise.resolve({ data: json, headers: response.headers });
-		});
+		return response.json()
+			.then(json => ({ data: json, headers: response.headers }));
 	}
 	return Promise.reject(new HTTPError(response));
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In case of file upload the file name is sent in the response headers so we need to have access to it in onResponse callback, might also be usefull in other cases.

**What is the chosen solution to this problem?**
adding headers as a parameter of onActionResponse callback.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
