### PR TITLE
fix(components/typeahead): icon style

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -7,8 +7,11 @@ src/Drawer/Drawer.scss
 src/FilterBar/FilterBar.scss
   47:6  warning  Vendor prefixes should not be used  no-vendor-prefixes
 
+src/Typeahead/Typeahead.scss
+  97:5  error  Nesting depth 4 greater than max of 3  nesting-depth
+
 src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
   2:24  error  Strings must use single quotes  quotes
 
-✖ 3 problems (1 error, 2 warnings)
+✖ 4 problems (2 errors, 2 warnings)
 

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -32,7 +32,7 @@ export function renderInputComponent(props) {
 				<FormControl id={key} autoFocus inputRef={inputRef} {...rest} />
 			)}
 			{hasIcon && (
-				<div className={theme['icon-cls']}>
+				<div className={classNames(theme['icon-cls'], caret && theme['icon-caret'])}>
 					{icon && <Icon {...icon} />}
 					{caret && <Icon name="talend-caret-down" />}
 				</div>

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -94,7 +94,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 			> svg {
 				height: $tc-typeahead-icon-size;
 				width: $tc-typeahead-icon-size;
-				margin: 0 0.5rem;
+				margin: 0 0.6rem;
 			}
 		}
 	}

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -12,7 +12,6 @@ $tc-typeahead-item-description-color: #c0c0c0 !default;
 $tc-typeahead-section-border-color: #e0e0e0 !default;
 
 $tc-typeahead-icon-color: $gray !default;
-$tc-typeahead-icon-size: $svg-md-size !default;
 $tc-typeahead-only-icon-color: #ccc !default;
 $tc-typeahead-section-header-color: #63aebd !default;
 
@@ -86,15 +85,19 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 		align-items: center;
 
 		.icon-cls {
-			position: absolute;
-			right: 0;
+			margin: -2em;
 			color: $tc-typeahead-icon-color;
 			pointer-events: none;
 
-			> svg {
-				height: $tc-typeahead-icon-size;
-				width: $tc-typeahead-icon-size;
-				margin: 0 0.6rem;
+			&.icon-caret {
+				position: absolute;
+				margin: 0;
+				right: 0;
+
+				> svg {
+					height: 0.8rem;
+					width: 0.8rem;
+				}
 			}
 		}
 	}

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -12,6 +12,7 @@ $tc-typeahead-item-description-color: #c0c0c0 !default;
 $tc-typeahead-section-border-color: #e0e0e0 !default;
 
 $tc-typeahead-icon-color: $gray !default;
+$tc-typeahead-icon-size: $svg-md-size !default;
 $tc-typeahead-only-icon-color: #ccc !default;
 $tc-typeahead-section-header-color: #63aebd !default;
 
@@ -91,8 +92,9 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 			pointer-events: none;
 
 			> svg {
-				height: 0.8rem;
-				width: 0.8rem;
+				height: $tc-typeahead-icon-size;
+				width: $tc-typeahead-icon-size;
+				margin: 0 0.5rem;
 			}
 		}
 	}

--- a/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultValueRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultValueRenderer.test.js.snap
@@ -74,13 +74,6 @@ exports[`#DefaultValueRenderer should render empty when the value is null 1`] = 
 />
 `;
 
-exports[`#DefaultValueRenderer should render empty when the value is undefined 1`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
-/>
-`;
-
 exports[`#DefaultValueRenderer should render the leading/trailing special character 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This magnifier used to look bigger but from several weeks it looks smaller (since #1592)
![image](https://user-images.githubusercontent.com/18534166/47086143-02ee7f00-d219-11e8-89d8-135eb67031e8.png)

**What is the chosen solution to this problem?**
Just revert the size if it not used from any other component
![image](https://user-images.githubusercontent.com/18534166/47086387-9aec6880-d219-11e8-85ef-f2b779120396.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
