### PR TITLE
fix(ComponentForm): extract complex items in trigger parameters

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,6 +2,13 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/createTriggers.test.js
+  1:8  error  'createTriggers' is defined but never used         no-unused-vars
+  3:2  error  'createCacheKey' is defined but never used         no-unused-vars
+  4:2  error  'toJSON' is defined but never used                 no-unused-vars
+  5:2  error  'toQueryParam' is defined but never used           no-unused-vars
+  6:2  error  'getPathWithArrayIndex' is defined but never used  no-unused-vars
+
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -17,5 +24,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 10 problems (10 errors, 0 warnings)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,6 +2,9 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.test.js
+  3:10  error  'noop' is defined but never used  no-unused-vars
+
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -17,5 +20,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,13 +2,6 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/createTriggers.test.js
-  1:8  error  'createTriggers' is defined but never used         no-unused-vars
-  3:2  error  'createCacheKey' is defined but never used         no-unused-vars
-  4:2  error  'toJSON' is defined but never used                 no-unused-vars
-  5:2  error  'toQueryParam' is defined but never used           no-unused-vars
-  6:2  error  'getPathWithArrayIndex' is defined but never used  no-unused-vars
-
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -24,5 +17,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 

--- a/packages/containers/src/ComponentForm/kit/createTriggers.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.js
@@ -77,10 +77,19 @@ export function extractParameters(parameters, properties, schema) {
 	if (!parameters || !Array.isArray(parameters)) {
 		return {};
 	}
-	const flattenProps = flatten(properties, true);
+	const flattenProps = flatten(properties);
 	return parameters.reduce((acc, param) => {
 		const path = getPathWithArrayIndex(param.path, schema);
-		acc[param.key] = flattenProps[path];
+		const value = flattenProps[path];
+		if (typeof value === 'object') {
+			Object.keys(value)
+				.filter(key => typeof value[key] !== 'object')
+				.forEach(key => {
+					acc[`${param.key}${key}`] = value[key];
+				});
+		} else {
+			acc[param.key] = value;
+		}
 		return acc;
 	}, {});
 }

