### PR TITLE
fix(components): ActionBar wraps with div instead of nav

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -147,7 +147,7 @@ export function ActionBarComponent(props) {
 		props.className,
 	);
 	return (
-		<nav className={cssClass}>
+		<div className={cssClass}>
 			{(left || !!props.selected) && (
 				<SwitchActions
 					getComponent={props.getComponent}
@@ -179,7 +179,7 @@ export function ActionBarComponent(props) {
 					t={props.t}
 				/>
 			)}
-		</nav>
+		</div>
 	);
 }
 

--- a/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
+++ b/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`ActionBar should render a btn-group 1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -30,11 +30,11 @@ exports[`ActionBar should render a btn-group 1`] = `
     left={true}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
 exports[`ActionBar should render no-selected actions, all on left  1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -75,547 +75,13 @@ exports[`ActionBar should render no-selected actions, all on left  1`] = `
     selected={0}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
-exports[`ActionBar should render no-selected actions, all on right 1`] = `
-<nav
-  className="theme-tc-actionbar-container tc-actionbar-container nav"
->
-  <SwitchActions
-    actions={
-      Array [
-        Object {
-          "bsStyle": "primary",
-          "icon": "fa fa-asterisk",
-          "label": "Primary",
-          "onClick": [Function],
-        },
-        Object {
-          "icon": "fa fa-asterisk",
-          "label": "Secondary",
-          "onClick": [Function],
-        },
-        Object {
-          "displayMode": "splitDropdown",
-          "emptyDropdownLabel": "No option",
-          "icon": "fa fa-plus",
-          "items": Array [
-            Object {
-              "label": "From Local",
-              "onClick": [Function],
-            },
-            Object {
-              "label": "From Remote",
-              "onClick": [Function],
-            },
-          ],
-          "label": "Add File",
-          "onClick": [Function],
-        },
-      ]
-    }
-    key="2"
-    right={true}
-    selected={0}
-    t={[Function]}
-  >
-    <Content
-      right={true}
-    >
-      <div
-        className="theme-navbar-right navbar-right"
-      >
-        <Action
-          bsStyle="primary"
-          icon="fa fa-asterisk"
-          key="0"
-          label="Primary"
-          onClick={[Function]}
-        >
-          <Translate(ActionButton)
-            bsStyle="primary"
-            icon="fa fa-asterisk"
-            label="Primary"
-            onClick={[Function]}
-          >
-            <I18n
-              bindI18n="languageChanged loaded"
-              bindStore="added removed"
-              bsStyle="primary"
-              i18n={Object {}}
-              icon="fa fa-asterisk"
-              label="Primary"
-              ns={
-                Array [
-                  "tui-components",
-                ]
-              }
-              nsMode="default"
-              onClick={[Function]}
-              translateFuncName="t"
-              usePureComponent={false}
-              wait={false}
-              withRef={false}
-            >
-              <ActionButton
-                available={true}
-                bsStyle="primary"
-                disabled={false}
-                i18n={Object {}}
-                icon="fa fa-asterisk"
-                inProgress={false}
-                label="Primary"
-                loading={false}
-                onClick={[Function]}
-                t={[Function]}
-                tReady={false}
-                tooltipPlacement="top"
-              >
-                <Button
-                  active={false}
-                  aria-label="Primary"
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="primary"
-                  className=""
-                  disabled={false}
-                  onClick={[Function]}
-                  onMouseDown={[Function]}
-                  role={null}
-                >
-                  <button
-                    aria-label="Primary"
-                    className="btn btn-primary"
-                    disabled={false}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    role={null}
-                    type="button"
-                  >
-                    <Icon
-                      key="icon"
-                      name="fa fa-asterisk"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="fa fa-asterisk"
-                        focusable="false"
-                        title={null}
-                      />
-                    </Icon>
-                    <span
-                      key="label"
-                    >
-                      Primary
-                    </span>
-                  </button>
-                </Button>
-              </ActionButton>
-            </I18n>
-          </Translate(ActionButton)>
-        </Action>
-        <Action
-          icon="fa fa-asterisk"
-          key="1"
-          label="Secondary"
-          onClick={[Function]}
-        >
-          <Translate(ActionButton)
-            icon="fa fa-asterisk"
-            label="Secondary"
-            onClick={[Function]}
-          >
-            <I18n
-              bindI18n="languageChanged loaded"
-              bindStore="added removed"
-              i18n={Object {}}
-              icon="fa fa-asterisk"
-              label="Secondary"
-              ns={
-                Array [
-                  "tui-components",
-                ]
-              }
-              nsMode="default"
-              onClick={[Function]}
-              translateFuncName="t"
-              usePureComponent={false}
-              wait={false}
-              withRef={false}
-            >
-              <ActionButton
-                available={true}
-                bsStyle="default"
-                disabled={false}
-                i18n={Object {}}
-                icon="fa fa-asterisk"
-                inProgress={false}
-                label="Secondary"
-                loading={false}
-                onClick={[Function]}
-                t={[Function]}
-                tReady={false}
-                tooltipPlacement="top"
-              >
-                <Button
-                  active={false}
-                  aria-label="Secondary"
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className=""
-                  disabled={false}
-                  onClick={[Function]}
-                  onMouseDown={[Function]}
-                  role={null}
-                >
-                  <button
-                    aria-label="Secondary"
-                    className="btn btn-default"
-                    disabled={false}
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    role={null}
-                    type="button"
-                  >
-                    <Icon
-                      key="icon"
-                      name="fa fa-asterisk"
-                    >
-                      <i
-                        aria-hidden="true"
-                        className="fa fa-asterisk"
-                        focusable="false"
-                        title={null}
-                      />
-                    </Icon>
-                    <span
-                      key="label"
-                    >
-                      Secondary
-                    </span>
-                  </button>
-                </Button>
-              </ActionButton>
-            </I18n>
-          </Translate(ActionButton)>
-        </Action>
-        <Translate(ActionSplitDropdown)
-          emptyDropdownLabel="No option"
-          icon="fa fa-plus"
-          items={
-            Array [
-              Object {
-                "label": "From Local",
-                "onClick": [Function],
-              },
-              Object {
-                "label": "From Remote",
-                "onClick": [Function],
-              },
-            ]
-          }
-          key="2"
-          label="Add File"
-          onClick={[Function]}
-        >
-          <I18n
-            bindI18n="languageChanged loaded"
-            bindStore="added removed"
-            emptyDropdownLabel="No option"
-            i18n={Object {}}
-            icon="fa fa-plus"
-            items={
-              Array [
-                Object {
-                  "label": "From Local",
-                  "onClick": [Function],
-                },
-                Object {
-                  "label": "From Remote",
-                  "onClick": [Function],
-                },
-              ]
-            }
-            label="Add File"
-            ns={
-              Array [
-                "tui-components",
-              ]
-            }
-            nsMode="default"
-            onClick={[Function]}
-            translateFuncName="t"
-            usePureComponent={false}
-            wait={false}
-            withRef={false}
-          >
-            <ActionSplitDropdown
-              emptyDropdownLabel="No option"
-              i18n={Object {}}
-              icon="fa fa-plus"
-              items={
-                Array [
-                  Object {
-                    "label": "From Local",
-                    "onClick": [Function],
-                  },
-                  Object {
-                    "label": "From Remote",
-                    "onClick": [Function],
-                  },
-                ]
-              }
-              label="Add File"
-              onClick={[Function]}
-              t={[Function]}
-              tReady={false}
-            >
-              <SplitButton
-                aria-label="Add File"
-                className="theme-tc-split-dropdown"
-                i18n={Object {}}
-                id={42}
-                onClick={[Function]}
-                tReady={false}
-                title={
-                  <span>
-                    <Icon
-                      name="fa fa-plus"
-                    />
-                    <span>
-                      Add File
-                    </span>
-                  </span>
-                }
-                toggleLabel="Open \\"Add File\\" menu"
-              >
-                <Uncontrolled(Dropdown)
-                  id={42}
-                >
-                  <Dropdown
-                    bsClass="dropdown"
-                    componentClass={[Function]}
-                    id={42}
-                    onToggle={[Function]}
-                  >
-                    <ButtonGroup
-                      block={false}
-                      bsClass="btn-group"
-                      className="dropdown"
-                      justified={false}
-                      vertical={false}
-                    >
-                      <div
-                        className="dropdown btn-group"
-                      >
-                        <Button
-                          active={false}
-                          aria-label="Add File"
-                          block={false}
-                          bsClass="btn"
-                          bsStyle="default"
-                          className="theme-tc-split-dropdown"
-                          disabled={false}
-                          i18n={Object {}}
-                          key=".0"
-                          onClick={[Function]}
-                          tReady={false}
-                        >
-                          <button
-                            aria-label="Add File"
-                            className="theme-tc-split-dropdown btn btn-default"
-                            disabled={false}
-                            i18n={Object {}}
-                            onClick={[Function]}
-                            tReady={false}
-                            type="button"
-                          >
-                            <span>
-                              <Icon
-                                name="fa fa-plus"
-                              >
-                                <i
-                                  aria-hidden="true"
-                                  className="fa fa-plus"
-                                  focusable="false"
-                                  title={null}
-                                />
-                              </Icon>
-                              <span>
-                                Add File
-                              </span>
-                            </span>
-                          </button>
-                        </Button>
-                        <SplitToggle
-                          aria-label="Open \\"Add File\\" menu"
-                          bsClass="dropdown-toggle"
-                          bsRole="toggle"
-                          id={42}
-                          key=".1"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          open={false}
-                          useAnchor={false}
-                        >
-                          <DropdownToggle
-                            aria-label="Open \\"Add File\\" menu"
-                            bsClass="dropdown-toggle"
-                            bsRole="toggle"
-                            id={42}
-                            noCaret={false}
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            open={false}
-                            useAnchor={false}
-                          >
-                            <Button
-                              active={false}
-                              aria-expanded={false}
-                              aria-haspopup={true}
-                              aria-label="Open \\"Add File\\" menu"
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="default"
-                              className="dropdown-toggle"
-                              disabled={false}
-                              id={42}
-                              onClick={[Function]}
-                              onKeyDown={[Function]}
-                              role="button"
-                            >
-                              <button
-                                aria-expanded={false}
-                                aria-haspopup={true}
-                                aria-label="Open \\"Add File\\" menu"
-                                className="dropdown-toggle btn btn-default"
-                                disabled={false}
-                                id={42}
-                                onClick={[Function]}
-                                onKeyDown={[Function]}
-                                role="button"
-                                type="button"
-                              >
-                                 
-                                <span
-                                  className="caret"
-                                />
-                              </button>
-                            </Button>
-                          </DropdownToggle>
-                        </SplitToggle>
-                        <DropdownMenu
-                          bsClass="dropdown-menu"
-                          bsRole="menu"
-                          key=".2"
-                          labelledBy={42}
-                          onClose={[Function]}
-                          onSelect={[Function]}
-                          pullRight={false}
-                        >
-                          <RootCloseWrapper
-                            disabled={true}
-                            event="click"
-                            onRootClose={[Function]}
-                          >
-                            <ul
-                              aria-labelledby={42}
-                              className="dropdown-menu"
-                              role="menu"
-                            >
-                              <MenuItem
-                                bsClass="dropdown"
-                                disabled={false}
-                                divider={false}
-                                header={false}
-                                key=".$0"
-                                label="From Local"
-                                onClick={[Function]}
-                                onKeyDown={[Function]}
-                                onSelect={[Function]}
-                              >
-                                <li
-                                  className=""
-                                  role="presentation"
-                                >
-                                  <SafeAnchor
-                                    componentClass="a"
-                                    label="From Local"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
-                                    role="menuitem"
-                                    tabIndex="-1"
-                                  >
-                                    <a
-                                      href="#"
-                                      label="From Local"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
-                                    >
-                                      From Local
-                                    </a>
-                                  </SafeAnchor>
-                                </li>
-                              </MenuItem>
-                              <MenuItem
-                                bsClass="dropdown"
-                                disabled={false}
-                                divider={false}
-                                header={false}
-                                key=".$1"
-                                label="From Remote"
-                                onClick={[Function]}
-                                onKeyDown={[Function]}
-                                onSelect={[Function]}
-                              >
-                                <li
-                                  className=""
-                                  role="presentation"
-                                >
-                                  <SafeAnchor
-                                    componentClass="a"
-                                    label="From Remote"
-                                    onClick={[Function]}
-                                    onKeyDown={[Function]}
-                                    role="menuitem"
-                                    tabIndex="-1"
-                                  >
-                                    <a
-                                      href="#"
-                                      label="From Remote"
-                                      onClick={[Function]}
-                                      onKeyDown={[Function]}
-                                      role="menuitem"
-                                      tabIndex="-1"
-                                    >
-                                      From Remote
-                                    </a>
-                                  </SafeAnchor>
-                                </li>
-                              </MenuItem>
-                            </ul>
-                          </RootCloseWrapper>
-                        </DropdownMenu>
-                      </div>
-                    </ButtonGroup>
-                  </Dropdown>
-                </Uncontrolled(Dropdown)>
-              </SplitButton>
-            </ActionSplitDropdown>
-          </I18n>
-        </Translate(ActionSplitDropdown)>
-      </div>
-    </Content>
-  </SwitchActions>
-</nav>
-`;
+exports[`ActionBar should render no-selected actions, all on right 1`] = `null`;
 
 exports[`ActionBar should render no-selected actions, some on left, the other on right 1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -666,11 +132,11 @@ exports[`ActionBar should render no-selected actions, some on left, the other on
     selected={0}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
 exports[`ActionBar should render selected count and multi-selected actions, all on left 1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -710,11 +176,11 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
     selected={1}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
 exports[`ActionBar should render selected count and multi-selected actions, all on right 1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -761,11 +227,11 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
     selected={1}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
 exports[`ActionBar should render selected count and multi-selected actions, count and some actions on left, the other on right 1`] = `
-<nav
+<div
   className="theme-tc-actionbar-container tc-actionbar-container nav"
 >
   <SwitchActions
@@ -815,7 +281,7 @@ exports[`ActionBar should render selected count and multi-selected actions, coun
     selected={1}
     t={[Function]}
   />
-</nav>
+</div>
 `;
 
 exports[`ActionBar.Count should render if selected 1`] = `

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -36,7 +36,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -76,7 +76,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;
@@ -137,7 +137,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -177,7 +177,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;
@@ -218,7 +218,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -258,7 +258,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;
@@ -299,7 +299,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -352,7 +352,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;
@@ -393,7 +393,7 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -433,7 +433,7 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;
@@ -463,7 +463,7 @@ exports[`ConfirmDialog should render without header 1`] = `
   <div
     className="Footer"
   >
-    <nav
+    <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
     >
       <div
@@ -503,7 +503,7 @@ exports[`ConfirmDialog should render without header 1`] = `
           </span>
         </button>
       </div>
-    </nav>
+    </div>
   </div>
 </div>
 `;

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -50,7 +50,7 @@ exports[`Drawer should render 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -62,7 +62,7 @@ exports[`Drawer should render 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -97,7 +97,7 @@ exports[`Drawer should render stacked 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -109,7 +109,7 @@ exports[`Drawer should render stacked 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -144,7 +144,7 @@ exports[`Drawer should render using custom className 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -156,7 +156,7 @@ exports[`Drawer should render using custom className 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -195,7 +195,7 @@ exports[`Drawer should render using custom styles 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -207,7 +207,7 @@ exports[`Drawer should render using custom styles 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -295,7 +295,7 @@ exports[`Drawer should render with tabs 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -307,7 +307,7 @@ exports[`Drawer should render with tabs 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>
@@ -334,7 +334,7 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
   t={[Function]}
   tReady={false}
 >
-  <nav
+  <div
     className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
   >
     <SwitchActions
@@ -461,7 +461,7 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
         />
       </Content>
     </SwitchActions>
-  </nav>
+  </div>
 </ActionBar>
 `;
 
@@ -493,7 +493,7 @@ exports[`Drawer should render without tc-drawer-transition class 1`] = `
       <div
         className="tc-drawer-actionbar-container theme-tc-drawer-actionbar-container"
       >
-        <nav
+        <div
           className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
         >
           <div
@@ -505,7 +505,7 @@ exports[`Drawer should render without tc-drawer-transition class 1`] = `
           <div
             className="theme-navbar-right navbar-right"
           />
-        </nav>
+        </div>
       </div>
     </div>
   </div>

--- a/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
+++ b/packages/components/src/List/Toolbar/__snapshots__/Toolbar.snapshot.test.js.snap
@@ -4,7 +4,7 @@ exports[`Toolbar should render actions toolbar 1`] = `
 <div
   className="tc-list-toolbar"
 >
-  <nav
+  <div
     className="theme-tc-actionbar-container tc-actionbar-container nav"
   >
     <div
@@ -36,7 +36,7 @@ exports[`Toolbar should render actions toolbar 1`] = `
         </span>
       </button>
     </div>
-  </nav>
+  </div>
 </div>
 `;
 
@@ -44,7 +44,7 @@ exports[`Toolbar should render actions toolbar with selected items 1`] = `
 <div
   className="tc-list-toolbar"
 >
-  <nav
+  <div
     className="theme-tc-actionbar-container tc-actionbar-container nav"
   >
     <div
@@ -81,7 +81,7 @@ exports[`Toolbar should render actions toolbar with selected items 1`] = `
         </span>
       </button>
     </div>
-  </nav>
+  </div>
 </div>
 `;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`ActionBar` wraps buttons with nav systematically

**What is the chosen solution to this problem?**
`ActionBar` wraps with div instead

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
