### PR TITLE
fix(components/dialog): design adjustments

### DIFF
--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -35,6 +35,8 @@
 		}
 
 		.modal-title {
+			text-transform: inherit;
+			font-weight: bold;
 			line-height: 1;
 		}
 

--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -42,7 +42,6 @@
 
 		.modal-subtitle {
 			margin-bottom: 0;
-			padding-top: 0.5rem;
 		}
 
 		.close {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Uppercase is applied on modal title + font weight is [wrong](https://company-57688.frontify.com/document/92132#/modal/dialog-box).

**What is the chosen solution to this problem?**

Fix case and font weight.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
