### PR TITLE
fix(Container) HeaderBar component update

### DIFF
--- a/packages/containers/src/HeaderBar/HeaderBar.actions.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.actions.js
@@ -1,0 +1,27 @@
+import Constants from './HeaderBar.constant';
+
+/**
+ * Action dispatched when fetching products is required for the container
+ * @param {String} url Fetch URL
+ * @returns {Object}
+ */
+export function fetchProducts(url) {
+	return {
+		type: Constants.HEADER_BAR_FETCH_PRODUCTS,
+		payload: { url },
+	};
+}
+
+/**
+ * Action dispatched when clicking on a product in the header bar
+ * @param {Object} product Opened product
+ * @returns {Object}
+ */
+export function openProduct(product) {
+	return {
+		type: Constants.HEADER_BAR_OPEN_PRODUCT,
+		payload: product,
+	};
+}
+
+export default { fetchProducts };

--- a/packages/containers/src/HeaderBar/HeaderBar.actions.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.actions.js
@@ -23,5 +23,3 @@ export function openProduct(product) {
 		payload: product,
 	};
 }
-
-export default { fetchProducts };

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -36,9 +36,9 @@ class HeaderBar extends React.Component {
 		// Trigger product fetch when there's an URL and
 		// products URL has changed or products have not been loaded yet
 		const hasProductsUrlChanged = this.props.productsUrl !== prevProps.productsUrl;
-		const hasProductsBeenLoaded = this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
+		const hasProductsNotBeenLoaded = this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
 
-		if (this.props.productsUrl && (hasProductsBeenLoaded || hasProductsUrlChanged)) {
+		if (this.props.productsUrl && (hasProductsNotBeenLoaded || hasProductsUrlChanged)) {
 			this.props.dispatch(fetchProducts(this.props.productsUrl));
 		}
 	}

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -31,16 +31,12 @@ class HeaderBar extends React.Component {
 	};
 
 	componentDidUpdate(prevProps) {
-		const { productsUrl } = prevProps;
-
 		// Trigger product fetch when there's an URL and
 		// products URL has changed or products have not been loaded yet
-		const shouldFetchProducts =
-			this.props.productsUrl &&
-			(this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED ||
-				this.props.productsUrl !== productsUrl);
+		const hasProductsUrlChanged = this.props.productsUrl !== prevProps.productsUrl;
+		const hasProductsBeenLoaded = this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
 
-		if (shouldFetchProducts) {
+		if (this.props.productsUrl && (hasProductsBeenLoaded || hasProductsUrlChanged)) {
 			this.props.dispatch({
 				type: Constants.HEADER_BAR_FETCH_PRODUCTS,
 				payload: { url: this.props.productsUrl },

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -5,6 +5,8 @@ import { Map } from 'immutable';
 import { cmfConnect } from '@talend/react-cmf';
 import { HeaderBar as Component } from '@talend/react-components';
 
+import { fetchProducts, openProduct } from './HeaderBar.actions';
+
 import Constants from './HeaderBar.constant';
 
 export const DEFAULT_STATE = new Map({
@@ -37,10 +39,7 @@ class HeaderBar extends React.Component {
 		const hasProductsBeenLoaded = this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
 
 		if (this.props.productsUrl && (hasProductsBeenLoaded || hasProductsUrlChanged)) {
-			this.props.dispatch({
-				type: Constants.HEADER_BAR_FETCH_PRODUCTS,
-				payload: { url: this.props.productsUrl },
-			});
+			this.props.dispatch(fetchProducts(this.props.productsUrl));
 		}
 	}
 
@@ -55,7 +54,7 @@ class HeaderBar extends React.Component {
 				.map(product => ({
 					label: product.name,
 					icon: `talend-${product.icon}-colored`,
-					onClickDispatch: { type: Constants.HEADER_BAR_OPEN_PRODUCT, payload: product },
+					onClickDispatch: openProduct(product),
 				}))
 				.sort(sortProductsByLabel);
 

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -30,20 +30,20 @@ class HeaderBar extends React.Component {
 		...cmfConnect.propTypes,
 	};
 
-	componentDidUpdate(props) {
-		const { productsUrl } = props;
+	componentDidUpdate(prevProps) {
+		const { productsUrl } = prevProps;
 
 		// Trigger product fetch when there's an URL and
 		// products URL has changed or products have not been loaded yet
 		const shouldFetchProducts =
-			productsUrl &&
+			this.props.productsUrl &&
 			(this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED ||
 				this.props.productsUrl !== productsUrl);
 
 		if (shouldFetchProducts) {
 			this.props.dispatch({
 				type: Constants.HEADER_BAR_FETCH_PRODUCTS,
-				payload: { url: productsUrl },
+				payload: { url: this.props.productsUrl },
 			});
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
HeaderBar container does not react properly on `productsUrl` prop change. `componentDidUpdate` takes old props as argument, not new props (there is a misconception in current code).

**What is the chosen solution to this problem?**
Fix `componentDidUpdate`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
