### PR TITLE
fix(Containers/ActionButton): add missing registry props

### DIFF
--- a/packages/containers/src/ActionButton/ActionButton.connect.js
+++ b/packages/containers/src/ActionButton/ActionButton.connect.js
@@ -61,6 +61,7 @@ export default cmfConnect({
 	mapStateToProps,
 	mergeProps,
 	omitCMFProps: true,
+	withComponentRegistry: true,
 	withDispatch: true,
 	withDispatchActionCreator: true,
 })(ContainerActionButton);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With UI 16.1, there has been a little regression on the action button. We dunnot pass the getComponent anymore but it is used by the overlay.
**What is the chosen solution to this problem?**
Simply add the missing props in the connect with the new api.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
