### PR TITLE
fix(components): bad display on actions hover on title

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -13,6 +13,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	height: $btn-line-height;
 
 	.cell-title-actions {
+		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
 		opacity: 0;
 		visibility: hidden;
 

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
@@ -24,6 +24,9 @@ $tc-list-large-field-value-color: $dove-gray !default;
 			flex-grow: 1;
 			flex-shrink: 1;
 		}
+		:global(.cell-title-actions) {
+			background: transparent;
+		}
 	}
 
 	.content {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The title text is still visible under the actions
<img width="904" alt="screenshot 2018-10-11 at 12 34 23" src="https://user-images.githubusercontent.com/2909671/46795159-206fa480-cd52-11e8-9152-023706e47882.png">

**What is the chosen solution to this problem?**
Add a background

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
