### PR TITLE
fix(AppLoader): do not set body style

### DIFF
--- a/packages/components/src/AppLoader/constant.js
+++ b/packages/components/src/AppLoader/constant.js
@@ -9,13 +9,6 @@ html {
 	-webkit-text-size-adjust: 100%;
 }
 
-body {
-	margin: 0;
-	height: 100vh;
-	width: 100vw;
-	overflow: hidden;
-}
-
 .tc-app-loader-container {
   display: flex;
   height: 100vh;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
AppLoader constant set body style.
This style is set directly in the index.html projects file, to display an app loader while loading the bundle.
But this is not necessary as 
* the AppLoader takes 100vh 100vw with nothing else in the page
* it interfere with dropdown automatic dropup feature (see explanation in #1828)

**What is the chosen solution to this problem?**
Remove all body style

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
