### PR TITLE
fix(datagrid): incorrect color after a horizontal scroll on the header

### DIFF
--- a/packages/datagrid/src/components/DataGrid/DataGrid.scss
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.scss
@@ -28,7 +28,7 @@ $td-datagrid-skeleton-height: 9.6rem !default;
 	}
 
 	/* ==== HEADER ==== */
-	:global(.ag-header-container) {
+	:global(.ag-header-viewport) {
 		background-color: $white;
 		color: $dove-gray;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
when i scroll horizontally, the header has a bad color 

**What is the chosen solution to this problem?**
apply the background on the good css 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
