### PR TITLE
fix(containers/DeleteResource): Add onHide handler

### DIFF
--- a/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
@@ -59,11 +59,11 @@ function ConfirmDialog({
 	if (progressValue) {
 		progress = { percent: progressValue, tooltip: progressLabel };
 	}
-	function onHideHandler() {
-		if (cancelAction) {
+	function onHideHandler(event) {
+		if (cancelAction && cancelAction.onClick) {
 			cancelAction.onClick();
 		}
-		return onHide();
+		return onHide(event);
 	}
 	return (
 		<Dialog

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -21,6 +21,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 		right: 100%;
 
 		padding-left: $padding-larger;
+		margin-right: $padding-smaller;
 
 		.cell-title-actions-menu {
 			&:after {

--- a/packages/containers/src/DeleteResource/DeleteResource.container.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.container.js
@@ -106,6 +106,9 @@ export class DeleteResource extends React.Component {
 				cancelAction={cancelAction}
 				validateAction={validateAction}
 				getComponent={this.props.getComponent}
+				onHide={() =>
+					this.props.dispatchActionCreator('DeleteResource#cancel', event, { model: resourceInfo })
+				}
 			>
 				<div>
 					{this.props.t('DELETE_RESOURCE_MESSAGE', {

--- a/packages/containers/src/DeleteResource/DeleteResource.container.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.container.js
@@ -59,7 +59,9 @@ export class DeleteResource extends React.Component {
 	 * @param event
 	 */
 	onHide(event) {
-		this.props.dispatchActionCreator('DeleteResource#cancel', event, { model: this.getResourceInfo() });
+		this.props.dispatchActionCreator('DeleteResource#cancel', event, {
+			model: this.getResourceInfo(),
+		});
 	}
 
 	/**

--- a/packages/containers/src/DeleteResource/DeleteResource.container.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.container.js
@@ -51,6 +51,15 @@ export class DeleteResource extends React.Component {
 		super(props, context);
 		this.getLabelInfo = this.getLabelInfo.bind(this);
 		this.getResourceInfo = this.getResourceInfo.bind(this);
+		this.onHide = this.onHide.bind(this);
+	}
+
+	/**
+	 * onHide handler, called when click outside delete modal
+	 * @param event
+	 */
+	onHide(event) {
+		this.props.dispatchActionCreator('DeleteResource#cancel', event, { model: this.getResourceInfo() });
 	}
 
 	/**
@@ -106,9 +115,7 @@ export class DeleteResource extends React.Component {
 				cancelAction={cancelAction}
 				validateAction={validateAction}
 				getComponent={this.props.getComponent}
-				onHide={() =>
-					this.props.dispatchActionCreator('DeleteResource#cancel', event, { model: resourceInfo })
-				}
+				onHide={this.onHide}
 			>
 				<div>
 					{this.props.t('DELETE_RESOURCE_MESSAGE', {

--- a/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
+++ b/packages/containers/src/DeleteResource/__snapshots__/DeleteResource.test.js.snap
@@ -23,6 +23,7 @@ exports[`Container DeleteResource should render with proper resourceInfo params 
   }
   getComponent={undefined}
   header="My header title"
+  onHide={[Function]}
   show={true}
   validateAction={
     Object {
@@ -78,6 +79,7 @@ exports[`Container DeleteResource should render with wrong resourceInfo params 1
   }
   getComponent={undefined}
   header="My header title"
+  onHide={[Function]}
   show={true}
   validateAction={
     Object {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When click outside delete modal, there will be js errors about onClick not a function.
**What is the chosen solution to this problem?**
Pass `onHide` handler from DeleteResource. when click outside modal, it'll hide.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
