### PR TITLE
fix(components/EditableText): fix position of edit icons

### DIFF
--- a/packages/components/src/EditableText/EditableText.scss
+++ b/packages/components/src/EditableText/EditableText.scss
@@ -53,6 +53,7 @@ $tc-circle-editable-text-size: 16px !default;
 	}
 
 	& &-form {
+		position: relative;
 		width: 100%;
 		display: flex;
 		align-items: center;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
before fix:
![beforefix](https://user-images.githubusercontent.com/3214228/45197796-bae15180-b295-11e8-95af-3a2c674fa515.png)
after fix:
![afterfix](https://user-images.githubusercontent.com/3214228/45197809-c6347d00-b295-11e8-8b8c-6f9b8e25286b.png)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
