### PR TITLE
fix(components/actiondropdown): add loader

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -10,6 +10,10 @@ import theme from './ActionDropdown.scss';
 import TooltipTrigger from '../../TooltipTrigger';
 import Icon from '../../Icon';
 import { wrapOnClick } from '../Action/Action.component';
+import CircularProgress from "../../CircularProgress/CircularProgress.component";
+import { translate } from "react-i18next";
+import I18N_DOMAIN_COMPONENTS from "../../constants";
+import getDefaultT from "../../translate";
 
 export const DROPDOWN_CONTAINER_CN = 'tc-dropdown-container';
 
@@ -158,7 +162,11 @@ class ActionDropdown extends React.Component {
 	}
 
 	onToggle(isOpen) {
-		this.setState({ isOpen });
+		this.setState({ isOpen }, () => {
+			if (this.props.onToggle) {
+				this.props.onToggle(isOpen);
+			}
+		});
 	}
 
 	render() {
@@ -175,6 +183,8 @@ class ActionDropdown extends React.Component {
 			getComponent,
 			components,
 			className,
+			loading,
+			t,
 			...rest
 		} = this.props;
 
@@ -210,9 +220,22 @@ class ActionDropdown extends React.Component {
 			>
 				{!items.length &&
 					!items.size &&
-					!components && <Renderers.MenuItem disabled>No options</Renderers.MenuItem>}
+					!loading &&
+					!components && <Renderers.MenuItem disabled>
+					{t('ACTION_DROPDOWN_EMPTY', { defaultValue: 'No options' })}
+				</Renderers.MenuItem>}
 				{injected('beforeItemsDropdown')}
 				{items.map((item, key) => getMenuItem(item, key, getComponent))}
+				{loading && <Renderers.MenuItem
+					key={items ? items.length + 1 : 0}
+					header={true}
+					className={classNames(
+						theme['tc-dropdown-item'], 'tc-dropdown-item',
+						theme['tc-dropdown-loader'], 'tc-dropdown-loader',
+					)}
+				>
+					<CircularProgress />
+				</Renderers.MenuItem>}
 				{injected('itemsDropdown')}
 				{injected('afterItemsDropdown')}
 			</Renderers.DropdownButton>
@@ -251,6 +274,7 @@ ActionDropdown.propTypes = {
 	]).isRequired,
 	label: PropTypes.string.isRequired,
 	link: PropTypes.bool,
+	loading: PropTypes.bool,
 	onSelect: PropTypes.func,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,
 	tooltipLabel: PropTypes.string,
@@ -260,12 +284,15 @@ ActionDropdown.propTypes = {
 		itemsDropdown: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 		afterItemsDropdown: PropTypes.oneOfType([PropTypes.object, PropTypes.array]),
 	}),
+	t: PropTypes.func,
 };
 
 ActionDropdown.defaultProps = {
 	bsStyle: 'default',
 	tooltipPlacement: 'top',
 	items: [],
+	t: getDefaultT(),
 };
 
-export { ActionDropdown as default, getMenuItem, InjectDropdownMenuItem };
+export { getMenuItem, InjectDropdownMenuItem };
+export default translate(I18N_DOMAIN_COMPONENTS)(ActionDropdown);

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.md
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.md
@@ -1,6 +1,6 @@
 # ActionDropdown component
 
