### PR TITLE
chore(components/Inject.getReactElement): remove key warning

### DIFF
--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -124,7 +124,7 @@ Inject.getReactElement = function getReactElement(
 	} else if (data === null) {
 		return data;
 	} else if (typeof data === 'string') {
-		const props = {getComponent, component: data };
+		const props = { getComponent, component: data };
 		if (withKey) {
 			props.key = `${data}#default`;
 		}
@@ -132,11 +132,11 @@ Inject.getReactElement = function getReactElement(
 	} else if (React.isValidElement(data)) {
 		return data;
 	} else if (typeof data === 'object') {
-		const props = {getComponent, ...data };
+		const props = { getComponent, ...data };
 		if (withKey) {
 			props.key = `${data.component}#${data.componentId || 'default'}`;
 		}
-		return <CustomInject {...props} />
+		return <CustomInject {...props} />;
 	}
 	return data; // We do not throw anything, proptypes should do the job
 };

--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -124,23 +124,19 @@ Inject.getReactElement = function getReactElement(
 	} else if (data === null) {
 		return data;
 	} else if (typeof data === 'string') {
-		return (
-			<CustomInject
-				getComponent={getComponent}
-				component={data}
-				key={withKey && `${data}#default`}
-			/>
-		);
+		const props = {getComponent, component: data };
+		if (withKey) {
+			props.key = `${data}#default`;
+		}
+		return <CustomInject {...props} />;
 	} else if (React.isValidElement(data)) {
 		return data;
 	} else if (typeof data === 'object') {
-		return (
-			<CustomInject
-				getComponent={getComponent}
-				{...data}
-				key={withKey && `${data.component}#${data.componentId || 'default'}`}
-			/>
-		);
+		const props = {getComponent, ...data };
+		if (withKey) {
+			props.key = `${data.component}#${data.componentId || 'default'}`;
+		}
+		return <CustomInject {...props} />
 	}
 	return data; // We do not throw anything, proptypes should do the job
 };

--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -113,17 +113,34 @@ Inject.getAll = function injectGetAll(getComponent, config) {
  * @param {function} getComponent
  * @param {object|string|React Element} data
  */
-Inject.getReactElement = function getReactElement(getComponent, data, CustomInject = Inject) {
+Inject.getReactElement = function getReactElement(
+	getComponent,
+	data,
+	CustomInject = Inject,
+	withKey,
+) {
 	if (Array.isArray(data)) {
-		return data.map(info => getReactElement(getComponent, info, CustomInject));
+		return data.map(info => getReactElement(getComponent, info, CustomInject, true));
 	} else if (data === null) {
 		return data;
 	} else if (typeof data === 'string') {
-		return <CustomInject getComponent={getComponent} component={data} />;
+		return (
+			<CustomInject
+				getComponent={getComponent}
+				component={data}
+				key={withKey && `${data}#default`}
+			/>
+		);
 	} else if (React.isValidElement(data)) {
 		return data;
 	} else if (typeof data === 'object') {
-		return <CustomInject getComponent={getComponent} {...data} />;
+		return (
+			<CustomInject
+				getComponent={getComponent}
+				{...data}
+				key={withKey && `${data.component}#${data.componentId || 'default'}`}
+			/>
+		);
 	}
 	return data; // We do not throw anything, proptypes should do the job
 };

--- a/packages/components/src/Inject/Inject.md
+++ b/packages/components/src/Inject/Inject.md
@@ -70,6 +70,7 @@ So ArticlePage is only responsible to give the global structure and styles.
 Sometimes you will need to wrap the injected elements.
 To support this you can create a CustomInject which can support specific props
 
+
 ```js
 function CustomInject(props) {
 	return (

--- a/packages/components/src/Inject/Inject.test.js
+++ b/packages/components/src/Inject/Inject.test.js
@@ -215,7 +215,7 @@ describe('Inject.getReactElement', () => {
 		const getComponent = jest.fn();
 		const data = [{ component: 'what', extra: true }];
 		expect(Inject.getReactElement(getComponent, data)).toEqual([
-			<Inject getComponent={getComponent} component="what" extra />,
+			<Inject getComponent={getComponent} component="what" extra key="what#default" />,
 		]);
 	});
 	it('should return undefined if data is undefined', () => {

--- a/packages/components/src/Inject/Inject.test.js
+++ b/packages/components/src/Inject/Inject.test.js
@@ -213,9 +213,10 @@ describe('Inject.getReactElement', () => {
 	});
 	it('should support element as Array', () => {
 		const getComponent = jest.fn();
-		const data = [{ component: 'what', extra: true }];
+		const data = [{ component: 'what', componentId: 'me', extra: true }, 'Foo'];
 		expect(Inject.getReactElement(getComponent, data)).toEqual([
-			<Inject getComponent={getComponent} component="what" extra key="what#default" />,
+			<Inject getComponent={getComponent} component="what" componentId="me" extra key="what#me" />,
+			<Inject getComponent={getComponent} component="Foo" key="Foo#default" />,
 		]);
 	});
 	it('should return undefined if data is undefined', () => {

--- a/packages/containers/src/AboutDialog/AboutDialog.container.js
+++ b/packages/containers/src/AboutDialog/AboutDialog.container.js
@@ -41,7 +41,7 @@ class AboutDialog extends React.Component {
 				expanded={state.get('expanded')}
 				show={state.get('show')}
 				loading={state.get('loading')}
-				{...omit(props, cmfConnect.INJECTED_PROPS)}
+				{...cmfConnect.omitAllCMFProps(props)}
 			/>
 		);
 	}

--- a/packages/containers/src/AboutDialog/AboutDialog.container.js
+++ b/packages/containers/src/AboutDialog/AboutDialog.container.js
@@ -41,7 +41,7 @@ class AboutDialog extends React.Component {
 				expanded={state.get('expanded')}
 				show={state.get('show')}
 				loading={state.get('loading')}
-				{...cmfConnect.omitAllCMFProps(props)}
+				{...omit(props, cmfConnect.INJECTED_PROPS)}
 			/>
 		);
 	}

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
@@ -43,7 +43,7 @@ if (process.env.NODE_ENV !== 'production') {
 	SimpleCheckBox.propTypes = {
 		describedby: PropTypes.string.isRequired,
 		id: PropTypes.string,
-		isValid: PropTypes.string,
+		isValid: PropTypes.bool,
 		label: PropTypes.string,
 		onChange: PropTypes.func.isRequired,
 		onFinish: PropTypes.func.isRequired,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When you use the Inject API with an array React complains to not have keys on it


**What is the chosen solution to this problem?**

Add key when use array. (build it using component/componentId)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
