### PR TITLE
fix(form/UIForm): avoid error when rendering without data props

### DIFF
--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -11,7 +11,7 @@ import { formPropTypes } from './utils/propTypes';
  * @return {FormSchema}
  */
 function addErrorObject(formSchema) {
-	if (!formSchema.errors) {
+	if (formSchema && !formSchema.errors) {
 		return { errors: {}, ...formSchema };
 	}
 	return formSchema;

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -22,6 +22,17 @@ describe('UIForm container', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render form without data', () => {
+		// when
+		const wrapper = shallow(<UIForm {...props} />);
+
+		// then
+		expect(
+			wrapper // eslint-disable-line no-underscore-dangle
+				.instance().state,
+		).toEqual({});
+	});
+
 	describe('#componentWillReceiveProps', () => {
 		it('should update state if form data structure changed', () => {
 			// given


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
data props is not required by UIForm.container, new version broke that so

**What is the chosen solution to this problem?**
we fix the issue by check if sub element of data exist before doing any operation on it.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
