### PR TITLE
fix(List/TUI-135): align select all

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -5,14 +5,11 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   105:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role
 
-/home/travis/build/Talend/ui/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
-  12:37  error  ["container"] is better written in dot notation  dot-notation
-
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 4 problems (3 errors, 1 warning)
+✖ 3 problems (2 errors, 1 warning)
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -5,11 +5,14 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   105:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role
 
+/home/travis/build/Talend/ui/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
+  12:37  error  ["container"] is better written in dot notation  dot-notation
+
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 3 problems (2 errors, 1 warning)
+✖ 4 problems (3 errors, 1 warning)
 

--- a/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
+++ b/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
@@ -9,7 +9,7 @@ function SelectAll({ id, items, isSelected, onToggleAll, t }) {
 	const isAllSelected = () => items.length > 0 && items.findIndex(item => !isSelected(item)) < 0;
 	const checkboxId = id && `${id}-check-all`;
 	return (
-		<form className="navbar-form navbar-left">
+		<form className={classNames(theme['container'], 'navbar-form navbar-left')}>
 			<div
 				className={classNames('checkbox-inline navbar-text', theme['tc-list-toolbar-select-all'])}
 			>

--- a/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
+++ b/packages/components/src/List/Toolbar/SelectAll/SelectAll.component.js
@@ -9,7 +9,7 @@ function SelectAll({ id, items, isSelected, onToggleAll, t }) {
 	const isAllSelected = () => items.length > 0 && items.findIndex(item => !isSelected(item)) < 0;
 	const checkboxId = id && `${id}-check-all`;
 	return (
-		<form className={classNames(theme['container'], 'navbar-form navbar-left')}>
+		<form className={classNames(theme.container, 'navbar-form navbar-left')}>
 			<div
 				className={classNames('checkbox-inline navbar-text', theme['tc-list-toolbar-select-all'])}
 			>

--- a/packages/components/src/List/Toolbar/SelectAll/SelectAll.scss
+++ b/packages/components/src/List/Toolbar/SelectAll/SelectAll.scss
@@ -1,4 +1,10 @@
+.container {
+	padding-left: 0;
+}
+
 .tc-list-toolbar-select-all {
+	margin-left: $padding-small;
+	padding-left: 0;
 	:global(label) {
 		margin-bottom: 0;
 		margin-left: 5px;

--- a/packages/components/src/List/Toolbar/SelectAll/__snapshots__/SelectAll.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/SelectAll/__snapshots__/SelectAll.snapshot.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`SelectAll should be unchecked when there is no items 1`] = `
 <form
-  className="navbar-form navbar-left"
+  className="theme-container navbar-form navbar-left"
 >
   <div
     className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"
@@ -28,7 +28,7 @@ exports[`SelectAll should be unchecked when there is no items 1`] = `
 
 exports[`SelectAll should render 1`] = `
 <form
-  className="navbar-form navbar-left"
+  className="theme-container navbar-form navbar-left"
 >
   <div
     className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"
@@ -54,7 +54,7 @@ exports[`SelectAll should render 1`] = `
 
 exports[`SelectAll should render id if provided 1`] = `
 <form
-  className="navbar-form navbar-left"
+  className="theme-container navbar-form navbar-left"
 >
   <div
     className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"

--- a/packages/components/src/List/Toolbar/Toolbar.scss
+++ b/packages/components/src/List/Toolbar/Toolbar.scss
@@ -8,6 +8,10 @@ $tc-list-toolbar-background-color: $concrete !default;
 	border-bottom: 1px solid $alto;
 	margin-bottom: 0;
 
+	> :global(.container-fluid) {
+		padding-left: 0;
+	}
+
 	:global(.navbar-btn) {
 		margin-top: 0;
 		margin-bottom: 0;

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -499,7 +499,7 @@ exports[`Toolbar should render select all checkbox 1`] = `
       className="container-fluid"
     >
       <form
-        className="navbar-form navbar-left"
+        className="theme-container navbar-form navbar-left"
       >
         <div
           className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -713,7 +713,7 @@ exports[`List should render 1`] = `
                         t={[Function]}
                       >
                         <form
-                          className="navbar-form navbar-left"
+                          className="theme-container navbar-form navbar-left"
                         >
                           <div
                             className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"
@@ -2528,7 +2528,7 @@ exports[`List should render id if provided 1`] = `
                         t={[Function]}
                       >
                         <form
-                          className="navbar-form navbar-left"
+                          className="theme-container navbar-form navbar-left"
                         >
                           <div
                             className="checkbox-inline navbar-text theme-tc-list-toolbar-select-all"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The select all checbox is not aligned with the content

**What is the chosen solution to this problem?**

align the content

![screen shot 2018-10-01 at 16 41 48](https://user-images.githubusercontent.com/19857479/46296837-8f533d80-c59b-11e8-8055-574f759a31e5.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
