### PR TITLE
fix(ComponentForm): fix linked saga

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
@@ -1,37 +1,40 @@
-import { call, take, takeEvery, takeLatest } from 'redux-saga/effects';
+import { call } from 'redux-saga/effects';
 import { fromJS, Map } from 'immutable';
 import cmf from '@talend/react-cmf';
 
 import * as sagas from './ComponentForm.sagas';
-import Component, { TCompForm } from './ComponentForm.component';
+import { TCompForm } from './ComponentForm.component';
 
 describe('ComponentForm saga', () => {
-	describe('*handle', () => {
-		it('should trigger didMount saga and listen to url change', () => {
-			// given
-			const props = { componentId: 'MyComponentId', submitURL: '/foo' };
-			const gen = sagas.handle(props);
+	describe('*checkFormComponentId', () => {
+		it('checkFormComponentId return true if provided componentId and action type match action', () => {
+			const componentId = 'componentId';
+			const actionType = 'actionType';
 
-			// when / then
-			const didMount = gen.next().value;
-			expect(didMount).toEqual(call(sagas.onDidMount, props));
+			const testAction = { type: actionType, componentId };
 
-			// when / then
-			const listenToURLChanges = gen.next().value;
-			expect(listenToURLChanges).toEqual(
-				takeEvery(Component.ON_DEFINITION_URL_CHANGED, sagas.fetchDefinition),
-			);
+			const test = sagas.checkFormComponentId(componentId, actionType);
+			expect(test(testAction)).toBe(true);
+		});
 
-			// when / then
-			const onSubmit = gen.next().value;
-			expect(onSubmit).toEqual(
-				takeLatest(Component.ON_SUBMIT, expect.anything(), props.componentId, props.submitURL),
-			);
+		it('checkFormComponentId return false if provided componentId does not match action', () => {
+			const componentId = 'componentId';
+			const actionType = 'actionType';
 
-			// then should not quit
-			const shouldNotQuit = gen.next().value;
-			expect(shouldNotQuit).toEqual(take('DO_NOT_QUIT'));
-			expect(gen.next().done).toBe(true);
+			const testAction = { type: actionType, componentId };
+
+			const test = sagas.checkFormComponentId('anotherComponentId', actionType);
+			expect(test(testAction)).toBe(false);
+		});
+
+		it('checkFormComponentId return false if provided action type does not match action', () => {
+			const componentId = 'componentId';
+			const actionType = 'actionType';
+
+			const testAction = { type: actionType, componentId };
+
+			const test = sagas.checkFormComponentId(componentId, 'anotherActionType');
+			expect(test(testAction)).toBe(false);
 		});
 	});
 

--- a/packages/containers/src/ComponentForm/ComponentForm.sagas.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.sagas.js
@@ -3,8 +3,11 @@ import cmf from '@talend/react-cmf';
 import get from 'lodash/get';
 import Component from './ComponentForm.component';
 
-export function* fetchDefinition({ definitionURL, componentId, uiSpecPath }) {
-	const { data, response } = yield call(cmf.sagas.http.get, definitionURL);
+/**
+ * @param {Action{definitionURL: String, uiSpecPath: String, componentId: String }} action
+ */
+export function* fetchDefinition(action) {
+	const { data, response } = yield call(cmf.sagas.http.get, action.definitionURL);
 	if (!response.ok) {
 		yield put(
 			Component.setStateAction(
@@ -14,21 +17,21 @@ export function* fetchDefinition({ definitionURL, componentId, uiSpecPath }) {
 						.set('uiSchema')
 						.set('response', response)
 						.set('dirty', false),
-				componentId,
+				action.componentId,
 			),
 		);
-	} else if (uiSpecPath) {
+	} else if (action.uiSpecPath) {
 		yield put(
 			Component.setStateAction(
 				{
 					definition: data,
-					...get(data, uiSpecPath),
+					...get(data, action.uiSpecPath),
 				},
-				componentId,
+				action.componentId,
 			),
 		);
 	} else {
-		yield put(Component.setStateAction(data, componentId));
+		yield put(Component.setStateAction(data, action.componentId));
 	}
 }
 
@@ -56,9 +59,23 @@ function* onFormSubmit(componentId, submitURL, action) {
 	});
 }
 
+/**
+ * check that the formId and action type match with the provided actions
+ * @param {String} componentId
+ * @return {(Action{type: String, componentid: String}) => Bool}
+ */
+export function checkFormComponentId(componentId, actionType) {
+	return function matchActionComponentid(action) {
+		return action.type === actionType && action.componentId === componentId;
+	};
+}
+
 export function* handle(props) {
 	yield call(onDidMount, props);
-	yield takeEvery(Component.ON_DEFINITION_URL_CHANGED, fetchDefinition);
+	yield takeEvery(
+		checkFormComponentId(props.componentId, Component.ON_DEFINITION_URL_CHANGED),
+		fetchDefinition,
+	);
 	yield takeLatest(Component.ON_SUBMIT, onFormSubmit, props.componentId, props.submitURL);
 	yield take('DO_NOT_QUIT');
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When two ComponentForm are mounted at same time, on of those form definitionURL change will trigger definition fetch on those two forms creating interesting bugs

**What is the chosen solution to this problem?**

add a function to be used on any redux-saga take*(pattern) that can be used to check both that action.type and action.componentId match.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
