### PR TITLE
feat(containers): analytics tags for app switcher

### DIFF
--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -36,7 +36,8 @@ class HeaderBar extends React.Component {
 		// Trigger product fetch when there's an URL and
 		// products URL has changed or products have not been loaded yet
 		const hasProductsUrlChanged = this.props.productsUrl !== prevProps.productsUrl;
-		const hasProductsNotBeenLoaded = this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
+		const hasProductsNotBeenLoaded =
+			this.props.state.get('productsFetchState') === Constants.PRODUCTS_NOT_LOADED;
 
 		if (this.props.productsUrl && (hasProductsNotBeenLoaded || hasProductsUrlChanged)) {
 			this.props.dispatch(fetchProducts(this.props.productsUrl));

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -52,6 +52,7 @@ class HeaderBar extends React.Component {
 		if (hasFetchedProducts && productsItems) {
 			const items = productsItems
 				.map(product => ({
+					'data-feature': `product.${(product.id || '').toLowerCase()}`,
 					label: product.name,
 					icon: `talend-${product.icon}-colored`,
 					onClickDispatch: openProduct(product),

--- a/packages/containers/src/HeaderBar/HeaderBar.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.test.js
@@ -21,9 +21,10 @@ describe('Container HeaderBar', () => {
 			...containerProps,
 			productsItems: [
 				{
-					url: 'http://foo',
-					name: 'foo',
+					id: 'foo',
 					icon: 'icon',
+					name: 'Foo',
+					url: 'http://foo.bar',
 				},
 			],
 			state: new Map({

--- a/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
+++ b/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
@@ -10,13 +10,15 @@ exports[`Container HeaderBar should render HeaderBar container with a list of it
     Object {
       "items": Array [
         Object {
+          "data-feature": "product.foo",
           "icon": "talend-icon-colored",
-          "label": "foo",
+          "label": "Foo",
           "onClickDispatch": Object {
             "payload": Object {
               "icon": "icon",
-              "name": "foo",
-              "url": "http://foo",
+              "id": "foo",
+              "name": "Foo",
+              "url": "http://foo.bar",
             },
             "type": "HEADER_BAR_OPEN_PRODUCT",
           },


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
App switcher hasn't analytics tag for each product

**What is the chosen solution to this problem?**
Generate them automatically

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
