### PR TITLE
fix(components/ObjectViewer): fix ie11 flex issue

### DIFF
--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.scss
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.scss
@@ -79,7 +79,7 @@
 		}
 
 		.complex-item {
-			flex: 1 1 100%;
+			flex: 1 1 auto;
 			border-left: solid 1px $alto;
 			margin-left: $padding-smaller;
 			max-width: 100%;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in IE11, flex items overflow the container
![image](https://user-images.githubusercontent.com/3214228/50475719-9b1a9880-0a00-11e9-9ca9-e2623c74d5cc.png)

**What is the chosen solution to this problem?**
Use `flex: 1 1 auto` instead of `flex: 1 1 100%`
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
