### PR TITLE
chore(scripts/webpack): Ensure talend script enable webpack progress mode in dev mode

### DIFF
--- a/packages/scripts/preset/config/webpack.config.prod.js
+++ b/packages/scripts/preset/config/webpack.config.prod.js
@@ -21,5 +21,6 @@ module.exports = ({ getUserConfig }) => {
 			],
 		},
 		plugins,
+		bail: true,
 	};
 };

--- a/packages/scripts/scripts/build.js
+++ b/packages/scripts/scripts/build.js
@@ -17,7 +17,7 @@ module.exports = function build(env) {
 	// Run webpack dev server
 	return spawn.sync(
 		webpack,
-		['--config', hereRelative(__dirname, '../config/webpack.config.js')],
+		['--config', hereRelative(__dirname, '../config/webpack.config.js'), '--progress'],
 		{ stdio: 'inherit', env }
 	);
 };

--- a/packages/scripts/scripts/start.js
+++ b/packages/scripts/scripts/start.js
@@ -11,8 +11,8 @@ module.exports = function start(env) {
 			'--config', hereRelative(__dirname, '../config/webpack.config.js'),
 			'--content-base', 'build/',
 			'--open',
+			'--progress',
 		],
 		{ stdio: 'inherit', env }
 	);
 };
-


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

No progress shown in dev mode for webpack. When the processing is long you get this bad "what is happening" feeling.

**What is the chosen solution to this problem?**

Enable progress by default in dev mode and make it configurable through talend-script config.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
