### PR TITLE
fix(component): remove two proptypes warnings

### DIFF
--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -34,7 +34,7 @@ function PlainTextTitle({ onEdit, disabled, text, inProgress, t }) {
 
 PlainTextTitle.propTypes = {
 	text: PropTypes.string.isRequired,
-	onEdit: PropTypes.bool,
+	onEdit: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
 	inProgress: PropTypes.bool,
 	t: PropTypes.func,
@@ -73,7 +73,7 @@ EditableText.propTypes = {
 	editMode: PropTypes.bool,
 	loading: PropTypes.bool,
 	inProgress: PropTypes.bool,
-	onEdit: PropTypes.bool,
+	onEdit: PropTypes.func.isRequired,
 	disabled: PropTypes.bool,
 	t: PropTypes.func,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
proptypes definition on EditableText requested that onEdit should be a boolean value, while the name and usage suggest that it is a function

**What is the chosen solution to this problem?**
fix proptypes and make it required since there is no internal check for onEdit existance.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
