### PR TITLE
fix(datagrid): add type button on the header

### DIFF
--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.component.js
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.component.js
@@ -22,6 +22,7 @@ export default function DefaultHeaderRenderer({ column, displayName, onFocusedCo
 				className={classNames(theme['td-header'], 'td-header')}
 				onClick={onHeaderClick}
 				onKeyDown={onHeaderKeyDown}
+				type="button"
 			>
 				<div className={classNames(theme['td-header-title'], 'td-header-title')}>
 					<span

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
@@ -8,6 +8,7 @@ exports[`#DefaultHeaderGrid should render DefaultHeaderGrid 1`] = `
     className="theme-td-header td-header"
     onClick={[Function]}
     onKeyDown={[Function]}
+    type="button"
   >
     <div
       className="theme-td-header-title td-header-title"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
by default, a button without type is set to submit. My datagrid is wrapped in a form, when i click on the header, my form is submitted

**What is the chosen solution to this problem?**
add type="button" to avoid it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
