### PR TITLE
fix(Layout): do not touch the body style

### DIFF
--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -9,13 +9,6 @@ $tc-layout-header-height: $navbar-height;
 $tc-layout-skip-links-z-index: 20;
 $tc-layout-header-z-index: 10;
 
-body {
-	margin: 0;
-	max-height: 100vh;
-	overflow: hidden; /* due to borders */
-	width: 100vw;
-}
-
 .layout {
 	display: flex;
 	flex-direction: column;

--- a/packages/components/stories/Layout.js
+++ b/packages/components/stories/Layout.js
@@ -55,7 +55,7 @@ const drawers = [
 const content = (
 	<div>
 		<h1>Welcome to the content for testing scroll</h1>
-		<ul>{[...new Array(38)].map(() => <li>one</li>)}</ul>
+		<ul>{[...new Array(138)].map(() => <li>one</li>)}</ul>
 	</div>
 );
 const sidePanel = (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The Layout component limits the body (100vh, 100vw).
But that is wrong, because the layout itself is already limited to those measures. And it introduce some side effect, for example with the dropdown.

![dropdown](https://user-images.githubusercontent.com/10761073/48478355-5649f200-e804-11e8-83df-a00aee8afe35.gif)

Here it looks at the body bottom position to decide if it will switch to dropup. We scroll, the body (limited to 100vh) is out of the window, the dropdown consider it is in overflow and switch.

**What is the chosen solution to this problem?**
Remove the specific style on body, the layout already limits itself.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
