### PR TITLE
fix(components/list): large display adjustments

### DIFF
--- a/packages/components/src/VirtualizedList/ListGrid/ListGrid.test.js
+++ b/packages/components/src/VirtualizedList/ListGrid/ListGrid.test.js
@@ -30,7 +30,7 @@ describe('ListGrid', () => {
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
 		expect(wrapper.getElement().props.rowRenderer.displayName).toBe(
-			'ListGesture(VirtualizedList(RowLarge))',
+			'ListGesture(Translate(VirtualizedList(RowLarge)))',
 		);
 	});
 
@@ -53,7 +53,7 @@ describe('ListGrid', () => {
 
 		// then
 		expect(wrapper.getElement().props.rowRenderer.displayName).toBe(
-			'RowSelection(ListGesture(VirtualizedList(RowLarge)))',
+			'RowSelection(ListGesture(Translate(VirtualizedList(RowLarge))))',
 		);
 	});
 

--- a/packages/components/src/VirtualizedList/RendererSelector.test.js
+++ b/packages/components/src/VirtualizedList/RendererSelector.test.js
@@ -115,7 +115,7 @@ describe('RendererSelector', () => {
 		);
 
 		// then
-		expect(wrapper.prop('rowRenderer').displayName).toBe('ListGesture(VirtualizedList(RowLarge))');
+		expect(wrapper.prop('rowRenderer').displayName).toBe('ListGesture(Translate(VirtualizedList(RowLarge)))');
 	});
 
 	it('should render the table with the default NoRows', () => {

--- a/packages/components/src/VirtualizedList/RendererSelector.test.js
+++ b/packages/components/src/VirtualizedList/RendererSelector.test.js
@@ -115,7 +115,9 @@ describe('RendererSelector', () => {
 		);
 
 		// then
-		expect(wrapper.prop('rowRenderer').displayName).toBe('ListGesture(Translate(VirtualizedList(RowLarge)))');
+		expect(wrapper.prop('rowRenderer').displayName).toBe(
+			'ListGesture(Translate(VirtualizedList(RowLarge)))',
+		);
 	});
 
 	it('should render the table with the default NoRows', () => {

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { translate } from 'react-i18next';
 import {
 	extractSpecialFields,
 	getCellData,
@@ -11,10 +12,13 @@ import {
 	renderCell,
 } from '../utils/gridrow';
 
+import getDefaultT from '../../translate';
 import { listTypes } from '../utils/constants';
 import withListGesture from '../../Gesture/withListGesture';
 import rowThemes from './RowThemes';
 import theme from './RowLarge.scss';
+
+import I18N_DOMAIN_COMPONENTS from '../../constants';
 
 const { LARGE } = listTypes;
 
@@ -41,7 +45,7 @@ class RowLarge extends React.Component {
 		return (
 			<div className={theme['field-group']} role="group" key={label || index}>
 				<dt key={fieldIndex} className={theme['field-label']}>
-					{label}
+					{label}{this.props.t('COLON', { defaultValue: ':' })}
 				</dt>
 				<dd className={theme['field-value']} title={tooltip}>
 					{cellContent}
@@ -119,6 +123,10 @@ RowLarge.propTypes = {
 	parent: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 	/** Custom style that react-virtualized provides */
 	style: PropTypes.object, // eslint-disable-line react/forbid-prop-types
+	t: PropTypes.func.isRequired,
+};
+RowLarge.defaultProps = {
+	t: getDefaultT(),
 };
 
-export default withListGesture(RowLarge);
+export default withListGesture(translate(I18N_DOMAIN_COMPONENTS)(RowLarge));

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.component.js
@@ -45,7 +45,8 @@ class RowLarge extends React.Component {
 		return (
 			<div className={theme['field-group']} role="group" key={label || index}>
 				<dt key={fieldIndex} className={theme['field-label']}>
-					{label}{this.props.t('COLON', { defaultValue: ':' })}
+					{label}
+					{this.props.t('COLON', { defaultValue: ':' })}
 				</dt>
 				<dd className={theme['field-value']} title={tooltip}>
 					{cellContent}

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
@@ -1,5 +1,4 @@
 $tc-list-large-hover-bg: $white !default;
-$tc-list-large-field-label-color: $brand-primary-darker !default;
 $tc-list-large-field-value-color: $dove-gray !default;
 
 .tc-list-large {
@@ -48,11 +47,9 @@ $tc-list-large-field-value-color: $dove-gray !default;
 	}
 
 	.field-label {
-		color: $tc-list-large-field-label-color;
-		font-weight: normal;
+		font-weight: 600;
 		margin-bottom: $padding-small;
-		margin-right: $padding-small;
-		text-transform: uppercase;
+		margin-right: .5rem;
 	}
 
 	.field-value {

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
@@ -49,7 +49,7 @@ $tc-list-large-field-value-color: $dove-gray !default;
 	.field-label {
 		font-weight: 600;
 		margin-bottom: $padding-small;
-		margin-right: .5rem;
+		margin-right: 0.5rem;
 	}
 
 	.field-value {

--- a/packages/components/src/VirtualizedList/RowLarge/__snapshots__/RowLarge.test.js.snap
+++ b/packages/components/src/VirtualizedList/RowLarge/__snapshots__/RowLarge.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RowLarge should render large row 1`] = `
-<VirtualizedList(RowLarge)
+<Translate(VirtualizedList(RowLarge))
   className="my-class-names"
   index={1}
   onKeyDown={[Function]}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Large display mode does not follow the [guidelines](https://company-57688.frontify.com/document/92132#/navigation-layout/list/list-views).

**What is the chosen solution to this problem?**

Change key font colour
Remove uppercase
Decrease padding between key and value

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
