### PR TITLE
feat(TUI-321/ComponentForm): add client side trigger

### DIFF
--- a/packages/containers/src/ComponentForm/kit/createTriggers.js
+++ b/packages/containers/src/ComponentForm/kit/createTriggers.js
@@ -182,6 +182,13 @@ export default function createTriggers({
 				trigger,
 			});
 		}
+		if (trigger.remote === false) {
+			const result = onSuccess();
+			if (result && result.then) {
+				return result.catch(onError);
+			}
+			return new Promise(resolve => resolve(result));
+		}
 		const fetchUrl = `${url}?${toQueryParam({
 			lang,
 			action: trigger.action,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

All triggers need a client side and remote implementation.
Goal is to enable to bypass the fetch for some triggers and just use a client function 
trigger will be the same as for suggestion but action will be "built_in_suggestable"  and a new trigger attribute "remote" will be set to false.

**What is the chosen solution to this problem?**

if remote is set to false do not call fetch, return promise in every case

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->