### PR TITLE
fix(components/DatePicker) Widget error handling with UIForm - poc1

### DIFF
--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -22,6 +22,7 @@ const INVALID_PLACEHOLDER = 'INVALID DATE';
 const INPUT_FULL_FORMAT = 'YYYY-MM-DD HH:mm';
 const INPUT_DATE_ONLY_FORMAT = 'YYYY-MM-DD';
 
+const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
 /*
  * Split the date and time parts based on the middle space
  * ex: '  whatever   other-string  ' => ['whatever', 'other-string']
@@ -65,7 +66,7 @@ function getTextDate(date, time) {
 
 function getDateTimeFrom(date, time) {
 	if (date === undefined || time === undefined) {
-		return undefined;
+		return INTERNAL_INVALID_DATE;
 	}
 
 	return setMinutes(date, time);
@@ -401,7 +402,8 @@ class InputDateTimePicker extends React.Component {
 
 		const isDatetimeValid = isDateValid(this.state.datetime);
 		const inputFocused = this.state.inputFocused;
-		const needInvalidPlaceholder = !isDatetimeValid && !inputFocused;
+		const isInternalInvalidDate = this.state.datetime === INTERNAL_INVALID_DATE;
+		const needInvalidPlaceholder = !isDatetimeValid && !isInternalInvalidDate && !inputFocused;
 
 		const placeholder = needInvalidPlaceholder
 			? INVALID_PLACEHOLDER

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -214,10 +214,10 @@ class InputDateTimePicker extends React.Component {
 		const newSelectedDateTime = nextProps.selectedDateTime;
 
 		const selectedDateTimePropsUpdated = newSelectedDateTime !== this.props.selectedDateTime;
-		const selectedDateTimePropDivergedFromState = !isSameMinute(
-			newSelectedDateTime,
-			this.state.datetime,
-		);
+		const selectedDateTimePropDivergedFromState =
+			newSelectedDateTime !== this.state.datetime &&
+			!isSameMinute(newSelectedDateTime, this.state.datetime);
+
 		const needDateTimeStateUpdate =
 			selectedDateTimePropsUpdated && selectedDateTimePropDivergedFromState;
 

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -10,7 +10,7 @@ import { formPropTypes } from './utils/propTypes';
 import { validateSingle, validateAll } from './utils/validation';
 import Widget from './Widget';
 import Buttons from './fields/Button/Buttons.component';
-import { getValue, mutateValue } from './utils/properties';
+import { getValue, mutateValue, mutateWidgetsErrors } from './utils/properties';
 import { removeError, addError } from './utils/errors';
 import getLanguage from './lang';
 import customFormats from './customFormats';
@@ -83,13 +83,16 @@ export class UIFormComponent extends React.Component {
 	 * @param schema The payload field schema
 	 * @param value The payload new value
 	 */
