### PR TITLE
feat: skip links

### DIFF
--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -72,7 +72,7 @@ function Layout({
 				<SkipLinks />
 			</div>
 			{safeHeader && (
-				<header key="banner" role="banner" className={headerCSS} z-index="10">
+				<header key="banner" role="banner" className={headerCSS}>
 					{safeHeader}
 				</header>
 			)}

--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -68,9 +68,11 @@ function Layout({
 
 	return (
 		<div id={id} className={appCSS}>
-			<SkipLinks />
+			<div className={theme['skip-links']}>
+				<SkipLinks />
+			</div>
 			{safeHeader && (
-				<header key="banner" role="banner" className={headerCSS}>
+				<header key="banner" role="banner" className={headerCSS} z-index="10">
 					{safeHeader}
 				</header>
 			)}

--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -49,12 +49,14 @@ function Layout({
 	const headerCSS = classnames('tc-layout-header', theme.header);
 	const footerCSS = classnames('tc-layout-footer', theme.footer);
 	let Component;
+	let skipLinkNavigationId;
 	switch (mode) {
 		case DISPLAY_MODE_ONE_COLUMN:
 			Component = OneColumn;
 			break;
 		case DISPLAY_MODE_TWO_COLUMNS:
 			Component = TwoColumns;
+			skipLinkNavigationId = '#tc-layout-side-menu';
 			break;
 		default:
 			Component = OneColumn;
@@ -69,7 +71,7 @@ function Layout({
 	return (
 		<div id={id} className={appCSS}>
 			<div className={theme['skip-links']}>
-				<SkipLinks />
+				<SkipLinks navigationId={skipLinkNavigationId} mainId="#tc-layout-main" />
 			</div>
 			{safeHeader && (
 				<header key="banner" role="banner" className={headerCSS}>

--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -5,6 +5,8 @@ import Inject from '../Inject';
 import TabBar from '../TabBar';
 import OneColumn from './OneColumn';
 import TwoColumns from './TwoColumns';
+import SkipLinks from './SkipLinks';
+
 import theme from './Layout.scss';
 import {
 	DISPLAY_MODES,
@@ -66,6 +68,7 @@ function Layout({
 
 	return (
 		<div id={id} className={appCSS}>
+			<SkipLinks />
 			{safeHeader && (
 				<header key="banner" role="banner" className={headerCSS}>
 					{safeHeader}

--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -20,8 +20,13 @@ body {
 	height: 100vh;
 	width: 100vw;
 
+	.skip-links {
+		z-index: 20;
+	}
+
 	.header {
 		flex: 0 0 $tc-layout-header-height;
+		z-index: 10;
 	}
 
 	.footer {

--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -6,6 +6,8 @@
 /// Layout height of the header
 /// @type Number (Unit)
 $tc-layout-header-height: $navbar-height;
+$tc-layout-skip-links-z-index: 20;
+$tc-layout-header-z-index: 10;
 
 body {
 	margin: 0;
@@ -21,12 +23,12 @@ body {
 	width: 100vw;
 
 	.skip-links {
-		z-index: 20;
+		z-index: $tc-layout-skip-links-z-index;
 	}
 
 	.header {
 		flex: 0 0 $tc-layout-header-height;
-		z-index: 10;
+		z-index: $tc-layout-header-z-index;
 	}
 
 	.footer {

--- a/packages/components/src/Layout/OneColumn/OneColumn.component.js
+++ b/packages/components/src/Layout/OneColumn/OneColumn.component.js
@@ -20,7 +20,7 @@ function OneColumn({ drawers, children, tabs, ...props }) {
 		flexDirection: 'column',
 	};
 	return (
-		<div role="main" className={container} {...props}>
+		<div role="main" id="tc-layout-main" tabIndex="-1" className={container} {...props}>
 			<WithDrawer drawers={drawers}>
 				{tabs && <TabBar {...tabs} />}
 				<div style={style}>{children}</div>

--- a/packages/components/src/Layout/OneColumn/__snapshots__/OneColumn.test.js.snap
+++ b/packages/components/src/Layout/OneColumn/__snapshots__/OneColumn.test.js.snap
@@ -3,7 +3,9 @@
 exports[`OneColumn should render 1`] = `
 <div
   className="tc-layout-one-column theme-main"
+  id="tc-layout-main"
   role="main"
+  tabIndex="-1"
 >
   <WithDrawer>
     <div

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
@@ -23,6 +23,11 @@ SkipTo.propTypes = {
 	label: PropTypes.string.isRequired,
 };
 
+/**
+ * Skip links are a technique to ease keyboard navigation.
+ * It consists in giving some links as the firsts focusable elements of the page
+ * to go directly to some meaningful content.
+ */
 function SkipLinks({ mainId, navigationId, t }) {
 	return (
 		<nav

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import theme from './SkipLinks.scss';
+
+function SkipLinks(props) {
+	const children = [];
+
+	if (props.navigation) {
+		children.push(
+			<li>
+				<a href="#tc-layout-side-menu">{'Skip header to navigation'}</a>
+			</li>,
+		);
+	}
+
+	if (props.main) {
+		children.push(
+			<li>
+				<a href="#tc-layout-main">{'Skip navigation to main content'}</a>
+			</li>,
+		);
+	}
+
+	return <ul className={theme['tc-skip-links']}>{children}</ul>;
+}
+
+SkipLinks.defaultProps = {
+	navigation: true,
+	main: true,
+};
+
+SkipLinks.propTypes = {
+	navigation: PropTypes.bool,
+	main: PropTypes.bool,
+};
+
+export default SkipLinks;

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
@@ -1,38 +1,66 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { translate } from 'react-i18next';
+
+import Icon from '../../Icon';
+import I18N_DOMAIN_COMPONENTS from '../../constants';
+import getDefaultT from '../../translate';
 
 import theme from './SkipLinks.scss';
 
-function SkipLinks(props) {
-	const children = [];
+function SkipTo({ href, label }) {
+	return (
+		<a href={href}>
+			<span className={theme.icon}>
+				<Icon transform="rotate-270" name="talend-arrow-left" />
+			</span>
+			<span className={theme.text}>{label}</span>
+		</a>
+	);
+}
+SkipTo.propTypes = {
+	href: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+};
 
-	if (props.navigation) {
-		children.push(
-			<li>
-				<a href="#tc-layout-side-menu">{'Skip header to navigation'}</a>
-			</li>,
-		);
-	}
-
-	if (props.main) {
-		children.push(
-			<li>
-				<a href="#tc-layout-main">{'Skip navigation to main content'}</a>
-			</li>,
-		);
-	}
-
-	return <ul className={theme['tc-skip-links']}>{children}</ul>;
+function SkipLinks({ mainId, navigationId, t }) {
+	return (
+		<nav
+			className={theme['tc-skip-links']}
+			aria-label={t('SKIP_LINKS', { defaultValue: 'Skip links' })}
+		>
+			<ul>
+				{navigationId && (
+					<li key="navigation">
+						<SkipTo
+							href={navigationId}
+							label={t('SKIP_TO_NAV', { defaultValue: 'Skip header to navigation' })}
+						/>
+					</li>
+				)}
+				{mainId && (
+					<li key="main">
+						<SkipTo
+							href={mainId}
+							label={t('SKIP_TO_MAIN', { defaultValue: 'Skip navigation to main content' })}
+						/>
+					</li>
+				)}
+			</ul>
+		</nav>
+	);
 }
 
 SkipLinks.defaultProps = {
-	navigation: true,
-	main: true,
+	navigationId: '#tc-layout-side-menu',
+	mainId: '#tc-layout-main',
+	t: getDefaultT(),
 };
 
 SkipLinks.propTypes = {
-	navigation: PropTypes.bool,
-	main: PropTypes.bool,
+	navigationId: PropTypes.string,
+	mainId: PropTypes.string,
+	t: PropTypes.func,
 };
 
-export default SkipLinks;
+export default translate(I18N_DOMAIN_COMPONENTS)(SkipLinks);

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
@@ -39,7 +39,7 @@ function SkipLinks({ mainId, navigationId, t }) {
 					<li key="navigation">
 						<SkipTo
 							href={navigationId}
-							label={t('SKIP_TO_NAV', { defaultValue: 'Skip header to navigation' })}
+							label={t('SKIP_TO_NAV', { defaultValue: 'Skip to navigation' })}
 						/>
 					</li>
 				)}
@@ -47,7 +47,7 @@ function SkipLinks({ mainId, navigationId, t }) {
 					<li key="main">
 						<SkipTo
 							href={mainId}
-							label={t('SKIP_TO_MAIN', { defaultValue: 'Skip navigation to main content' })}
+							label={t('SKIP_TO_MAIN', { defaultValue: 'Skip to main content' })}
 						/>
 					</li>
 				)}

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.component.js
@@ -43,28 +43,24 @@ function SkipLinks({ mainId, navigationId, t }) {
 						/>
 					</li>
 				)}
-				{mainId && (
-					<li key="main">
-						<SkipTo
-							href={mainId}
-							label={t('SKIP_TO_MAIN', { defaultValue: 'Skip to main content' })}
-						/>
-					</li>
-				)}
+				<li key="main">
+					<SkipTo
+						href={mainId}
+						label={t('SKIP_TO_MAIN', { defaultValue: 'Skip to main content' })}
+					/>
+				</li>
 			</ul>
 		</nav>
 	);
 }
 
 SkipLinks.defaultProps = {
-	navigationId: '#tc-layout-side-menu',
-	mainId: '#tc-layout-main',
 	t: getDefaultT(),
 };
 
 SkipLinks.propTypes = {
 	navigationId: PropTypes.string,
-	mainId: PropTypes.string,
+	mainId: PropTypes.string.isRequired,
 	t: PropTypes.func,
 };
 

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.scss
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.scss
@@ -4,19 +4,31 @@
 	height: 1px;
 	overflow: hidden;
 
-	> li {
-		> a {
-			&:focus {
-				position: fixed;
-				top: 0;
-				left: 0;
-				height: $navbar-height;
-				visibility: visible;
-				background: $white;
-				color: $dove-gray;
-				font-weight: bold;
-				padding: 0 $padding-small;
-			}
+	ul > li > a {
+		height: $navbar-height;
+		background: $white;
+		color: $dove-gray;
+		font-weight: bold;
+
+		display: flex;
+		align-items: center;
+
+		&:focus {
+			position: fixed;
+			top: 0;
+			left: 0;
+			visibility: visible;
+		}
+
+		> .icon {
+			padding: 0 $padding-small;
+			border-right: 1px solid black;
+			display: flex;
+			align-items: center;
+		}
+
+		> .text {
+			padding: 0 $padding-small;
 		}
 	}
 }

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.scss
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.scss
@@ -1,14 +1,21 @@
 .tc-skip-links {
-	> li {
-		@extend .sr-only;
-		z-index: 20;
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	overflow: hidden;
 
+	> li {
 		> a {
 			&:focus {
-				position: absolute;
+				position: fixed;
+				top: 0;
+				left: 0;
 				height: $navbar-height;
 				visibility: visible;
 				background: $white;
+				color: $dove-gray;
+				font-weight: bold;
+				padding: 0 $padding-small;
 			}
 		}
 	}

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.scss
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.scss
@@ -1,0 +1,15 @@
+.tc-skip-links {
+	> li {
+		@extend .sr-only;
+		z-index: 20;
+
+		> a {
+			&:focus {
+				position: absolute;
+				height: $navbar-height;
+				visibility: visible;
+				background: $white;
+			}
+		}
+	}
+}

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
@@ -1,0 +1,25 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import toJson from 'enzyme-to-json';
+
+import SkipLinks from './SkipLinks.component';
+
+describe('Skip links', () => {
+	it('should render default layout links', () => {
+		// when
+		const wrapper = mount(<SkipLinks.WrappedComponent />);
+
+		// then
+		expect(toJson(wrapper)).toMatchSnapshot();
+	});
+
+	it('should render custom links', () => {
+		// when
+		const wrapper = mount(
+			<SkipLinks.WrappedComponent mainId="#my-custom-main-id" navigationId="#my-custom-nav-id" />,
+		);
+
+		// then
+		expect(toJson(wrapper)).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
@@ -5,15 +5,15 @@ import toJson from 'enzyme-to-json';
 import SkipLinks from './SkipLinks.component';
 
 describe('Skip links', () => {
-	it('should render default layout links', () => {
+	it('should render only main link', () => {
 		// when
-		const wrapper = mount(<SkipLinks.WrappedComponent />);
+		const wrapper = mount(<SkipLinks.WrappedComponent mainId="#my-custom-main-id" />);
 
 		// then
 		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 
-	it('should render custom links', () => {
+	it('should render navigation link', () => {
 		// when
 		const wrapper = mount(
 			<SkipLinks.WrappedComponent mainId="#my-custom-main-id" navigationId="#my-custom-nav-id" />,

--- a/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
+++ b/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Skip links should render custom links 1`] = `
+exports[`Skip links should render navigation link 1`] = `
 <SkipLinks
   mainId="#my-custom-main-id"
   navigationId="#my-custom-nav-id"
@@ -16,7 +16,7 @@ exports[`Skip links should render custom links 1`] = `
       >
         <SkipTo
           href="#my-custom-nav-id"
-          label="Skip header to navigation"
+          label="Skip to navigation"
         >
           <a
             href="#my-custom-nav-id"
@@ -44,7 +44,7 @@ exports[`Skip links should render custom links 1`] = `
             <span
               className="theme-text"
             >
-              Skip header to navigation
+              Skip to navigation
             </span>
           </a>
         </SkipTo>
@@ -54,7 +54,7 @@ exports[`Skip links should render custom links 1`] = `
       >
         <SkipTo
           href="#my-custom-main-id"
-          label="Skip navigation to main content"
+          label="Skip to main content"
         >
           <a
             href="#my-custom-main-id"
@@ -82,7 +82,7 @@ exports[`Skip links should render custom links 1`] = `
             <span
               className="theme-text"
             >
-              Skip navigation to main content
+              Skip to main content
             </span>
           </a>
         </SkipTo>
@@ -92,10 +92,9 @@ exports[`Skip links should render custom links 1`] = `
 </SkipLinks>
 `;
 
-exports[`Skip links should render default layout links 1`] = `
+exports[`Skip links should render only main link 1`] = `
 <SkipLinks
-  mainId="#tc-layout-main"
-  navigationId="#tc-layout-side-menu"
+  mainId="#my-custom-main-id"
   t={[Function]}
 >
   <nav
@@ -104,52 +103,14 @@ exports[`Skip links should render default layout links 1`] = `
   >
     <ul>
       <li
-        key="navigation"
-      >
-        <SkipTo
-          href="#tc-layout-side-menu"
-          label="Skip header to navigation"
-        >
-          <a
-            href="#tc-layout-side-menu"
-          >
-            <span
-              className="theme-icon"
-            >
-              <Icon
-                name="talend-arrow-left"
-                transform="rotate-270"
-              >
-                <svg
-                  aria-hidden="true"
-                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
-                  focusable="false"
-                  name="talend-arrow-left"
-                  title={null}
-                >
-                  <use
-                    xlinkHref="#talend-arrow-left"
-                  />
-                </svg>
-              </Icon>
-            </span>
-            <span
-              className="theme-text"
-            >
-              Skip header to navigation
-            </span>
-          </a>
-        </SkipTo>
-      </li>
-      <li
         key="main"
       >
         <SkipTo
-          href="#tc-layout-main"
-          label="Skip navigation to main content"
+          href="#my-custom-main-id"
+          label="Skip to main content"
         >
           <a
-            href="#tc-layout-main"
+            href="#my-custom-main-id"
           >
             <span
               className="theme-icon"
@@ -174,7 +135,7 @@ exports[`Skip links should render default layout links 1`] = `
             <span
               className="theme-text"
             >
-              Skip navigation to main content
+              Skip to main content
             </span>
           </a>
         </SkipTo>

--- a/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
+++ b/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
@@ -1,0 +1,185 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Skip links should render custom links 1`] = `
+<SkipLinks
+  mainId="#my-custom-main-id"
+  navigationId="#my-custom-nav-id"
+  t={[Function]}
+>
+  <nav
+    aria-label="Skip links"
+    className="theme-tc-skip-links"
+  >
+    <ul>
+      <li
+        key="navigation"
+      >
+        <SkipTo
+          href="#my-custom-nav-id"
+          label="Skip header to navigation"
+        >
+          <a
+            href="#my-custom-nav-id"
+          >
+            <span
+              className="theme-icon"
+            >
+              <Icon
+                name="talend-arrow-left"
+                transform="rotate-270"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </Icon>
+            </span>
+            <span
+              className="theme-text"
+            >
+              Skip header to navigation
+            </span>
+          </a>
+        </SkipTo>
+      </li>
+      <li
+        key="main"
+      >
+        <SkipTo
+          href="#my-custom-main-id"
+          label="Skip navigation to main content"
+        >
+          <a
+            href="#my-custom-main-id"
+          >
+            <span
+              className="theme-icon"
+            >
+              <Icon
+                name="talend-arrow-left"
+                transform="rotate-270"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </Icon>
+            </span>
+            <span
+              className="theme-text"
+            >
+              Skip navigation to main content
+            </span>
+          </a>
+        </SkipTo>
+      </li>
+    </ul>
+  </nav>
+</SkipLinks>
+`;
+
+exports[`Skip links should render default layout links 1`] = `
+<SkipLinks
+  mainId="#tc-layout-main"
+  navigationId="#tc-layout-side-menu"
+  t={[Function]}
+>
+  <nav
+    aria-label="Skip links"
+    className="theme-tc-skip-links"
+  >
+    <ul>
+      <li
+        key="navigation"
+      >
+        <SkipTo
+          href="#tc-layout-side-menu"
+          label="Skip header to navigation"
+        >
+          <a
+            href="#tc-layout-side-menu"
+          >
+            <span
+              className="theme-icon"
+            >
+              <Icon
+                name="talend-arrow-left"
+                transform="rotate-270"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </Icon>
+            </span>
+            <span
+              className="theme-text"
+            >
+              Skip header to navigation
+            </span>
+          </a>
+        </SkipTo>
+      </li>
+      <li
+        key="main"
+      >
+        <SkipTo
+          href="#tc-layout-main"
+          label="Skip navigation to main content"
+        >
+          <a
+            href="#tc-layout-main"
+          >
+            <span
+              className="theme-icon"
+            >
+              <Icon
+                name="talend-arrow-left"
+                transform="rotate-270"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </Icon>
+            </span>
+            <span
+              className="theme-text"
+            >
+              Skip navigation to main content
+            </span>
+          </a>
+        </SkipTo>
+      </li>
+    </ul>
+  </nav>
+</SkipLinks>
+`;

--- a/packages/components/src/Layout/SkipLinks/index.js
+++ b/packages/components/src/Layout/SkipLinks/index.js
@@ -1,0 +1,3 @@
+import SkipLinks from './SkipLinks.component';
+
+export default SkipLinks;

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.component.js
@@ -26,8 +26,10 @@ function TwoColumns({ one, drawers, children, tabs, getComponent, ...props }) {
 
 	return (
 		<div className={containerCSS} {...props}>
-			<div className={sidemenuCSS}>{safeOne}</div>
-			<div className={mainCSS} role="main">
+			<div className={sidemenuCSS} id="tc-layout-side-menu" tabIndex="-1">
+				{safeOne}
+			</div>
+			<div className={mainCSS} role="main" id="tc-layout-main" tabIndex="-1">
 				<WithDrawer drawers={drawers}>
 					{tabs && <TabBar {...tabs} />}
 					<div style={style}>{children}</div>

--- a/packages/components/src/Layout/TwoColumns/__snapshots__/TwoColumns.test.js.snap
+++ b/packages/components/src/Layout/TwoColumns/__snapshots__/TwoColumns.test.js.snap
@@ -11,6 +11,8 @@ exports[`TwoColumns should render two columns 1`] = `
 >
   <div
     className="tc-layout-two-columns-left theme-sidemenu"
+    id="tc-layout-side-menu"
+    tabIndex="-1"
   >
     <div>
       Hello world
@@ -18,7 +20,9 @@ exports[`TwoColumns should render two columns 1`] = `
   </div>
   <div
     className="tc-layout-two-columns-main theme-main"
+    id="tc-layout-main"
     role="main"
+    tabIndex="-1"
   >
     <WithDrawer>
       <div

--- a/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
+++ b/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
@@ -8,7 +8,10 @@ exports[`Layout should render layout with footer component 1`] = `
   <div
     className="theme-skip-links"
   >
-    <Translate(SkipLinks) />
+    <Translate(SkipLinks)
+      mainId="#tc-layout-main"
+      navigationId={undefined}
+    />
   </div>
   <header
     className="tc-layout-header theme-header"

--- a/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
+++ b/packages/components/src/Layout/__snapshots__/Layout.test.js.snap
@@ -5,6 +5,11 @@ exports[`Layout should render layout with footer component 1`] = `
   className="tc-layout theme-layout"
   id={undefined}
 >
+  <div
+    className="theme-skip-links"
+  >
+    <Translate(SkipLinks) />
+  </div>
   <header
     className="tc-layout-header theme-header"
     role="banner"

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -2436,7 +2436,7 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
               <span
                 className="theme-text"
               >
-                Skip header to navigation
+                Skip to navigation
               </span>
             </a>
           </li>
@@ -2462,7 +2462,7 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
               <span
                 className="theme-text"
               >
-                Skip navigation to main content
+                Skip to main content
               </span>
             </a>
           </li>
@@ -3192,7 +3192,7 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
               <span
                 className="theme-text"
               >
-                Skip header to navigation
+                Skip to navigation
               </span>
             </a>
           </li>
@@ -3218,7 +3218,7 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
               <span
                 className="theme-text"
               >
-                Skip navigation to main content
+                Skip to main content
               </span>
             </a>
           </li>

--- a/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
+++ b/packages/components/src/SidePanel/__snapshots__/SidePanel.snapshot.test.js.snap
@@ -2407,10 +2407,75 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
     id={undefined}
   >
     <div
+      className="theme-skip-links"
+    >
+      <nav
+        aria-label="Skip links"
+        className="theme-tc-skip-links"
+      >
+        <ul>
+          <li>
+            <a
+              href="#tc-layout-side-menu"
+            >
+              <span
+                className="theme-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </span>
+              <span
+                className="theme-text"
+              >
+                Skip header to navigation
+              </span>
+            </a>
+          </li>
+          <li>
+            <a
+              href="#tc-layout-main"
+            >
+              <span
+                className="theme-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </span>
+              <span
+                className="theme-text"
+              >
+                Skip navigation to main content
+              </span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div
       className="tc-layout-two-columns theme-container"
     >
       <div
         className="tc-layout-two-columns-left theme-sidemenu"
+        id="tc-layout-side-menu"
+        tabIndex="-1"
       >
         <nav
           aria-expanded={true}
@@ -2579,7 +2644,9 @@ exports[`Storyshots SidePanel reverse with layout (toggle interactive) 1`] = `
       </div>
       <div
         className="tc-layout-two-columns-main theme-main"
+        id="tc-layout-main"
         role="main"
+        tabIndex="-1"
       >
         <div
           className="theme-tc-with-drawer"
@@ -3096,10 +3163,75 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
     id={undefined}
   >
     <div
+      className="theme-skip-links"
+    >
+      <nav
+        aria-label="Skip links"
+        className="theme-tc-skip-links"
+      >
+        <ul>
+          <li>
+            <a
+              href="#tc-layout-side-menu"
+            >
+              <span
+                className="theme-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </span>
+              <span
+                className="theme-text"
+              >
+                Skip header to navigation
+              </span>
+            </a>
+          </li>
+          <li>
+            <a
+              href="#tc-layout-main"
+            >
+              <span
+                className="theme-icon"
+              >
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon theme-rotate-270"
+                  focusable="false"
+                  name="talend-arrow-left"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-arrow-left"
+                  />
+                </svg>
+              </span>
+              <span
+                className="theme-text"
+              >
+                Skip navigation to main content
+              </span>
+            </a>
+          </li>
+        </ul>
+      </nav>
+    </div>
+    <div
       className="tc-layout-two-columns theme-container"
     >
       <div
         className="tc-layout-two-columns-left theme-sidemenu"
+        id="tc-layout-side-menu"
+        tabIndex="-1"
       >
         <nav
           aria-expanded={true}
@@ -3268,7 +3400,9 @@ exports[`Storyshots SidePanel with layout (toggle interactive) 1`] = `
       </div>
       <div
         className="tc-layout-two-columns-main theme-main"
+        id="tc-layout-main"
         role="main"
+        tabIndex="-1"
       >
         <div
           className="theme-tc-with-drawer"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
To provide skip links to all react projects using Talend/ui, we can add it into layout component.
So next upgrade will automatically bring them in the apps.

The choice of Layout is to control the ids, z-index and placement in 1 place.

**What is the chosen solution to this problem?**
Implement that, so it's free for the apps.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