--- a/packages/containers/src/ComponentForm/kit/createTriggers.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.js
@@ -77,7 +77,7 @@ export function extractParameters(parameters, properties, schema) {
 	if (!parameters || !Array.isArray(parameters)) {
 		return {};
 	}
-	const flattenProps = flatten(properties);
+	const flattenProps = flatten(properties, true);
 	return parameters.reduce((acc, param) => {
 		const path = getPathWithArrayIndex(param.path, schema);
 		acc[param.key] = flattenProps[path];

--- a/packages/containers/src/ComponentForm/kit/createTriggers.test.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.test.js
@@ -20,7 +20,7 @@ const properties = {
 		password: 'secret',
 	},
 };
-
+/*
 describe('createTriggers', () => {
 	let triggers;
 	let response;
@@ -90,7 +90,7 @@ describe('getPathWithArrayIndex', () => {
 		expect(getPathWithArrayIndex(specPath, arraySchema)).toBe(expectedPath);
 	});
 });
-
+*/
 describe('extractParameters', () => {
 	it('should return object with extracted value from properties', () => {
 		expect(extractParameters(trigger.parameters, properties, schema)).toEqual({
@@ -101,18 +101,19 @@ describe('extractParameters', () => {
 		const parameters = [{ path: 'obj.myArray', key: 'lol-array' }];
 		const complexProperties = {
 			obj: {
-				myArray: ['lol'],
+				myArray: ['lol', { toto: 'mdr' }],
 			},
 		};
 		expect(extractParameters(parameters, complexProperties, {})).toEqual({
-			'lol-array': ['lol'],
+			'lol-array[0]': 'lol',
+			'lol-array[1].toto': 'mdr',
 		});
 	});
 	it('should return empty object if no parameters', () => {
 		expect(extractParameters(undefined, properties, schema)).toEqual({});
 	});
 });
-
+/*
 describe('createCacheKey', () => {
 	it('should return undefined if not suggestions', () => {
 		expect(createCacheKey({ type: 'foo' })).toBeUndefined();
@@ -158,3 +159,4 @@ describe('toQueryParam', () => {
 		expect(toQueryParam({ foo: 'foo space', bar: 'bar' })).toEqual('foo=foo%20space&bar=bar');
 	});
 });
+*/

--- a/packages/containers/src/ComponentForm/kit/createTriggers.test.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.test.js
@@ -97,6 +97,17 @@ describe('extractParameters', () => {
 			url: properties.obj.url,
 		});
 	});
+	it('should return extract complex values (object/array)', () => {
+		const parameters = [{ path: 'obj.myArray', key: 'lol-array' }];
+		const complexProperties = {
+			obj: {
+				myArray: ['lol'],
+			},
+		};
+		expect(extractParameters(parameters, complexProperties, {})).toEqual({
+			'lol-array': ['lol'],
+		});
+	});
 	it('should return empty object if no parameters', () => {
 		expect(extractParameters(undefined, properties, schema)).toEqual({});
 	});

--- a/packages/containers/src/ComponentForm/kit/createTriggers.test.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.test.js
@@ -20,7 +20,7 @@ const properties = {
 		password: 'secret',
 	},
 };
-/*
+
 describe('createTriggers', () => {
 	let triggers;
 	let response;
@@ -90,7 +90,7 @@ describe('getPathWithArrayIndex', () => {
 		expect(getPathWithArrayIndex(specPath, arraySchema)).toBe(expectedPath);
 	});
 });
-*/
+
 describe('extractParameters', () => {
 	it('should return object with extracted value from properties', () => {
 		expect(extractParameters(trigger.parameters, properties, schema)).toEqual({
@@ -113,7 +113,7 @@ describe('extractParameters', () => {
 		expect(extractParameters(undefined, properties, schema)).toEqual({});
 	});
 });
-/*
+
 describe('createCacheKey', () => {
 	it('should return undefined if not suggestions', () => {
 		expect(createCacheKey({ type: 'foo' })).toBeUndefined();
@@ -159,4 +159,3 @@ describe('toQueryParam', () => {
 		expect(toQueryParam({ foo: 'foo space', bar: 'bar' })).toEqual('foo=foo%20space&bar=bar');
 	});
 });
-*/

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -28,13 +28,13 @@ function step(anything, key, payload) {
 		if (Array.isArray(anything)) {
 			anything.forEach((item, index) => {
 				const itemKey = `[${index}]`;
-				step(item, itemKey, subPayload, false);
+				step(item, itemKey, subPayload);
 			});
 		} else {
 			Object.keys(anything).forEach(nextKey => {
-				const itemKey = key ? `.${nextKey}` : nextKey;
+				const itemKey = `.${nextKey}`;
 				const item = anything[nextKey];
-				step(item, itemKey, subPayload, false);
+				step(item, itemKey, subPayload);
 			});
 		}
 
@@ -57,7 +57,8 @@ function step(anything, key, payload) {
  * // { 'level1.level2': 'foo' }
  */
 export default function flatten(obj) {
-	const payload = {};
-	step(obj, '', payload);
-	return payload;
+	return Object.keys(obj).reduce((accu, key) => {
+		step(obj[key], key, accu);
+		return accu;
+	}, {});
 }

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-param-reassign */
 /**
  *  Copyright (C) 2006-2018 Talend Inc. - www.talend.com
  *
@@ -13,42 +14,50 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
+
+function step(anything, key, payload) {
+	// on native values, we just add it in the payload
+	if (typeof anything !== 'object') {
+		payload[key] = anything;
+	} else {
+		// for objects (including arrays), we flatten it. The we store it in 2 forms.
+		// Let's say that we have a key 'my-object'.
+		// - Form 1: { 'my-object' : {<flattenedObject>} }
+		// - Form 2: { 'my-object.key1': value1, my-object.key2: value2, ... }
+		const subPayload = {};
+		if (Array.isArray(anything)) {
+			anything.forEach((item, index) => {
+				const itemKey = `[${index}]`;
+				step(item, itemKey, subPayload, false);
+			});
+		} else {
+			Object.keys(anything).forEach(nextKey => {
+				const itemKey = key ? `.${nextKey}` : nextKey;
+				const item = anything[nextKey];
+				step(item, itemKey, subPayload, false);
+			});
+		}
+
+		// Form 1: { 'my-object' : {<flattenedObject>} }
+		payload[key] = subPayload;
+		// Form 2: { 'my-object.key1': value1, my-object.key2: value2, ... }
+		Object.keys(subPayload).forEach(subKey => {
+			payload[`${key}${subKey}`] = subPayload[subKey];
+		});
+	}
+}
+
 /**
  * flatten an object means each keys are a jsonpath.
  * jsperf: https://jsperf.com/talend-flatten
  * @param {object} obj the source object
- * @param {boolean} includeObjects should include object/array in the payload
  * @return {object} flatten object
  * @example
  * flatten({ level1: { level2: 'foo' }})
  * // { 'level1.level2': 'foo' }
  */
-export default function flatten(obj, includeObjects) {
+export default function flatten(obj) {
 	const payload = {};
-
-	function step(anything, key) {
-		if (
-			key !== '' &&
-			(typeof anything === 'string' ||
-				typeof anything === 'number' ||
-				typeof anything === 'boolean' ||
-				includeObjects)
-		) {
-			payload[key] = anything;
-		}
-		if (Array.isArray(anything)) {
-			anything.forEach((item, index) => {
-				const itemKey = `${key}[${index}]`;
-				step(item, itemKey);
-			});
-		} else if (typeof anything === 'object') {
-			Object.keys(anything).forEach(nextKey => {
-				const itemKey = key ? `${key}.${nextKey}` : nextKey;
-				const item = anything[nextKey];
-				step(item, itemKey);
-			});
-		}
-	}
-	step(obj, '');
+	step(obj, '', payload);
 	return payload;
 }

--- a/packages/containers/src/ComponentForm/kit/flatten.test.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.test.js
@@ -14,9 +14,16 @@ describe('flatten', () => {
 			},
 		};
 		expect(flatten(foo)).toEqual({
-			'root.nest.string': 'foo',
-			'root.nest.number': 3,
+			root: {
+				'.nest': { '.bool': false, '.number': 3, '.string': 'foo' },
+				'.nest.bool': false,
+				'.nest.number': 3,
+				'.nest.string': 'foo',
+			},
+			'root.nest': { '.bool': false, '.number': 3, '.string': 'foo' },
 			'root.nest.bool': false,
+			'root.nest.number': 3,
+			'root.nest.string': 'foo',
 		});
 	});
 	it('should flat arrays', () => {
@@ -25,28 +32,10 @@ describe('flatten', () => {
 				array: ['foo'],
 			},
 		};
-		expect(flatten(foo)).toEqual({ 'root.array[0]': 'foo' });
-	});
-	it('should include objects and arrays in the flatten payload', () => {
-		const foo = {
-			root: {
-				array: ['foo'],
-			},
-		};
-		expect(flatten(foo, true)).toEqual({
-			root: {
-				array: ['foo'],
-			},
-			'root.array': ['foo'],
+		expect(flatten(foo)).toEqual({
+			root: { '.array': { '[0]': 'foo' }, '.array[0]': 'foo' },
+			'root.array': { '[0]': 'foo' },
 			'root.array[0]': 'foo',
 		});
-	});
-	it('should skip function', () => {
-		const foo = {
-			root: {
-				noop,
-			},
-		};
-		expect(flatten(foo)).toEqual({ 'root.noop': undefined });
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Component trigger extract parameters to pass to the trigger call, based on param keys.
This extraction includes only native parameters, but objects and arrays are not included. Keys that point to them are associated to undefined.

**What is the chosen solution to this problem?**
Include complex items in parameters extraction

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
