### PR TITLE
fix(ComponentKit): include objects and arrays in payload flatten

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,6 +2,9 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.js
+  20:1  error  Line 20 exceeds the maximum line length of 100  max-len
+
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -17,5 +20,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,9 +2,6 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.js
-  20:1  error  Line 20 exceeds the maximum line length of 100  max-len
-
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -20,5 +17,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -17,7 +17,7 @@
  * flatten an object means each keys are a jsonpath.
  * jsperf: https://jsperf.com/talend-flatten
  * @param {object} obj the source object
- * @param {boolean} includeObjects should include the complex structures (object/array) in the payload
+ * @param {boolean} includeObjects should include object/array in the payload
  * @return {object} flatten object
  * @example
  * flatten({ level1: { level2: 'foo' }})

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -17,15 +17,25 @@
  * flatten an object means each keys are a jsonpath.
  * jsperf: https://jsperf.com/talend-flatten
  * @param {object} obj the source object
+ * @param {boolean} includeObjects should include the complex structures (object/array) in the payload
  * @return {object} flatten object
  * @example
  * flatten({ level1: { level2: 'foo' }})
  * // { 'level1.level2': 'foo' }
  */
-export default function flatten(obj) {
+export default function flatten(obj, includeObjects) {
 	const payload = {};
 
 	function step(anything, key) {
+		if (
+			key !== '' &&
+			(typeof anything === 'string' ||
+				typeof anything === 'number' ||
+				typeof anything === 'boolean' ||
+				includeObjects)
+		) {
+			payload[key] = anything;
+		}
 		if (Array.isArray(anything)) {
 			anything.forEach((item, index) => {
 				const itemKey = `${key}[${index}]`;
@@ -37,12 +47,6 @@ export default function flatten(obj) {
 				const item = anything[nextKey];
 				step(item, itemKey);
 			});
-		} else if (typeof anything === 'string') {
-			payload[key] = anything;
-		} else if (typeof anything === 'number') {
-			payload[key] = anything;
-		} else if (typeof anything === 'boolean') {
-			payload[key] = anything;
 		}
 	}
 	step(obj, '');

--- a/packages/containers/src/ComponentForm/kit/flatten.test.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.test.js
@@ -27,6 +27,20 @@ describe('flatten', () => {
 		};
 		expect(flatten(foo)).toEqual({ 'root.array[0]': 'foo' });
 	});
+	it('should include objects and arrays in the flatten payload', () => {
+		const foo = {
+			root: {
+				array: ['foo'],
+			},
+		};
+		expect(flatten(foo, true)).toEqual({
+			root: {
+				array: ['foo'],
+			},
+			'root.array': ['foo'],
+			'root.array[0]': 'foo',
+		});
+	});
 	it('should skip function', () => {
 		const foo = {
 			root: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Component kit `flatten(payload)` was not including arrays and objects.
So during triggers, it is not possible to send complex items, with their key.

```
const payload = {
    a: [{ b: 'lol', c: 'mdr' }]
}

flatten(payload);
{
    a[0].b: 'lol',
    a[0].c: 'mdr',
}
```

**What is the chosen solution to this problem?**
Include add an option to include arrays and objects

```
const payload = {
    a: [{ b: 'lol', c: 'mdr' }]
}

flatten(payload, true);
{
    a: [{ b: 'lol', c: 'mdr' }],
    a[0]: { b: 'lol', c: 'mdr' },
    a[0].b: 'lol',
    a[0].c: 'mdr',
}
```

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
