### PR TITLE
feat(cmf): support multiple cmf settings

### DIFF
--- a/packages/cmf/scripts/cmf-settings.merge.js
+++ b/packages/cmf/scripts/cmf-settings.merge.js
@@ -17,6 +17,14 @@ const {
 
 const DEFAULT_CONFIG_FILENAME = 'cmf.json';
 
+function getCmfconfig(cmfconfigPath, onError) {
+	const cmfconfig = importAndValidate(cmfconfigPath, onError);
+	if (process.env.CMF_ENV) {
+		return cmfconfig[process.env.CMF_ENV];
+	}
+	return cmfconfig;
+}
+
 function merge(options, errorCallback) {
 	const onErrorCallback = errorCallback || Function.prototype;
 	function onError(...args) {
@@ -38,7 +46,7 @@ function merge(options, errorCallback) {
 
 	// Init some stuff to use next
 	const cmfconfigPath = path.join(process.cwd(), DEFAULT_CONFIG_FILENAME);
-	const cmfconfig = options.cmfConfig || importAndValidate(cmfconfigPath, onError);
+	const cmfconfig = options.cmfConfig || getCmfconfig(cmfconfigPath, onError);
 	const sources = dev ? cmfconfig.settings['sources-dev'] : cmfconfig.settings.sources;
 	let destination = cmfconfig.settings.destination;
 	if (destination && !path.isAbsolute(destination)) {

--- a/packages/cmf/scripts/index.md
+++ b/packages/cmf/scripts/index.md
@@ -130,3 +130,39 @@ e.g. For the destination "src/assets/settings.json", each translated settings wi
 ```
 
 Warning : if the namespace is not define in the settings files or if it is not define in the config file the key will not be extracted
+
+### Multiple settings
+If you need to use multiple settings in one project you can do so with an environment variable `CMF_ENV`.
+
+`$ cross-env CMF_ENV=withoutMyOtherDep cmf-settings`
+
+```json
+{
+	"settings": {
+		"sources": [
+			"src/settings",
+			"node_modules/@talend/dataset/lib/settings",
+			"node_modules/@talend/myOtherDep/lib/file.json"
+		],
+		"sources-dev": [
+			"src/settings",
+			"../../dataset/webapp/src/settings",
+			"../../myOtherDep/lib/file.json"
+		],
+		"destination": "src/assets/cmf-settings.json"
+	},
+	"withoutMyOtherDep": {
+		"settings": {
+			"sources": [
+				"src/settings",
+				"node_modules/@talend/dataset/lib/settings"
+			],
+			"sources-dev": [
+				"src/settings",
+				"../../dataset/webapp/src/settings"
+			],
+			"destination": "src/assets/cmf-settings.json"
+		}
+	}
+}
+```


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We need to be able to produce a build with different settings files than default. 

**What is the chosen solution to this problem?**
Support multiple settings objects in cmf.json

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
