### PR TITLE
feat(UIForm): improve tabs widget a11y

### DIFF
--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -226,6 +226,7 @@ exports[`Drawer should render with tabs 1`] = `
       className="tc-drawer-tabs-container theme-tc-drawer-tabs-container"
     >
       <div
+        className="tc-drawer-tabs theme-tc-drawer-tabs"
         id="my-tabs"
         onKeyDown={[Function]}
       >

--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -52,11 +52,12 @@ class TabBar extends React.Component {
 	}
 
 	render() {
-		const { id, items, selectedKey, children, generateChildId } = this.props;
+		const { className, id, items, selectedKey, children, generateChildId } = this.props;
 		return (
 			<Tab.Container
 				id={id}
 				activeKey={selectedKey}
+				className={className}
 				onSelect={this.handleSelect}
 				onKeyDown={this.handleKeyDown}
 				generateChildId={generateChildId}
@@ -78,6 +79,7 @@ class TabBar extends React.Component {
 					<Tab.Content>
 						{items.map(item => (
 							<Tab.Pane eventKey={item.key} key={item.key}>
+								{item.children}
 								{selectedKey === item.key ? children : null}
 							</Tab.Pane>
 						))}
@@ -92,6 +94,7 @@ TabBar.displayName = 'TabBar';
 
 TabBar.propTypes = {
 	children: PropTypes.node,
+	className: PropTypes.string,
 	generateChildId: PropTypes.func,
 	id: PropTypes.string.isRequired,
 	items: PropTypes.arrayOf(
@@ -102,7 +105,7 @@ TabBar.propTypes = {
 		}).isRequired,
 	).isRequired,
 	onSelect: PropTypes.func.isRequired,
-	selectedKey: PropTypes.string,
+	selectedKey: PropTypes.any,
 };
 
 TabBar.Tab = Tab;

--- a/packages/components/src/TabBar/TabBar.test.js
+++ b/packages/components/src/TabBar/TabBar.test.js
@@ -5,6 +5,7 @@ import TabBar from './TabBar.component';
 
 const tabProps = {
 	id: 'my-tabs',
+	className: 'tabs-classname',
 	items: [
 		{
 			key: '1',
@@ -42,6 +43,20 @@ describe('TabBar component', () => {
 
 		// when
 		const wrapper = shallow(<TabBar {...tabProps}>I'm the content</TabBar>);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render items with defined children', () => {
+		// given
+		const items = tabProps.items.map((item, index) => ({
+			...item,
+			children: <div>child {index}</div>,
+		}));
+
+		// when
+		const wrapper = shallow(<TabBar {...tabProps} items={items} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/TabBar/__snapshots__/TabBar.test.js.snap
+++ b/packages/components/src/TabBar/__snapshots__/TabBar.test.js.snap
@@ -3,6 +3,7 @@
 exports[`TabBar component should render 1`] = `
 <Uncontrolled(TabContainer)
   activeKey="3"
+  className="tabs-classname"
   generateChildId={undefined}
   id="my-tabs"
   onKeyDown={[Function]}
@@ -79,11 +80,15 @@ exports[`TabBar component should render 1`] = `
       <TabPane
         bsClass="tab-pane"
         eventKey="1"
-      />
+      >
+        
+      </TabPane>
       <TabPane
         bsClass="tab-pane"
         eventKey="2"
-      />
+      >
+        
+      </TabPane>
       <TabPane
         bsClass="tab-pane"
         eventKey="3"
@@ -93,11 +98,142 @@ exports[`TabBar component should render 1`] = `
       <TabPane
         bsClass="tab-pane"
         eventKey="4"
-      />
+      >
+        
+      </TabPane>
       <TabPane
         bsClass="tab-pane"
         eventKey="5"
