### PR TITLE
fix(UIForms): datalist titlemap without empty value

### DIFF
--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -101,6 +101,7 @@ class Datalist extends Component {
 			}
 
 			const additionalOptions = values
+				.filter(value => value)
 				.filter(value => !titleMapFind.find(option => option.value === value))
 				.map(value => this.addCustomValue(value, isMultiSection))
 				.reduce((acc, titleMapEntry) => {

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
@@ -297,6 +297,30 @@ describe('Datalist component', () => {
 			]);
 		});
 
+		it('should NOT add empty value to the titleMap', () => {
+			// when
+			const props = {
+				onChange: jest.fn(),
+				onFinish: jest.fn(),
+				onTrigger: jest.fn(),
+				schema: { ...schema, restricted: false },
+				value: '',
+			};
+			const wrapper = shallow(<Datalist.WrappedComponent {...props} />);
+
+			// then
+			expect(
+				wrapper
+					.find('FieldTemplate')
+					.find('Datalist')
+					.prop('titleMap'),
+			).toEqual([
+				{ name: 'Foo', value: 'foo' },
+				{ name: 'Bar', value: 'bar' },
+				{ name: 'Lol', value: 'lol' },
+			]);
+		});
+
 		it('should add unknown value with custom category to the titleMap if not restricted', () => {
 			// given
 			const multiSectionSchema = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On empty datalist (i.e with no value), an empty entry is created in titlemap.
This is du to the fact that we add the current value in title map if it's missing.

**What is the chosen solution to this problem?**
Filter empty values before adding missing ones in title map

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
