### PR TITLE
feat(development): add mainSrc field in package.json

### DIFF
--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-cmf-cqrs",
   "description": "@talend/react-cmf plugin for CQRS backend architecture",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "scripts": {
     "prepublish": "npm run build",
     "build": "rimraf ./lib &&  babel -d lib ./src/ --ignore **/*.test.js",

--- a/packages/cmf-webpack-plugin/package.json
+++ b/packages/cmf-webpack-plugin/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-cmf-webpack-plugin",
   "description": "@talend/react-cmf webpack plugin for merging CMF settings",
   "main": "dist/index.js",
+  "mainSrc": "src/index.js",
   "scripts": {
     "prepublish": "npm run build && npm run test",
     "build": "rimraf ./dist && babel -d dist ./src/ --ignore **/*.test.js",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-cmf",
   "description": "A framework built on top of best react libraries",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "babel -d lib ./src/",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-components",
   "description": "Set of react widgets.",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "test": "jest",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-containers",
   "description": "Provide connected components aka containers for @talend/react-cmf based on @talend/react-components.",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "babel -d lib ./src/ && rimraf lib/**/*.test.js && cpx -v \"./src/**/*.scss\" ./lib",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-datagrid",
   "description": "Provide a datagrid for at least talend applications based on ag-grid",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "babel -d lib ./src/ && rimraf lib/**/*.test.js && cpx -v \"./src/**/*.scss\" ./lib",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/react-forms",
   "description": "React forms library based on json schema form.",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "rimraf lib && babel -d lib ./src/ && cpx -v \"./src/**/*.scss\" lib",

--- a/packages/jsfc/package.json
+++ b/packages/jsfc/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0-alpha.4",
   "description": "JSON-Schema and JSON-UI-Schema utilities for form generation.",
   "main": "dist/module.js",
+  "mainSrc": "src/module.js",
   "scripts": {
     "prepublish": "babel -d dist ./src/ && rimraf dist/**/*.spec.js",
     "build": "webpack",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/log",
   "description": "Small wrapper over TraceKit, that allows to inject error reporting as redux-logger middleware",
   "main": "lib/api/errorTransformer.js",
+  "mainSrc": "src/api/errorTransformer.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "babel -d lib ./src/ && rimraf lib/**/*.test.js",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.1",
   "description": "App wide redux sagas",
   "main": "lib/index.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "rimraf lib && babel -d lib ./src/",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -2,6 +2,7 @@
   "name": "@talend/bootstrap-theme",
   "description": "Bootstrap theme based on Talend styleguide",
   "main": "dist/bootstrap.js",
+  "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
     "prepublish": "webpack -p",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We need to know the main file, but for the source files, in packages. With this info we will be able to use the library without having to run prepublish after every change. 

This is still in testing phase, but here's the related PR why we need this: https://github.com/Talend/ui/pull/1646

**What is the chosen solution to this problem?**
Add a "mainSrc" field, which should not disturb anything else. 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
