### PR TITLE
fix(compnents): update AppHeader logo padding

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -61,7 +61,7 @@ $background-color-on-hover: shade($brand-primary, 30);
 
 		.tc-header-bar-logo:global(.btn):global(.btn-link) {
 			line-height: $svg-lg-size;
-			padding: 12px $padding-large 12px $padding-normal;
+			padding: 12px $padding-normal 12px $padding-small;
 
 			:global(.tc-svg-icon) {
 				height: $svg-lg-size;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The padding on the "talend logo" were not as designed in the guidelines
https://company-57688.frontify.com/document/92132#/navigation-layout/app-header
**What is the chosen solution to this problem?**
Update it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
