### PR TITLE
fix(components): App switcher should not display no options

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -45,7 +45,7 @@ function Brand({ label, isSeparated, getComponent, t, ...props }) {
 	let ActionComponent;
 	let clickAction;
 	let ariaLabel;
-	if (props && props.items) {
+	if (props && props.items && props.items.length) {
 		ActionComponent = Renderers.ActionDropdown;
 		ariaLabel = t('HEADER_BAR_APP_SWITCHER', {
 			defaultValue: 'Switch to another application. Current application: {{appName}}',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If I pass products as an empty array, app switcher will display "No options" and we want to render a simple span instead

**What is the chosen solution to this problem?**
Improve the check

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
