### PR TITLE
doc: remove all breaking change log note

### DIFF
--- a/packages/cmf-cqrs/README.md
+++ b/packages/cmf-cqrs/README.md
@@ -17,13 +17,6 @@ This is a library to help you to build configurable React App with CQRS pattern.
 [devdependencies-image]: https://david-dm.org/Talend/ui/dev-status.svg?path=packages/cmf-cqrs
 [devdependencies-url]: https://david-dm.org/Talend/ui?path=packages/cmf-cqrs&type=dev
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-cmf-cqrs` do NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 ## Content
 
 This package provides tools to deal with cqrs backend allowing websocket handling :

--- a/packages/components/README.md
+++ b/packages/components/README.md
@@ -20,13 +20,6 @@ A set of stateless components which follows the [Talend Guidelines](http://guide
 [peerdependencies-image]: https://david-dm.org/Talend/ui/peer-status.svg?path=packages/components
 [peerdependencies-url]: https://david-dm.org/Talend/ui?path=packages/components&type=peer
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-components` does NOT follow semver in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 ## Conventions
 
 Please look at our [CONTRIBUTING](https://github.com/Talend/tools/blob/master/tools-root-github/CONTRIBUTING.md) first.

--- a/packages/containers/README.md
+++ b/packages/containers/README.md
@@ -20,12 +20,6 @@ This library provide a set of widgets to be ready to start with [react-cmf](http
 [peerdependencies-image]: https://david-dm.org/Talend/ui/peer-status.svg?path=packages/containers
 [peerdependencies-url]: https://david-dm.org/Talend/ui?path=packages/containers&type=peer
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-containers` does NOT follow semver in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 ## Dependencies
 

--- a/packages/datagrid/README.md
+++ b/packages/datagrid/README.md
@@ -2,10 +2,6 @@
 
 This library provide a datagrid to show some datas !
 
-## Breaking changes log
-
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-
 ## Guidelines
 
 [Datagrid](https://company-57688.frontify.com/document/92132#/navigation-layout/data-grid)

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -2,13 +2,6 @@
 
 [![Build Status](https://travis-ci.org/Talend/ui.svg?branch=master)](https://travis-ci.org/Talend/ui)
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-forms` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 ## Introduction
 
 This library is designed to be used on top of [react-jsonschema-form](https://mozilla-services.github.io/react-jsonschema-form/), a React component for building Web forms from JSONSchema.

--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -18,13 +18,6 @@
 [quality-badge]: http://npm.packagequality.com/shield/generator-talend.svg
 [quality-url]: http://packagequality.com/#?package=generator-talend
 
-## Breaking changes log
-
-Before 1.0, `generator-talend` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 ## Installation
 
 You'll first need to install [yeoman](http://yeoman.io/) then install

--- a/packages/icons/README.md
+++ b/packages/icons/README.md
@@ -23,12 +23,6 @@ This is the set of SVG icons used in our apps.
 [quality-badge]: http://npm.packagequality.com/shield/talend-icons.svg
 [quality-url]: http://packagequality.com/#?package=talend-icons
 
-# Breaking changes log
-
-Before 1.0, `@talend/icons` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 # How to use
 

--- a/packages/logging/README.md
+++ b/packages/logging/README.md
@@ -9,13 +9,6 @@ A small library that provides a centralized error logger.
 * Redux [documentation](./src/redux)
 * Framework free: see next section
 
-#### Breaking changes log
-
-Before 1.0, `@talend/log` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 #### Advanced config
 
 Look in ./src/errorTransformer.js for jsDoc on each parameter

--- a/packages/sagas/README.md
+++ b/packages/sagas/README.md
@@ -24,13 +24,6 @@ A set of generic sagas that are reusable accross the app(http://guidelines.talen
 [quality-badge]: http://npm.packagequality.com/shield/react-talend-sagas.svg
 [quality-url]: http://packagequality.com/#?package=react-talend-sagas
 
-## Breaking changes log
-
-Before 1.0, `@talend/react-sagas` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
-
 ## Conventions
 
 Please look at our [CONTRIBUTING](https://github.com/Talend/tools/blob/master/tools-root-github/CONTRIBUTING.md) first.

--- a/packages/theme/README.md
+++ b/packages/theme/README.md
@@ -13,12 +13,6 @@ Note: The example has been taken from the excellent project [Bootstwatch](https:
 * [Example page](https://talend.github.io/bootstrap-theme)
 * [Sass Api](https://talend.github.io/bootstrap-theme/sassdoc)
 
-# Breaking changes log
-
-Before 1.0, `@talend/bootstrap-theme` does NOT follow semver version in releases.
-You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
-Before 2.0, we will try not to introduce breaking changes, as possible.
-After 2.0, we will only introduce breaking changes in major releases, and follow semver.
 
 # How to use
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

every package readme contains:

```
## Breaking changes log

 Before 1.0, `@talend/react-cmf-cqrs` do NOT follow semver version in releases.
You will find a [list of breaking changes here](https://github.com/Talend/ui/wiki/BREAKING-CHANGE).
Before 2.0, we will try not to introduce breaking changes, as possible.
After 2.0, we will only introduce breaking changes in major releases, and follow semver.
```

which is not anymore relevant.

**What is the chosen solution to this problem?**

just remove

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
