### PR TITLE
fix(ObjectViewer): Fix object viewer header style

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -7,14 +7,11 @@ src/Drawer/Drawer.scss
 src/FilterBar/FilterBar.scss
   47:6  warning  Vendor prefixes should not be used  no-vendor-prefixes
 
-src/ObjectViewer/Table/Table.scss
-  23:3  error  Property `text-weight` appears to be spelled incorrectly  no-misspelled-properties
-
 src/Typeahead/Typeahead.scss
   97:5  error  Nesting depth 4 greater than max of 3  nesting-depth
 
 src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
   2:24  error  Strings must use single quotes  quotes
 
-✖ 5 problems (3 errors, 2 warnings)
+✖ 4 problems (2 errors, 2 warnings)
 

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -20,7 +20,7 @@
 		background-color: $brand-primary-dark;
 		color: $white;
 		font-family: 'Source Sans Pro';
-		text-transform: uppercase;
+		text-weight: $headings-font-weight;
 
 		& > td {
 			padding: $padding-smaller;

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -20,7 +20,7 @@
 		background-color: $brand-primary-dark;
 		color: $white;
 		font-family: 'Source Sans Pro';
-		
+
 		& > th {
 			font-weight: $headings-font-weight;
 		}

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -20,7 +20,10 @@
 		background-color: $brand-primary-dark;
 		color: $white;
 		font-family: 'Source Sans Pro';
-		text-weight: $headings-font-weight;
+		
+		& > th {
+			text-weight: $headings-font-weight;
+		}
 
 		& > td {
 			padding: $padding-smaller;

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -22,7 +22,7 @@
 		font-family: 'Source Sans Pro';
 		
 		& > th {
-			text-weight: $headings-font-weight;
+			font-weight: $headings-font-weight;
 		}
 
 		& > td {

--- a/packages/components/src/ObjectViewer/Table/Table.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.scss
@@ -22,7 +22,7 @@
 		font-family: 'Source Sans Pro';
 
 		& > th {
-			font-weight: $headings-font-weight;
+			font-weight: $font-weight-bold;
 		}
 
 		& > td {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Object Viewer "Grid" mode have column title in uppercase, and in a bad font-weight.

**What is the chosen solution to this problem?**
Update style to cancel uppercase and update font-weight.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->


