### PR TITLE
fix(Theme): button info color

### DIFF
--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -23,7 +23,7 @@ $brand-primary-dark: shade($brand-primary, 12) !default;
 $brand-primary-darker: shade($brand-primary, 25) !default;
 $brand-secondary: $rio-grande !default;
 $brand-success: $rio-grande !default;
-$brand-info: $scooter !default;
+$brand-info: $st-tropaz !default;
 $brand-warning: $lightning-yellow !default;
 $brand-danger: $chestnut-rose !default;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
<img width="97" alt="capture d ecran 2018-10-05 a 11 30 41" src="https://user-images.githubusercontent.com/10761073/46527653-279a3c80-c892-11e8-8946-c7a61fb92a18.png">

Button info is used almost everywhere. But it's not really accessible in common contexts, like a grey background, which is the case in a lot of our components.

**What is the chosen solution to this problem?**
Switch color to `$st-tropaz`
<img width="96" alt="capture d ecran 2018-10-05 a 11 32 36" src="https://user-images.githubusercontent.com/10761073/46527767-63cd9d00-c892-11e8-811c-3ea0a1b67b15.png">

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
