### PR TITLE
fix(components): apply dove-gray by default on actions on the list

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -1,6 +1,6 @@
 @import '../colors';
 
-$tc-list-title-actions-color: $brand-primary-darker !default;
+$tc-list-title-actions-hover-color: $brand-primary-darker !default;
 $tc-list-title-actions-ellipsis: '\22ee';
 $tc-list-title-dropdown-menu-triangle: '\25b2';
 $tc-list-title-dropup-menu-triangle: '\25bc';
@@ -39,8 +39,12 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 
 	:global {
 		.btn-link {
-			color: $tc-list-title-actions-color;
 			padding: 0 $padding-small;
+			color: $dove-gray;
+
+			&:hover {
+				color: $tc-list-title-actions-hover-color;
+			}
 		}
 
 		.btn-group > .dropdown-menu,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
change color in the actions buttons (primary color to dove gray) to respect the guideline.

https://company-57688.frontify.com/document/92132#/navigation-layout/list

**What is the chosen solution to this problem?**
apply the new css

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
