### PR TITLE
fix(TabBar): children from item definition are displayed again

### DIFF
--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -77,7 +77,7 @@ class TabBar extends React.Component {
 							</NavItem>
 						))}
 					</Nav>
-					{hasChildren ? (
+					{hasChildren && (
 						<Tab.Content>
 							{items.map(item => (
 								<Tab.Pane eventKey={item.key} key={item.key}>
@@ -86,7 +86,7 @@ class TabBar extends React.Component {
 								</Tab.Pane>
 							))}
 						</Tab.Content>
-					) : null}
+					)}
 				</div>
 			</Tab.Container>
 		);

--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -53,6 +53,7 @@ class TabBar extends React.Component {
 
 	render() {
 		const { className, id, items, selectedKey, children, generateChildId } = this.props;
+		const hasChildren = children || items.some(item => item.children);
 		return (
 			<Tab.Container
 				id={id}
@@ -76,7 +77,7 @@ class TabBar extends React.Component {
 							</NavItem>
 						))}
 					</Nav>
-					{children && (
+					{hasChildren ? (
 						<Tab.Content>
 							{items.map(item => (
 								<Tab.Pane eventKey={item.key} key={item.key}>
@@ -85,7 +86,7 @@ class TabBar extends React.Component {
 								</Tab.Pane>
 							))}
 						</Tab.Content>
-					)}
+					) : null}
 				</div>
 			</Tab.Container>
 		);

--- a/packages/components/src/TabBar/TabBar.test.js
+++ b/packages/components/src/TabBar/TabBar.test.js
@@ -38,7 +38,7 @@ const tabProps = {
 };
 
 describe('TabBar component', () => {
-	it('should render', () => {
+	it('should render with selected children managed by user', () => {
 		// given
 
 		// when
@@ -48,7 +48,7 @@ describe('TabBar component', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should render items with defined children', () => {
+	it('should render with selected children from item definition', () => {
 		// given
 		const items = tabProps.items.map((item, index) => ({
 			...item,

--- a/packages/components/src/TabBar/__snapshots__/TabBar.test.js.snap
+++ b/packages/components/src/TabBar/__snapshots__/TabBar.test.js.snap
@@ -1,6 +1,133 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`TabBar component should render 1`] = `
+exports[`TabBar component should render with selected children from item definition 1`] = `
+<Uncontrolled(TabContainer)
+  activeKey="3"
+  className="tabs-classname"
+  generateChildId={undefined}
+  id="my-tabs"
+  onKeyDown={[Function]}
+  onSelect={[Function]}
+>
+  <div>
+    <Nav
+      bsClass="nav"
+      bsStyle="tabs"
+      className="tc-tab-bar"
+      justified={false}
+      pullLeft={false}
+      pullRight={false}
+      stacked={false}
+    >
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.1"
+        disabled={false}
+        eventKey="1"
+        label="Tab1"
+      >
+        Tab1
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.2"
+        disabled={false}
+        eventKey="2"
+        label="Tab2"
+      >
+        Tab2
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.3"
+        disabled={false}
+        eventKey="3"
+        label="Tab3"
+      >
+        Tab3
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.4"
+        disabled={false}
+        eventKey="4"
+        label="Tab4"
+      >
+        Tab4
+      </NavItem>
+      <NavItem
+        active={false}
+        componentClass="button"
+        data-feature="action.5"
+        disabled={false}
+        eventKey="5"
+        label="Tab5"
+      >
+        Tab5
+      </NavItem>
+    </Nav>
+    <TabContent
+      animation={true}
+      bsClass="tab"
+      componentClass="div"
+      mountOnEnter={false}
+      unmountOnExit={false}
+    >
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="1"
+      >
+        <div>
+          child 
+          0
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="2"
+      >
+        <div>
+          child 
+          1
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="3"
+      >
+        <div>
+          child 
+          2
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="4"
+      >
+        <div>
+          child 
+          3
+        </div>
+      </TabPane>
+      <TabPane
+        bsClass="tab-pane"
+        eventKey="5"
+      >
+        <div>
+          child 
+          4
+        </div>
+      </TabPane>
+    </TabContent>
+  </div>
+</Uncontrolled(TabContainer)>
+`;
+
+exports[`TabBar component should render with selected children managed by user 1`] = `
 <Uncontrolled(TabContainer)
   activeKey="3"
   className="tabs-classname"
@@ -108,80 +235,6 @@ exports[`TabBar component should render 1`] = `
         
       </TabPane>
     </TabContent>
-  </div>
-</Uncontrolled(TabContainer)>
-`;
-
-exports[`TabBar component should render items with defined children 1`] = `
-<Uncontrolled(TabContainer)
-  activeKey="3"
-  className="tabs-classname"
-  generateChildId={undefined}
-  id="my-tabs"
-  onKeyDown={[Function]}
-  onSelect={[Function]}
->
-  <div>
-    <Nav
-      bsClass="nav"
-      bsStyle="tabs"
-      className="tc-tab-bar"
-      justified={false}
-      pullLeft={false}
-      pullRight={false}
-      stacked={false}
-    >
-      <NavItem
-        active={false}
-        componentClass="button"
-        data-feature="action.1"
-        disabled={false}
-        eventKey="1"
-        label="Tab1"
-      >
-        Tab1
-      </NavItem>
-      <NavItem
-        active={false}
-        componentClass="button"
-        data-feature="action.2"
-        disabled={false}
-        eventKey="2"
-        label="Tab2"
-      >
-        Tab2
-      </NavItem>
-      <NavItem
-        active={false}
-        componentClass="button"
-        data-feature="action.3"
-        disabled={false}
-        eventKey="3"
-        label="Tab3"
-      >
-        Tab3
-      </NavItem>
-      <NavItem
-        active={false}
-        componentClass="button"
-        data-feature="action.4"
-        disabled={false}
-        eventKey="4"
-        label="Tab4"
-      >
-        Tab4
-      </NavItem>
-      <NavItem
-        active={false}
-        componentClass="button"
-        data-feature="action.5"
-        disabled={false}
-        eventKey="5"
-        label="Tab5"
-      >
-        Tab5
-      </NavItem>
-    </Nav>
   </div>
 </Uncontrolled(TabContainer)>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
#1722 introduced a regression on TabBar.
There are 3 ways to manage children in TabBar : 
- user pass children props, it is displayed everytime
- user pass children in items definition, they are set in tab panels. react-bootstrap manages the display
- no children at all, user manage the display under the tabs

The second is broken, because we test if there is a children prop.

**What is the chosen solution to this problem?**

Check if we have children attribute in items to see if we display the tab panel

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
