### PR TITLE
feat(generator/cmf): add option --yarn to using yarn install cmd

### DIFF
--- a/packages/generator/README.md
+++ b/packages/generator/README.md
@@ -49,6 +49,8 @@ It will do the following:
 
 Run the `yo talend:dotfiles` command again when you want to make sure configuration files and license are up to date.
 
+You can use yarn by adding --yarn option or the classic --skip-install if you just want to escape install step.
+
 ## License
 
 Copyright (c) 2006-2016 Talend

--- a/packages/generator/generators/react-cmf/index.js
+++ b/packages/generator/generators/react-cmf/index.js
@@ -52,6 +52,10 @@ module.exports = class CMFAppGenerator extends Generator {
 		});
 	}
 	install() {
-		this.npmInstall();
+		if (this.options.yarn) {
+			this.yarnInstall();
+		} else {
+			this.npmInstall();
+		}
 	}
 };

--- a/packages/generator/generators/react-cmf/templates/package.json
+++ b/packages/generator/generators/react-cmf/templates/package.json
@@ -22,15 +22,15 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "license": "Apache-2.0",
   "devDependencies": {
-    "@talend/scripts": "0.3.1"
+    "@talend/scripts": "0.5.1"
   },
   "dependencies": {
-    "@talend/bootstrap-theme": "1.10.0",
-    "@talend/icons": "1.10.0",
-    "@talend/react-cmf": "1.10.0",
-    "@talend/react-components": "1.10.0",
-    "@talend/react-containers": "1.10.0",
-    "@talend/react-forms": "1.10.0",
+    "@talend/bootstrap-theme": "1.11.0",
+    "@talend/icons": "1.11.0",
+    "@talend/react-cmf": "1.11.0",
+    "@talend/react-components": "1.11.0",
+    "@talend/react-containers": "1.11.0",
+    "@talend/react-forms": "1.11.0",
     "bootstrap-sass": "3.3.7",
     "bson-objectid": "^1.1.5",
     "classnames": "^2.2.5",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`yo talend:react-cmf` command create structure to start a project and the it install it using `npm` client.

So If I want to use `yarn` I need to escape the install step using `--skip-install` then I must go into the project and do yarn.

**What is the chosen solution to this problem?**

add --yarn option to use yarn command.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
