### PR TITLE
fix(sidepanel): add withrouter

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -12,11 +12,8 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:80  error  'notifications' is missing in props validation  react/prop-types
 
-/home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
-  2:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
-
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 6 problems (6 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
 

--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -12,8 +12,11 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:80  error  'notifications' is missing in props validation  react/prop-types
 
+/home/travis/build/Talend/ui/packages/containers/src/SidePanel/SidePanel.connect.js
+  2:1  error  'react-router' should be listed in the project's dependencies, not devDependencies  import/no-extraneous-dependencies
+
 /home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
-✖ 5 problems (5 errors, 0 warnings)
+✖ 6 problems (6 errors, 0 warnings)
 

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -91,7 +91,6 @@
     "react-dom": "^16.0.0",
     "react-i18next": "^7.6.1",
     "react-redux": "^5.0.7",
-    "react-router": "^3.2.0",
     "react-router-redux": "^4.0.8",
     "react-stub-context": "^0.7.0",
     "react-test-renderer": "^16.0.0",
@@ -152,6 +151,7 @@
   "version": "1.6.0",
   "dependencies": {
     "memoize-one": "^4.0.0",
-    "react-immutable-proptypes": "^2.1.0"
+    "react-immutable-proptypes": "^2.1.0",
+    "react-router": "^3.2.0"
   }
 }

--- a/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
+++ b/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
@@ -111,7 +111,7 @@ exports[`Component HomeListView should render with object props 1`] = `
   id={undefined}
   mode="TwoColumns"
   one={
-    <Connect(CMF(Container(SidePanel)))
+    <withRouter(Connect(CMF(Container(SidePanel))))
       actionIds={
         Array [
           "menu:demo",

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+import { withRouter } from 'react-router';
 import cmf, { cmfConnect } from '@talend/react-cmf';
 import Container, { DEFAULT_STATE } from './SidePanel.container';
 import { ACTION_TYPE_LINK } from './constants';
@@ -151,14 +152,16 @@ export function mergeProps(stateProps, dispatchProps, ownProps) {
 	return props;
 }
 
-export default cmfConnect({
-	defaultState: DEFAULT_STATE,
-	omitCMFProps: true,
-	withComponentRegistry: true,
-	withDispatch: true,
-	withDispatchActionCreator: true,
-	withComponentId: true,
-	keepComponentState: true,
-	mapStateToProps,
-	mergeProps,
-})(Container);
+export default withRouter(
+	cmfConnect({
+		defaultState: DEFAULT_STATE,
+		omitCMFProps: true,
+		withComponentRegistry: true,
+		withDispatch: true,
+		withDispatchActionCreator: true,
+		withComponentId: true,
+		keepComponentState: true,
+		mapStateToProps,
+		mergeProps,
+	})(Container),
+);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

in #1766 we have removed the withouter HOC because no code was based on the router in the container.
But existing project use expressions.

**What is the chosen solution to this problem?**

rewrap it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