-	onChange(event, { schema, value }) {
+	onChange(event, { schema, value, widgetError }) {
 		const newProperties = mutateValue(this.props.properties, schema, value);
+		const newWidgetsErrors = mutateWidgetsErrors(this.props.widgetsErrors, schema, widgetError);
 		this.props.onChange(event, {
 			schema,
 			value,
 			oldProperties: this.props.properties,
 			properties: newProperties,
+			oldWidgetsErrors: this.props.widgetsErrors,
+			widgetsErrors: newWidgetsErrors,
 			formData: newProperties,
 		});
 	}
@@ -122,6 +125,7 @@ export class UIFormComponent extends React.Component {
 			this.props.properties,
 			this.props.customValidation,
 			deepValidation,
+			this.props.widgetsErrors,
 		)[schema.key];
 
 		// update errors map
@@ -213,8 +217,8 @@ export class UIFormComponent extends React.Component {
 		}
 
 		const { mergedSchema } = this.state;
-		const { properties, customValidation } = this.props;
-		const errors = validateAll(mergedSchema, properties, customValidation);
+		const { properties, customValidation, widgetsErrors } = this.props;
+		const errors = validateAll(mergedSchema, properties, customValidation, widgetsErrors);
 		this.props.setErrors(event, errors);
 
 		const isValid = !Object.keys(errors).length;
@@ -310,7 +314,8 @@ if (process.env.NODE_ENV !== 'production') {
 		properties: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
 		/** Form definition: The forms errors { [fieldKey]: errorMessage } */
 		errors: PropTypes.object.isRequired, // eslint-disable-line react/forbid-prop-types
-
+		/** The form widgets errors { [fieldKey]: widgetErrorMessage } */
+		widgetsErrors: PropTypes.object.isRequired,
 		/**
 		 * Actions buttons to display at the bottom of the form.
 		 * If not provided, a single submit button is displayed.

--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -13,6 +13,11 @@ export default class UIForm extends React.Component {
 		if (!this.state.errors) {
 			this.state.errors = {};
 		}
+
+		if (!this.state.widgetsErrors) {
+			this.state.widgetsErrors = {};
+		}
+
 		this.onChange = this.onChange.bind(this);
 		this.onTrigger = this.onTrigger.bind(this);
 		this.setErrors = this.setErrors.bind(this);
@@ -42,6 +47,7 @@ export default class UIForm extends React.Component {
 	onChange(event, payload) {
 		this.setState({
 			properties: payload.properties,
+			widgetsErrors: payload.widgetsErrors,
 		});
 
 		if (this.props.onChange) {

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -5,8 +5,8 @@ import InputDateTimePickerComponent from '@talend/react-components/lib/DateTimeP
 import FieldTemplate from '../FieldTemplate';
 import { isoDateTimeRegExp } from '../../customFormats';
 import {
-	UnhandleTypeError,
-	UnexpectedTypeError,
+	WidgetUnhandleTypeError,
+	WidgetUnexpectedTypeError,
 	WidgetTextEntryFormatError,
 } from './WrongTypeError';
 
@@ -52,7 +52,7 @@ function convertToDate(type, value) {
 
 	if (typeOfValue !== type) {
 		// eslint-disable-next-line no-console
-		console.error(new UnexpectedTypeError(type, typeOfValue));
+		console.error(new WidgetUnexpectedTypeError(type, typeOfValue));
 		return INVALID_DATE;
 	}
 
@@ -63,7 +63,7 @@ function convertToDate(type, value) {
 			return convertStringToDate(value);
 		default:
 			// eslint-disable-next-line no-console
-			console.error(new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
+			console.error(new WidgetUnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
 			return INVALID_DATE;
 	}
 }
@@ -79,7 +79,7 @@ function convertFromDate(type, date) {
 		case 'string':
 			return convertDateToString(date);
 		default: {
-			const unhandleTypeError = new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type);
+			const unhandleTypeError = new WidgetUnhandleTypeError(HANDLE_CONVERTION_TYPE, type);
 			// eslint-disable-next-line no-console
 			console.error(unhandleTypeError);
 			return unhandleTypeError;

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -87,22 +87,9 @@ class InputDateTimePicker extends React.Component {
 	constructor(props) {
 		super(props);
 
-		this.state = {
-			value: props.value,
-		};
-
 		this.onChange = this.onChange.bind(this);
 		this.onBlur = this.onBlur.bind(this);
 		this.convertToDate = memoize(convertToDate, (type, value) => `${type}||${value}`);
-	}
-
-	componentWillReceiveProps(nextProps) {
-		const newValue = nextProps.value;
-		if (newValue !== this.state.value && !(newValue instanceof Error)) {
-			this.setState({
-				value: newValue,
-			});
-		}
 	}
 
 	/**
@@ -115,11 +102,10 @@ class InputDateTimePicker extends React.Component {
 
 		const hasError = errorMessage !== undefined;
 
-		const value = hasError ? new Error(errorMessage) : convertFromDate(type, date);
-
 		const payload = {
 			schema: this.props.schema,
-			value,
+			value: hasError ? date : convertFromDate(type, date),
+			widgetError: errorMessage,
 		};
 		this.props.onChange(event, payload);
 	}
@@ -133,10 +119,8 @@ class InputDateTimePicker extends React.Component {
 	render() {
 		const { schema } = this.props;
 		const type = schema.schema.type;
-		const datetime = this.convertToDate(type, this.state.value);
-		const isWidgetError = this.props.value instanceof Error;
-		const errorMessage =
-			isWidgetError || isDateValid(datetime) ? this.props.errorMessage : GENERIC_FORMAT_ERROR;
+		const datetime = this.convertToDate(type, this.props.value);
+		const errorMessage = this.props.errorMessage;
 
 		return (
 			<FieldTemplate
@@ -183,7 +167,7 @@ if (process.env.NODE_ENV !== 'production') {
 			required: PropTypes.bool,
 			title: PropTypes.string,
 		}),
-		value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Error)]),
+		value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.any]),
 	};
 }
 

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -123,7 +123,8 @@ class InputDateTimePicker extends React.Component {
 	render() {
 		const { schema } = this.props;
 		const type = schema.schema.type;
-		const datetime = this.convertToDate(type, this.props.value);
+		const isAlreadyADate = this.props.value instanceof Date;
+		const datetime = isAlreadyADate ? this.props.value : this.convertToDate(type, this.props.value);
 		const errorMessage = this.props.errorMessage;
 
 		return (

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -4,7 +4,11 @@ import memoize from 'lodash/memoize';
 import InputDateTimePickerComponent from '@talend/react-components/lib/DateTimePickers';
 import FieldTemplate from '../FieldTemplate';
 import { isoDateTimeRegExp } from '../../customFormats';
-import { UnhandleTypeError, UnexpectedTypeError } from './WrongTypeError';
+import {
+	UnhandleTypeError,
+	UnexpectedTypeError,
+	WidgetTextEntryFormatError,
+} from './WrongTypeError';
 
 export const GENERIC_FORMAT_ERROR = 'GENERIC FORMAT ERROR';
 
@@ -105,7 +109,7 @@ class InputDateTimePicker extends React.Component {
 		const payload = {
 			schema: this.props.schema,
 			value: hasError ? date : convertFromDate(type, date),
-			widgetError: errorMessage,
+			widgetError: hasError ? new WidgetTextEntryFormatError(errorMessage) : undefined,
 		};
 		this.props.onChange(event, payload);
 	}

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
@@ -12,3 +12,5 @@ export class UnexpectedTypeError extends Error {
 		super(message);
 	}
 }
+
+export class WidgetTextEntryFormatError extends Error {}

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
@@ -1,4 +1,4 @@
-export class UnhandleTypeError extends Error {
+export class WidgetUnhandleTypeError extends Error {
 	constructor(acceptedTypes, typeGiven) {
 		const acceptedTypesFormated = acceptedTypes.map(acceptedType => `'${acceptedType}'`).join(', ');
 		const message = `[${acceptedTypesFormated}] types accepted, given '${typeGiven}'`;
@@ -6,7 +6,7 @@ export class UnhandleTypeError extends Error {
 	}
 }
 
-export class UnexpectedTypeError extends Error {
+export class WidgetUnexpectedTypeError extends Error {
 	constructor(typeExpected, typeGiven) {
 		const message = `Expected type of '${typeExpected}' and got '${typeGiven}'`;
 		super(message);

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
@@ -14,3 +14,5 @@ export class WidgetUnexpectedTypeError extends Error {
 }
 
 export class WidgetTextEntryFormatError extends Error {}
+
+export class WidgetBadUsageError extends Error {}

--- a/packages/forms/src/UIForm/utils/properties.js
+++ b/packages/forms/src/UIForm/utils/properties.js
@@ -61,3 +61,7 @@ function mutateValueFromKey(properties = {}, key, value) {
 export function mutateValue(properties, schema, value) {
 	return mutateValueFromKey(properties, schema.key, value);
 }
+
+export function mutateWidgetsErrors(widgetsErrors, schema, widgetError) {
+	return mutateValueFromKey(widgetsErrors, schema.key, widgetError);
+}

--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -48,8 +48,8 @@ export function adaptAdditionalRules(mergedSchema) {
  */
 export function validateValue(schema, value, properties, customValidationFn, widgetsErrors) {
 	const widgetError = widgetsErrors[schema.key];
-	if (widgetError !== undefined) {
-		return widgetError;
+	if (widgetError instanceof Error) {
+		return widgetError.message;
 	}
 
 	const validationSchema = adaptAdditionalRules(schema);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Avoid loss of synchronicity between form property `value` and its `errorMessage`.

**What is the chosen solution to this problem?**
Create a new Map object in the form component/container to store a widget error, and use it as a new validation rule.

The tests have not been updated on purpose, to wait the validation of the implementation before them.


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
