### PR TITLE
fix(components/DatePicker) Widget error handling with UIForm - poc2

### DIFF
--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -22,6 +22,8 @@ const INVALID_PLACEHOLDER = 'INVALID DATE';
 const INPUT_FULL_FORMAT = 'YYYY-MM-DD HH:mm';
 const INPUT_DATE_ONLY_FORMAT = 'YYYY-MM-DD';
 
+const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
+
 /*
  * Split the date and time parts based on the middle space
  * ex: '  whatever   other-string  ' => ['whatever', 'other-string']
@@ -65,7 +67,7 @@ function getTextDate(date, time) {
 
 function getDateTimeFrom(date, time) {
 	if (date === undefined || time === undefined) {
-		return undefined;
+		return INTERNAL_INVALID_DATE;
 	}
 
 	return setMinutes(date, time);
@@ -214,10 +216,9 @@ class InputDateTimePicker extends React.Component {
 		const newSelectedDateTime = nextProps.selectedDateTime;
 
 		const selectedDateTimePropsUpdated = newSelectedDateTime !== this.props.selectedDateTime;
-		const selectedDateTimePropDivergedFromState = !isSameMinute(
-			newSelectedDateTime,
-			this.state.datetime,
-		);
+		const selectedDateTimePropDivergedFromState =
+			newSelectedDateTime !== this.state.datetime &&
+			!isSameMinute(newSelectedDateTime, this.state.datetime);
 		const needDateTimeStateUpdate =
 			selectedDateTimePropsUpdated && selectedDateTimePropDivergedFromState;
 
@@ -401,7 +402,8 @@ class InputDateTimePicker extends React.Component {
 
 		const isDatetimeValid = isDateValid(this.state.datetime);
 		const inputFocused = this.state.inputFocused;
-		const needInvalidPlaceholder = !isDatetimeValid && !inputFocused;
+		const isInternalInvalidDate = this.state.datetime === INTERNAL_INVALID_DATE;
+		const needInvalidPlaceholder = !isDatetimeValid && !isInternalInvalidDate && !inputFocused;
 
 		const placeholder = needInvalidPlaceholder
 			? INVALID_PLACEHOLDER

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -252,10 +252,10 @@ class InputDateTimePicker extends React.Component {
 			textInput: getTextDate(date, time),
 			datetime: getDateTimeFrom(date, time),
 			errorMessage: undefined,
+		}).then(() => {
+			this.switchDropdownVisibility(false);
+			this.triggerBlur(event);
 		});
-
-		this.switchDropdownVisibility(false);
-		this.triggerBlur(event);
 	}
 
 	onChangeInput(event) {
@@ -366,16 +366,19 @@ class InputDateTimePicker extends React.Component {
 	}
 
 	updateDatePartStateAndTriggerChange(event, dateStatePart) {
-		const lastInfos = {
-			datetime: this.state.datetime,
-			errorMessage: this.state.errorMessage,
-		};
-		this.setState(dateStatePart, () => {
-			const newInfos = {
-				datetime: dateStatePart.datetime,
-				errorMessage: dateStatePart.errorMessage,
+		return new Promise(resolve => {
+			const lastInfos = {
+				datetime: this.state.datetime,
+				errorMessage: this.state.errorMessage,
 			};
-			this.triggerChange(event, lastInfos, newInfos);
+			this.setState(dateStatePart, () => {
+				const newInfos = {
+					datetime: dateStatePart.datetime,
+					errorMessage: dateStatePart.errorMessage,
+				};
+				this.triggerChange(event, lastInfos, newInfos);
+				resolve();
+			});
 		});
 	}
 

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -246,7 +246,7 @@ class InputDateTimePicker extends React.Component {
 	}
 
 	onSubmitPicker(event, { date, time }) {
-		this.updateDatePartStateAndTriggerChange(event, {
+		return this.updateDatePartStateAndTriggerChange(event, {
 			date,
 			time,
 			textInput: getTextDate(date, time),

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -246,6 +246,7 @@ class InputDateTimePicker extends React.Component {
 	}
 
 	onSubmitPicker(event, { date, time }) {
+		event.persist();
 		return this.updateDatePartStateAndTriggerChange(event, {
 			date,
 			time,

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.md
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.md
@@ -7,7 +7,7 @@ This component display an input with a [datetime picker](../DateTimePicker/DateT
 | name | description |
 |------|-------------|
 | selectedDateTime | Datetime selected for initial rendering or to used in a controlled way<br/>- An InvalidDate object can be given resulting in a message indicating the date is not valid in the input<br/>- Update the internal state only when needed |
-| onChange         | Trigger when defined datetime or error change (event, errorMessage, datetime)<br/>- Return the event object which validate the change, the error message (or undefined) and a valid Date object (or undefined if no date chosen or if an error occurs) |
+| onChange         | Trigger when defined datetime or error change (event, errorMessage, datetime)<br/>- Return the event object which validate the change, the error message (or undefined) and a valid Date object (or undefined if no date chosen or an InvalidDate if an error occurs) |
 | onBlur           | Trigger when the component loose focus (outside the picker AND the input), give the event object as first arg only<br/>|
 
 All the remaining props are spread to the input

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
@@ -1312,8 +1312,7 @@ describe('InputDateTimePicker', () => {
 					inputFocused: isFocused,
 				});
 
-				const inputWrapper = wrapper.find('DebounceInput');
-				const placeholder = inputWrapper.prop('placeholder');
+				const placeholder = wrapper.find('DebounceInput').prop('placeholder');
 
 				if (overrideExpected) {
 					expect(placeholder).not.toBe(REGULAR_PLACEHOLDER);
@@ -1394,8 +1393,7 @@ describe('InputDateTimePicker', () => {
 
 				wrapper.update();
 
-				const inputWrapper = wrapper.find('DebounceInput');
-				const placeholder = inputWrapper.prop('placeholder');
+				const placeholder = wrapper.find('DebounceInput').prop('placeholder');
 
 				expect(placeholder).not.toBe(REGULAR_PLACEHOLDER);
 			});

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
@@ -1358,8 +1358,7 @@ describe('InputDateTimePicker', () => {
 					},
 				);
 
-				const inputWrapperBefore = wrapper.find('DebounceInput');
-				inputWrapperBefore.prop('onChange')({
+				wrapper.find('DebounceInput').prop('onChange')({
 					target: {
 						value: 'a really baaaad date format',
 					},
@@ -1371,8 +1370,7 @@ describe('InputDateTimePicker', () => {
 
 				wrapper.update();
 
-				const inputWrapperAfter = wrapper.find('DebounceInput');
-				const placeholder = inputWrapperAfter.prop('placeholder');
+				const placeholder = wrapper.find('DebounceInput').prop('placeholder');
 
 				expect(placeholder).toBe(REGULAR_PLACEHOLDER);
 			});

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
@@ -1349,9 +1349,8 @@ describe('InputDateTimePicker', () => {
 			],
 		);
 
-		cases(
-			'should NOT apply an "invalid placeholder" on input AND override the regular one when InvalidDate value is internal, ie: wrong input value to keep visible',
-			({ isInternalInvalidDate, overrideExpected }) => {
+		describe('InvalidDate internal vs external one', () => {
+			it('should NOT apply an "invalid placeholder" on input AND override the regular one when InvalidDate value is internal, ie: wrong input value to keep visible', () => {
 				const REGULAR_PLACEHOLDER = 'REGULAR_PLACEHOLDER';
 				const wrapper = shallow(
 					<InputDateTimePicker id={DEFAULT_ID} placeholder={REGULAR_PLACEHOLDER} />,
@@ -1360,21 +1359,36 @@ describe('InputDateTimePicker', () => {
 					},
 				);
 
-				if (isInternalInvalidDate) {
-					const inputWrapper = wrapper.find('DebounceInput');
-
-					inputWrapper.prop('onChange')({
-						target: {
-							value: 'a really baaaad date format',
-						},
-					});
-				} else {
-					wrapper.setState({
-						datetime: new Date('whatever external InvalidDate'),
-					});
-				}
+				const inputWrapperBefore = wrapper.find('DebounceInput');
+				inputWrapperBefore.prop('onChange')({
+					target: {
+						value: 'a really baaaad date format',
+					},
+				});
 
 				wrapper.setState({
+					inputFocused: false,
+				});
+
+				wrapper.update();
+
+				const inputWrapperAfter = wrapper.find('DebounceInput');
+				const placeholder = inputWrapperAfter.prop('placeholder');
+
+				expect(placeholder).toBe(REGULAR_PLACEHOLDER);
+			});
+
+			it('should apply an "invalid placeholder" on input AND override the regular one when InvalidDate value is external', () => {
+				const REGULAR_PLACEHOLDER = 'REGULAR_PLACEHOLDER';
+				const wrapper = shallow(
+					<InputDateTimePicker id={DEFAULT_ID} placeholder={REGULAR_PLACEHOLDER} />,
+					{
+						disableLifecycleMethods: true,
+					},
+				);
+
+				wrapper.setState({
+					datetime: new Date('whatever external InvalidDate'),
 					inputFocused: false,
 				});
 
@@ -1383,24 +1397,8 @@ describe('InputDateTimePicker', () => {
 				const inputWrapper = wrapper.find('DebounceInput');
 				const placeholder = inputWrapper.prop('placeholder');
 
-				if (overrideExpected) {
-					expect(placeholder).not.toBe(REGULAR_PLACEHOLDER);
-				} else {
-					expect(placeholder).toBe(REGULAR_PLACEHOLDER);
-				}
-			},
-			[
-				{
-					name: 'InvalidDate coming from inside (internal generation)',
-					isInternalInvalidDate: true,
-					overrideExpected: false,
-				},
-				{
-					name: 'InvalidDate coming from outside',
-					isInternalInvalidDate: false,
-					overrideExpected: true,
-				},
-			],
-		);
+				expect(placeholder).not.toBe(REGULAR_PLACEHOLDER);
+			});
+		});
 	});
 });

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
@@ -1136,12 +1136,14 @@ describe('InputDateTimePicker', () => {
 			const dropdownContent = new ReactWrapper(portalInstance.props.children);
 
 			const pickerWrapper = dropdownContent.find(DateTimePicker);
-			pickerWrapper.prop('onSubmit')(null, {
-				date: new Date(2018, 0, 1),
-				time: 50,
-			});
-
-			expect(onBlur).toHaveBeenCalledTimes(1);
+			return pickerWrapper
+				.prop('onSubmit')(null, {
+					date: new Date(2018, 0, 1),
+					time: 50,
+				})
+				.then(() => {
+					expect(onBlur).toHaveBeenCalledTimes(1);
+				});
 		});
 	});
 
@@ -1266,15 +1268,17 @@ describe('InputDateTimePicker', () => {
 			const dropdownContent = new ReactWrapper(portalInstance.props.children);
 
 			const pickerWrapper = dropdownContent.find(DateTimePicker);
-			pickerWrapper.prop('onSubmit')(null, {
-				date: new Date(2018, 0, 1),
-				time: 50,
-			});
+			return pickerWrapper
+				.prop('onSubmit')(null, {
+					date: new Date(2018, 0, 1),
+					time: 50,
+				})
+				.then(() => {
+					wrapper.update();
 
-			wrapper.update();
-
-			const overlayWrapperAfter = wrapper.find('Overlay').first();
-			expect(overlayWrapperAfter.prop('show')).toBe(false);
+					const overlayWrapperAfter = wrapper.find('Overlay').first();
+					expect(overlayWrapperAfter.prop('show')).toBe(false);
+				});
 		});
 	});
 

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.test.js
@@ -13,12 +13,19 @@ import InputDateTimePicker from './InputDateTimePicker.component';
 import DateTimePicker from '../DateTimePicker';
 import { mockDate, restoreDate } from '../shared/utils/test/dateMocking';
 
+const DEFAULT_ID = 'DEFAULT_ID';
+
 function getRootElement() {
 	const rootElement = document.createElement('div');
 	document.body.appendChild(rootElement);
 	return rootElement;
 }
-const DEFAULT_ID = 'DEFAULT_ID';
+
+function getSyntheticMockedEvent() {
+	return {
+		persist: jest.fn(),
+	};
+}
 
 describe('InputDateTimePicker', () => {
 	beforeAll(() => {
@@ -561,7 +568,8 @@ describe('InputDateTimePicker', () => {
 			);
 			const dateTimePickerWrapper = wrapper.find(DateTimePicker);
 
-			dateTimePickerWrapper.prop('onSubmit')(null, {
+			const mockedEvent = getSyntheticMockedEvent();
+			dateTimePickerWrapper.prop('onSubmit')(mockedEvent, {
 				date: testedDate,
 				time: testedTime,
 			});
@@ -581,7 +589,8 @@ describe('InputDateTimePicker', () => {
 
 			const dateTimePickerWrapper = wrapper.find(DateTimePicker);
 
-			dateTimePickerWrapper.prop('onSubmit')(null, {
+			const mockedEvent = getSyntheticMockedEvent();
+			dateTimePickerWrapper.prop('onSubmit')(mockedEvent, {
 				date: testedDate,
 				time: testedTime,
 			});
@@ -699,9 +708,7 @@ describe('InputDateTimePicker', () => {
 			);
 			const dateTimePickerWrapper = wrapper.find(DateTimePicker);
 
-			const mockedEvent = {
-				whatever: 'prop',
-			};
+			const mockedEvent = getSyntheticMockedEvent();
 			dateTimePickerWrapper.prop('onSubmit')(mockedEvent, {
 				date: testedDate,
 				time: testedTime,
@@ -773,7 +780,8 @@ describe('InputDateTimePicker', () => {
 			onChange.mockReset();
 
 			const dateTimePickerWrapper = wrapper.find(DateTimePicker);
-			dateTimePickerWrapper.prop('onSubmit')(null, pickerIndenticalDatas);
+			const mockedEvent = getSyntheticMockedEvent();
+			dateTimePickerWrapper.prop('onSubmit')(mockedEvent, pickerIndenticalDatas);
 
 			expect(onChange).not.toHaveBeenCalled();
 		});
@@ -1048,7 +1056,8 @@ describe('InputDateTimePicker', () => {
 
 			const dateTimePickerWrapper = wrapper.find(DateTimePicker);
 
-			dateTimePickerWrapper.prop('onSubmit')(null, pickerDatas);
+			const mockedEvent = getSyntheticMockedEvent();
+			dateTimePickerWrapper.prop('onSubmit')(mockedEvent, pickerDatas);
 
 			expect(onChange).not.toHaveBeenCalled();
 		});
@@ -1136,13 +1145,15 @@ describe('InputDateTimePicker', () => {
 			const dropdownContent = new ReactWrapper(portalInstance.props.children);
 
 			const pickerWrapper = dropdownContent.find(DateTimePicker);
+			const mockedEvent = getSyntheticMockedEvent();
 			return pickerWrapper
-				.prop('onSubmit')(null, {
+				.prop('onSubmit')(mockedEvent, {
 					date: new Date(2018, 0, 1),
 					time: 50,
 				})
 				.then(() => {
 					expect(onBlur).toHaveBeenCalledTimes(1);
+					expect(mockedEvent.persist).toHaveBeenCalledTimes(1);
 				});
 		});
 	});
@@ -1268,8 +1279,10 @@ describe('InputDateTimePicker', () => {
 			const dropdownContent = new ReactWrapper(portalInstance.props.children);
 
 			const pickerWrapper = dropdownContent.find(DateTimePicker);
+
+			const mockedEvent = getSyntheticMockedEvent();
 			return pickerWrapper
-				.prop('onSubmit')(null, {
+				.prop('onSubmit')(mockedEvent, {
 					date: new Date(2018, 0, 1),
 					time: 50,
 				})

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -4,7 +4,7 @@ import memoize from 'lodash/memoize';
 import InputDateTimePickerComponent from '@talend/react-components/lib/DateTimePickers';
 import FieldTemplate from '../FieldTemplate';
 import { isoDateTimeRegExp } from '../../customFormats';
-import { UnhandleTypeError, UnexpectedTypeError } from './WrongTypeError';
+import { WidgetUnhandleTypeError, WidgetUnexpectedTypeError } from './WrongTypeError';
 
 const HANDLE_CONVERTION_TYPE = ['string', 'number'];
 
@@ -41,7 +41,7 @@ function convertToDate(type, value) {
 
 	if (typeOfValue !== type) {
 		// eslint-disable-next-line no-console
-		console.error(new UnexpectedTypeError(type, typeOfValue));
+		console.error(new WidgetUnexpectedTypeError(type, typeOfValue));
 		return generateInvalidDate();
 	}
 
@@ -52,7 +52,7 @@ function convertToDate(type, value) {
 			return convertStringToDate(value);
 		default:
 			// eslint-disable-next-line no-console
-			console.error(new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
+			console.error(new WidgetUnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
 			return generateInvalidDate();
 	}
 }
@@ -69,7 +69,7 @@ function convertFromDate(type, date) {
 			return convertDateToString(date);
 		default: {
 			// eslint-disable-next-line no-console
-			console.error(new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
+			console.error(new WidgetUnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
 			return generateInvalidDate();
 		}
 	}

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -79,6 +79,8 @@ class InputDateTimePicker extends React.Component {
 	constructor(props) {
 		super(props);
 
+		this.lastValueChanged = props.value;
+
 		this.onChange = this.onChange.bind(this);
 		this.onBlur = this.onBlur.bind(this);
 		this.convertToDate = memoize(convertToDate, (type, value) => `${type}||${value}`);
@@ -99,13 +101,14 @@ class InputDateTimePicker extends React.Component {
 			schema: this.props.schema,
 			value,
 		};
+		this.lastValueChanged = value;
 		this.props.onChange(event, payload);
 	}
 
 	onBlur(event) {
-		// TODO: Forcer l'envoi des dernières données reçues lors du onChange pour s'assurer de valider les dernières données dans le formulaire
 		this.props.onFinish(event, {
 			schema: this.props.schema,
+			value: this.lastValueChanged,
 		});
 	}
 

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -163,7 +163,7 @@ if (process.env.NODE_ENV !== 'production') {
 			required: PropTypes.bool,
 			title: PropTypes.string,
 		}),
-		value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Error)]),
+		value: PropTypes.oneOfType([PropTypes.number, PropTypes.string, PropTypes.instanceOf(Date)]),
 	};
 }
 

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -7,6 +7,7 @@ import { isoDateTimeRegExp } from '../../customFormats';
 import { WidgetUnhandleTypeError, WidgetUnexpectedTypeError } from './WrongTypeError';
 
 const HANDLE_CONVERTION_TYPE = ['string', 'number'];
+const UNIQUE_ERROR_MESSAGE = 'The date format is not valid. Expected format: YYYY-MM-DD HH:mm';
 
 function generateInvalidDate() {
 	return new Date('');
@@ -118,10 +119,12 @@ class InputDateTimePicker extends React.Component {
 		const isAlreadyADate = this.props.value instanceof Date;
 		const datetime = isAlreadyADate ? this.props.value : this.convertToDate(type, this.props.value);
 
+		const errorMessage = this.props.errorMessage ? UNIQUE_ERROR_MESSAGE : undefined;
+
 		return (
 			<FieldTemplate
 				description={schema.description}
-				errorMessage={this.props.errorMessage}
+				errorMessage={errorMessage}
 				id={this.props.id}
 				isValid={this.props.isValid}
 				label={schema.title}

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -103,6 +103,7 @@ class InputDateTimePicker extends React.Component {
 	}
 
 	onBlur(event) {
+		// TODO: Forcer l'envoi des dernières données reçues lors du onChange pour s'assurer de valider les dernières données dans le formulaire
 		this.props.onFinish(event, {
 			schema: this.props.schema,
 		});

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.component.js
@@ -6,8 +6,11 @@ import FieldTemplate from '../FieldTemplate';
 import { isoDateTimeRegExp } from '../../customFormats';
 import { UnhandleTypeError, UnexpectedTypeError } from './WrongTypeError';
 
-const INVALID_DATE = new Date('');
 const HANDLE_CONVERTION_TYPE = ['string', 'number'];
+
+function generateInvalidDate() {
+	return new Date('');
+}
 
 function convertDateToTimestamp(date) {
 	return date.getTime();
@@ -23,7 +26,7 @@ function convertDateToString(date) {
 
 function convertStringToDate(str) {
 	if (!isoDateTimeRegExp.test(str)) {
-		return INVALID_DATE;
+		return generateInvalidDate();
 	}
 
 	return new Date(str);
@@ -39,7 +42,7 @@ function convertToDate(type, value) {
 	if (typeOfValue !== type) {
 		// eslint-disable-next-line no-console
 		console.error(new UnexpectedTypeError(type, typeOfValue));
-		return INVALID_DATE;
+		return generateInvalidDate();
 	}
 
 	switch (type) {
@@ -50,7 +53,7 @@ function convertToDate(type, value) {
 		default:
 			// eslint-disable-next-line no-console
 			console.error(new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
-			return INVALID_DATE;
+			return generateInvalidDate();
 	}
 }
 
@@ -67,7 +70,7 @@ function convertFromDate(type, date) {
 		default: {
 			// eslint-disable-next-line no-console
 			console.error(new UnhandleTypeError(HANDLE_CONVERTION_TYPE, type));
-			return INVALID_DATE;
+			return generateInvalidDate();
 		}
 	}
 }

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
@@ -446,5 +446,32 @@ describe('InputDateTimePicker', () => {
 			expect(onFinishEvent).toBe(fakeEvent);
 			expect(onFinishPayload.schema).toBe(initialSchema);
 		});
+
+		it('should trigger onFinish with the latest onChange value particularly in synchronously calling onChange and onBlur', () => {
+			const initialValue = undefined;
+			const initialSchema = getSchema('number');
+			const fakeEvent = {
+				whatever: 'property',
+			};
+			const changedDate = new Date(2015, 10, 25, 19, 11);
+			const onFinish = jest.fn();
+			const wrapper = shallow(
+				<InputDateTimePicker
+					id="my-datepicker"
+					isValid
+					onChange={jest.fn()}
+					onFinish={onFinish}
+					schema={initialSchema}
+					value={initialValue}
+				/>,
+			);
+
+			const componentWrapper = wrapper.find('InputDateTimePicker');
+			componentWrapper.prop('onChange')(fakeEvent, undefined, changedDate);
+			componentWrapper.prop('onBlur')(fakeEvent);
+
+			const onFinishPayload = onFinish.mock.calls[0][1];
+			expect(onFinishPayload.value).toBe(changedDate.getTime());
+		});
 	});
 });

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import cases from 'jest-in-case';
+import uniq from 'lodash/uniq';
 import {
 	mockDate,
 	restoreDate,
@@ -375,6 +376,45 @@ describe('InputDateTimePicker', () => {
 				const componentWrapper = wrapper.find('InputDateTimePicker');
 				const selectedDateTime = componentWrapper.prop('selectedDateTime');
 				expect(selectedDateTime).toBe(formProperty);
+			});
+
+			it('should give a different InvalidDate for each error cases', () => {
+				function getSelectedDateTime(wrapper) {
+					const componentWrapper = wrapper.find('InputDateTimePicker');
+					return componentWrapper.prop('selectedDateTime');
+				}
+				const selectedDateTimes = [];
+				const wrapper = shallow(
+					<InputDateTimePicker
+						id="my-datepicker"
+						isValid
+						errorMessage="You've done something wrong"
+						onChange={jest.fn()}
+						onFinish={jest.fn()}
+						schema={getSchema('string')}
+						value={'whatever wrong data'}
+					/>,
+				);
+				// Bad string format
+				selectedDateTimes.push(getSelectedDateTime(wrapper));
+
+				// Bad type (number against string)
+				wrapper.setProps({
+					value: 545646456464564,
+				});
+				wrapper.update();
+				selectedDateTimes.push(getSelectedDateTime(wrapper));
+
+				// Unhandle type (boolean)
+				wrapper.setProps({
+					schema: getSchema('boolean'),
+				});
+				wrapper.update();
+				selectedDateTimes.push(getSelectedDateTime(wrapper));
+
+				const uniqSelectedDateTimes = uniq(selectedDateTimes);
+
+				expect(uniqSelectedDateTimes).toHaveLength(selectedDateTimes.length);
 			});
 		});
 	});

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/InputDateTimePicker.test.js
@@ -6,7 +6,7 @@ import {
 	restoreDate,
 } from '@talend/react-components/lib/DateTimePickers/shared/utils/test/dateMocking';
 
-import InputDateTimePicker, { GENERIC_FORMAT_ERROR } from './InputDateTimePicker.component';
+import InputDateTimePicker from './InputDateTimePicker.component';
 
 const schema = {
 	autoFocus: true,
@@ -229,8 +229,8 @@ describe('InputDateTimePicker', () => {
 	});
 
 	describe('errors handling', () => {
-		describe('coming from component', () => {
-			it('should spread an Error object to the form when receiving a message error from the component', () => {
+		describe('from component to form', () => {
+			it('should spread the date value as is when receiving a message error', () => {
 				const initialDateStr = '2027-01-01T03:35:00.000Z';
 				const onChange = jest.fn();
 				const wrapper = shallow(
@@ -247,105 +247,14 @@ describe('InputDateTimePicker', () => {
 				const componentWrapper = wrapper.find('InputDateTimePicker');
 				const componentOnChange = componentWrapper.prop('onChange');
 				const errorMessage = "An error message from the underlying widget's component";
-				componentOnChange(null, errorMessage, undefined);
+				const anyDateValue = new Date('An InvalidDate');
+				componentOnChange(null, errorMessage, anyDateValue);
 
 				const onChangePayload = onChange.mock.calls[0][1];
-				expect(onChangePayload.value).toBeInstanceOf(Error);
-				expect(onChangePayload.value.message).toBe(errorMessage);
+				expect(onChangePayload.value).toBe(anyDateValue);
 			});
 
-			it('should not spread an Error object but the last value to the component when receiving an Error object from the form which was coming first from widget', () => {
-				const initialDateStr = '2027-01-01T03:35:00.000Z';
-				const expectedDateSpread = new Date(2027, 0, 1, 3, 35);
-				const onChange = jest.fn();
-				const wrapper = shallow(
-					<InputDateTimePicker
-						id="my-datepicker"
-						isValid
-						onChange={onChange}
-						onFinish={jest.fn()}
-						schema={getSchema('string')}
-						value={initialDateStr}
-					/>,
-				);
-
-				const errorMessage = "An error message from the underlying widget's component";
-				wrapper.setProps({
-					value: new Error(errorMessage),
-				});
-
-				wrapper.update();
-
-				const componentWrapper = wrapper.find('InputDateTimePicker');
-
-				const datetime = componentWrapper.prop('selectedDateTime');
-				expect(datetime.getTime()).toBe(expectedDateSpread.getTime());
-			});
-		});
-
-		describe('coming from form', () => {
-			cases(
-				'should override the form error message only if the data result in an invalid date',
-				({ formErrorMessage, formValue, genericMessageExpected }) => {
-					const initialTimestamp = 999999999999999999999;
-					const onChange = jest.fn();
-
-					const wrapper = shallow(
-						<InputDateTimePicker
-							id="my-datepicker"
-							isValid
-							onChange={onChange}
-							onFinish={jest.fn()}
-							schema={getSchema('number')}
-							value={initialTimestamp}
-						/>,
-					);
-
-					wrapper.setProps({
-						errorMessage: formErrorMessage,
-						value: formValue,
-					});
-
-					const fieldWrapper = wrapper.find('FieldTemplate');
-
-					const expectedMessage = genericMessageExpected ? GENERIC_FORMAT_ERROR : formErrorMessage;
-					expect(fieldWrapper.prop('errorMessage')).toBe(expectedMessage);
-				},
-				[
-					{
-						name: 'Widget Error => Display the form error (which is the widget error)',
-						formErrorMessage: "An error message from the underlying widget's component",
-						formValue: new Error("An error message from the underlying widget's component"),
-						genericMessageExpected: false,
-					},
-					{
-						name: 'Form Error with InvalidDate => Display the generic error',
-						formErrorMessage: 'The timestamp format is invalid',
-						formValue: 99999999999999999999,
-						genericMessageExpected: true,
-					},
-					{
-						name: 'Form Error wrong type => Display the generic error',
-						formErrorMessage: 'number expected but got string',
-						formValue: '2018-01-01T00:00:00.000Z',
-						genericMessageExpected: true,
-					},
-					{
-						name: 'Form Error with Date valid => Display the form error',
-						formErrorMessage: 'The date should be in year 2018',
-						formValue: 1483228800000,
-						genericMessageExpected: false,
-					},
-					{
-						name: 'Form Error required value => Display the form error',
-						formErrorMessage: 'The value is required',
-						formValue: undefined,
-						genericMessageExpected: false,
-					},
-				],
-			);
-
-			it('should spread an Error object to the form when type defined is not handled by the widget and a value try to be converted to date', () => {
+			it('should spread an InvalidDate when there is no errorMessage and type defined in form schema is not handled by the widget', () => {
 				const initialValue = undefined;
 				const changedDate = new Date(2015, 10, 25, 19, 11);
 				const onChange = jest.fn();
@@ -366,107 +275,92 @@ describe('InputDateTimePicker', () => {
 				componentOnChange(null, undefined, changedDate);
 
 				const onChangePayload = onChange.mock.calls[0][1];
-				expect(onChangePayload.value).toBeInstanceOf(Error);
+				expect(onChangePayload.value).toBeInstanceOf(Date);
+				expect(isNaN(onChangePayload.value.getTime())).toBe(true);
 			});
 		});
 
-		describe('coming from one then the other', () => {
-			it('should spread the component error when coming from the component lastly', () => {
-				const wrapper = shallow(
-					<InputDateTimePicker
-						id="my-datepicker"
-						isValid
-						onChange={jest.fn()}
-						onFinish={jest.fn()}
-						schema={getSchema('number')}
-						value={undefined}
-					/>,
-				);
+		describe('from form to component', () => {
+			cases(
+				"should give an 'InvalidDate' to the component if date cannot be converted",
+				({ value, specifiedType }) => {
+					const wrapper = shallow(
+						<InputDateTimePicker
+							id="my-datepicker"
+							isValid
+							errorMessage="You've done something wrong"
+							onChange={jest.fn()}
+							onFinish={jest.fn()}
+							schema={getSchema(specifiedType)}
+							value={value}
+						/>,
+					);
+					const componentWrapper = wrapper.find('InputDateTimePicker');
+					const selectedDateTime = componentWrapper.prop('selectedDateTime');
+					expect(selectedDateTime).toBeInstanceOf(Date);
+					expect(isNaN(selectedDateTime.getTime())).toBe(true);
+				},
+				[
+					{
+						name: 'unknown type',
+						value: 1081866600000,
+						specifiedType: 'whatever',
+					},
+					{
+						name: 'unhandle type object',
+						value: {},
+						specifiedType: 'object',
+					},
+					{
+						name: 'unhandle type boolean',
+						value: true,
+						specifiedType: 'boolean',
+					},
+					{
+						name: 'wrong value type against specified type',
+						value: 1081866600000,
+						specifiedType: 'string',
+					},
+					{
+						name: 'number too high',
+						value: 86400000000000000,
+						specifiedType: 'number',
+					},
+					{
+						name: 'number too low',
+						value: -86400000000000000,
+						specifiedType: 'number',
+					},
+					{
+						name: 'string non sens',
+						value: 'hkqkjaezlrnezncfkl',
+						specifiedType: 'string',
+					},
+					{
+						name: 'string missing "T" format part',
+						value: '2018-01-01 00:00:00.000Z',
+						specifiedType: 'string',
+					},
+					{
+						name: 'string missing "-" format separators',
+						value: '2018 01 01T00:00:00.000Z',
+						specifiedType: 'string',
+					},
+					{
+						name: 'string missing ":" format separators',
+						value: '2018-01-01T00 00 00.000Z',
+						specifiedType: 'string',
+					},
+					{
+						name: 'string non accepting comma for second fraction',
+						value: '2018-01-01T00:00:00,000Z',
+						specifiedType: 'string',
+					},
+				],
+			);
 
-				// Update to a form data error
-				const formError = 'Wrong timestamp format';
-				const badTimestamp = 8640000000000002;
-				wrapper.setProps({
-					errorMessage: formError,
-					value: badTimestamp,
-				});
-				wrapper.update();
-
-				const fieldWrapperBefore = wrapper.find('FieldTemplate');
-				expect(fieldWrapperBefore.prop('errorMessage')).toBe(GENERIC_FORMAT_ERROR);
-
-				const componentWrapperBefore = wrapper.find('InputDateTimePicker');
-				const datetimeBefore = componentWrapperBefore.prop('selectedDateTime');
-				expect(isNaN(datetimeBefore.getTime())).toBe(true);
-
-				// Update to a component input error
-				const componentErrorMessage = 'A component format error';
-				const componentError = new Error(componentErrorMessage);
-				wrapper.setProps({
-					errorMessage: componentErrorMessage,
-					value: componentError,
-				});
-				wrapper.update();
-
-				const fieldWrapperAfter = wrapper.find('FieldTemplate');
-				expect(fieldWrapperAfter.prop('errorMessage')).toBe(componentErrorMessage);
-
-				const componentWrapperAfter = wrapper.find('InputDateTimePicker');
-				const datetimeAfter = componentWrapperAfter.prop('selectedDateTime');
-				expect(datetimeAfter).toBe(datetimeBefore);
-			});
-
-			it('should spread the generic error message when coming from the form lastly', () => {
-				const wrapper = shallow(
-					<InputDateTimePicker
-						id="my-datepicker"
-						isValid
-						onChange={jest.fn()}
-						onFinish={jest.fn()}
-						schema={getSchema('number')}
-						value={784561354}
-					/>,
-				);
-				const componentWrapperInitial = wrapper.find('InputDateTimePicker');
-				const datetimeInitial = componentWrapperInitial.prop('selectedDateTime');
-
-				// Update to a component input error
-				const componentErrorMessage = 'A component format error';
-				const componentError = new Error(componentErrorMessage);
-				wrapper.setProps({
-					errorMessage: componentErrorMessage,
-					value: componentError,
-				});
-				wrapper.update();
-
-				const fieldWrapperBefore = wrapper.find('FieldTemplate');
-				expect(fieldWrapperBefore.prop('errorMessage')).toBe(componentErrorMessage);
-
-				const componentWrapperBefore = wrapper.find('InputDateTimePicker');
-				const datetimeBefore = componentWrapperBefore.prop('selectedDateTime');
-				expect(datetimeBefore).toBe(datetimeInitial);
-
-				// Update to a form data error
-				const formError = 'Wrong timestamp format';
-				const badTimestamp = 8640000000000002;
-				wrapper.setProps({
-					errorMessage: formError,
-					value: badTimestamp,
-				});
-				wrapper.update();
-
-				const fieldWrapperAfter = wrapper.find('FieldTemplate');
-				expect(fieldWrapperAfter.prop('errorMessage')).toBe(GENERIC_FORMAT_ERROR);
-
-				const componentWrapperAfter = wrapper.find('InputDateTimePicker');
-				const datetimeAfter = componentWrapperAfter.prop('selectedDateTime');
-				expect(isNaN(datetimeAfter.getTime())).toBe(true);
-			});
-		});
-
-		cases(
-			"should give an 'InvalidDate' to the component if date cannot be converted",
-			({ value, specifiedType }) => {
+			it("should spread the value as is if it's already a Date object", () => {
+				const formProperty = new Date('Whatever date');
 				const wrapper = shallow(
 					<InputDateTimePicker
 						id="my-datepicker"
@@ -474,99 +368,43 @@ describe('InputDateTimePicker', () => {
 						errorMessage="You've done something wrong"
 						onChange={jest.fn()}
 						onFinish={jest.fn()}
-						schema={getSchema(specifiedType)}
-						value={value}
+						schema={getSchema('number')}
+						value={formProperty}
 					/>,
 				);
 				const componentWrapper = wrapper.find('InputDateTimePicker');
 				const selectedDateTime = componentWrapper.prop('selectedDateTime');
-				expect(selectedDateTime).toBeInstanceOf(Date);
-				expect(isNaN(selectedDateTime.getTime())).toBe(true);
-			},
-			[
-				{
-					name: 'unknown type',
-					value: 1081866600000,
-					specifiedType: 'whatever',
-				},
-				{
-					name: 'unhandle type object',
-					value: {},
-					specifiedType: 'object',
-				},
-				{
-					name: 'unhandle type boolean',
-					value: true,
-					specifiedType: 'boolean',
-				},
-				{
-					name: 'wrong value type against specified type',
-					value: 1081866600000,
-					specifiedType: 'string',
-				},
-				{
-					name: 'number too high',
-					value: 86400000000000000,
-					specifiedType: 'number',
-				},
-				{
-					name: 'number too low',
-					value: -86400000000000000,
-					specifiedType: 'number',
-				},
-				{
-					name: 'string non sens',
-					value: 'hkqkjaezlrnezncfkl',
-					specifiedType: 'string',
-				},
-				{
-					name: 'string missing "T" format part',
-					value: '2018-01-01 00:00:00.000Z',
-					specifiedType: 'string',
-				},
-				{
-					name: 'string missing "-" format separators',
-					value: '2018 01 01T00:00:00.000Z',
-					specifiedType: 'string',
-				},
-				{
-					name: 'string missing ":" format separators',
-					value: '2018-01-01T00 00 00.000Z',
-					specifiedType: 'string',
-				},
-				{
-					name: 'string non accepting comma for second fraction',
-					value: '2018-01-01T00:00:00,000Z',
-					specifiedType: 'string',
-				},
-			],
-		);
+				expect(selectedDateTime).toBe(formProperty);
+			});
+		});
 	});
 
-	it('should trigger onFinish when the component blur', () => {
-		const initialTimestamp = 1533884400000;
-		const initialSchema = getSchema('number');
-		const fakeEvent = {
-			whatever: 'property',
-		};
-		const onFinish = jest.fn();
-		const wrapper = shallow(
-			<InputDateTimePicker
-				id="my-datepicker"
-				isValid
-				onChange={jest.fn()}
-				onFinish={onFinish}
-				schema={initialSchema}
-				value={initialTimestamp}
-			/>,
-		);
+	describe('end of edition', () => {
+		it('should trigger onFinish when the component blur', () => {
+			const initialTimestamp = 1533884400000;
+			const initialSchema = getSchema('number');
+			const fakeEvent = {
+				whatever: 'property',
+			};
+			const onFinish = jest.fn();
+			const wrapper = shallow(
+				<InputDateTimePicker
+					id="my-datepicker"
+					isValid
+					onChange={jest.fn()}
+					onFinish={onFinish}
+					schema={initialSchema}
+					value={initialTimestamp}
+				/>,
+			);
 
-		const componentWrapper = wrapper.find('InputDateTimePicker');
-		componentWrapper.prop('onBlur')(fakeEvent);
+			const componentWrapper = wrapper.find('InputDateTimePicker');
+			componentWrapper.prop('onBlur')(fakeEvent);
 
-		const onFinishEvent = onFinish.mock.calls[0][0];
-		const onFinishPayload = onFinish.mock.calls[0][1];
-		expect(onFinishEvent).toBe(fakeEvent);
-		expect(onFinishPayload.schema).toBe(initialSchema);
+			const onFinishEvent = onFinish.mock.calls[0][0];
+			const onFinishPayload = onFinish.mock.calls[0][1];
+			expect(onFinishEvent).toBe(fakeEvent);
+			expect(onFinishPayload.schema).toBe(initialSchema);
+		});
 	});
 });

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
@@ -4,13 +4,13 @@ This widget surprisingly allows you to render an InputDateTimePicker.
 
 ## Data conversion
 
-The underlying _InputDateTimePicker_ component handles a Date object and the form handles the final submited format, which can be an iso string or a timestamp number. Thereby, a conversion need to be done, in both way, and [some errors can occur](#error-handling).
+The underlying _InputDateTimePicker_ component handles a Date object and the form handles the final submited format, which can be an iso string or a timestamp number. Thereby, a conversion need to be done, in both way, and some errors can occur. In case of an error, an InvalidDate is generated and spread to the destination either to the form or to the component.
 
 ### Procedure
 
 The form give the value to the widget. It try to convert the value to a Date based on the form property type (number or string) and spread it to the _InputDateTimePicker_ component.
 
-In the other way, the widget give a Date object to the widget, which is converted to number or string (is still based on the form property type).
+In the other way, the widget give a Date object to the widget, which is converted to number or string (still based on the form property type).
 
 ### Timestamp format
 
@@ -65,6 +65,7 @@ Example : "2018-01-01T10:35:48.951Z"
 | disabled    | Disable the input                                              | `false` |
 | placeholder | Text to display as placeholder                                 |         |
 | readOnly    | Set the input as non modifiable and prevent datepicker to open | `false` |
+| validationMessage | Required to override all the technical error message not wanted to display for the user ||
 
 ```json
 [
@@ -75,23 +76,8 @@ Example : "2018-01-01T10:35:48.951Z"
 		"autoFocus": false,
 		"disabled": false,
 		"placeholder": "Type the date here...",
-		"readOnly": false
+		"readOnly": false,
+		"validationMessage": "The date is not valid"
 	}
 ]
 ```
-
-## Error handling
-
-### Widget error
-
-Those type of errors occur when the text input typed don't match the format required. An error message is sent to the widget, which wrap it in an Error object and spread it to the form as the value.
-
-The form interpret the Error object value as an error and extract the message before any other checks (require check, type check, custom check, etc.). The error is giving back to the widget in the normal path as the _errorMessage_. The last widget value held in widget state is spread to the component and not the Error object.
-
-### Form data error
-
-Those type of errors occur when the data is invalidated by the form.
-
-If the data has an invalid format and therefore is impossible to convert to a valid Date, an InvalidDate is spread to the component and the _widget generic format error_ is used as an override of the _form error message_ to display.
-
-If the data is a valid format and can be converted to a valid Date but some rule is not validated (like a range rule or a value required), the value is spread as is to the component and the _form error message_ is kept to display.

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
@@ -57,15 +57,14 @@ Example : "2018-01-01T10:35:48.951Z"
 
 ## UI Schema
 
-| Property          | Description                                                                                                            | Default |
-| ----------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- |
-| widget            | `inputDateTimePicker`                                                                                                  |         |
-| title             | The title to display above field                                                                                       |         |
-| autoFocus         | Focus input on render                                                                                                  | `false` |
-| disabled          | Disable the input                                                                                                      | `false` |
-| placeholder       | Text to display as placeholder                                                                                         |         |
-| readOnly          | Set the input as non modifiable and prevent datepicker to open                                                         | `false` |
-| validationMessage | Required to override all the error message where technical one are included and are not wanted to display for the user |         |
+| Property    | Description                                                    | Default |
+| ----------- | -------------------------------------------------------------- | ------- |
+| widget      | `inputDateTimePicker`                                          |         |
+| title       | The title to display above field                               |         |
+| autoFocus   | Focus input on render                                          | `false` |
+| disabled    | Disable the input                                              | `false` |
+| placeholder | Text to display as placeholder                                 |         |
+| readOnly    | Set the input as non modifiable and prevent datepicker to open | `false` |
 
 ```json
 [
@@ -76,8 +75,7 @@ Example : "2018-01-01T10:35:48.951Z"
 		"autoFocus": false,
 		"disabled": false,
 		"placeholder": "Type the date here...",
-		"readOnly": false,
-		"validationMessage": "The date format is not valid. Expected format: YYYY-MM-DD HH:mm"
+		"readOnly": false
 	}
 ]
 ```

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/README.md
@@ -57,15 +57,15 @@ Example : "2018-01-01T10:35:48.951Z"
 
 ## UI Schema
 
-| Property    | Description                                                    | Default |
-| ----------- | -------------------------------------------------------------- | ------- |
-| widget      | `inputDateTimePicker`                                          |         |
-| title       | The title to display above field                               |         |
-| autoFocus   | Focus input on render                                          | `false` |
-| disabled    | Disable the input                                              | `false` |
-| placeholder | Text to display as placeholder                                 |         |
-| readOnly    | Set the input as non modifiable and prevent datepicker to open | `false` |
-| validationMessage | Required to override all the technical error message not wanted to display for the user ||
+| Property          | Description                                                                                                            | Default |
+| ----------------- | ---------------------------------------------------------------------------------------------------------------------- | ------- |
+| widget            | `inputDateTimePicker`                                                                                                  |         |
+| title             | The title to display above field                                                                                       |         |
+| autoFocus         | Focus input on render                                                                                                  | `false` |
+| disabled          | Disable the input                                                                                                      | `false` |
+| placeholder       | Text to display as placeholder                                                                                         |         |
+| readOnly          | Set the input as non modifiable and prevent datepicker to open                                                         | `false` |
+| validationMessage | Required to override all the error message where technical one are included and are not wanted to display for the user |         |
 
 ```json
 [
@@ -77,7 +77,7 @@ Example : "2018-01-01T10:35:48.951Z"
 		"disabled": false,
 		"placeholder": "Type the date here...",
 		"readOnly": false,
-		"validationMessage": "The date is not valid"
+		"validationMessage": "The date format is not valid. Expected format: YYYY-MM-DD HH:mm"
 	}
 ]
 ```

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/WrongTypeError.js
@@ -1,4 +1,4 @@
-export class UnhandleTypeError extends Error {
+export class WidgetUnhandleTypeError extends Error {
 	constructor(acceptedTypes, typeGiven) {
 		const acceptedTypesFormated = acceptedTypes.map(acceptedType => `'${acceptedType}'`).join(', ');
 		const message = `[${acceptedTypesFormated}] types accepted, given '${typeGiven}'`;
@@ -6,7 +6,7 @@ export class UnhandleTypeError extends Error {
 	}
 }
 
-export class UnexpectedTypeError extends Error {
+export class WidgetUnexpectedTypeError extends Error {
 	constructor(typeExpected, typeGiven) {
 		const message = `Expected type of '${typeExpected}' and got '${typeGiven}'`;
 		super(message);

--- a/packages/forms/src/UIForm/fields/InputDateTimePicker/__snapshots__/InputDateTimePicker.test.js.snap
+++ b/packages/forms/src/UIForm/fields/InputDateTimePicker/__snapshots__/InputDateTimePicker.test.js.snap
@@ -3,7 +3,7 @@
 exports[`InputDateTimePicker should render 1`] = `
 <FieldTemplate
   description="This is my date picker"
-  errorMessage="You've done something wrong"
+  errorMessage="The date format is not valid. Expected format: YYYY-MM-DD HH:mm"
   id="my-datepicker"
   isValid={false}
   label="My date picker"

--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -47,10 +47,6 @@ export function adaptAdditionalRules(mergedSchema) {
  * @returns {object} The validation result.
  */
 export function validateValue(schema, value, properties, customValidationFn) {
-	if (typeof value === 'object' && value instanceof Error) {
-		return value.message;
-	}
-
 	const validationSchema = adaptAdditionalRules(schema);
 	const staticResult = validate(validationSchema, value);
 	if (staticResult.valid && schema.customValidation && customValidationFn) {

--- a/packages/forms/src/UIForm/utils/validation.test.js
+++ b/packages/forms/src/UIForm/utils/validation.test.js
@@ -77,26 +77,6 @@ describe('Validation utils', () => {
 			// then
 			expect(errors).toBe(null);
 		});
-
-		it('should return the error.message if the value is an Error object, without validating further', () => {
-			const schema = {
-				key: ['firstname'],
-				customValidation: true,
-				required: true,
-				schema: {
-					type: 'string',
-				},
-				type: 'text',
-			};
-			const errorMessage = 'This is a custom error message bubbling up from the widget';
-			const widgetError = new Error(errorMessage);
-			const value = widgetError;
-			const properties = { firstname: '' };
-
-			const errors = validateValue(schema, value, properties, customValidationFn);
-
-			expect(errors).toBe(widgetError.message);
-		});
 	});
 
 	describe('#validateArray', () => {

--- a/packages/forms/stories-core/json/fields/core-inputDateTimePicker.json
+++ b/packages/forms/stories-core/json/fields/core-inputDateTimePicker.json
@@ -39,52 +39,45 @@
     {
       "key": "propSimpleNumber",
       "title": "Basic with number type",
-      "widget": "inputDateTimePicker",
-      "validationMessage": "Invalid date format"
+      "widget": "inputDateTimePicker"
     },
     {
       "key": "propAutofocus",
       "title": "Autofocus input",
       "widget": "inputDateTimePicker",
       "autoFocus": true,
-      "placeholder": "Type the date here...",
-      "validationMessage": "Invalid date format"
+      "placeholder": "Type the date here..."
     },
     {
       "key": "propSimpleString",
       "title": "Basic with string type",
-      "widget": "inputDateTimePicker",
-      "validationMessage": "Invalid date format"
+      "widget": "inputDateTimePicker"
     },
     {
       "key": "propNumberInitWithError",
       "title": "Basic with number type",
       "description": "Initialised with a bad format",
-      "widget": "inputDateTimePicker",
-      "validationMessage": "Invalid date format"
+      "widget": "inputDateTimePicker"
     },
     {
       "key": "propStringInitWithError",
       "title": "Basic with string type",
       "description": "Initialised with a bad format",
-      "widget": "inputDateTimePicker",
-      "validationMessage": "Invalid date format"
+      "widget": "inputDateTimePicker"
     },
     {
       "key": "propDisabled",
       "title": "Disabled widget",
       "widget": "inputDateTimePicker",
       "description": "You can always try to click...",
-      "disabled": true,
-      "validationMessage": "Invalid date format"
+      "disabled": true
     },
     {
       "key": "propReadOnly",
       "title": "Readonly widget",
       "widget": "inputDateTimePicker",
       "description": "You can always try to change me",
-      "readOnly": true,
-      "validationMessage": "Invalid date format"
+      "readOnly": true
     }
   ],
   "properties": {

--- a/packages/forms/stories-core/json/fields/core-inputDateTimePicker.json
+++ b/packages/forms/stories-core/json/fields/core-inputDateTimePicker.json
@@ -39,45 +39,52 @@
     {
       "key": "propSimpleNumber",
       "title": "Basic with number type",
-      "widget": "inputDateTimePicker"
+      "widget": "inputDateTimePicker",
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propAutofocus",
       "title": "Autofocus input",
       "widget": "inputDateTimePicker",
       "autoFocus": true,
-      "placeholder": "Type the date here..."
+      "placeholder": "Type the date here...",
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propSimpleString",
       "title": "Basic with string type",
-      "widget": "inputDateTimePicker"
+      "widget": "inputDateTimePicker",
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propNumberInitWithError",
       "title": "Basic with number type",
       "description": "Initialised with a bad format",
-      "widget": "inputDateTimePicker"
+      "widget": "inputDateTimePicker",
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propStringInitWithError",
       "title": "Basic with string type",
       "description": "Initialised with a bad format",
-      "widget": "inputDateTimePicker"
+      "widget": "inputDateTimePicker",
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propDisabled",
       "title": "Disabled widget",
       "widget": "inputDateTimePicker",
       "description": "You can always try to click...",
-      "disabled": true
+      "disabled": true,
+      "validationMessage": "Invalid date format"
     },
     {
       "key": "propReadOnly",
       "title": "Readonly widget",
       "widget": "inputDateTimePicker",
       "description": "You can always try to change me",
-      "readOnly": true
+      "readOnly": true,
+      "validationMessage": "Invalid date format"
     }
   ],
   "properties": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Avoid loss of synchronicity between form property value and its `errorMessage`.
Having a not too bad way to handle errors. To just have at least a way to do it

**What is the chosen solution to this problem?**
Let spread all values not handled in the conversion, and have the form validation handle it.
Let the custom uiSchema `validationMessage` override all the error messages to avoid displaying an understandable message to the user.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