-      />
+      >
+        
+      </TabPane>
+    </TabContent>
+  </div>
+</Uncontrolled(TabContainer)>
+`;
+
+exports[`TabBar component should render items with defined children 1`] = `
+<Uncontrolled(TabContainer)
+  activeKey="3"
+  className="tabs-classname"
+  generateChildId={undefined}
+  id="my-tabs"
+  onKeyDown={[Function]}
+  onSelect={[Function]}
+>
+  <div>
+    <Nav
+      bsClass="nav"
+      bsStyle="tabs"
+      className="tc-tab-bar"
+      justified={false}
+      pullLeft={false}
+      pullRight={false}
+      stacked={false}
+    >
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.1"
+        disabled={false}
+        eventKey="1"
+        label="Tab1"
+      >
+        Tab1
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.2"
+        disabled={false}
+        eventKey="2"
+        label="Tab2"
+      >
+        Tab2
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.3"
+        disabled={false}
+        eventKey="3"
+        label="Tab3"
+      >
+        Tab3
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.4"
+        disabled={false}
+        eventKey="4"
+        label="Tab4"
+      >
+        Tab4
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.5"
+        disabled={false}
+        eventKey="5"
+        label="Tab5"
+      >
+        Tab5
+      </NavItem>
+    </Nav>
+    <TabContent
+      animation={true}
+      bsClass="tab"
+      componentClass="div"
+      mountOnEnter={false}
+      unmountOnExit={false}
+    >
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="1"
+      >
+        <div>
+          child 
+          0
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="2"
+      >
+        <div>
+          child 
+          1
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="3"
+      >
+        <div>
+          child 
+          2
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="4"
+      >
+        <div>
+          child 
+          3
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="5"
+      >
+        <div>
+          child 
+          4
+        </div>
+      </TabPane>
     </TabContent>
   </div>
 </Uncontrolled(TabContainer)>

--- a/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.component.js
@@ -1,48 +1,70 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { Tabs as RBTabs, Tab as RBTab } from 'react-bootstrap';
+import TabBar from '@talend/react-components/lib/TabBar';
 import classNames from 'classnames';
+import { translate } from 'react-i18next';
 
 import Fieldset from '../Fieldset';
 import { isValid } from '../../utils/validation';
 import theme from './Tabs.scss';
+import { I18N_DOMAIN_FORMS } from '../../../constants';
+import getDefaultT from '../../../translate';
 
-export default function Tabs(props) {
-	const { schema, ...restProps } = props;
-	const tabs = schema.items;
+class Tabs extends React.Component {
+	constructor(props) {
+		super(props);
+		this.state = { selectedKey: 0 };
+		this.onSelect = this.onSelect.bind(this);
+	}
 
-	return (
-		<RBTabs
-			className={classNames(theme['tf-tabs'], 'tf-tabs')}
-			id={`${restProps.id}-tabs`}
-		>
-			{tabs.map((tabSchema, index) => {
-				const tabIsValid = isValid(tabSchema, restProps.errors);
-				return (
-					<RBTab
-						eventKey={index}
-						key={index}
-						title={tabSchema.title}
-						tabClassName={classNames({ [theme['has-error']]: !tabIsValid })}
-					>
-						<Fieldset {...restProps} schema={tabSchema} />
-					</RBTab>
-				);
-			})}
-		</RBTabs>
-	);
+	onSelect(event, item) {
+		this.setState({ selectedKey: item.key });
+	}
+
+	render() {
+		const { schema, t, ...restProps } = this.props;
+		const tabs = schema.items.map((item, index) => {
+			const tabIsValid = isValid(item, restProps.errors);
+			return {
+				key: index,
+				label: item.title,
+				className: classNames({ [theme['has-error']]: !tabIsValid }),
+				'aria-label': tabIsValid
+					? undefined
+					: `${item.title} (${t('TF_TABS_HAS_ERRORS', { defaultValue: 'has errors' })})`,
+				children: <Fieldset {...restProps} schema={item} />,
+			};
+		});
+		const { selectedKey } = this.state;
+
+		return (
+			<TabBar
+				className={classNames(theme['tf-tabs'], 'tf-tabs')}
+				id={`${restProps.id}-tabs`}
+				items={tabs}
+				onSelect={this.onSelect}
+				selectedKey={selectedKey}
+			/>
+		);
+	}
 }
+Tabs.defaultProps = {
+	t: getDefaultT(),
+};
 
 if (process.env.NODE_ENV !== 'production') {
 	Tabs.propTypes = {
-		errors: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+		errors: PropTypes.object,
 		schema: PropTypes.shape({
 			items: PropTypes.arrayOf(
 				PropTypes.shape({
 					title: PropTypes.string.isRequired,
 					items: PropTypes.array.isRequired,
-				})
+				}),
 			).isRequired,
 		}).isRequired,
+		t: PropTypes.func,
 	};
 }
+
+export default translate(I18N_DOMAIN_FORMS)(Tabs);