-This component display a dropdown with items in it. It used react-bootstrap component [DropdownButton](https://react-bootstrap.github.io/components/dropdowns/#btn-dropdowns), [MenuItem](https://react-bootstrap.github.io/components/dropdowns/#menu-items) and [TooltipTrigger](https://react-bootstrap.github.io/components/tooltips/#tooltips).
+This component displays a dropdown with items in it. It uses react-bootstrap component [DropdownButton](https://react-bootstrap.github.io/components/dropdowns/#btn-dropdowns), [MenuItem](https://react-bootstrap.github.io/components/dropdowns/#menu-items) and [TooltipTrigger](https://react-bootstrap.github.io/components/tooltips/#tooltips).
 
 A basic example of use
 
@@ -147,7 +147,9 @@ With the onSelect props you can add a callback when an item is selected.
 | items            | array of items displayed in the dropdown                                                                                     |
 | label            | string that defines the title used in the dropdown button or in the tooltip                                                  |
 | link             | boolean which condition the bsStyle                                                                                          |
+| loader           | boolean to indicate if we have to display a loader at then end of the dropdown                                               |
 | onSelect         | callback used when dropdown clicked                                                                                          |
+| onToggle         | callback used when dropdown is opened or hidden                                                                              |
 | tooltipPlacement | string ('up', 'down' ...) to position the tooltip overlay                                                                    |
 | tooltipLabel     | string label used to condition the used of overlay and label of overlay                                                      |
 | getComponent     | please see the component.md in cmf for more information.                                                                     |

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
@@ -1,13 +1,28 @@
-.tc-dropdown-button:global(.btn-link) {
-	&:hover,
-	&:focus,
-	&:active {
-		text-decoration: none;
-	}
-}
+$tc-dropdown-loader-padding: $padding-small !default;
 
-.tc-dropdown-item {
-	a svg {
-		margin: 0 $padding-smaller;
-	}
+.tc-dropdown {
+  &-button:global(.btn-link) {
+    &:hover,
+    &:focus,
+    &:active {
+      text-decoration: none;
+    }
+  }
+
+  &-item {
+    a svg {
+      margin: 0 $padding-smaller;
+    }
+  }
+
+  &-loader {
+    margin: -$tc-dropdown-loader-padding 0;
+    padding: $tc-dropdown-loader-padding 0;
+    text-align: center;
+    background: $concrete;
+
+    :global(.divider) + & {
+      margin: -($tc-dropdown-loader-padding - 1px) 0;
+    }
+  }
 }

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { mount } from 'enzyme';
 import Immutable from 'immutable';
-import toJson from 'enzyme-to-json';
+import toJsonWithoutI18n from '../../../test/props-without-i18n';
 
 import ActionDropdown from './ActionDropdown.component';
 
@@ -28,10 +28,10 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const wrapper = mount(<ActionDropdown {...props} />);
+		const wrapper = mount(<ActionDropdown {...props} />).find('ActionDropdown');
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render the same as when plain object or immutable list', () => {
@@ -47,8 +47,8 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const immutableWrapper = shallow(<ActionDropdown {...immutableProps} />);
-		const wrapper = shallow(<ActionDropdown {...props} />);
+		const immutableWrapper = mount(<ActionDropdown {...immutableProps} />);
+		const wrapper = mount(<ActionDropdown {...props} />);
 
 		// then
 		expect(wrapper.html()).toEqual(immutableWrapper.html());
@@ -63,10 +63,10 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const wrapper = mount(<ActionDropdown {...props} />);
+		const wrapper = mount(<ActionDropdown {...props} />).find('ActionDropdown');
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render a button with icon and label', () => {
@@ -79,10 +79,10 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const wrapper = shallow(<ActionDropdown {...props} />);
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownButton');
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render icon only with hideLabel props', () => {
@@ -97,10 +97,10 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const wrapper = shallow(<ActionDropdown {...props} />);
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownButton');
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render a button with "link" theme', () => {
@@ -113,10 +113,10 @@ describe('ActionDropdown', () => {
 		};
 
 		// when
-		const wrapper = shallow(<ActionDropdown {...props} />);
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownButton');
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render "no option" item when items array is empty', () => {
@@ -131,7 +131,39 @@ describe('ActionDropdown', () => {
 		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownMenu');
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
+	});
+
+	it('should render loader item', () => {
+		// given
+		const props = {
+			id: 'dropdown-id',
+			label: 'related items',
+			loading: true,
+			items: [],
+		};
+
+		// when
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownMenu');
+
+		// then
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
+	});
+
+	it('should render loader item below existing items', () => {
+		// given
+		const props = {
+			id: 'dropdown-id',
+			label: 'related items',
+			loading: true,
+			items,
+		};
+
+		// when
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownMenu');
+
+		// then
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 
 	it('should render icon-only items with item hideLabel props', () => {
@@ -146,6 +178,6 @@ describe('ActionDropdown', () => {
 		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownMenu');
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
@@ -10,6 +10,38 @@ function getComponent(key) {
 }
 
 describe('ActionDropdown', () => {
+	it('should call onToggle callback when click on trigger', () => {
+		// given
+		const onToggle = jest.fn();
+		const props = {
+			id: 'dropdwon-id',
+			label: 'Dropdown',
+			onToggle,
+			items: [
+				{ id: 'item1', label: 'Item 1', model: 'model' },
+				{ id: 'item2', label: 'Item 2', model: 'model' },
+			],
+		};
+
+		const actionDropdownInstance = mount(
+			<ActionDropdown {...props} />
+		);
+		const dropdownButton = actionDropdownInstance
+			.find('DropdownToggle');
+
+		// when
+		dropdownButton.simulate('click');
+
+		// then
+		expect(onToggle).toBeCalledWith(true);
+
+		// when
+		dropdownButton.simulate('click');
+
+		// then
+		expect(onToggle).toBeCalledWith(false);
+	});
+
 	it('should call onSelect callback when click on item', () => {
 		// given
 		const onSelectClick = jest.fn();

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -60,6 +60,7 @@ exports[`ActionDropdown should render "no option" item when items array is empty
 exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
 <ActionDropdown
   bsStyle="default"
+  i18n={Object {}}
   id="dropdown-id"
   items={
     Array [
@@ -75,16 +76,20 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
     ]
   }
   label="related items"
+  t={[Function]}
+  tReady={false}
   tooltipPlacement="top"
 >
   <DropdownButton
     aria-label="related items"
     bsStyle="default"
     className="theme-tc-dropdown-button tc-dropdown-button"
+    i18n={Object {}}
     id="dropdown-id"
     onSelect={[Function]}
     onToggle={[Function]}
     role="button"
+    tReady={false}
     title={
       Array [
         null,
@@ -129,12 +134,14 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
               bsRole="toggle"
               bsStyle="default"
               className="theme-tc-dropdown-button tc-dropdown-button"
+              i18n={Object {}}
               id="dropdown-id"
               key=".0"
               onClick={[Function]}
               onKeyDown={[Function]}
               open={false}
               role="button"
+              tReady={false}
               useAnchor={false}
             >
               <Button
@@ -147,10 +154,12 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                 bsStyle="default"
                 className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle"
                 disabled={false}
+                i18n={Object {}}
                 id="dropdown-id"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="button"
+                tReady={false}
               >
                 <button
                   aria-expanded={false}
@@ -158,10 +167,12 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                   aria-label="related items"
                   className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-default"
                   disabled={false}
+                  i18n={Object {}}
                   id="dropdown-id"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="button"
+                  tReady={false}
                   type="button"
                 >
                   <span
@@ -323,10 +334,12 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
   aria-label="related items"
   bsStyle="link"
   className="theme-tc-dropdown-button tc-dropdown-button"
+  i18n={Object {}}
   id="dropdown-id"
   onSelect={[Function]}
   onToggle={[Function]}
   role="button"
+  tReady={false}
   title={
     Array [
       null,
@@ -338,47 +351,230 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
     ]
   }
 >
-  <MenuItem
-    bsClass="dropdown"
-    className="theme-tc-dropdown-item tc-dropdown-item"
-    disabled={false}
-    divider={false}
-    eventKey={
-      Object {
-        "icon": "talend-icon",
-        "label": "document 1",
-        "onClick": [Function],
-      }
-    }
-    header={false}
-    icon="talend-icon"
-    label="document 1"
-    onClick={[Function]}
-    title="document 1"
+  <Uncontrolled(Dropdown)
+    bsStyle="link"
+    id="dropdown-id"
+    onSelect={[Function]}
+    onToggle={[Function]}
+    role="button"
   >
-    <Icon
-      name="talend-icon"
-    />
-    document 1
-  </MenuItem>
-  <MenuItem
-    bsClass="dropdown"
-    className="theme-tc-dropdown-item tc-dropdown-item"
-    disabled={false}
-    divider={false}
-    eventKey={
-      Object {
-        "label": "document 2",
-        "onClick": [Function],
-      }
-    }
-    header={false}
-    label="document 2"
-    onClick={[Function]}
-    title="document 2"
-  >
-    document 2
-  </MenuItem>
+    <Dropdown
+      bsClass="dropdown"
+      bsStyle="link"
+      componentClass={[Function]}
+      id="dropdown-id"
+      onSelect={[Function]}
+      onToggle={[Function]}
+      role="button"
+    >
+      <ButtonGroup
+        block={false}
+        bsClass="btn-group"
+        bsStyle="link"
+        className="dropdown"
+        justified={false}
+        vertical={false}
+      >
+        <div
+          className="dropdown btn-group btn-group-link"
+        >
+          <DropdownToggle
+            aria-label="related items"
+            bsClass="dropdown-toggle"
+            bsRole="toggle"
+            bsStyle="link"
+            className="theme-tc-dropdown-button tc-dropdown-button"
+            i18n={Object {}}
+            id="dropdown-id"
+            key=".0"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            open={false}
+            role="button"
+            tReady={false}
+            useAnchor={false}
+          >
+            <Button
+              active={false}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="related items"
+              block={false}
+              bsClass="btn"
+              bsStyle="link"
+              className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle"
+              disabled={false}
+              i18n={Object {}}
+              id="dropdown-id"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tReady={false}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="related items"
+                className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-link"
+                disabled={false}
+                i18n={Object {}}
+                id="dropdown-id"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tReady={false}
+                type="button"
+              >
+                <span
+                  className="tc-dropdown-button-title-label"
+                  key="label"
+                >
+                  related items
+                </span>
+                 
+                <span
+                  className="caret"
+                />
+              </button>
+            </Button>
+          </DropdownToggle>
+          <DropdownMenu
+            bsClass="dropdown-menu"
+            bsRole="menu"
+            key=".1"
+            labelledBy="dropdown-id"
+            onClose={[Function]}
+            onSelect={[Function]}
+            pullRight={false}
+          >
+            <RootCloseWrapper
+              disabled={true}
+              event="click"
+              onRootClose={[Function]}
+            >
+              <ul
+                aria-labelledby="dropdown-id"
+                className="dropdown-menu"
+                role="menu"
+              >
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "icon": "talend-icon",
+                      "label": "document 1",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  icon="talend-icon"
+                  key=".2:$0"
+                  label="document 1"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 1"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      icon="talend-icon"
+                      label="document 1"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 1"
+                    >
+                      <a
+                        href="#"
+                        icon="talend-icon"
+                        label="document 1"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 1"
+                      >
+                        <Icon
+                          name="talend-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="theme-tc-svg-icon tc-svg-icon"
+                            focusable="false"
+                            name="talend-icon"
+                            title={null}
+                          >
+                            <use
+                              xlinkHref="#talend-icon"
+                            />
+                          </svg>
+                        </Icon>
+                        document 1
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "label": "document 2",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  key=".2:$1"
+                  label="document 2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 2"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      label="document 2"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 2"
+                    >
+                      <a
+                        href="#"
+                        label="document 2"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 2"
+                      >
+                        document 2
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+              </ul>
+            </RootCloseWrapper>
+          </DropdownMenu>
+        </div>
+      </ButtonGroup>
+    </Dropdown>
+  </Uncontrolled(Dropdown)>
 </DropdownButton>
 `;
 
@@ -387,10 +583,12 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
   aria-label="related items"
   bsStyle="default"
   className="theme-tc-dropdown-button tc-dropdown-button"
+  i18n={Object {}}
   id="dropdown-id"
   onSelect={[Function]}
   onToggle={[Function]}
   role="button"
+  tReady={false}
   title={
     Array [
       <Icon
@@ -404,117 +602,502 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
     ]
   }
 >
-  <MenuItem
-    bsClass="dropdown"
-    className="theme-tc-dropdown-item tc-dropdown-item"
-    disabled={false}
-    divider={false}
-    eventKey={
-      Object {
-        "icon": "talend-icon",
-        "label": "document 1",
-        "onClick": [Function],
-      }
-    }
-    header={false}
-    icon="talend-icon"
-    key="0"
-    label="document 1"
-    onClick={[Function]}
-    title="document 1"
-  >
-    <Icon
-      name="talend-icon"
-    />
-    document 1
-  </MenuItem>
-  <MenuItem
-    bsClass="dropdown"
-    className="theme-tc-dropdown-item tc-dropdown-item"
-    disabled={false}
-    divider={false}
-    eventKey={
-      Object {
-        "label": "document 2",
-        "onClick": [Function],
-      }
-    }
-    header={false}
-    key="1"
-    label="document 2"
-    onClick={[Function]}
-    title="document 2"
-  >
-    document 2
-  </MenuItem>
-</DropdownButton>
-`;
-
-exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
-<TooltipTrigger
-  label="related items"
-  tooltipPlacement="right"
->
-  <DropdownButton
-    aria-label="related items"
+  <Uncontrolled(Dropdown)
     bsStyle="default"
-    className="theme-tc-dropdown-button tc-dropdown-button"
     id="dropdown-id"
     onSelect={[Function]}
     onToggle={[Function]}
     role="button"
-    title={
-      Array [
-        <Icon
-          name="fa fa-file-excel-o"
-      />,
-        null,
-      ]
-    }
   >
-    <MenuItem
+    <Dropdown
       bsClass="dropdown"
-      className="theme-tc-dropdown-item tc-dropdown-item"
-      disabled={false}
-      divider={false}
-      eventKey={
-        Object {
-          "icon": "talend-icon",
-          "label": "document 1",
-          "onClick": [Function],
-        }
-      }
-      header={false}
-      icon="talend-icon"
-      label="document 1"
-      onClick={[Function]}
-      title="document 1"
+      bsStyle="default"
+      componentClass={[Function]}
+      id="dropdown-id"
+      onSelect={[Function]}
+      onToggle={[Function]}
+      role="button"
     >
+      <ButtonGroup
+        block={false}
+        bsClass="btn-group"
+        bsStyle="default"
+        className="dropdown"
+        justified={false}
+        vertical={false}
+      >
+        <div
+          className="dropdown btn-group btn-group-default"
+        >
+          <DropdownToggle
+            aria-label="related items"
+            bsClass="dropdown-toggle"
+            bsRole="toggle"
+            bsStyle="default"
+            className="theme-tc-dropdown-button tc-dropdown-button"
+            i18n={Object {}}
+            id="dropdown-id"
+            key=".0"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            open={false}
+            role="button"
+            tReady={false}
+            useAnchor={false}
+          >
+            <Button
+              active={false}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="related items"
+              block={false}
+              bsClass="btn"
+              bsStyle="default"
+              className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle"
+              disabled={false}
+              i18n={Object {}}
+              id="dropdown-id"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="button"
+              tReady={false}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="related items"
+                className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-default"
+                disabled={false}
+                i18n={Object {}}
+                id="dropdown-id"
+                onClick={[Function]}
+                onKeyDown={[Function]}
+                role="button"
+                tReady={false}
+                type="button"
+              >
+                <Icon
+                  key="icon"
+                  name="fa fa-file-excel-o"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-file-excel-o"
+                    focusable="false"
+                    title={null}
+                  />
+                </Icon>
+                <span
+                  className="tc-dropdown-button-title-label"
+                  key="label"
+                >
+                  related items
+                </span>
+                 
+                <span
+                  className="caret"
+                />
+              </button>
+            </Button>
+          </DropdownToggle>
+          <DropdownMenu
+            bsClass="dropdown-menu"
+            bsRole="menu"
+            key=".1"
+            labelledBy="dropdown-id"
+            onClose={[Function]}
+            onSelect={[Function]}
+            pullRight={false}
+          >
+            <RootCloseWrapper
+              disabled={true}
+              event="click"
+              onRootClose={[Function]}
+            >
+              <ul
+                aria-labelledby="dropdown-id"
+                className="dropdown-menu"
+                role="menu"
+              >
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "icon": "talend-icon",
+                      "label": "document 1",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  icon="talend-icon"
+                  key=".2:$0"
+                  label="document 1"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 1"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      icon="talend-icon"
+                      label="document 1"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 1"
+                    >
+                      <a
+                        href="#"
+                        icon="talend-icon"
+                        label="document 1"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 1"
+                      >
+                        <Icon
+                          name="talend-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="theme-tc-svg-icon tc-svg-icon"
+                            focusable="false"
+                            name="talend-icon"
+                            title={null}
+                          >
+                            <use
+                              xlinkHref="#talend-icon"
+                            />
+                          </svg>
+                        </Icon>
+                        document 1
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "label": "document 2",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  key=".2:$1"
+                  label="document 2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 2"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      label="document 2"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 2"
+                    >
+                      <a
+                        href="#"
+                        label="document 2"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 2"
+                      >
+                        document 2
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+              </ul>
+            </RootCloseWrapper>
+          </DropdownMenu>
+        </div>
+      </ButtonGroup>
+    </Dropdown>
+  </Uncontrolled(Dropdown)>
+</DropdownButton>
+`;
+
+exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
+<DropdownButton
+  aria-label="related items"
+  bsStyle="default"
+  className="theme-tc-dropdown-button tc-dropdown-button"
+  i18n={Object {}}
+  id="dropdown-id"
+  onFocus={[Function]}
+  onMouseOver={[Function]}
+  onSelect={[Function]}
+  onToggle={[Function]}
+  role="button"
+  tReady={false}
+  title={
+    Array [
       <Icon
-        name="talend-icon"
-      />
-      document 1
-    </MenuItem>
-    <MenuItem
+        name="fa fa-file-excel-o"
+    />,
+      null,
+    ]
+  }
+>
+  <Uncontrolled(Dropdown)
+    bsStyle="default"
+    id="dropdown-id"
+    onSelect={[Function]}
+    onToggle={[Function]}
+    role="button"
+  >
+    <Dropdown
       bsClass="dropdown"
-      className="theme-tc-dropdown-item tc-dropdown-item"
-      disabled={false}
-      divider={false}
-      eventKey={
-        Object {
-          "label": "document 2",
-          "onClick": [Function],
-        }
-      }
-      header={false}
-      label="document 2"
-      onClick={[Function]}
-      title="document 2"
+      bsStyle="default"
+      componentClass={[Function]}
+      id="dropdown-id"
+      onSelect={[Function]}
+      onToggle={[Function]}
+      role="button"
     >
-      document 2
-    </MenuItem>
-  </DropdownButton>
-</TooltipTrigger>
+      <ButtonGroup
+        block={false}
+        bsClass="btn-group"
+        bsStyle="default"
+        className="dropdown"
+        justified={false}
+        vertical={false}
+      >
+        <div
+          className="dropdown btn-group btn-group-default"
+        >
+          <DropdownToggle
+            aria-label="related items"
+            bsClass="dropdown-toggle"
+            bsRole="toggle"
+            bsStyle="default"
+            className="theme-tc-dropdown-button tc-dropdown-button"
+            i18n={Object {}}
+            id="dropdown-id"
+            key=".0"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onKeyDown={[Function]}
+            onMouseOver={[Function]}
+            open={false}
+            role="button"
+            tReady={false}
+            useAnchor={false}
+          >
+            <Button
+              active={false}
+              aria-expanded={false}
+              aria-haspopup={true}
+              aria-label="related items"
+              block={false}
+              bsClass="btn"
+              bsStyle="default"
+              className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle"
+              disabled={false}
+              i18n={Object {}}
+              id="dropdown-id"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onKeyDown={[Function]}
+              onMouseOver={[Function]}
+              role="button"
+              tReady={false}
+            >
+              <button
+                aria-expanded={false}
+                aria-haspopup={true}
+                aria-label="related items"
+                className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-default"
+                disabled={false}
+                i18n={Object {}}
+                id="dropdown-id"
+                onClick={[Function]}
+                onFocus={[Function]}
+                onKeyDown={[Function]}
+                onMouseOver={[Function]}
+                role="button"
+                tReady={false}
+                type="button"
+              >
+                <Icon
+                  key="icon"
+                  name="fa fa-file-excel-o"
+                >
+                  <i
+                    aria-hidden="true"
+                    className="fa fa-file-excel-o"
+                    focusable="false"
+                    title={null}
+                  />
+                </Icon>
+                 
+                <span
+                  className="caret"
+                />
+              </button>
+            </Button>
+          </DropdownToggle>
+          <DropdownMenu
+            bsClass="dropdown-menu"
+            bsRole="menu"
+            key=".1"
+            labelledBy="dropdown-id"
+            onClose={[Function]}
+            onSelect={[Function]}
+            pullRight={false}
+          >
+            <RootCloseWrapper
+              disabled={true}
+              event="click"
+              onRootClose={[Function]}
+            >
+              <ul
+                aria-labelledby="dropdown-id"
+                className="dropdown-menu"
+                role="menu"
+              >
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "icon": "talend-icon",
+                      "label": "document 1",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  icon="talend-icon"
+                  key=".2:$0"
+                  label="document 1"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 1"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      icon="talend-icon"
+                      label="document 1"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 1"
+                    >
+                      <a
+                        href="#"
+                        icon="talend-icon"
+                        label="document 1"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 1"
+                      >
+                        <Icon
+                          name="talend-icon"
+                        >
+                          <svg
+                            aria-hidden="true"
+                            className="theme-tc-svg-icon tc-svg-icon"
+                            focusable="false"
+                            name="talend-icon"
+                            title={null}
+                          >
+                            <use
+                              xlinkHref="#talend-icon"
+                            />
+                          </svg>
+                        </Icon>
+                        document 1
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+                <MenuItem
+                  bsClass="dropdown"
+                  className="theme-tc-dropdown-item tc-dropdown-item"
+                  disabled={false}
+                  divider={false}
+                  eventKey={
+                    Object {
+                      "label": "document 2",
+                      "onClick": [Function],
+                    }
+                  }
+                  header={false}
+                  key=".2:$1"
+                  label="document 2"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  onSelect={[Function]}
+                  title="document 2"
+                >
+                  <li
+                    className="theme-tc-dropdown-item tc-dropdown-item"
+                    role="presentation"
+                  >
+                    <SafeAnchor
+                      componentClass="a"
+                      label="document 2"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                      title="document 2"
+                    >
+                      <a
+                        href="#"
+                        label="document 2"
+                        onClick={[Function]}
+                        onKeyDown={[Function]}
+                        role="menuitem"
+                        tabIndex="-1"
+                        title="document 2"
+                      >
+                        document 2
+                      </a>
+                    </SafeAnchor>
+                  </li>
+                </MenuItem>
+              </ul>
+            </RootCloseWrapper>
+          </DropdownMenu>
+        </div>
+      </ButtonGroup>
+    </Dropdown>
+  </Uncontrolled(Dropdown)>
+</DropdownButton>
 `;
 
 exports[`ActionDropdown should render icon-only items with item hideLabel props 1`] = `
@@ -661,6 +1244,7 @@ exports[`ActionDropdown should render icon-only items with item hideLabel props 
 exports[`ActionDropdown should render immutable items 1`] = `
 <ActionDropdown
   bsStyle="default"
+  i18n={Object {}}
   id="dropdown-id"
   items={
     Immutable.List [
@@ -676,16 +1260,20 @@ exports[`ActionDropdown should render immutable items 1`] = `
     ]
   }
   label="related items"
+  t={[Function]}
+  tReady={false}
   tooltipPlacement="top"
 >
   <DropdownButton
     aria-label="related items"
     bsStyle="default"
     className="theme-tc-dropdown-button tc-dropdown-button"
+    i18n={Object {}}
     id="dropdown-id"
     onSelect={[Function]}
     onToggle={[Function]}
     role="button"
+    tReady={false}
     title={
       Array [
         null,
@@ -730,12 +1318,14 @@ exports[`ActionDropdown should render immutable items 1`] = `
               bsRole="toggle"
               bsStyle="default"
               className="theme-tc-dropdown-button tc-dropdown-button"
+              i18n={Object {}}
               id="dropdown-id"
               key=".0"
               onClick={[Function]}
               onKeyDown={[Function]}
               open={false}
               role="button"
+              tReady={false}
               useAnchor={false}
             >
               <Button
@@ -748,10 +1338,12 @@ exports[`ActionDropdown should render immutable items 1`] = `
                 bsStyle="default"
                 className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle"
                 disabled={false}
+                i18n={Object {}}
                 id="dropdown-id"
                 onClick={[Function]}
                 onKeyDown={[Function]}
                 role="button"
+                tReady={false}
               >
                 <button
                   aria-expanded={false}
@@ -759,10 +1351,12 @@ exports[`ActionDropdown should render immutable items 1`] = `
                   aria-label="related items"
                   className="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-default"
                   disabled={false}
+                  i18n={Object {}}
                   id="dropdown-id"
                   onClick={[Function]}
                   onKeyDown={[Function]}
                   role="button"
+                  tReady={false}
                   type="button"
                 >
                   <span
@@ -917,4 +1511,291 @@ exports[`ActionDropdown should render immutable items 1`] = `
     </Uncontrolled(Dropdown)>
   </DropdownButton>
 </ActionDropdown>
+`;
+
+exports[`ActionDropdown should render loader item 1`] = `
+<DropdownMenu
+  bsClass="dropdown-menu"
+  bsRole="menu"
+  key=".1"
+  labelledBy="dropdown-id"
+  onClose={[Function]}
+  onSelect={[Function]}
+  pullRight={false}
+>
+  <RootCloseWrapper
+    disabled={true}
+    event="click"
+    onRootClose={[Function]}
+  >
+    <ul
+      aria-labelledby="dropdown-id"
+      className="dropdown-menu"
+      role="menu"
+    >
+      <MenuItem
+        bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item theme-tc-dropdown-loader tc-dropdown-loader"
+        disabled={false}
+        divider={false}
+        header={true}
+        key=".$1"
+        onKeyDown={[Function]}
+        onSelect={[Function]}
+      >
+        <li
+          className="theme-tc-dropdown-item tc-dropdown-item theme-tc-dropdown-loader tc-dropdown-loader dropdown-header"
+          onKeyDown={[Function]}
+          role="heading"
+        >
+          <Translate(CircularProgress)>
+            <I18n
+              bindI18n="languageChanged loaded"
+              bindStore="added removed"
+              i18n={Object {}}
+              ns={
+                Array [
+                  "tui-components",
+                ]
+              }
+              nsMode="default"
+              translateFuncName="t"
+              usePureComponent={false}
+              wait={false}
+              withRef={false}
+            >
+              <CircularProgress
+                i18n={Object {}}
+                size="default"
+                t={[Function]}
+                tReady={false}
+              >
+                <svg
+                  aria-busy="true"
+                  aria-label="Loading "
+                  className="tc-circular-progress theme-loader theme-animate theme-default"
+                  focusable="false"
+                  viewBox="0 0 50 50"
+                >
+                  <circle
+                    className="theme-path"
+                    cx={25}
+                    cy={25}
+                    fill="none"
+                    r={20}
+                    style={
+                      Object {
+                        "strokeDasharray": 12.566370614359172,
+                        "strokeDashoffset": 0,
+                      }
+                    }
+                  />
+                </svg>
+              </CircularProgress>
+            </I18n>
+          </Translate(CircularProgress)>
+        </li>
+      </MenuItem>
+    </ul>
+  </RootCloseWrapper>
+</DropdownMenu>
+`;
+
+exports[`ActionDropdown should render loader item below existing items 1`] = `
+<DropdownMenu
+  bsClass="dropdown-menu"
+  bsRole="menu"
+  key=".1"
+  labelledBy="dropdown-id"
+  onClose={[Function]}
+  onSelect={[Function]}
+  pullRight={false}
+>
+  <RootCloseWrapper
+    disabled={true}
+    event="click"
+    onRootClose={[Function]}
+  >
+    <ul
+      aria-labelledby="dropdown-id"
+      className="dropdown-menu"
+      role="menu"
+    >
+      <MenuItem
+        bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item"
+        disabled={false}
+        divider={false}
+        eventKey={
+          Object {
+            "icon": "talend-icon",
+            "label": "document 1",
+            "onClick": [Function],
+          }
+        }
+        header={false}
+        icon="talend-icon"
+        key=".2:$0"
+        label="document 1"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onSelect={[Function]}
+        title="document 1"
+      >
+        <li
+          className="theme-tc-dropdown-item tc-dropdown-item"
+          role="presentation"
+        >
+          <SafeAnchor
+            componentClass="a"
+            icon="talend-icon"
+            label="document 1"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+            title="document 1"
+          >
+            <a
+              href="#"
+              icon="talend-icon"
+              label="document 1"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex="-1"
+              title="document 1"
+            >
+              <Icon
+                name="talend-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon"
+                  focusable="false"
+                  name="talend-icon"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-icon"
+                  />
+                </svg>
+              </Icon>
+              document 1
+            </a>
+          </SafeAnchor>
+        </li>
+      </MenuItem>
+      <MenuItem
+        bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item"
+        disabled={false}
+        divider={false}
+        eventKey={
+          Object {
+            "label": "document 2",
+            "onClick": [Function],
+          }
+        }
+        header={false}
+        key=".2:$1"
+        label="document 2"
+        onClick={[Function]}
+        onKeyDown={[Function]}
+        onSelect={[Function]}
+        title="document 2"
+      >
+        <li
+          className="theme-tc-dropdown-item tc-dropdown-item"
+          role="presentation"
+        >
+          <SafeAnchor
+            componentClass="a"
+            label="document 2"
+            onClick={[Function]}
+            onKeyDown={[Function]}
+            role="menuitem"
+            tabIndex="-1"
+            title="document 2"
+          >
+            <a
+              href="#"
+              label="document 2"
+              onClick={[Function]}
+              onKeyDown={[Function]}
+              role="menuitem"
+              tabIndex="-1"
+              title="document 2"
+            >
+              document 2
+            </a>
+          </SafeAnchor>
+        </li>
+      </MenuItem>
+      <MenuItem
+        bsClass="dropdown"
+        className="theme-tc-dropdown-item tc-dropdown-item theme-tc-dropdown-loader tc-dropdown-loader"
+        disabled={false}
+        divider={false}
+        header={true}
+        key=".$3"
+        onKeyDown={[Function]}
+        onSelect={[Function]}
+      >
+        <li
+          className="theme-tc-dropdown-item tc-dropdown-item theme-tc-dropdown-loader tc-dropdown-loader dropdown-header"
+          onKeyDown={[Function]}
+          role="heading"
+        >
+          <Translate(CircularProgress)>
+            <I18n
+              bindI18n="languageChanged loaded"
+              bindStore="added removed"
+              i18n={Object {}}
+              ns={
+                Array [
+                  "tui-components",
+                ]
+              }
+              nsMode="default"
+              translateFuncName="t"
+              usePureComponent={false}
+              wait={false}
+              withRef={false}
+            >
+              <CircularProgress
+                i18n={Object {}}
+                size="default"
+                t={[Function]}
+                tReady={false}
+              >
+                <svg
+                  aria-busy="true"
+                  aria-label="Loading "
+                  className="tc-circular-progress theme-loader theme-animate theme-default"
+                  focusable="false"
+                  viewBox="0 0 50 50"
+                >
+                  <circle
+                    className="theme-path"
+                    cx={25}
+                    cy={25}
+                    fill="none"
+                    r={20}
+                    style={
+                      Object {
+                        "strokeDasharray": 12.566370614359172,
+                        "strokeDashoffset": 0,
+                      }
+                    }
+                  />
+                </svg>
+              </CircularProgress>
+            </I18n>
+          </Translate(CircularProgress)>
+        </li>
+      </MenuItem>
+    </ul>
+  </RootCloseWrapper>
+</DropdownMenu>
 `;

--- a/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
+++ b/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
@@ -127,9 +127,8 @@ exports[`Breadcrumbs should render dropdown containing 3 items 1`] = `
     <li
       className="tc-breadcrumb-menu"
     >
-      <ActionDropdown
+      <Translate(ActionDropdown)
         aria-label="Open first links menu"
-        bsStyle="default"
         id="42-ellipsis"
         items={
           Array [
@@ -156,7 +155,6 @@ exports[`Breadcrumbs should render dropdown containing 3 items 1`] = `
         label="…"
         link={true}
         noCaret={true}
-        tooltipPlacement="top"
       />
     </li>
     <li
@@ -214,9 +212,8 @@ exports[`Breadcrumbs should render items ids when provided 1`] = `
     <li
       className="tc-breadcrumb-menu"
     >
-      <ActionDropdown
+      <Translate(ActionDropdown)
         aria-label="Open first links menu"
-        bsStyle="default"
         id="my-breadcrumb-ellipsis"
         items={
           Array [
@@ -231,7 +228,6 @@ exports[`Breadcrumbs should render items ids when provided 1`] = `
         label="…"
         link={true}
         noCaret={true}
-        tooltipPlacement="top"
       />
     </li>
     <li
@@ -309,9 +305,8 @@ exports[`Breadcrumbs should render items with ellipsis and 3 visible items by de
     <li
       className="tc-breadcrumb-menu"
     >
-      <ActionDropdown
+      <Translate(ActionDropdown)
         aria-label="Open first links menu"
-        bsStyle="default"
         id="42-ellipsis"
         items={
           Array [
@@ -326,7 +321,6 @@ exports[`Breadcrumbs should render items with ellipsis and 3 visible items by de
         label="…"
         link={true}
         noCaret={true}
-        tooltipPlacement="top"
       />
     </li>
     <li

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
@@ -28,8 +28,7 @@ exports[`CellTitleActions should display 2 actions and the rest in an ellipsis d
       link={true}
       onClick={[Function]}
     />
-    <ActionDropdown
-      bsStyle="default"
+    <Translate(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       items={
@@ -60,7 +59,6 @@ exports[`CellTitleActions should display 2 actions and the rest in an ellipsis d
       label="Open menu"
       link={true}
       noCaret={true}
-      tooltipPlacement="top"
     />
   </div>
 </div>
@@ -213,8 +211,7 @@ exports[`CellTitleActions should extract dropdown actions, completed with simple
       link={true}
       pullRight={true}
     />
-    <ActionDropdown
-      bsStyle="default"
+    <Translate(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       items={
@@ -252,7 +249,6 @@ exports[`CellTitleActions should extract dropdown actions, completed with simple
       label="Open menu"
       link={true}
       noCaret={true}
-      tooltipPlacement="top"
     />
   </div>
 </div>
@@ -328,8 +324,7 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
       label="Open with Data Preparation"
       link={true}
     />
-    <ActionDropdown
-      bsStyle="default"
+    <Translate(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       items={
@@ -374,7 +369,6 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
       label="Open menu"
       link={true}
       noCaret={true}
-      tooltipPlacement="top"
     />
   </div>
 </div>

--- a/packages/components/stories/ActionDropdown.js
+++ b/packages/components/stories/ActionDropdown.js
@@ -31,6 +31,31 @@ const myAction = {
 	],
 };
 
+const loadingAdditionalContent = {
+	id: 'context-dropdown-related-items',
+	label: 'related items',
+	loading: true,
+	icon: 'talend-file-xls-o',
+	items: [],
+};
+
+const contentAndLoadingAdditionalContent = {
+	...loadingAdditionalContent,
+	items: [
+		{
+			id: 'context-dropdown-item-document-1',
+			icon: 'talend-file-json-o',
+			label: 'document 1',
+			'data-feature': 'actiondropdown.items',
+			onClick: action('document 1 click'),
+		},
+		{
+			divider: true,
+		},
+
+	]
+};
+
 const withImmutable = {
 	id: 'context-dropdown-related-items',
 	label: 'related immutable items',
@@ -160,7 +185,11 @@ const propsTooltip = {
 const oneEventAction = {
 	id: 'context-dropdown-events',
 	label: 'Dropdown',
-	items: [{ id: 'item-1', label: 'Item 1', 'data-feature': 'actiondropdown.items' }, { id: 'item-2', label: 'Item 2', 'data-feature': 'actiondropdown.items' }],
+	items: [{ id: 'item-1', label: 'Item 1', 'data-feature': 'actiondropdown.items' }, {
+		id: 'item-2',
+		label: 'Item 2',
+		'data-feature': 'actiondropdown.items'
+	}],
 	onSelect: action('onItemSelect'),
 };
 
@@ -189,7 +218,8 @@ storiesOf('ActionDropdown', module)
 				<ActionDropdown {...myAction} dropup />
 			</div>
 			<h3>Automatic Dropup : this is contained in a restricted ".tc-dropdown-container" element.</h3>
-			<div id="auto-dropup" className={'tc-dropdown-container'} style={{ border: '1px solid black', overflow: 'scroll', height: '300px' }}>
+			<div id="auto-dropup" className={'tc-dropdown-container'}
+			     style={{ border: '1px solid black', overflow: 'scroll', height: '300px' }}>
 				Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor<br />
 				ut labore et dolore magna aliqua.<br />
 				Ut enim ad minim veniam, quis nostrud exercitation ullamco la<br />
@@ -226,6 +256,14 @@ storiesOf('ActionDropdown', module)
 			<h3>With immutable items :</h3>
 			<div id="default">
 				<ActionDropdown {...withImmutable} />
+			</div>
+			<h3>Loading additional content</h3>
+			<div id="loadingAdditionalContent">
+				<ActionDropdown {...loadingAdditionalContent} />
+			</div>
+			<h3>Content and loading additional content</h3>
+			<div id="contentAndLoadingAdditionalContent">
+				<ActionDropdown {...contentAndLoadingAdditionalContent} />
 			</div>
 			<h3>Opened and with immutable items :</h3>
 			<div id="openImmutable">


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`ActionDropdown` is an uncontrolled dropdown, we have to update its content with Promise.

**What is the chosen solution to this problem?**
`ActionDropdown` is now be able to display a loader with(out) content and to accept `onToggle(isOpen)` callback

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
