### PR TITLE
fix(forms): Exclude readonly fields from label focus style

### DIFF
--- a/packages/forms/src/UIForm/__snapshots__/widgets.json
+++ b/packages/forms/src/UIForm/__snapshots__/widgets.json
@@ -1,96 +1,96 @@
 [
-	{
-		"title": "Widgets",
-		"widget": "fieldset",
-		"items": [
-			{
-				"key": "enumeration",
-				"title": "Enumeration",
-				"widget": "enumeration"
-			},
-			{
-				"key": "stringFormats",
-				"title": "String formats",
-				"widget": "fieldset",
-				"items": [
-					{
-						"key": "stringFormats.email",
-						"type": "email",
-						"widget": "text"
-					},
-					{
-						"key": "stringFormats.uri",
-						"widget": "text",
-						"type": "url"
-					}
-				]
-			},
-			{
-				"key": "boolean",
-				"title": "Boolean field",
-				"widget": "fieldset",
-				"items": [
-					{
-						"key": "boolean.default",
-						"title": "checkbox (default)"
-					},
-					{
-						"key": "boolean.radio",
-						"title": "radio buttons",
-						"widget": "radios"
-					},
-					{
-						"key": "boolean.select",
-						"title": "select box",
-						"widget": "select"
-					}
-				]
-			},
-			{
-				"key": "string",
-				"title": "String field",
-				"widget": "fieldset",
-				"items": [
-					{
-						"key": "string.default",
-						"title": "text input (default)",
-						"widget": "text"
-					},
-					{
-						"key": "string.textarea",
-						"title": "textarea",
-						"widget": "textarea"
-					},
-					{
-						"key": "string.color",
-						"title": "color picker",
-						"widget": "text",
-						"type": "color"
-					}
-				]
-			},
-			{
-				"key": "secret",
-				"widget": "hidden"
-			},
-			{
-				"key": "disabled",
-				"title": "A disabled field",
-				"widget": "text",
-				"disabled": true
-			},
-			{
-				"key": "readonly",
-				"title": "A readonly field",
-				"widget": "text",
-				"readonly": true
-			},
-			{
-				"key": "readonlyEmpty",
-				"title": "An empty readonly field",
-				"widget": "text",
-				"readonly": true
-			}
-		]
-	}
+  {
+    "title": "Widgets",
+    "widget": "fieldset",
+    "items": [
+      {
+        "key": "enumeration",
+        "title": "Enumeration",
+        "widget": "enumeration"
+      },
+      {
+        "key": "stringFormats",
+        "title": "String formats",
+        "widget": "fieldset",
+        "items": [
+          {
+            "key": "stringFormats.email",
+            "type": "email",
+            "widget": "text"
+          },
+          {
+            "key": "stringFormats.uri",
+            "widget": "text",
+            "type": "url"
+          }
+        ]
+      },
+      {
+        "key": "boolean",
+        "title": "Boolean field",
+        "widget": "fieldset",
+        "items": [
+          {
+            "key": "boolean.default",
+            "title": "checkbox (default)"
+          },
+          {
+            "key": "boolean.radio",
+            "title": "radio buttons",
+            "widget": "radios"
+          },
+          {
+            "key": "boolean.select",
+            "title": "select box",
+            "widget": "select"
+          }
+        ]
+      },
+      {
+        "key": "string",
+        "title": "String field",
+        "widget": "fieldset",
+        "items": [
+          {
+            "key": "string.default",
+            "title": "text input (default)",
+            "widget": "text"
+          },
+          {
+            "key": "string.textarea",
+            "title": "textarea",
+            "widget": "textarea"
+          },
+          {
+            "key": "string.color",
+            "title": "color picker",
+            "widget": "text",
+            "type": "color"
+          }
+        ]
+      },
+      {
+        "key": "secret",
+        "widget": "hidden"
+      },
+      {
+        "key": "disabled",
+        "title": "A disabled field",
+        "widget": "text",
+        "disabled": true
+      },
+      {
+        "key": "readonly",
+        "title": "A readonly field",
+        "widget": "text",
+        "readonly": true
+      },
+      {
+        "key": "readonlyEmpty",
+        "title": "An empty readonly field",
+        "widget": "text",
+        "readonly": true
+      }
+    ]
+  }
 ]

--- a/packages/forms/src/UIForm/__snapshots__/widgets.json
+++ b/packages/forms/src/UIForm/__snapshots__/widgets.json
@@ -84,6 +84,12 @@
 				"title": "A readonly field",
 				"widget": "text",
 				"readonly": true
+			},
+			{
+				"key": "readonlyEmpty",
+				"title": "An empty readonly field",
+				"widget": "text",
+				"readonly": true
 			}
 		]
 	}

--- a/packages/forms/stories/json/widgets.json
+++ b/packages/forms/stories/json/widgets.json
@@ -82,6 +82,11 @@
         "type": "string",
         "title": "A readonly field",
         "default": "I am read-only."
+      },
+      "readonlyEmpty": {
+        "type": "string",
+        "title": "An empty readonly field",
+        "default": ""
       }
     }
   },
@@ -112,6 +117,9 @@
       "ui:disabled": true
     },
     "readonly": {
+      "ui:readonly": true
+    },
+    "readonlyEmpty": {
       "ui:readonly": true
     }
   },

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -396,7 +396,7 @@ form {
 	}
 
 	&-control-container,
-	&-control:focus,
+	&-control:focus:not([readonly]),
 	&-control[placeholder]:not([placeholder='']),
 	&-control:not(:empty),
 	&-control:disabled,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If you click on a readonly empty field the label will move up. This is confusing since you can't write anything anyway. 

![readonly-empty](https://user-images.githubusercontent.com/36537247/48350725-5cb35f00-e688-11e8-97bc-0ae7d5612ab7.gif)

**What is the chosen solution to this problem?**
Exclude readonly fields from the focus style on the label. 

storybook: Add an empty readonly in forms -> widgets

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
