### PR TITLE
fix(components): align dialog with guidelines

### DIFF
--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -2,6 +2,19 @@
 	.modal-flex .modal-body {
 		display: flex;
 		flex-direction: column;
+		padding-top: $padding-larger;
+	}
+
+	.modal-body {
+		padding-top: $padding-larger;
+	}
+
+	.modal-footer {
+		padding-bottom: $padding-larger;
+	}
+
+	.tc-actionbar-container {
+		padding: 0;
 	}
 
 	.modal-content,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Paddings are not that good
<img width="1566" alt="screenshot 2018-10-04 at 16 36 18" src="https://user-images.githubusercontent.com/2909671/46481519-db002400-c7f3-11e8-8d22-a9438329ca28.png">

**What is the chosen solution to this problem?**
Change them according to guidelines ( https://company-57688.frontify.com/document/92132#/modal/dialog-box )
<img width="1616" alt="screenshot 2018-10-04 at 16 35 57" src="https://user-images.githubusercontent.com/2909671/46481542-e4898c00-c7f3-11e8-994b-637dba28e1e7.png">

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
