### PR TITLE
fix(ComponentForm): flatten use option to include objects

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,8 +2,8 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.test.js
-  3:10  error  'noop' is defined but never used  no-unused-vars
+/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.js
+  23:1  error  Line 23 exceeds the maximum line length of 100  max-len
 
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -2,9 +2,6 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/flatten.js
-  23:1  error  Line 23 exceeds the maximum line length of 100  max-len
-
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
@@ -20,5 +17,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 

--- a/packages/containers/src/ComponentForm/kit/createTriggers.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.js
@@ -77,7 +77,7 @@ export function extractParameters(parameters, properties, schema) {
 	if (!parameters || !Array.isArray(parameters)) {
 		return {};
 	}
-	const flattenProps = flatten(properties);
+	const flattenProps = flatten(properties, { includeObjects: true });
 	return parameters.reduce((acc, param) => {
 		const path = getPathWithArrayIndex(param.path, schema);
 		const value = flattenProps[path];

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -20,7 +20,8 @@ function step(anything, key, payload, options = {}) {
 	if (typeof anything !== 'object') {
 		payload[key] = anything;
 	} else {
-		// for objects (including arrays), we flatten it. The we store it in 2 forms depending on options.
+		// for objects (including arrays), we flatten it.
+		// We store it in 2 forms depending on options.
 		// Let's say that we have a key 'my-object'.
 		// - Form 1: { 'my-object' : {<flattenedObject>} }
 		// - Form 2: { 'my-object.key1': value1, my-object.key2: value2, ... }

--- a/packages/containers/src/ComponentForm/kit/flatten.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.js
@@ -20,11 +20,16 @@ function step(anything, key, payload, options = {}) {
 	if (typeof anything !== 'object') {
 		payload[key] = anything;
 	} else {
-		// for objects (including arrays), we flatten it.
+		// For objects (including arrays), we flatten it.
 		// We store it in 2 forms depending on options.
-		// Let's say that we have a key 'my-object'.
-		// - Form 1: { 'my-object' : {<flattenedObject>} }
-		// - Form 2: { 'my-object.key1': value1, my-object.key2: value2, ... }
+		//
+		// Let's say that we have an array { 'my-array': ['tata', 'toto'] }.
+		// - Form 1: { 'my-array' : { '[0]': 'tata', '[1]': 'toto' } }
+		// - Form 2: { 'my-array[0]': 'tata', 'my-array[1]': 'toto' }
+		//
+		// And for objects { 'my-object': { first: 'tata', second: 'toto' } }.
+		// - Form 1: { 'my-object' : { '.first': 'tata', '.second': 'toto' } }
+		// - Form 2: { 'my-object.first': 'tata', 'my-object.second': 'toto' }
 		const subPayload = {};
 		if (Array.isArray(anything)) {
 			anything.forEach((item, index) => {

--- a/packages/containers/src/ComponentForm/kit/flatten.test.js
+++ b/packages/containers/src/ComponentForm/kit/flatten.test.js
@@ -1,7 +1,5 @@
 import flatten from './flatten';
 
-function noop() {}
-
 describe('flatten', () => {
 	it('should flat nested data structure', () => {
 		const foo = {
@@ -14,25 +12,28 @@ describe('flatten', () => {
 			},
 		};
 		expect(flatten(foo)).toEqual({
-			root: {
-				'.nest': { '.bool': false, '.number': 3, '.string': 'foo' },
-				'.nest.bool': false,
-				'.nest.number': 3,
-				'.nest.string': 'foo',
-			},
-			'root.nest': { '.bool': false, '.number': 3, '.string': 'foo' },
 			'root.nest.bool': false,
 			'root.nest.number': 3,
 			'root.nest.string': 'foo',
 		});
 	});
-	it('should flat arrays', () => {
+	it('should flatten arrays', () => {
 		const foo = {
 			root: {
 				array: ['foo'],
 			},
 		};
 		expect(flatten(foo)).toEqual({
+			'root.array[0]': 'foo',
+		});
+	});
+	it('should include objects sub-flatten in payload', () => {
+		const foo = {
+			root: {
+				array: ['foo'],
+			},
+		};
+		expect(flatten(foo, { includeObjects: true })).toEqual({
 			root: { '.array': { '[0]': 'foo' }, '.array[0]': 'foo' },
 			'root.array': { '[0]': 'foo' },
 			'root.array[0]': 'foo',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
#1732 included a regression, as flatten function is exposed and used.
The default result of flatten include objects sub flatten part, but should not, it is only used in trigger param extraction.

**What is the chosen solution to this problem?**
Restore the previous default result, and condition the objects sub-part inclusion.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
