### PR TITLE
fix(AboutDialog): dot not escape single quote

### DIFF
--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -89,7 +89,11 @@ function AboutDialog({
 				<Icon name={icon} className={classNames(theme['about-logo'], 'about-logo')} />
 				<div className={classNames(theme['about-excerpt'], 'about-excerpt')}>
 					<Text
-						text={t('ABOUT_VERSION_NAME', { defaultValue: 'Version: {{version}}', version, interpolation: { escapeValue: false } })}
+						text={t('ABOUT_VERSION_NAME', {
+							defaultValue: 'Version: {{version}}',
+							version,
+							interpolation: { escapeValue: false },
+						})}
 						size={Skeleton.SIZES.xlarge}
 						loading={loading}
 					/>

--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -89,7 +89,7 @@ function AboutDialog({
 				<Icon name={icon} className={classNames(theme['about-logo'], 'about-logo')} />
 				<div className={classNames(theme['about-excerpt'], 'about-excerpt')}>
 					<Text
-						text={t('ABOUT_VERSION_NAME', { defaultValue: 'Version: {{version}}', version })}
+						text={t('ABOUT_VERSION_NAME', { defaultValue: 'Version: {{version}}', version, interpolation: { escapeValue: false } })}
 						size={Skeleton.SIZES.xlarge}
 						loading={loading}
 					/>

--- a/packages/components/stories/AboutDialog.js
+++ b/packages/components/stories/AboutDialog.js
@@ -7,7 +7,7 @@ import { AboutDialog, IconsProvider } from '../src/index';
 const props = {
 	show: true,
 	onToggle: action('onToggle'),
-	version: 'Summer 18',
+	version: 'Summer \'18',
 	icon: 'talend-tdp-colored',
 	services: ['API', 'Dataset', 'Preparation', 'Transformation'].map(name => ({
 		version: '2.8.0-SNAPSHOT',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The cloud version of our app has a single quote before the year (Spring '18), however that single quote is escaped in i18next interpolation and then we try to display it within react dynamic content.
And so we end up with : 
![image](https://user-images.githubusercontent.com/14272767/47160254-cfcaef00-d2ef-11e8-9c40-15f0f64bdb46.png)


**What is the chosen solution to this problem?**
Skip the escape part of i18next interpolation for that specific case.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
