### PR TITLE
fix(cmf): cmfConnect with no param

### DIFF
--- a/packages/cmf/__tests__/cmfConnect.test.js
+++ b/packages/cmf/__tests__/cmfConnect.test.js
@@ -206,6 +206,15 @@ describe('cmfConnect', () => {
 		};
 		Button.displayName = 'Button';
 		const CMFConnectedButton = cmfConnect({})(Button);
+		it('should create a connected component even without params', () => {
+			const TestComponent = jest.fn();
+			TestComponent.displayName = 'TestComponent';
+			mapStateToViewProps.cache.clear();
+			const CMFConnected = cmfConnect()(TestComponent);
+			expect(CMFConnected.displayName).toBe('Connect(CMF(TestComponent))');
+			expect(CMFConnected.WrappedComponent).toBe(TestComponent);
+		});
+
 		it('should create a connected component', () => {
 			const TestComponent = jest.fn();
 			TestComponent.displayName = 'TestComponent';

--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -196,7 +196,7 @@ export default function cmfConnect({
 	withDispatchActionCreator = false,
 	withComponentId = false,
 	...rest
-}) {
+} = {}) {
 	const propsToOmit = [];
 	if (omitCMFProps) {
 		if (!defaultState) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
A component cannot be `cmfConnect`ed with no parameter provided to `cmfConnect`, even if it has no `mapStateToProps`, `mapDispatchToProps`, etc

**What is the chosen solution to this problem?**
Provide a default value to the method.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
