### PR TITLE
doc(UIForm): import error in the samples

### DIFF
--- a/packages/forms/src/UIForm/README.md
+++ b/packages/forms/src/UIForm/README.md
@@ -449,7 +449,7 @@ So you need to synchronize the UIForm's state with your own stat system
 
 You can add new widgets, or override an existing widget by passing a widget dictionary to the form.
 
-```
+```javascript
 import React from 'react';
 import { UIForm } from '@talend/react-forms/lib/UIForm';
 
@@ -468,10 +468,10 @@ function MyComponent(props) {
 
 To develop a custom widget, you can use the following template
 
-```
+```javascript
 import PropTypes from 'prop-types';
 import React from 'react';
-import FieldTemplate from '@talend/react-forms/lib/UIForm/FieldTemplate';
+import FieldTemplate from '@talend/react-forms/lib/UIForm/fields/FieldTemplate';
 
 export default function MyWidget(props) {
 	const { id, isValid, errorMessage, onChange, onFinish, schema, value } = props;
@@ -542,7 +542,7 @@ Text.defaultProps = {
 
 UIForm accept a `displayMode` props. The value `text` will switch display to a definition list, following the ui specs.
 
-```
+```javascript
 import React from 'react';
 import { UIForm } from '@talend/react-forms/lib/UIForm';
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
While trying to make a custom widget, I've found a small error in the samples.

**What is the chosen solution to this problem?**
Correct the typo.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
