### PR TITLE
fix(containers/SubHeaderBar): remove undefined selector

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -15,9 +15,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:80  error  'notifications' is missing in props validation  react/prop-types
 
-/home/travis/build/Talend/ui/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
-  8:1  error  Prefer default export  import/prefer-default-export
-
-✖ 6 problems (6 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)
   3 errors, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
+++ b/packages/containers/src/SubHeaderBar/SubHeaderBar.selectors.js
@@ -5,6 +5,7 @@ import { DEFAULT_STATE, DISPLAY_NAME } from './SubHeaderBar.container';
  * @param {object} state
  * @param {string} idComponent
  */
+// eslint-disable-next-line import/prefer-default-export
 export function getComponentState(state, idComponent) {
 	return state.cmf.components.getIn([DISPLAY_NAME, idComponent], DEFAULT_STATE);
 }

--- a/packages/containers/src/SubHeaderBar/index.js
+++ b/packages/containers/src/SubHeaderBar/index.js
@@ -1,8 +1,7 @@
 import SubHeaderBar from './SubHeaderBar.connect';
-import { getQuery, getComponentState } from './SubHeaderBar.selectors';
+import { getComponentState } from './SubHeaderBar.selectors';
 
 SubHeaderBar.selectors = {
-	getQuery,
 	getComponentState,
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

yarn start-containers produce the following error:

```
WARNING in ./src/SubHeaderBar/index.js 4:12-20
"export 'getQuery' was not found in './SubHeaderBar.selectors'
 @ ./src/containers.js
 @ ./src/index.js
 @ ./src/register.js
 @ ./.storybook/config.js
 @ multi /Users/jmfrancois/github/talend/ui/node_modules/@storybook/core/dist/server/config/polyfills.js /Users/jmfrancois/github/talend/ui/node_modules/@storybook/core/dist/server/config/globals.js ./.storybook/config.js (webpack)-hot-middleware/client.js?reload=true
```

**What is the chosen solution to this problem?**

remove the not existing selector from index.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->