### PR TITLE
chore(container): remove componentForm events in redux payload

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -106,10 +106,7 @@ export class TCompForm extends React.Component {
 		}
 	}
 
-	onChange(event, payload) {
-		if (event.persist) {
-			event.persist();
-		}
+	onChange(_, payload) {
 		if (!this.props.state.get('dirty')) {
 			this.props.setState({ dirty: true });
 		}
@@ -122,7 +119,6 @@ export class TCompForm extends React.Component {
 				type: TCompForm.ON_CHANGE,
 				component: TCompForm.displayName,
 				componentId: this.props.componentId,
-				event,
 				...payload,
 			});
 		}
@@ -154,15 +150,11 @@ export class TCompForm extends React.Component {
 		});
 	}
 
-	onSubmit(event, properties) {
-		if (event.persist) {
-			event.persist();
-		}
+	onSubmit(_, properties) {
 		this.props.dispatch({
 			type: TCompForm.ON_SUBMIT,
 			component: TCompForm.displayName,
 			componentId: this.props.componentId,
-			event,
 			properties,
 		});
 	}

--- a/packages/containers/src/ComponentForm/ComponentForm.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.test.js
@@ -365,7 +365,7 @@ describe('ComponentForm', () => {
 				expect(args.type).toBe(TCompForm.ON_CHANGE);
 				expect(args.component).toBe(TCompForm.displayName);
 				expect(args.componentId).toBe(componentId);
-				expect(args.event).toBe(event);
+				expect(args.event).toBe(undefined);
 				expect(args.schema).toBe(changePayload.schema);
 				expect(args.value).toBe(changePayload.value);
 				expect(args.properties).toBe(changePayload.properties);
@@ -447,7 +447,7 @@ describe('ComponentForm', () => {
 				expect(args.type).toBe(TCompForm.ON_SUBMIT);
 				expect(args.component).toBe(TCompForm.displayName);
 				expect(args.componentId).toBe(componentId);
-				expect(args.event).toBe(event);
+				expect(args.event).toBe(undefined);
 				expect(args.properties).toEqual(payload);
 			});
 		});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, when we change a field in the form or whatever, we dispatch in redux the event.
The event contains the target ... the target contains the props ... component form props contains all the traductions as it's wrapped by i18n component 😢, in some project, we have like 12MB redux payload each time we update a field. My redux extension is broken with some few events.
**What is the chosen solution to this problem?**
As we don't use the content of the event, currently remove it. If for some future development we need something coming from the event, i advise to extract the information from the event & forward it to the payload, but not all the event himself 😃 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
