### PR TITLE
feat(TUI-202/ComponentForm): add loading feedback

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,6 +2,12 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/ComponentForm.component.js
+  204:3  warning  Unexpected console statement  no-console
+  209:3  warning  Unexpected console statement  no-console
+  220:3  warning  Unexpected console statement  no-console
+  226:3  warning  Unexpected console statement  no-console
+
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -17,5 +23,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 9 problems (5 errors, 4 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,9 +5,20 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+  27:18  error  'loading' is missing in props validation  react/prop-types
+
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Text/Text.component.js
+  9:72  error  'loading' is missing in props validation  react/prop-types
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/Array.component.js
   10:11  error  Trailing spaces not allowed                     no-trailing-spaces
   12:1   error  Line 12 exceeds the maximum line length of 100  max-len
 
-✖ 3 problems (3 errors, 0 warnings)
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/Widget/Widget.component.js
+  42:32  error  'loadingKeys' is missing in props validation           react/prop-types
+  43:13  error  'loadingKeys' is missing in props validation           react/prop-types
+  43:25  error  'loadingKeys.includes' is missing in props validation  react/prop-types
+
+✖ 8 problems (8 errors, 0 warnings)
 

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -199,7 +199,7 @@ export class TCompForm extends React.Component {
 					return { ...acc, [this.state[key]]: true };
 				}
 				return acc;
-			}, {})
+			}, {}),
 		);
 		console.log('getLoadingKeys', keys);
 		return keys;

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublish": "rimraf lib && babel -d lib ./src/ && cpx -v \"./src/**/*.scss\" lib",
+    "prepublish": "babel -d lib ./src/ && cpx -v \"./src/**/*.scss\" lib",
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -258,6 +258,7 @@ export class UIFormComponent extends React.Component {
 					templates={this.props.templates}
 					widgets={this.state.widgets}
 					displayMode={this.props.displayMode}
+					loadingKeys={this.props.loadingKeys}
 				/>
 			));
 		const buttonsRenderer = () => (
@@ -344,6 +345,7 @@ if (process.env.NODE_ENV !== 'production') {
 		/** State management impl: Set All fields validations errors */
 		setErrors: PropTypes.func,
 		getComponent: PropTypes.func,
+		loadingKeys: PropTypes.arrayOf(PropTypes.string),
 	};
 	UIFormComponent.propTypes = I18NUIForm.propTypes;
 }

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -37,6 +37,14 @@ export default function Widget(props) {
 	const id = sfPath.name(key, '_', props.id);
 	const error = getError(props.errors, props.schema);
 	const errorMessage = validationMessage || error;
+
+	let loading;
+	if (props.schema.key && props.loadingKeys) {
+		if (props.loadingKeys.includes(props.schema.key.join('.'))) {
+			loading = true;
+		}
+	}
+
 	return (
 		<WidgetImpl
 			{...props}
@@ -46,6 +54,7 @@ export default function Widget(props) {
 			isValid={!error}
 			value={getValue(props.properties, props.schema)}
 			options={options}
+			loading={loading}
 		/>
 	);
 }

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -24,6 +24,7 @@ function FieldTemplate(props) {
 	const groupsClassNames = classNames('form-group', theme.template, {
 		'has-error': !props.isValid,
 		required: props.required,
+		loading: props.loading,
 	});
 
 	return (

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
@@ -1,5 +1,10 @@
+@import '~@talend/bootstrap-theme/src/theme/animation';
+
 .template {
 	&:global(.required) :global(.control-label):after {
 		content: '*';
+	}
+	&:global(.loading) {
+		@include heartbeat(object-blink);
 	}
 }

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -6,7 +6,7 @@ import { generateDescriptionId, generateErrorId } from '../../Message/generateId
 import { convertValue } from '../../utils/properties';
 
 export default function Text(props) {
-	const { id, isValid, errorMessage, onChange, onFinish, schema, value } = props;
+	const { id, isValid, errorMessage, onChange, onFinish, schema, value, loading } = props;
 	const {
 		autoFocus,
 		description,
@@ -34,6 +34,7 @@ export default function Text(props) {
 			label={title}
 			labelAfter
 			required={schema.required}
+			loading={loading}
 		>
 			<input
 				id={id}
@@ -45,7 +46,7 @@ export default function Text(props) {
 					onChange(event, { schema, value: convertValue(type, event.target.value) })
 				}
 				placeholder={placeholder}
-				readOnly={readOnly}
+				readOnly={readOnly || loading}
 				type={type}
 				value={value}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current ComponentForm when a trigger is called no feedback is gave to the enduser.

**What is the chosen solution to this problem?**

Status: POC http://recordit.co/nhIRucBpn3

in UIForm:
Add `loadingKeys` array props to give a set of key path that should not be edited because under loading their value.

in ComponentForm:
during the ontrigger add the info in the loadingKeys.
Once the trigger is done remove the key from the loadingKeys

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
