### PR TITLE
fix(components/SubHeader): Button text-transform

### DIFF
--- a/packages/components/src/SubHeaderBar/SubHeaderBar.scss
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.scss
@@ -14,8 +14,6 @@ $tc-svg-icon-size: $padding-large !default;
 	width: 100%;
 
 	button {
-		text-transform: none;
-
 		&:global(.btn-link) {
 			color: $tc-subheader-color;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Buttons label should always be in uppercase, it is not the case when they are inside a SubHeader component due to a CSS rules that cancels the `.btn`'s `text-transform` (was there to handle a specific case for TDC, see http://guidelines.talend.com/document/215501).

**What is the chosen solution to this problem?**
Remove the CSS `text-transform` cancellation.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
