### PR TITLE
Revert "feat(components): new list style (#1665)"

### DIFF
--- a/packages/components/src/List/List.scss
+++ b/packages/components/src/List/List.scss
@@ -17,6 +17,5 @@
 		flex-grow: 1;
 		flex-shrink: 1;
 		box-shadow: $shadow-default;
-		background-color: $wild-sand;
 	}
 }

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -192,7 +192,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                   disableHeader={false}
                   estimatedRowSize={30}
                   gridClassName="theme-grid tc-dropdown-container"
-                  headerHeight={40}
+                  headerHeight={35}
                   headerRowRenderer={[Function]}
                   headerStyle={Object {}}
                   height={250}
@@ -225,7 +225,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                       role="row"
                       style={
                         Object {
-                          "height": 40,
+                          "height": 35,
                           "overflow": "hidden",
                           "paddingRight": 0,
                           "width": 0,
@@ -310,10 +310,10 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                       estimatedRowSize={30}
                       getScrollbarSize={[Function]}
                       gridClassName="theme-grid tc-dropdown-container"
-                      headerHeight={40}
+                      headerHeight={35}
                       headerRowRenderer={[Function]}
                       headerStyle={Object {}}
-                      height={210}
+                      height={215}
                       noContentRenderer={[Function]}
                       noRowsRenderer={[Function]}
                       onRowDoubleClick={[Function]}
@@ -358,7 +358,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                             "WebkitOverflowScrolling": "touch",
                             "boxSizing": "border-box",
                             "direction": "ltr",
-                            "height": 210,
+                            "height": 215,
                             "overflowX": "hidden",
                             "overflowY": "hidden",
                             "position": "relative",
@@ -2002,7 +2002,7 @@ exports[`List should render 1`] = `
                   disableHeader={false}
                   estimatedRowSize={30}
                   gridClassName="theme-grid tc-dropdown-container"
-                  headerHeight={40}
+                  headerHeight={35}
                   headerRowRenderer={[Function]}
                   headerStyle={Object {}}
                   height={250}
@@ -2035,7 +2035,7 @@ exports[`List should render 1`] = `
                       role="row"
                       style={
                         Object {
-                          "height": 40,
+                          "height": 35,
                           "overflow": "hidden",
                           "paddingRight": 0,
                           "width": 0,
@@ -2120,10 +2120,10 @@ exports[`List should render 1`] = `
                       estimatedRowSize={30}
                       getScrollbarSize={[Function]}
                       gridClassName="theme-grid tc-dropdown-container"
-                      headerHeight={40}
+                      headerHeight={35}
                       headerRowRenderer={[Function]}
                       headerStyle={Object {}}
-                      height={210}
+                      height={215}
                       noContentRenderer={[Function]}
                       noRowsRenderer={[Function]}
                       onRowDoubleClick={[Function]}
@@ -2168,7 +2168,7 @@ exports[`List should render 1`] = `
                             "WebkitOverflowScrolling": "touch",
                             "boxSizing": "border-box",
                             "direction": "ltr",
-                            "height": 210,
+                            "height": 215,
                             "overflowX": "hidden",
                             "overflowY": "hidden",
                             "position": "relative",
@@ -3871,7 +3871,7 @@ exports[`List should render id if provided 1`] = `
                   disableHeader={false}
                   estimatedRowSize={30}
                   gridClassName="theme-grid tc-dropdown-container"
-                  headerHeight={40}
+                  headerHeight={35}
                   headerRowRenderer={[Function]}
                   headerStyle={Object {}}
                   height={250}
@@ -3906,7 +3906,7 @@ exports[`List should render id if provided 1`] = `
                       role="row"
                       style={
                         Object {
-                          "height": 40,
+                          "height": 35,
                           "overflow": "hidden",
                           "paddingRight": 0,
                           "width": 0,
@@ -3991,10 +3991,10 @@ exports[`List should render id if provided 1`] = `
                       estimatedRowSize={30}
                       getScrollbarSize={[Function]}
                       gridClassName="theme-grid tc-dropdown-container"
-                      headerHeight={40}
+                      headerHeight={35}
                       headerRowRenderer={[Function]}
                       headerStyle={Object {}}
-                      height={210}
+                      height={215}
                       noContentRenderer={[Function]}
                       noRowsRenderer={[Function]}
                       onRowDoubleClick={[Function]}
@@ -4039,7 +4039,7 @@ exports[`List should render id if provided 1`] = `
                             "WebkitOverflowScrolling": "touch",
                             "boxSizing": "border-box",
                             "direction": "ltr",
-                            "height": 210,
+                            "height": 215,
                             "overflowX": "hidden",
                             "overflowY": "hidden",
                             "position": "relative",

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -43,7 +43,7 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 
 		color: $tc-list-title-color;
 		font-size: inherit;
-		font-weight: 600;
+		font-weight: 700;
 		letter-spacing: inherit;
 		text-transform: none;
 		text-align: left;

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
@@ -43,7 +43,7 @@ function ListTable(props) {
 		<VirtualizedTable
 			className={`tc-list-table ${theme['tc-list-table']}`}
 			gridClassName={`${theme.grid} ${DROPDOWN_CONTAINER_CN}`}
-			headerHeight={40}
+			headerHeight={35}
 			id={id}
 			onRowClick={onRowClickCallback}
 			onRowDoubleClick={onRowDoubleClickCallback}

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.scss
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.scss
@@ -1,35 +1,31 @@
 @import '../colors';
 
-$tc-list-table-cell-padding: $padding-small !default;
-$tc-list-table-header-color: $dove-gray !default;
-$tc-list-table-border: 1px solid darken($concrete, 5%);
+$tc-list-table-cell-padding: 8px !default;
+$tc-list-table-header-color: $black !default;
 
 .tc-list-table {
-	background-color: $wild-sand;
-
 	.row {
-		border-bottom: $tc-list-table-border;
-		background: $white;
+		border-bottom: 1px solid darken($concrete, 5%);
 		display: flex;
 		align-items: center;
 
 		&:hover,
 		&:focus,
 		&:global(.ally-focus-within) {
-			background: $wild-sand;
-			.cell {
-				border-left: 1px solid $white;
-			}
+			background: $tc-list-row-hover-bg;
 		}
 	}
 
 	:global(.ReactVirtualized__Table__headerRow) {
+		box-shadow: $shadow-default;
+
 		.header {
 			color: $tc-list-table-header-color;
 			display: inline-flex;
-			font-size: 1.2rem;
-			font-weight: 600;
+			font-size: 1.4rem;
+			font-weight: bold;
 			padding: $tc-list-table-cell-padding;
+			text-transform: uppercase;
 		}
 	}
 
@@ -38,15 +34,14 @@ $tc-list-table-border: 1px solid darken($concrete, 5%);
 	}
 
 	.grid {
+		box-shadow: $shadow-default;
+
 		.cell {
-			&:first-child {
-				border-left: none;
-			}
-			border-left: $tc-list-table-border;
 			white-space: nowrap;
 			overflow: hidden;
 			text-overflow: ellipsis;
 			padding: 0 $tc-list-table-cell-padding;
+
 			height: 100%;
 			display: flex;
 			align-items: center;

--- a/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
@@ -16,7 +16,7 @@ exports[`ListGrid should render noRows 1`] = `
     disableHeader={false}
     estimatedRowSize={30}
     gridClassName="theme-grid tc-dropdown-container"
-    headerHeight={40}
+    headerHeight={35}
     headerRowRenderer={[Function]}
     headerStyle={Object {}}
     height={600}
@@ -48,7 +48,7 @@ exports[`ListGrid should render noRows 1`] = `
         role="row"
         style={
           Object {
-            "height": 40,
+            "height": 35,
             "overflow": "hidden",
             "paddingRight": 0,
             "width": 1024,
@@ -114,10 +114,10 @@ exports[`ListGrid should render noRows 1`] = `
         estimatedRowSize={30}
         getScrollbarSize={[Function]}
         gridClassName="theme-grid tc-dropdown-container"
-        headerHeight={40}
+        headerHeight={35}
         headerRowRenderer={[Function]}
         headerStyle={Object {}}
-        height={560}
+        height={565}
         noContentRenderer={[Function]}
         noRowsRenderer={[Function]}
         onRowsRendered={[Function]}
@@ -159,7 +159,7 @@ exports[`ListGrid should render noRows 1`] = `
               "WebkitOverflowScrolling": "touch",
               "boxSizing": "border-box",
               "direction": "ltr",
-              "height": 560,
+              "height": 565,
               "overflowX": "hidden",
               "overflowY": "hidden",
               "position": "relative",
@@ -185,7 +185,7 @@ exports[`ListGrid should render react-virtualized table 1`] = `
   disableHeader={false}
   estimatedRowSize={30}
   gridClassName="theme-grid tc-dropdown-container"
-  headerHeight={40}
+  headerHeight={35}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}
   height={600}
@@ -250,7 +250,7 @@ exports[`ListGrid should render react-virtualized table without header 1`] = `
   disableHeader={true}
   estimatedRowSize={30}
   gridClassName="theme-grid tc-dropdown-container"
-  headerHeight={40}
+  headerHeight={35}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}
   height={600}
@@ -315,7 +315,7 @@ exports[`ListGrid should render table with sort props 1`] = `
   disableHeader={false}
   estimatedRowSize={30}
   gridClassName="theme-grid tc-dropdown-container"
-  headerHeight={40}
+  headerHeight={35}
   headerRowRenderer={[Function]}
   headerStyle={Object {}}
   height={600}


### PR DESCRIPTION
This reverts commit d4e2257e420f14899dd0c14a286b1d3a610eda4a.

**What is the problem this PR is trying to solve?**
#1665 introduce issues
* no ellispsis anymore
* weird extra space on hover

**What is the chosen solution to this problem?**
Revert for now

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
