### PR TITLE
fix(UIForm): Missing event object spread in callback

### DIFF
--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -134,10 +134,10 @@ export default class UIForm extends React.Component {
 	/**
 	 * On user reset change local state and call this.props.onReset
 	 */
-	onReset() {
+	onReset(event) {
 		this.setState(setInitialStateAsLiveState);
 		if (typeof this.props.onReset === 'function') {
-			this.props.onReset();
+			this.props.onReset(event);
 		}
 	}
 

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -142,6 +142,20 @@ describe('UIForm container', () => {
 		});
 	});
 
+	describe('#onReset', () => {
+		it('should spread the event object to "onReset" prop callback', () => {
+			const onReset = jest.fn();
+			const resetEvent = { whateverProp: "whatever value" };
+			const wrapper = shallow(<UIForm data={data} {...props} onReset={onReset} />);
+
+			wrapper.prop('onReset')(resetEvent);
+
+			expect(onReset).toHaveBeenCalledTimes(1);
+			expect(onReset).toHaveBeenCalledWith(resetEvent);
+		});
+
+	});
+
 	describe('#setErrors', () => {
 		it('should update state errors', () => {
 			// given

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -145,7 +145,7 @@ describe('UIForm container', () => {
 	describe('#onReset', () => {
 		it('should spread the event object to "onReset" prop callback', () => {
 			const onReset = jest.fn();
-			const resetEvent = { whateverProp: "whatever value" };
+			const resetEvent = { whateverProp: 'whatever value' };
 			const wrapper = shallow(<UIForm data={data} {...props} onReset={onReset} />);
 
 			wrapper.prop('onReset')(resetEvent);
@@ -153,7 +153,6 @@ describe('UIForm container', () => {
 			expect(onReset).toHaveBeenCalledTimes(1);
 			expect(onReset).toHaveBeenCalledWith(resetEvent);
 		});
-
 	});
 
 	describe('#setErrors', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The native event object is not spread in the `UIForm container` `onReset` callback.
Can be needed for custom reasons.
In my case, CMF with `ActionCreator` expect one to be persisted when the callback is fired.

**What is the chosen solution to this problem?**
Just spread the event object in the `UIForm container` `onReset`.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
