### PR TITLE
fix(components): hiding the tooltip when the button is disabled

### DIFF
--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -113,6 +113,9 @@ class TooltipTrigger extends React.Component {
 			</Tooltip>
 		);
 		// TODO jmfrancois : render the Tooltip in a provider so use context for that.
+		// fix with disabling element https://github.com/react-bootstrap/react-bootstrap/pull/3251
+		// we add onClick={() => this.overlay.handleDelayedHide() to hide the overlay
+		// it stays when the element inside is disabled
 		return (
 			<OverlayTrigger
 				ref={ref => {

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -122,6 +122,7 @@ class TooltipTrigger extends React.Component {
 				overlay={tooltip}
 				delayShow={400}
 				animation={false}
+				onClick={() => this.overlay.handleDelayedHide()}
 			>
 				{cloneElement(child, {
 					onMouseDown: this.onMouseDown,

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.test.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.test.js
@@ -96,4 +96,34 @@ describe('ActionTooltip', () => {
 		// then
 		expect(wrapper.update().getElement()).toMatchSnapshot();
 	});
+
+	it('should force to hide the overlay', () => {
+		// given
+		const overlayApi = { handleDelayedHide: jest.fn() };
+		const props = {
+			label: 'toto',
+			tooltipPlacement: 'right',
+		};
+
+		// when
+		const wrapper = shallow(
+			<TooltipTrigger {...props}>
+				<div>Action</div>
+			</TooltipTrigger>,
+		);
+
+		wrapper.instance().overlay = overlayApi;
+		wrapper
+			.find('div')
+			.at(0)
+			.simulate('mouseOver');
+
+		wrapper
+			.find('OverlayTrigger')
+			.at(0)
+			.simulate('click');
+
+		// then
+		expect(overlayApi.handleDelayedHide).toHaveBeenCalled();
+	});
 });

--- a/packages/components/src/TooltipTrigger/__snapshots__/TooltipTrigger.test.js.snap
+++ b/packages/components/src/TooltipTrigger/__snapshots__/TooltipTrigger.test.js.snap
@@ -5,6 +5,7 @@ exports[`ActionTooltip should render custom tooltip when focus the children 1`] 
   animation={false}
   defaultOverlayShown={false}
   delayShow={400}
+  onClick={[Function]}
   overlay={
     <Tooltip
       bsClass="tooltip"
@@ -50,6 +51,7 @@ exports[`ActionTooltip should render tooltip when focus the children 1`] = `
   animation={false}
   defaultOverlayShown={false}
   delayShow={400}
+  onClick={[Function]}
   overlay={
     <Tooltip
       bsClass="tooltip"
@@ -84,6 +86,7 @@ exports[`ActionTooltip should render tooltip when hover the children 1`] = `
   animation={false}
   defaultOverlayShown={false}
   delayShow={400}
+  onClick={[Function]}
   overlay={
     <Tooltip
       bsClass="tooltip"

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -31,7 +31,7 @@ const mouseDownAction = {
 const ACTION1 = 'Action 1';
 const ACTION2 = 'Action 2';
 
-class DisablingActionButton extends React.Component {
+class DisableActionButton extends React.Component {
 	constructor(props) {
 		super(props);
 
@@ -76,9 +76,9 @@ storiesOf('Action', module)
 			{story()}
 		</div>
 	))
-	.addWithInfo('Disabling element', () => (
+	.addWithInfo('Disable the buttons', () => (
 		<div>
-			<DisablingActionButton />
+			<DisableActionButton />
 		</div>
 	))
 	.addWithInfo('default', () => (

--- a/packages/components/stories/Action.js
+++ b/packages/components/stories/Action.js
@@ -28,12 +28,57 @@ const mouseDownAction = {
 	onMouseDown: action('You clicked me'),
 };
 
+const ACTION1 = 'Action 1';
+const ACTION2 = 'Action 2';
+
+class DisablingActionButton extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			active: ACTION1,
+		};
+	}
+
+	render() {
+		const props = {
+			icon: 'talend-panel-opener-right',
+			tooltipPlacement: 'top',
+			tooltip: true,
+		};
+		return (
+			<React.Fragment>
+				<p>Switch Button</p>
+				<Action
+					{...props}
+					label={ACTION1}
+					active={this.state.active === ACTION1}
+					disabled={this.state.active === ACTION1}
+					onClick={() => this.setState({ active: ACTION1 })}
+				/>
+				<Action
+					{...props}
+					label={ACTION2}
+					active={this.state.active === ACTION2}
+					disabled={this.state.active === ACTION2}
+					onClick={() => this.setState({ active: ACTION2 })}
+				/>
+			</React.Fragment>
+		);
+	}
+}
+
 storiesOf('Action', module)
 	.addDecorator(checkA11y)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
 			<IconsProvider defaultIcons={icons} />
 			{story()}
+		</div>
+	))
+	.addWithInfo('Disabling element', () => (
+		<div>
+			<DisablingActionButton />
 		</div>
 	))
 	.addWithInfo('default', () => (

--- a/packages/components/stories/ActionIconToggle.js
+++ b/packages/components/stories/ActionIconToggle.js
@@ -32,7 +32,7 @@ const activeIconToggle = {
 const ACTION1 = 'Action 1';
 const ACTION2 = 'Action 2';
 
-class DisablingActionIconToggle extends React.Component {
+class DisableActionIconToggle extends React.Component {
 	constructor(props) {
 		super(props);
 
@@ -76,9 +76,9 @@ storiesOf('Action Icon Toggle', module)
 			{story()}
 		</div>
 	))
-	.addWithInfo('disabling element', () => (
+	.addWithInfo('disable the buttons', () => (
 		<div>
-			<DisablingActionIconToggle />
+			<DisableActionIconToggle />
 		</div>
 	))
 	.addWithInfo('default', () => (

--- a/packages/components/stories/ActionIconToggle.js
+++ b/packages/components/stories/ActionIconToggle.js
@@ -13,7 +13,7 @@ const icons = {
 const inactiveIconToggle = {
 	icon: 'talend-panel-opener-right',
 	id: 'my-inactive-action',
-	label: 'Click me, I\'m inactive',
+	label: "Click me, I'm inactive",
 	'data-feature': 'actionicontoggle',
 	onClick: action('You clicked the inactive button'),
 	tooltipPlacement: 'top',
@@ -23,11 +23,50 @@ const activeIconToggle = {
 	active: true,
 	icon: 'talend-panel-opener-right',
 	id: 'my-active-action',
-	label: 'Click me, I\'m inactive',
+	label: "Click me, I'm inactive",
 	'data-feature': 'actionicontoggle',
 	onClick: action('You clicked the active button'),
 	tooltipPlacement: 'top',
 };
+
+const ACTION1 = 'Action 1';
+const ACTION2 = 'Action 2';
+
+class DisablingActionIconToggle extends React.Component {
+	constructor(props) {
+		super(props);
+
+		this.state = {
+			active: ACTION1,
+		};
+	}
+
+	render() {
+		const props = {
+			icon: 'talend-panel-opener-right',
+			tooltipPlacement: 'top',
+		};
+		return (
+			<React.Fragment>
+				<p>Switch Button</p>
+				<ActionIconToggle
+					{...props}
+					label={ACTION1}
+					active={this.state.active === ACTION1}
+					disabled={this.state.active === ACTION1}
+					onClick={() => this.setState({ active: ACTION1 })}
+				/>
+				<ActionIconToggle
+					{...props}
+					label={ACTION2}
+					active={this.state.active === ACTION2}
+					disabled={this.state.active === ACTION2}
+					onClick={() => this.setState({ active: ACTION2 })}
+				/>
+			</React.Fragment>
+		);
+	}
+}
 
 storiesOf('Action Icon Toggle', module)
 	.addDecorator(checkA11y)
@@ -35,6 +74,11 @@ storiesOf('Action Icon Toggle', module)
 		<div className="col-lg-offset-2 col-lg-8">
 			<IconsProvider defaultIcons={icons} />
 			{story()}
+		</div>
+	))
+	.addWithInfo('disabling element', () => (
+		<div>
+			<DisablingActionIconToggle />
 		</div>
 	))
 	.addWithInfo('default', () => (
@@ -50,29 +94,24 @@ storiesOf('Action Icon Toggle', module)
 		<div>
 			<p>You can customize a specific icon toggle using a sass mixin</p>
 			<pre>
-				{
-					`// sass file
+				{`// sass file
 @import '~@talend/react-components/lib/Actions/ActionIconToggle/ActionIconToggle.scss'
 $my-btn-size: 4rem;
 $my-btn-icon-size: 2.5rem;
 .tc-icon-toggle.my-custom-icon-toggle {
 	@include tc-icon-toggle($my-btn-size, $my-btn-icon-size);
-}`
-				}
+}`}
 			</pre>
 			<pre>
-				{
-`// component file
+				{`// component file
 <ActionIconToggle
 	className={'my-custom-icon-toggle'}
 	{...otherProps}
-/>`
-				}
+/>`}
 			</pre>
 
 			<style>
-				{
-					`.tc-icon-toggle.my-custom-icon-toggle {
+				{`.tc-icon-toggle.my-custom-icon-toggle {
 						height: 4rem;
 						width: 4rem;
 						border-radius:2rem;
@@ -81,8 +120,7 @@ $my-btn-icon-size: 2.5rem;
 					.tc-icon-toggle.my-custom-icon-toggle svg {
 						height: 2.5rem;
 						width: 2.5rem;
-					}`
-				}
+					}`}
 			</style>
 
 			<p>Custom sizes</p>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix this issue https://github.com/react-bootstrap/react-bootstrap/issues/2969 by inspiriting of https://github.com/react-bootstrap/react-bootstrap/pull/3251

**What is the chosen solution to this problem?**
when the click on the overlaytrigger, we force to hide the tooltip

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
