### PR TITLE
chore: try to speedup e2e

### DIFF
--- a/packages/components/e2e/component-objects/src/test/java/org/talend/config/BrowserStackWebDriverTest.java
+++ b/packages/components/e2e/component-objects/src/test/java/org/talend/config/BrowserStackWebDriverTest.java
@@ -20,6 +20,8 @@ public class BrowserStackWebDriverTest extends WebDriverTest {
         capabilities.setCapability("os_version", "10");
         capabilities.setCapability("resolution", "1600x1200");
         // capabilities.setCapability("browserstack.debug", "false");
+        capabilities.setCapability("browserstack.console", "disable");
+        capabilities.setCapability("browserstack.video", "false");
         if (System.getProperty("storybook.host") == "localhost") {
             capabilities.setCapability("browserstack.local", "true");
         }

--- a/packages/components/e2e/component-objects/src/test/java/org/talend/config/BrowserStackWebDriverTest.java
+++ b/packages/components/e2e/component-objects/src/test/java/org/talend/config/BrowserStackWebDriverTest.java
@@ -19,7 +19,7 @@ public class BrowserStackWebDriverTest extends WebDriverTest {
         capabilities.setCapability("os", "Windows");
         capabilities.setCapability("os_version", "10");
         capabilities.setCapability("resolution", "1600x1200");
-        capabilities.setCapability("browserstack.debug", "true");
+        // capabilities.setCapability("browserstack.debug", "false");
         if (System.getProperty("storybook.host") == "localhost") {
             capabilities.setCapability("browserstack.local", "true");
         }

--- a/packages/components/e2e/component-objects/src/test/resources/log4j2.xml
+++ b/packages/components/e2e/component-objects/src/test/resources/log4j2.xml
@@ -6,7 +6,7 @@
         </Console>
     </Appenders>
     <Loggers>
-        <Root level="info">
+        <Root level="off">
             <AppenderRef ref="Console"/>
         </Root>
     </Loggers>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

e2e tests take 20 minutes.

log level is info.
browserstack is configurer in debug.

**What is the chosen solution to this problem?**

put log level to off
remove browserstack.debug capabilities.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
