### PR TITLE
fix(ListView) Remove useless scrollbars

### DIFF
--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -3,7 +3,6 @@ $tc-listview-height: 40vh !default;
 .tc-listview-items {
 	padding-left: 0;
 	min-height: 0;
-	overflow-y: auto;
 	list-style: none;
 	box-shadow: inset 0 21px 3px -20px $shadow, inset 0 -21px 3px -20px $shadow;
 	height: $tc-listview-height;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
ListView sometimes gets useless scrollbars (content still fits container)
Plus, those scrollbars don't allow to browse the full content of ListView

**What is the chosen solution to this problem?**
Remove auto overflow CSS rule

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
