### PR TITLE
fix(List): removing hover style on actions on selected/active items

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -78,7 +78,7 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 }
 
 // manage actions display on row hover
-:global(.tc-list-large-row),
+:global(.tc-list-large-inner-box),
 :global(.ReactVirtualized__Table__row) {
 	&:hover,
 	&:focus,
@@ -91,7 +91,7 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 	}
 }
 
-:global(.tc-list-large-row.active),
+:global(.tc-list-large-row.active .tc-list-large-inner-box),
 :global(.ReactVirtualized__Table__row.active) {
 	&:hover,
 	&:focus,
@@ -102,7 +102,7 @@ $tc-list-title-icon-size: $svg-lg-size !default;
 	}
 }
 
-:global(.tc-list-large-row.selected),
+:global(.tc-list-large-row.selected .tc-list-large-inner-box),
 :global(.ReactVirtualized__Table__row.selected) {
 	&:hover,
 	&:focus,

--- a/packages/components/src/VirtualizedList/ListGrid/ListGrid.component.js
+++ b/packages/components/src/VirtualizedList/ListGrid/ListGrid.component.js
@@ -33,7 +33,7 @@ function ListGrid(props) {
 
 	return (
 		<VirtualizedList
-			className={theme['tc-list-list']}
+			className={`tc-list-list ${theme['tc-list-list']}`}
 			collection={collection}
 			overscanRowCount={10}
 			onRowClick={decorateRowClick(onRowClick)}

--- a/packages/components/src/VirtualizedList/ListGrid/__snapshots__/ListGrid.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListGrid/__snapshots__/ListGrid.test.js.snap
@@ -14,7 +14,7 @@ exports[`ListGrid should render noRows 1`] = `
   <List
     aria-label="list"
     autoHeight={false}
-    className="theme-tc-list-list"
+    className="tc-list-list theme-tc-list-list"
     collection={Array []}
     containerRole="list"
     estimatedRowSize={30}
@@ -43,7 +43,7 @@ exports[`ListGrid should render noRows 1`] = `
       autoWidth={false}
       cellRangeRenderer={[Function]}
       cellRenderer={[Function]}
-      className="ReactVirtualized__List theme-tc-list-list"
+      className="ReactVirtualized__List tc-list-list theme-tc-list-list"
       collection={Array []}
       columnCount={1}
       columnWidth={1024}
@@ -80,7 +80,7 @@ exports[`ListGrid should render noRows 1`] = `
       <div
         aria-label="list"
         aria-readonly={true}
-        className="ReactVirtualized__Grid ReactVirtualized__List theme-tc-list-list"
+        className="ReactVirtualized__Grid ReactVirtualized__List tc-list-list theme-tc-list-list"
         id="my-list"
         onScroll={[Function]}
         role="group"
@@ -112,7 +112,7 @@ exports[`ListGrid should render react-virtualized list 1`] = `
 <List
   aria-label="list"
   autoHeight={false}
-  className="theme-tc-list-list"
+  className="tc-list-list theme-tc-list-list"
   collection={
     Array [
       Object {

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
@@ -86,7 +86,7 @@ class RowLarge extends React.Component {
 				aria-setsize={parent.props.rowCount}
 				aria-label={titleField && getCellData(titleField, parent, index)}
 			>
-				<div className={theme['inner-box']} key="inner-box">
+				<div className={`tc-list-large-inner-box ${theme['inner-box']}`} key="inner-box">
 					<div className={theme.header} key="header">
 						{titleCell}
 						{selectionCell}

--- a/packages/components/src/VirtualizedList/RowSelection/RowSelection.scss
+++ b/packages/components/src/VirtualizedList/RowSelection/RowSelection.scss
@@ -5,7 +5,8 @@
 		background: $tc-list-row-selected-bg;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:global(.ally-focus-within) {
 			background: $tc-list-row-selected-hover-bg;
 		}
 	}
@@ -13,7 +14,8 @@
 		background: $tc-list-row-active-bg;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:global(.ally-focus-within) {
 			background: $tc-list-row-active-hover-bg;
 		}
 	}
@@ -24,7 +26,8 @@
 		background: $tc-list-row-selected-bg;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:global(.ally-focus-within) {
 			background: $tc-list-row-selected-hover-bg;
 		}
 	}
@@ -32,7 +35,8 @@
 		background: $tc-list-row-active-bg;
 
 		&:hover,
-		&:focus {
+		&:focus,
+		&:global(.ally-focus-within) {
 			background: $tc-list-row-active-hover-bg;
 		}
 	}

--- a/packages/components/src/VirtualizedList/RowSelection/RowSelection.scss
+++ b/packages/components/src/VirtualizedList/RowSelection/RowSelection.scss
@@ -1,7 +1,6 @@
 @import '../colors';
 
-:global(.tc-list-table),
-:global(.tc-list-large) {
+:global(.tc-list-table) {
 	.row-selection.selected {
 		background: $tc-list-row-selected-bg;
 
@@ -19,3 +18,23 @@
 		}
 	}
 }
+
+:global(.tc-list-list) {
+	.row-selection.selected :global(.tc-list-large-inner-box) {
+		background: $tc-list-row-selected-bg;
+
+		&:hover,
+		&:focus {
+			background: $tc-list-row-selected-hover-bg;
+		}
+	}
+	.row-selection.active :global(.tc-list-large-inner-box) {
+		background: $tc-list-row-active-bg;
+
+		&:hover,
+		&:focus {
+			background: $tc-list-row-active-hover-bg;
+		}
+	}
+}
+


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Background issue while hovering selected/active items :
![image](https://user-images.githubusercontent.com/14272767/46964829-6eb1da00-d0a9-11e8-8a82-a0122843c7e5.png)

In fact the issue is that the background doesn't apply to the whole item anymore
**What is the chosen solution to this problem?**
The selector used until now are not working anymore, updating them.
we should have this : 
![image](https://user-images.githubusercontent.com/14272767/47005748-af0a6a00-d134-11e8-9d0e-606dfab8055d.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
