### PR TITLE
fix(datagrid): remove the prefix data in the header

### DIFF
--- a/packages/datagrid/src/components/DatasetSerializer/__snapshots__/datasetSerializer.test.js.snap
+++ b/packages/datagrid/src/components/DatasetSerializer/__snapshots__/datasetSerializer.test.js.snap
@@ -52,7 +52,6 @@ Array [
       },
     },
     "avro": Object {
-      "doc": "Code UIC",
       "name": "field1",
       "type": Object {
         "@talend-quality@": Object {
@@ -67,7 +66,7 @@ Array [
       },
     },
     "field": "data.field1",
-    "headerName": "Code UIC",
+    "headerName": "field1",
     "type": "int*",
   },
 ]
@@ -125,7 +124,6 @@ Array [
       },
     },
     "avro": Object {
-      "doc": "Code UIC",
       "name": "field1",
       "type": Object {
         "@talend-quality@": Object {
@@ -140,7 +138,7 @@ Array [
       },
     },
     "field": "data.field1",
-    "headerName": "Code UIC",
+    "headerName": "field1",
     "type": "int*",
   },
 ]
@@ -198,7 +196,6 @@ Array [
       },
     },
     "avro": Object {
-      "doc": "Code UIC",
       "name": "field1",
       "type": Object {
         "@talend-quality@": Object {
@@ -213,7 +210,7 @@ Array [
       },
     },
     "field": "data.field1",
-    "headerName": "Code UIC",
+    "headerName": "field1",
     "type": "int*",
   },
 ]

--- a/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
+++ b/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
@@ -123,7 +123,7 @@ export function getColumnDefs(sample) {
 	return get(plainObjectSample, 'schema.fields', []).map(avroField => ({
 		avro: sanitizeAvro(avroField),
 		field: `${NAMESPACE_DATA}${avroField.name}`,
-		headerName: avroField.doc,
+		headerName: avroField.doc || avroField.name,
 		type: getType(avroField.type),
 		[QUALITY_KEY]: getFieldQuality(avroField.type),
 	}));

--- a/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.test.js
+++ b/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.test.js
@@ -44,7 +44,6 @@ const sample = {
 			},
 			{
 				name: 'field1',
-				doc: 'Code UIC',
 				type: {
 					'@talend-quality@': {
 						0: 0,

--- a/packages/datagrid/stories/sample.json
+++ b/packages/datagrid/stories/sample.json
@@ -25,7 +25,6 @@
             ]
         }, {
             "name": "field1",
-            "doc": "Code UIC",
             "type": [{
               "type": "null",
               "dqType": "",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When doc field isn't present, the headername has a prefix Data. doc is optional on the Avro spec. we fallback on the field name.

**What is the chosen solution to this problem?**
take the name of the field if doc isn't present in avro sample.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
