### PR TITLE
feat(uiform): keep the errors provide by triggers during onSubmit

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import tv4 from 'tv4';
 import { translate } from 'react-i18next';
-import get from 'lodash/get';
 
 import { DefaultFormTemplate, TextModeFormTemplate } from './FormTemplate';
 import merge from './merge';

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import tv4 from 'tv4';
 import { translate } from 'react-i18next';
+import get from 'lodash/get';
 
 import { DefaultFormTemplate, TextModeFormTemplate } from './FormTemplate';
 import merge from './merge';
@@ -214,7 +215,8 @@ export class UIFormComponent extends React.Component {
 
 		const { mergedSchema } = this.state;
 		const { properties, customValidation } = this.props;
-		const errors = validateAll(mergedSchema, properties, customValidation);
+		const newErrors = validateAll(mergedSchema, properties, customValidation);
+		const errors = { ...this.props.errors, ...newErrors };
 		this.props.setErrors(event, errors);
 
 		const isValid = !Object.keys(errors).length;

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -273,6 +273,28 @@ describe('UIForm component', () => {
 			});
 		});
 
+		it('should validate all fields with existing errors', () => {
+			// given
+			const dataProperties = { lastname: 'dupont' };
+			const errors = {
+				lastname: 'String is too short (6 chars), minimum 10',
+				checked: 'error added via a trigger',
+			};
+			// props.errors.lastname =
+			const wrapper = shallow(
+				<UIFormComponent {...data} properties={dataProperties} errors={errors} {...props} />);
+
+			// when
+			wrapper.instance().onSubmit(submitEvent);
+
+			// then
+			expect(props.setErrors).toBeCalledWith(submitEvent, {
+				checked: 'error added via a trigger',
+				firstname: 'Missing required field',
+				lastname: 'String is too short (6 chars), minimum 10',
+			});
+		});
+
 		it('should validate all fields with custom error messages', () => {
 			const props2 = {
 				...props,

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -282,7 +282,8 @@ describe('UIForm component', () => {
 			};
 			// props.errors.lastname =
 			const wrapper = shallow(
-				<UIFormComponent {...data} properties={dataProperties} errors={errors} {...props} />);
+				<UIFormComponent {...data} properties={dataProperties} errors={errors} {...props} />,
+			);
 
 			// when
 			wrapper.instance().onSubmit(submitEvent);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In case of we use a trigger to manage validation of some fields (e.g. specific validation rules in an array), during the onSubmit, we need to keep errors added and merge them with errors founded during the onSubmit.

**What is the chosen solution to this problem?**
keep existing errors

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