--- a/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.component.test.js
@@ -39,7 +39,7 @@ describe('Tabs widget', () => {
 		};
 
 		// when
-		const wrapper = shallow(<Tabs schema={schema} errors={errors} />);
+		const wrapper = shallow(<Tabs.WrappedComponent schema={schema} errors={errors} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -80,9 +80,10 @@ describe('Tabs widget', () => {
 		};
 
 		// when
-		const wrapper = shallow(<Tabs schema={schema} errors={errors} />);
+		const wrapper = shallow(<Tabs.WrappedComponent schema={schema} errors={errors} />);
+		const invalidItem = wrapper.prop('items')[0];
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(invalidItem.className).toBe('theme-has-error');
 	});
 });

--- a/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.scss
+++ b/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.scss
@@ -1,11 +1,10 @@
 .tf-tabs {
 	li.has-error {
-		> a,
-		> a:focus {
+		> button {
 			color: $brand-danger;
 		}
 
-		&:global(.active) > a {
+		&:global(.active) > button {
 			@include box-shadow(inset 0 -2px 0 $brand-danger);
 		}
 	}

--- a/packages/forms/src/UIForm/fieldsets/Tabs/__snapshots__/Tabs.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Tabs/__snapshots__/Tabs.component.test.js.snap
@@ -1,147 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tabs widget should render fieldset 1`] = `
-<Uncontrolled(Tabs)
+<TabBar
   className="theme-tf-tabs tf-tabs"
   id="undefined-tabs"
->
-  <Tab
-    eventKey={0}
-    tabClassName=""
-    title="User"
-  >
-    <Fieldset
-      errors={Object {}}
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "key": Array [
-                "user",
-                "firstname",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-            Object {
-              "key": Array [
-                "user",
-                "lastname",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-          ],
-          "title": "User",
-        }
-      }
-    />
-  </Tab>
-  <Tab
-    eventKey={1}
-    tabClassName=""
-    title="Other"
-  >
-    <Fieldset
-      errors={Object {}}
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "key": Array [
-                "comment",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-          ],
-          "title": "Other",
-        }
-      }
-    />
-  </Tab>
-</Uncontrolled(Tabs)>
-`;
-
-exports[`Tabs widget should render invalid tab 1`] = `
-<Uncontrolled(Tabs)
-  className="theme-tf-tabs tf-tabs"
-  id="undefined-tabs"
->
-  <Tab
-    eventKey={0}
-    tabClassName="theme-has-error"
-    title="User"
-  >
-    <Fieldset
-      errors={
-        Object {
-          "user,firstname": "This is wrong",
-        }
-      }
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "key": Array [
-                "user",
-                "firstname",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-            Object {
-              "key": Array [
-                "user",
-                "lastname",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-          ],
-          "title": "User",
-        }
-      }
-    />
-  </Tab>
-  <Tab
-    eventKey={1}
-    tabClassName=""
-    title="Other"
-  >
-    <Fieldset
-      errors={
-        Object {
-          "user,firstname": "This is wrong",
-        }
-      }
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "key": Array [
-                "comment",
-              ],
-              "schema": Object {
-                "type": "string",
-              },
-              "type": "text",
-            },
-          ],
-          "title": "Other",
-        }
-      }
-    />
-  </Tab>
-</Uncontrolled(Tabs)>
+  items={
+    Array [
+      Object {
+        "aria-label": undefined,
+        "children": <Fieldset
+          errors={Object {}}
+          schema={
+                Object {
+                      "items": Array [
+                        Object {
+                          "key": Array [
+                            "user",
+                            "firstname",
+                          ],
+                          "schema": Object {
+                            "type": "string",
+                          },
+                          "type": "text",
+                        },
+                        Object {
+                          "key": Array [
+                            "user",
+                            "lastname",
+                          ],
+                          "schema": Object {
+                            "type": "string",
+                          },
+                          "type": "text",
+                        },
+                      ],
+                      "title": "User",
+                    }
+          }
+    />,
+        "className": "",
+        "key": 0,
+        "label": "User",
+      },
+      Object {
+        "aria-label": undefined,
+        "children": <Fieldset
+          errors={Object {}}
+          schema={
+                Object {
+                      "items": Array [
+                        Object {
+                          "key": Array [
+                            "comment",
+                          ],
+                          "schema": Object {
+                            "type": "string",
+                          },
+                          "type": "text",
+                        },
+                      ],
+                      "title": "Other",
+                    }
+          }
+    />,
+        "className": "",
+        "key": 1,
+        "label": "Other",
+      },
+    ]
+  }
+  onSelect={[Function]}
+  selectedKey={0}
+/>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
* Tabs widget use react-bootstrap tabs that doesn't implement all accessibility gestures
* tab with error holds the info only with red color. Need text aternative.

**What is the chosen solution to this problem?**
* use components TabBar
* add text alternative to tabs with error

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
