### PR TITLE
fix(components/ConfirmDialog): onHide called only if provided

### DIFF
--- a/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.component.js
@@ -63,7 +63,7 @@ function ConfirmDialog({
 		if (cancelAction && cancelAction.onClick) {
 			cancelAction.onClick();
 		}
-		return onHide(event);
+		return onHide ? onHide(event) : null;
 	}
 	return (
 		<Dialog


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a warning poping when a `ConfirmDialog` component is hidden but no `onHide` handler has been provided.

**What is the chosen solution to this problem?**
Only call the handler if it is provided (since prop is not marked as required).

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
