### PR TITLE
fix(UIForms): hidden input don't have labels anymore

### DIFF
--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -16,6 +16,10 @@ export default function Text(props) {
 		type,
 	} = schema;
 
+	if (type === 'hidden') {
+		return <input id={id} type={type} value={value} />;
+	}
+
 	return (
 		<FieldTemplate
 			description={description}

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -168,4 +168,26 @@ describe('Text field', () => {
 		// then
 		expect(onFinish).toBeCalledWith(event, { schema });
 	});
+
+	it('should render hidden input', () => {
+		// given
+		const hiddenSchema = {
+			...schema,
+			type: 'hidden',
+		};
+
+		// when
+		const wrapper = shallow(
+			<Text
+				id={'myForm'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={hiddenSchema}
+				value={'toto'}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
 });

--- a/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
@@ -26,6 +26,14 @@ exports[`Text field should render disabled input 1`] = `
 </FieldTemplate>
 `;
 
+exports[`Text field should render hidden input 1`] = `
+<input
+  id="myForm"
+  type="hidden"
+  value="toto"
+/>
+`;
+
 exports[`Text field should render input 1`] = `
 <FieldTemplate
   description="my text input hint"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When defining a hidden input in uiSchema, the input is not displayed, but its attached label and form-group are visible.

**What is the chosen solution to this problem?**
Render only the hidden input.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
