### PR TITLE
fix(containers/DeleteResource): Dispatch error action when delete request failed

### DIFF
--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -82,7 +82,7 @@ export function* deleteResourceValidate(
 		} else {
 			yield put({
 				type: deleteResourceConst.DIALOG_BOX_DELETE_RESOURCE_ERROR,
-				model: result.data,
+				error: result.data,
 			});
 		}
 		yield call(redirect, get(action, 'data.model.redirectUrl'));

--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -70,14 +70,19 @@ export function* deleteResourceValidate(
 		resourceUri || `${safeURI}/${safeType}/${safeId}`,
 	);
 	if (resource && safeResourceUri) {
-		const { response } = yield call(cmf.sagas.http.delete, safeResourceUri);
-		if (response.ok) {
+		const result = yield call(cmf.sagas.http.delete, safeResourceUri);
+		if (result.response.ok) {
 			yield put({
 				type: deleteResourceConst.DIALOG_BOX_DELETE_RESOURCE_SUCCESS,
 				model: {
 					id: safeId,
 					labelResource: resource.get('label') || resource.get('name', ''),
 				},
+			});
+		} else {
+			yield put({
+				type: deleteResourceConst.DIALOG_BOX_DELETE_RESOURCE_ERROR,
+				model: result.data,
 			});
 		}
 		yield call(redirect, get(action, 'data.model.redirectUrl'));

--- a/packages/containers/src/DeleteResource/sagas.test.js
+++ b/packages/containers/src/DeleteResource/sagas.test.js
@@ -187,7 +187,7 @@ describe('internals', () => {
 			gen.next(resource);
 			expect(gen.next(failedRequest).value).toEqual(put({
 				type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_ERROR,
-				model: failedRequest.data,
+				error: failedRequest.data,
 			}));
 		})
 	});

--- a/packages/containers/src/DeleteResource/sagas.test.js
+++ b/packages/containers/src/DeleteResource/sagas.test.js
@@ -1,7 +1,7 @@
 // import SagaTester from 'redux-saga-tester';
 import { Map } from 'immutable';
 import cmf from '@talend/react-cmf';
-import { take } from 'redux-saga/effects';
+import { take, put } from 'redux-saga/effects';
 import CONSTANTS from './constants';
 // import actions from './actions';
 import sagas, * as internals from './sagas';
@@ -159,6 +159,37 @@ describe('internals', () => {
 			expect(effect.SELECT.args[0]).toBe('myResource');
 			expect(effect.SELECT.args[1]).toBe('runProfileId');
 		});
+		it('should dispatch DIALOG_BOX_DELETE_RESOURCE_ERROR event when delete request fails', () => {
+			const action = {
+				type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_OK,
+				data: {
+					model: {
+						resourceType: 'myResource',
+						id: 'resourceId',
+					},
+				},
+			};
+			const resource = {
+				id: 'resourceId',
+			};
+			const failedRequest = {
+				response: {
+					ok: false
+				},
+				data: {
+					error: 'can\'t delete resource in use',
+				},
+			};
+
+			const gen = internals.deleteResourceValidate();
+			gen.next();
+			gen.next(action);
+			gen.next(resource);
+			expect(gen.next(failedRequest).value).toEqual(put({
+				type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_ERROR,
+				model: failedRequest.data,
+			}));
+		})
 	});
 	describe('deleteResourceCancel', () => {
 		it('should call redirect ', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No event dispatched for failed delete request.
**What is the chosen solution to this problem?**
Dispatch an `DIALOG_BOX_DELETE_RESOURCE_ERROR` event with error messages when request went wrong.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
