### PR TITLE
fix(UIForm): Buttons wrapper rendered even if no actions

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -261,18 +261,24 @@ export class UIFormComponent extends React.Component {
 					displayMode={this.props.displayMode}
 				/>
 			));
-		const buttonsRenderer = () => (
-			<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')} key="form-buttons">
-				<Buttons
-					id={`${this.props.id}-${this.props.id}-actions`}
-					onTrigger={this.onTrigger}
-					className={this.props.buttonBlockClass}
-					schema={{ items: actions }}
-					onClick={this.onActionClick}
-					getComponent={this.props.getComponent}
-				/>
-			</div>
-		);
+		const buttonsRenderer = () => {
+			if (actions.length === 0) {
+				return null;
+			}
+
+			return (
+				<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')} key="form-buttons">
+					<Buttons
+						id={`${this.props.id}-${this.props.id}-actions`}
+						onTrigger={this.onTrigger}
+						className={this.props.buttonBlockClass}
+						schema={{ items: actions }}
+						onClick={this.onActionClick}
+						getComponent={this.props.getComponent}
+					/>
+				</div>
+			);
+		};
 
 		return (
 			<form

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import tv4 from 'tv4';
 import { actions, data, mergedSchema, initProps } from '../../__mocks__/data';
-
 import UIForm, { UIFormComponent } from './UIForm.component';
 
 describe('UIForm component', () => {
@@ -38,6 +37,12 @@ describe('UIForm component', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should not render any div if an empty "actions" array is provided', () => {
+		const wrapper = shallow(<UIFormComponent {...data} {...props} actions={[]} />);
+		const buttonsWrapper = wrapper.find('div.tf-actions-wrapper');
+		expect(buttonsWrapper).toHaveLength(0);
 	});
 
 	it('should take in account customFormat', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
A div wrapper is rendered even if an empty `actions` is provided.

**What is the chosen solution to this problem?**
Don't render anything related to the footer buttons if an empty `actions` prop is provided.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
