### PR TITLE
doc: add versions precision in readme files

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,7 @@ To start to dev on a package and see it in action just use one of the following
 - yarn start-containers on localhost:6007
 - yarn start-forms on localhost:6008
 - yarn start-theme on localhost:1337
+
+## Versions and breaking changes
+
+[See the wiki](https://github.com/Talend/ui/wiki/Workflow#major--breaking-change-aka-next)

--- a/packages/cmf-cqrs/README.md
+++ b/packages/cmf-cqrs/README.md
@@ -26,6 +26,9 @@ This is a library to help you to build configurable React App with CQRS pattern.
 Before 1.0, `@talend/react-cmf-cqrs` do NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Content
 
 This package provides tools to deal with cqrs backend allowing websocket handling :

--- a/packages/cmf-cqrs/README.md
+++ b/packages/cmf-cqrs/README.md
@@ -25,9 +25,8 @@ This is a library to help you to build configurable React App with CQRS pattern.
 
 Before 1.0, `@talend/react-cmf-cqrs` do NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Content
 

--- a/packages/cmf-webpack-plugin/README.md
+++ b/packages/cmf-webpack-plugin/README.md
@@ -21,11 +21,6 @@ Simplifies merging of CMF settings files to serve your webpack bundles.
 [quality-badge]: http://npm.packagequality.com/shield/@talend/react-cmf-webpack-plugin.svg
 [quality-url]: http://packagequality.com/#?package=@talend/react-cmf-webpack-plugin
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-cmf-webpack-plugin` does NOT follow semver in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 ## Content
 
 This package provides Webpack plugin to deal with several React CMF settings files.

--- a/packages/cmf/README.md
+++ b/packages/cmf/README.md
@@ -22,9 +22,8 @@ It provides a set of base APIs and patterns.
 
 Before 1.0, `@talend/react-cmf` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Requirements
 

--- a/packages/cmf/README.md
+++ b/packages/cmf/README.md
@@ -23,6 +23,9 @@ It provides a set of base APIs and patterns.
 Before 1.0, `@talend/react-cmf` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Requirements
 
 Before trying CMF you must know:
@@ -207,14 +210,10 @@ you may change the following using simple props:
 
 ## ROADMAP
 
-For 1.0
+For 2.0
 
 * [ ] documentation review
 * [ ] provide an example OSS demo app
 * [ ] remove all deprecated code
 * [ ] update or remove react-router
 * [ ] move from peer dependencies to dependencies
-* [x] integrate redux-saga
-* [x] add a yeoman generator
-* [x] actionCreator should become first class
-* [x] embedable apps

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -25,6 +25,9 @@ A set of stateless components which follows the [Talend Guidelines](http://guide
 Before 1.0, `@talend/react-components` does NOT follow semver in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Conventions
 
 Please look at our [CONTRIBUTING](https://github.com/Talend/tools/blob/master/tools-root-github/CONTRIBUTING.md) first.

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -24,9 +24,8 @@ A set of stateless components which follows the [Talend Guidelines](http://guide
 
 Before 1.0, `@talend/react-components` does NOT follow semver in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Conventions
 

--- a/packages/containers/README.md
+++ b/packages/containers/README.md
@@ -26,9 +26,8 @@ This library provide a set of widgets to be ready to start with [react-cmf](http
 
 Before 1.0, `@talend/react-containers` does NOT follow semver in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Dependencies
 

--- a/packages/containers/README.md
+++ b/packages/containers/README.md
@@ -27,6 +27,9 @@ This library provide a set of widgets to be ready to start with [react-cmf](http
 Before 1.0, `@talend/react-containers` does NOT follow semver in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Dependencies
 
 * react

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -6,9 +6,8 @@
 
 Before 1.0, `@talend/react-forms` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Introduction
 

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -7,6 +7,9 @@
 Before 1.0, `@talend/react-forms` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Introduction
 
 This library is designed to be used on top of [react-jsonschema-form](https://mozilla-services.github.io/react-jsonschema-form/), a React component for building Web forms from JSONSchema.

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -23,6 +23,9 @@
 Before 1.0, `generator-talend` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Installation
 
 You'll first need to install [yeoman](http://yeoman.io/) then install

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -22,9 +22,8 @@
 
 Before 1.0, `generator-talend` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Installation
 

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -28,6 +28,9 @@ This is the set of SVG icons used in our apps.
 Before 1.0, `@talend/icons` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 # How to use
 
 To use this icon set you just have to install it through NPM.

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -27,9 +27,8 @@ This is the set of SVG icons used in our apps.
 
 Before 1.0, `@talend/icons` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 # How to use
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -14,6 +14,9 @@ A small library that provides a centralized error logger.
 Before 1.0, `@talend/log` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 #### Advanced config
 
 Look in ./src/errorTransformer.js for jsDoc on each parameter

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -13,9 +13,8 @@ A small library that provides a centralized error logger.
 
 Before 1.0, `@talend/log` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 #### Advanced config
 

--- a/packages/sagas/README.md
+++ b/packages/sagas/README.md
@@ -28,9 +28,8 @@ A set of generic sagas that are reusable accross the app(http://guidelines.talen
 
 Before 1.0, `@talend/react-sagas` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Conventions
 

--- a/packages/sagas/README.md
+++ b/packages/sagas/README.md
@@ -29,6 +29,9 @@ A set of generic sagas that are reusable accross the app(http://guidelines.talen
 Before 1.0, `@talend/react-sagas` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 ## Conventions
 
 Please look at our [CONTRIBUTING](https://github.com/Talend/tools/blob/master/tools-root-github/CONTRIBUTING.md) first.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -18,6 +18,9 @@ Note: The example has been taken from the excellent project [Bootstwatch](https:
 Before 1.0, `@talend/bootstrap-theme` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
 
+Before 2.0, we will try not to introduce breaking changes, as possible.
+From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+
 # How to use
 
 ## Install dependency

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -17,9 +17,8 @@ Note: The example has been taken from the excellent project [Bootstwatch](https:
 
 Before 1.0, `@talend/bootstrap-theme` does NOT follow semver version in releases.
 You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 Before 2.0, we will try not to introduce breaking changes, as possible.
-From 3.0, we will only introduce breaking changes in major releases, and follow semver.
+After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 # How to use
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In packages, we have precision about not following semver before 1.0.
Now we are in 1.0 but we will allow exceptions, depending on the case.

**What is the chosen solution to this problem?**
Added precision about future versionning.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
