### PR TITLE
fix(List): title actions positions

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -7,6 +7,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 
 .main-title-actions-group {
 	flex-grow: 0;
+	position: relative;
 	right: 0;
 	top: 0;
 	height: $btn-line-height;
@@ -15,9 +16,9 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
 		opacity: 0;
 		visibility: hidden;
-		right: 0;
 
 		position: absolute;
+		right: 100%;
 
 		padding-left: $padding-larger;
 		margin-right: $padding-smaller;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Visual regression on List title actions position
<img width="412" alt="capture d ecran 2018-12-05 a 08 42 42" src="https://user-images.githubusercontent.com/10761073/49497901-c67aef00-f869-11e8-9a1d-7ebd3970ed75.png">

**What is the chosen solution to this problem?**
Revert the css change that cause that (sorry it was my idea to fix an IE issue.
<img width="465" alt="capture d ecran 2018-12-05 a 08 42 28" src="https://user-images.githubusercontent.com/10761073/49497955-e6aaae00-f869-11e8-8ac7-eabac11afa0b.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
