### PR TITLE
 feat(components): manage object item in datalist_3

### DIFF
--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -179,8 +179,6 @@ class Datalist extends Component {
 	 */
 	getSelectedLabel() {
 		if (this.state.titleMapping) {
-			// const titleMap = this.state.titleMapping[this.state.value];
-			// return (titleMap && titleMap.name) || this.state.value;
 			return this.state.titleMapping[this.state.value] || this.state.value;
 		}
 		return this.state.value;
@@ -249,9 +247,10 @@ class Datalist extends Component {
 	 */
 	updateValue(event, value, persist) {
 		const previousValue = persist ? value : this.state.previousValue;
+		const newValue = typeof value === 'object' ? value.name : value;
 		this.setState({
 			// setting the filtered value so it needs to be actual value
-			value: value.name,
+			value: newValue,
 		});
 		if (persist) {
 			let enumValue = value;
@@ -259,7 +258,7 @@ class Datalist extends Component {
 				const groups = this.props.titleMap;
 				for (let sectionIndex = 0; sectionIndex < groups.length; sectionIndex += 1) {
 					const itemObj = groups[sectionIndex].suggestions.find(
-						item => (item.title || item.name) === value,
+						item => item.name === value,
 					);
 					if (itemObj) {
 						enumValue = itemObj;
@@ -271,7 +270,7 @@ class Datalist extends Component {
 			if (selectedEnumValue || !this.props.restricted) {
 				this.props.onChange(event, { value: selectedEnumValue || value });
 				this.setState({
-					previousValue: previousValue.title || previousValue.name,
+					previousValue: previousValue.name,
 				});
 			} else {
 				this.resetValue();
@@ -324,14 +323,14 @@ class Datalist extends Component {
 					.map(group => ({
 						...group,
 						suggestions: value
-							? group.suggestions.filter(item => regex.test(item.title || item.name))
+							? group.suggestions.filter(item => regex.test(item.name))
 							: group.suggestions,
 					}))
 					.filter(group => group.suggestions.length > 0);
 			} else {
 				// only one group so items are inline
 				groups = value
-					? groups.filter(itemValue => regex.test(itemValue.title || itemValue.name))
+					? groups.filter(itemValue => regex.test(itemValue.name))
 					: groups;
 			}
 		}

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -179,6 +179,8 @@ class Datalist extends Component {
 	 */
 	getSelectedLabel() {
 		if (this.state.titleMapping) {
+			// const titleMap = this.state.titleMapping[this.state.value];
+			// return (titleMap && titleMap.name) || this.state.value;
 			return this.state.titleMapping[this.state.value] || this.state.value;
 		}
 		return this.state.value;
@@ -247,17 +249,18 @@ class Datalist extends Component {
 	 */
 	updateValue(event, value, persist) {
 		const previousValue = persist ? value : this.state.previousValue;
-		const newValue = typeof value === 'object' ? value.title : value;
 		this.setState({
 			// setting the filtered value so it needs to be actual value
-			value: newValue,
+			value: value.name,
 		});
 		if (persist) {
-			let enumValue = this.props.titleMap.find(item => item.name === value);
+			let enumValue = value;
 			if (this.props.multiSection) {
 				const groups = this.props.titleMap;
 				for (let sectionIndex = 0; sectionIndex < groups.length; sectionIndex += 1) {
-					const itemObj = groups[sectionIndex].suggestions.find(item => item.name === newValue);
+					const itemObj = groups[sectionIndex].suggestions.find(
+						item => (item.title || item.name) === value,
+					);
 					if (itemObj) {
 						enumValue = itemObj;
 						break;
@@ -268,7 +271,7 @@ class Datalist extends Component {
 			if (selectedEnumValue || !this.props.restricted) {
 				this.props.onChange(event, { value: selectedEnumValue || value });
 				this.setState({
-					previousValue: typeof previousValue === 'object' ? previousValue.title : previousValue,
+					previousValue: previousValue.title || previousValue.name,
 				});
 			} else {
 				this.resetValue();
@@ -294,13 +297,7 @@ class Datalist extends Component {
 	 * return the items list
 	 */
 	buildGroupItems() {
-		if (this.props.multiSection) {
-			return this.props.titleMap.map(group => ({
-				title: group.title,
-				suggestions: group.suggestions.map(item => ({ title: item.name })),
-			}));
-		}
-		return this.props.titleMap.map(item => item.name);
+		return this.props.titleMap;
 	}
 
 	/**
@@ -327,13 +324,15 @@ class Datalist extends Component {
 					.map(group => ({
 						...group,
 						suggestions: value
-							? group.suggestions.filter(item => regex.test(item.title))
+							? group.suggestions.filter(item => regex.test(item.title || item.name))
 							: group.suggestions,
 					}))
 					.filter(group => group.suggestions.length > 0);
 			} else {
 				// only one group so items are inline
-				groups = value ? groups.filter(itemValue => regex.test(itemValue)) : groups;
+				groups = value
+					? groups.filter(itemValue => regex.test(itemValue.title || itemValue.name))
+					: groups;
 			}
 		}
 

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -257,9 +257,7 @@ class Datalist extends Component {
 			if (this.props.multiSection) {
 				const groups = this.props.titleMap;
 				for (let sectionIndex = 0; sectionIndex < groups.length; sectionIndex += 1) {
-					const itemObj = groups[sectionIndex].suggestions.find(
-						item => item.name === value,
-					);
+					const itemObj = groups[sectionIndex].suggestions.find(item => item.name === value);
 					if (itemObj) {
 						enumValue = itemObj;
 						break;
@@ -329,9 +327,7 @@ class Datalist extends Component {
 					.filter(group => group.suggestions.length > 0);
 			} else {
 				// only one group so items are inline
-				groups = value
-					? groups.filter(itemValue => regex.test(itemValue.name))
-					: groups;
+				groups = value ? groups.filter(itemValue => regex.test(itemValue.name)) : groups;
 			}
 		}
 

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -12,17 +12,17 @@ const props = {
 	readOnly: false,
 	title: 'My List',
 	titleMap: [
-		{ name: 'foo', value: 'foo' },
+		{ name: 'foo', value: 'foo', description: 'foo description' },
 		{ name: 'bar', value: 'bar' },
-		{ name: 'foobar', value: 'foobar' },
+		{ name: 'foobar', value: 'foobar', description: 'foobar description' },
 		{ name: 'lol', value: 'lol' },
 	],
 };
 
 const multiSectionMap = [
-	{ title: 'cat 1', suggestions: [{ name: 'foo', value: 'foo' }] },
+	{ title: 'cat 1', suggestions: [{ name: 'foo', value: 'foo', description: 'foo description' }] },
 	{ title: 'cat 2', suggestions: [{ name: 'bar', value: 'bar' }] },
-	{ title: 'cat 3', suggestions: [{ name: 'foobar', value: 'foobar' }] },
+	{ title: 'cat 3', suggestions: [{ name: 'foobar', value: 'foobar', description: 'foobar description' }] },
 	{ title: 'cat 4', suggestions: [{ name: 'lol', value: 'lol' }] },
 ];
 
@@ -69,8 +69,8 @@ describe('Datalist component', () => {
 
 		// then
 		expect(wrapper.find(Typeahead).props().items).toEqual([
-			{ suggestions: [{ title: 'foo' }], title: 'cat 1' },
-			{ suggestions: [{ title: 'foobar' }], title: 'cat 3' },
+			{ suggestions: [{ name: 'foo', value: 'foo', description: 'foo description' }], title: 'cat 1' },
+			{ suggestions: [{ name: 'foobar', value: 'foobar', description: 'foobar description' }], title: 'cat 3' },
 		]);
 	});
 
@@ -124,7 +124,7 @@ describe('Datalist component', () => {
 			.at(0)
 			.simulate('change', { target: { value: 'foo' } });
 		// then
-		expect(wrapper.find(Typeahead).props().items).toEqual(['foo', 'foobar']);
+		expect(wrapper.find(Typeahead).props().items).toEqual([{ name: 'foo', value: 'foo', description: 'foo description' }, { name: 'foobar', value: 'foobar', description: 'foobar description' }]);
 	});
 
 	it('should reset suggestions and change value on blur when value in suggestions', () => {
@@ -230,7 +230,7 @@ describe('Datalist component', () => {
 			.simulate('focus');
 
 		// then
-		expect(wrapper.find(Typeahead).props().items).toEqual(['foo', 'bar', 'foobar', 'lol']);
+		expect(wrapper.find(Typeahead).props().items).toEqual([{ name: 'foo', value: 'foo', description: 'foo description' }, { name: 'bar', value: 'bar' }, { name: 'foobar', value: 'foobar', description: 'foobar description' }, { name: 'lol', value: 'lol' }]);
 		expect(wrapper.find(Typeahead).props().value).toBe('foo');
 	});
 

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -171,7 +171,7 @@ export function renderItem(item, { value }) {
 	if (typeof item === 'string') {
 		title = item;
 	} else {
-		title = item.title ? item.title.trim() : '';
+		title = (item.title || item.name || '').trim();
 		description = item.description;
 	}
 	return (

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -171,7 +171,7 @@ export function renderItem(item, { value }) {
 	if (typeof item === 'string') {
 		title = item;
 	} else {
-		title = (item.title || item.name || '').trim();
+		title = item ? item.name.trim() : '';
 		description = item.description;
 	}
 	return (

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -171,7 +171,7 @@ export function renderItem(item, { value }) {
 	if (typeof item === 'string') {
 		title = item;
 	} else {
-		title = item ? item.name.trim() : '';
+		title = item && item.name ? item.name.trim() : '';
 		description = item.description;
 	}
 	return (

--- a/packages/components/stories/Datalist.js
+++ b/packages/components/stories/Datalist.js
@@ -11,9 +11,9 @@ const propsMultiSection = {
 	placeholder: 'search for something ...',
 	readOnly: false,
 	titleMap: [
-		{ title: 'cat 1', suggestions: [{ name: 'foo', value: 'foo' }, { name: 'faa', value: 'faa' }] },
+		{ title: 'cat 1', suggestions: [{ name: 'foo', value: 'foo', description: 'foo description' }, { name: 'faa', value: 'faa' }] },
 		{ title: 'cat 2', suggestions: [{ name: 'bar', value: 'bar' }] },
-		{ title: 'cat 3', suggestions: [{ name: 'foobar', value: 'foobar' }] },
+		{ title: 'cat 3', suggestions: [{ name: 'foobar', value: 'foobar', description: 'foobar description' }] },
 		{ title: 'cat 4', suggestions: [{ name: 'lol', value: 'lol' }] },
 	],
 	onFinish: action('onFinish'),
@@ -27,9 +27,9 @@ const singleSectionProps = {
 	placeholder: 'search for something ...',
 	readOnly: false,
 	titleMap: [
-		{ name: 'My foo', value: 'foo' },
+		{ name: 'My foo', value: 'foo', description: 'foo description' },
 		{ name: 'My bar', value: 'bar' },
-		{ name: 'My foobar', value: 'foobar' },
+		{ name: 'My foobar', value: 'foobar', description: 'foobar description' },
 		{ name: 'My lol', value: 'lol' },
 	],
 	onFinish: action('onFinish'),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add the possibility to have a description on one or more item in the datalist

![image](https://user-images.githubusercontent.com/32456736/44906133-59106d00-ad14-11e8-8779-cff0dbea7533.png)


**What is the chosen solution to this problem?**
manage items as object

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
