### PR TITLE
fix: SubHeader and Dialog headings

### DIFF
--- a/packages/components/src/ConfirmDialog/ConfirmDialog.test.js
+++ b/packages/components/src/ConfirmDialog/ConfirmDialog.test.js
@@ -8,7 +8,7 @@ import ConfirmDialog from './ConfirmDialog.component';
 
 function mockFakeComponent(name) {
 	const fakeComponent = ({ children, className, ...rest }) => {
-		const mergedClassName = classNames(className, name);
+		const mergedClassName = classNames(className, name, 'mocked-component');
 		return (
 			<div {...rest} className={mergedClassName}>
 				{children}
@@ -22,7 +22,6 @@ function mockFakeComponent(name) {
 	return fakeComponent;
 }
 
-jest.mock('react-dom');
 jest.mock('react-bootstrap/lib/Modal', () => {
 	const Modal = mockFakeComponent('Modal');
 	Modal.Header = mockFakeComponent('Header');

--- a/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
+++ b/packages/components/src/ConfirmDialog/__snapshots__/ConfirmDialog.test.js.snap
@@ -7,7 +7,7 @@ exports[`ConfirmDialog should render with a large container 1`] = `
   autoFocus={true}
   backdrop={true}
   bsSize="large"
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -16,25 +16,26 @@ exports[`ConfirmDialog should render with a large container 1`] = `
   show={true}
 >
   <div
-    className="Header"
+    className="Header mocked-component"
     closeButton={false}
   >
     <div
-      className="Title"
+      className="Title mocked-component"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
     </div>
   </div>
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
@@ -88,7 +89,7 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   autoFocus={true}
   backdrop={true}
   bsSize="large"
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -97,11 +98,12 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
   show={true}
 >
   <div
-    className="Header"
+    className="Header mocked-component"
     closeButton={false}
   >
     <div
-      className="Title"
+      className="Title mocked-component"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -127,14 +129,14 @@ exports[`ConfirmDialog should render with a progress bar 1`] = `
     />
   </div>
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
@@ -188,7 +190,7 @@ exports[`ConfirmDialog should render with a small container 1`] = `
   autoFocus={true}
   backdrop={true}
   bsSize="small"
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -197,25 +199,26 @@ exports[`ConfirmDialog should render with a small container 1`] = `
   show={true}
 >
   <div
-    className="Header"
+    className="Header mocked-component"
     closeButton={false}
   >
     <div
-      className="Title"
+      className="Title mocked-component"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
     </div>
   </div>
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
@@ -268,7 +271,7 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
   aria-modal="true"
   autoFocus={true}
   backdrop={true}
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -277,25 +280,26 @@ exports[`ConfirmDialog should render with additional actions 1`] = `
   show={true}
 >
   <div
-    className="Header"
+    className="Header mocked-component"
     closeButton={false}
   >
     <div
-      className="Title"
+      className="Title mocked-component"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
     </div>
   </div>
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
@@ -361,7 +365,7 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
   aria-modal="true"
   autoFocus={true}
   backdrop={true}
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -370,25 +374,26 @@ exports[`ConfirmDialog should render with defaults values 1`] = `
   show={true}
 >
   <div
-    className="Header"
+    className="Header mocked-component"
     closeButton={false}
   >
     <div
-      className="Title"
+      className="Title mocked-component"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
     </div>
   </div>
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"
@@ -441,7 +446,7 @@ exports[`ConfirmDialog should render without header 1`] = `
   aria-modal="true"
   autoFocus={true}
   backdrop={true}
-  className="Modal"
+  className="Modal mocked-component"
   enforceFocus={true}
   keyboard={true}
   onHide={[Function]}
@@ -450,14 +455,14 @@ exports[`ConfirmDialog should render without header 1`] = `
   show={true}
 >
   <div
-    className="Body"
+    className="Body mocked-component"
   >
     <div>
       BODY
     </div>
   </div>
   <div
-    className="Footer"
+    className="Footer mocked-component"
   >
     <div
       className="theme-tc-actionbar-container tc-actionbar-container nav"

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -68,7 +68,9 @@ function Dialog({
 					className={classNames({ informative: type === Dialog.TYPES.INFORMATIVE })}
 					closeButton={closeButton}
 				>
-					<Modal.Title id={headerId}>{header}</Modal.Title>
+					<Modal.Title id={headerId} componentClass="h1">
+						{header}
+					</Modal.Title>
 					{subtext &&
 						subtext.length && (
 							<h3 className={classNames({ error: error && error.length }, 'modal-subtitle')}>

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -71,12 +71,11 @@ function Dialog({
 					<Modal.Title id={headerId} componentClass="h1">
 						{header}
 					</Modal.Title>
-					{subtext &&
-						subtext.length && (
-							<h3 className={classNames({ error: error && error.length }, 'modal-subtitle')}>
-								{subtext}
-							</h3>
-						)}
+					{subtext && subtext.length && (
+						<h3 className={classNames({ error: error && error.length }, 'modal-subtitle')}>
+							{subtext}
+						</h3>
+					)}
 				</Modal.Header>
 			)}
 			{injected('after-modal-header')}

--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -35,8 +35,7 @@
 		}
 
 		.modal-title {
-			text-transform: inherit;
-			font-weight: bold;
+			text-transform: none;
 			line-height: 1;
 		}
 

--- a/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
+++ b/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
@@ -79,7 +79,7 @@ exports[`Dialog should render action 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -143,7 +143,7 @@ exports[`Dialog should render error 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -203,7 +203,7 @@ exports[`Dialog should render header 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -260,7 +260,7 @@ exports[`Dialog should render large 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -326,7 +326,7 @@ exports[`Dialog should render small 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world
@@ -390,7 +390,7 @@ exports[`Dialog should render subtitle 1`] = `
   >
     <ModalTitle
       bsClass="modal-title"
-      componentClass="h4"
+      componentClass="h1"
       id="tc-dialog-header"
     >
       Hello world

--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -17,12 +17,12 @@ export function PlainTextTitle({ componentClass, onEdit, disabled, text, inProgr
 	return (
 		<div className={theme['tc-editable-text-title']}>
 			<TooltipTrigger label={text} tooltipPlacement="bottom">
-				<componentClass
+				<ComponentClass
 					className={classNames(theme['tc-editable-text-wording'], 'tc-editable-text-wording')}
 					onDoubleClick={isDisabled ? undefined : onEdit}
 				>
 					{text}
-				</componentClass>
+				</ComponentClass>
 			</TooltipTrigger>
 			<Action
 				name="action-edit"

--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -11,17 +11,18 @@ import getDefaultT from '../translate';
 
 import I18N_DOMAIN_COMPONENTS from '../constants';
 
-export function PlainTextTitle({ onEdit, disabled, text, inProgress, feature, t }) {
+export function PlainTextTitle({ componentClass, onEdit, disabled, text, inProgress, feature, t }) {
 	const isDisabled = disabled || inProgress;
+	const ComponentClass = componentClass;
 	return (
 		<div className={theme['tc-editable-text-title']}>
 			<TooltipTrigger label={text} tooltipPlacement="bottom">
-				<span
+				<ComponentClass
 					className={classNames(theme['tc-editable-text-wording'], 'tc-editable-text-wording')}
 					onDoubleClick={isDisabled ? undefined : onEdit}
 				>
 					{text}
-				</span>
+				</ComponentClass>
 			</TooltipTrigger>
 			<Action
 				name="action-edit"
@@ -37,17 +38,18 @@ export function PlainTextTitle({ onEdit, disabled, text, inProgress, feature, t 
 		</div>
 	);
 }
-
 PlainTextTitle.propTypes = {
-	text: PropTypes.string.isRequired,
-	onEdit: PropTypes.func.isRequired,
+	componentClass: PropTypes.string,
 	disabled: PropTypes.bool,
-	inProgress: PropTypes.bool,
 	feature: PropTypes.string,
+	inProgress: PropTypes.bool,
+	onEdit: PropTypes.func.isRequired,
+	text: PropTypes.string.isRequired,
 	t: PropTypes.func,
 };
 
 PlainTextTitle.defaultProps = {
+	componentClass: 'span',
 	t: getDefaultT(),
 };
 
@@ -80,19 +82,20 @@ export function EditableTextComponent({ editMode, loading, inProgress, ...rest }
 EditableTextComponent.displayName = 'EditableText';
 
 EditableTextComponent.propTypes = {
-	text: PropTypes.string.isRequired,
-	editMode: PropTypes.bool,
-	loading: PropTypes.bool,
-	inProgress: PropTypes.bool,
-	onEdit: PropTypes.func.isRequired,
+	componentClass: PropTypes.string,
 	disabled: PropTypes.bool,
+	editMode: PropTypes.bool,
+	inProgress: PropTypes.bool,
+	loading: PropTypes.bool,
+	onEdit: PropTypes.func.isRequired,
+	text: PropTypes.string.isRequired,
 	t: PropTypes.func,
 };
 
 EditableTextComponent.defaultProps = {
 	editMode: false,
-	loading: false,
 	inProgress: false,
+	loading: false,
 	t: getDefaultT(),
 };
 

--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -17,12 +17,12 @@ export function PlainTextTitle({ componentClass, onEdit, disabled, text, inProgr
 	return (
 		<div className={theme['tc-editable-text-title']}>
 			<TooltipTrigger label={text} tooltipPlacement="bottom">
-				<ComponentClass
+				<componentClass
 					className={classNames(theme['tc-editable-text-wording'], 'tc-editable-text-wording')}
 					onDoubleClick={isDisabled ? undefined : onEdit}
 				>
 					{text}
-				</ComponentClass>
+				</componentClass>
 			</TooltipTrigger>
 			<Action
 				name="action-edit"
@@ -82,7 +82,7 @@ export function EditableTextComponent({ editMode, loading, inProgress, ...rest }
 EditableTextComponent.displayName = 'EditableText';
 
 EditableTextComponent.propTypes = {
-	componentClass: PropTypes.string,
+	componentClass: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 	disabled: PropTypes.bool,
 	editMode: PropTypes.bool,
 	inProgress: PropTypes.bool,

--- a/packages/components/src/EditableText/EditableText.scss
+++ b/packages/components/src/EditableText/EditableText.scss
@@ -6,19 +6,7 @@
 	overflow: hidden;
 }
 
-@mixin input-text($weight) {
-	color: $black;
-	font-size: $tc-input-editable-text-size-medium;
-	font-weight: $weight;
-}
-
-$tc-input-editable-text-size-large: 2.4rem !default;
-$tc-input-editable-text-size-medium: 1.4rem !default;
-$tc-input-editable-text-size-small: 1rem !default;
-$tc-input-editable-text-title-weight: 900 !default;
-$tc-input-editable-text-input-weight: $form-base-font-weight !default;
-
-$tc-icon-editable-text-size: 8px !default;
+$tc-icon-editable-text-size: 0.8rem !default;
 $tc-circle-editable-text-size: 16px !default;
 
 :global(.tc-editable-text-blink) {
@@ -40,7 +28,6 @@ $tc-circle-editable-text-size: 16px !default;
 	}
 
 	&-wording {
-		@include input-text($tc-input-editable-text-title-weight);
 		@include ellipsis;
 		flex: 0 1 auto;
 	}
@@ -70,7 +57,6 @@ $tc-circle-editable-text-size: 16px !default;
 		}
 
 		& .tc-editable-text-form-input {
-			@include input-text($tc-input-editable-text-input-weight);
 			width: 100%;
 			padding-right: 2 * $tc-circle-editable-text-size + $padding-large;
 			&::selection {

--- a/packages/components/src/EditableText/EditableText.test.js
+++ b/packages/components/src/EditableText/EditableText.test.js
@@ -6,15 +6,13 @@ import InlineForm from './InlineForm.component';
 
 describe('EditableText', () => {
 	let defaultProps;
-	beforeEach(
-		() =>
-			(defaultProps = {
-				text: 'my text',
-				feature: 'my.custom.feature',
-				onEdit: jest.fn(),
-				onSubmit: jest.fn(),
-			}),
-	);
+	beforeEach(() =>
+		(defaultProps = {
+			text: 'my text',
+			feature: 'my.custom.feature',
+			onEdit: jest.fn(),
+			onSubmit: jest.fn(),
+		}));
 	it('should render', () => {
 		const wrapper = shallow(<EditableTextComponent {...defaultProps} />);
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -39,6 +37,17 @@ describe('PlainTextTitle', () => {
 			text: 'text',
 			feature: 'my.custom.feature',
 			onEdit: jest.fn(),
+		};
+		const wrapper = shallow(<PlainTextTitle {...props} />);
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render provided component class', () => {
+		const props = {
+			text: 'text',
+			feature: 'my.custom.feature',
+			onEdit: jest.fn(),
+			componentClass: 'h1',
 		};
 		const wrapper = shallow(<PlainTextTitle {...props} />);
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/EditableText/EditableText.test.js
+++ b/packages/components/src/EditableText/EditableText.test.js
@@ -6,15 +6,13 @@ import InlineForm from './InlineForm.component';
 
 describe('EditableText', () => {
 	let defaultProps;
-	beforeEach(
-		() =>
-			(defaultProps = {
-				text: 'my text',
-				feature: 'my.custom.feature',
-				onEdit: jest.fn(),
-				onSubmit: jest.fn(),
-			}),
-	);
+	beforeEach(() =>
+		(defaultProps = {
+			text: 'my text',
+			feature: 'my.custom.feature',
+			onEdit: jest.fn(),
+			onSubmit: jest.fn(),
+		}));
 	it('should render', () => {
 		const wrapper = shallow(<EditableTextComponent {...defaultProps} />);
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/EditableText/EditableText.test.js
+++ b/packages/components/src/EditableText/EditableText.test.js
@@ -6,13 +6,15 @@ import InlineForm from './InlineForm.component';
 
 describe('EditableText', () => {
 	let defaultProps;
-	beforeEach(() =>
-		(defaultProps = {
-			text: 'my text',
-			feature: 'my.custom.feature',
-			onEdit: jest.fn(),
-			onSubmit: jest.fn(),
-		}));
+	beforeEach(
+		() =>
+			(defaultProps = {
+				text: 'my text',
+				feature: 'my.custom.feature',
+				onEdit: jest.fn(),
+				onSubmit: jest.fn(),
+			}),
+	);
 	it('should render', () => {
 		const wrapper = shallow(<EditableTextComponent {...defaultProps} />);
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/EditableText/__snapshots__/EditableText.test.js.snap
+++ b/packages/components/src/EditableText/__snapshots__/EditableText.test.js.snap
@@ -5,6 +5,7 @@ exports[`EditableText should render 1`] = `
   className="theme-tc-editable-text tc-editable-text"
 >
   <PlainTextTitle
+    componentClass="span"
     feature="my.custom.feature"
     inProgress={false}
     onEdit={[MockFunction]}
@@ -37,6 +38,7 @@ exports[`EditableText should render inProgress 1`] = `
   className="theme-tc-editable-text tc-editable-text theme-tc-editable-text-blink tc-editable-text-blink"
 >
   <PlainTextTitle
+    componentClass="span"
     feature="my.custom.feature"
     inProgress={true}
     onEdit={[MockFunction]}
@@ -110,6 +112,34 @@ exports[`PlainTextTitle should render 1`] = `
     >
       text
     </span>
+  </TooltipTrigger>
+  <Action
+    bsStyle="link"
+    className="theme-tc-editable-text-pencil tc-editable-text-pencil"
+    data-feature="my.custom.feature"
+    hideLabel={true}
+    icon="talend-pencil"
+    label="Edit"
+    name="action-edit"
+    onClick={[MockFunction]}
+  />
+</div>
+`;
+
+exports[`PlainTextTitle should render provided component class 1`] = `
+<div
+  className="theme-tc-editable-text-title"
+>
+  <TooltipTrigger
+    label="text"
+    tooltipPlacement="bottom"
+  >
+    <h1
+      className="theme-tc-editable-text-wording tc-editable-text-wording"
+      onDoubleClick={[MockFunction]}
+    >
+      text
+    </h1>
   </TooltipTrigger>
   <Action
     bsStyle="link"

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -49,6 +49,7 @@ function TitleSubHeader({
 							text={title}
 							inProgress={inProgress}
 							feature="subheaderbar.rename"
+							componentClass="h1"
 							{...rest}
 						/>
 					) : (

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
@@ -6,15 +6,8 @@
 	overflow: hidden;
 }
 
-@mixin input-text($weight) {
-	color: $black;
-	font-size: $tc-input-subheader-size-medium;
-	font-weight: $weight;
-}
-
 $tc-input-subheader-size-large: 2.4rem !default;
 $tc-input-subheader-size-medium: 1.4rem !default;
-$tc-input-subheader-title-weight: 900 !default;
 
 :global(.tc-subheader-details-blink) {
 	@include heartbeat(object-blink);
@@ -48,19 +41,26 @@ $tc-input-subheader-title-weight: 900 !default;
 
 			&-wording,
 			&-wording-button {
-				@include input-text($tc-input-subheader-title-weight);
 				@include ellipsis;
+				line-height: unset;
 				margin: 0;
 			}
 
-			:global(.tc-editable-text-form-input) {
-				width: 30rem;
+			:global{
+				.tc-editable-text-wording {
+					line-height: unset;
+					margin: 0;
+				}
+
+				.tc-editable-text-form-input {
+					width: 30rem;
+				}
 			}
 		}
 
 		&-subtitle {
 			@include ellipsis;
-			color: $dark-silver;
+			color: $black;
 			font-size: $tc-input-subheader-size-medium;
 		}
 	}

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
@@ -46,7 +46,7 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 				margin: 0;
 			}
 
-			:global{
+			:global {
 				.tc-editable-text-wording {
 					line-height: unset;
 					margin: 0;

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -5,12 +5,14 @@ import TitleSubHeader from './TitleSubHeader.component';
 
 describe('TitleSubHeader', () => {
 	let defaultProps;
-	beforeEach(() =>
-		(defaultProps = {
-			title: 'myTitle',
-			onEdit: jest.fn(),
-			onSubmit: jest.fn(),
-		}));
+	beforeEach(
+		() =>
+			(defaultProps = {
+				title: 'myTitle',
+				onEdit: jest.fn(),
+				onSubmit: jest.fn(),
+			}),
+	);
 	it('should render', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} iconId="myIconId" />);
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -5,14 +5,12 @@ import TitleSubHeader from './TitleSubHeader.component';
 
 describe('TitleSubHeader', () => {
 	let defaultProps;
-	beforeEach(
-		() =>
-			(defaultProps = {
-				title: 'myTitle',
-				onEdit: jest.fn(),
-				onSubmit: jest.fn(),
-			}),
-	);
+	beforeEach(() =>
+		(defaultProps = {
+			title: 'myTitle',
+			onEdit: jest.fn(),
+			onSubmit: jest.fn(),
+		}));
 	it('should render', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} iconId="myIconId" />);
 		expect(wrapper.getElement()).toMatchSnapshot();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dialogs and Subheader titles should be h1, without custom font style.

**What is the chosen solution to this problem?**
* fix the markup
* remove style
* editable text accepts now a componentClass props

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

The text mode style in EditableText has changed. We don't apply any default font style because you can insert any component you'd like.
To have the same rendering as before you must style yourself the text

```css
.tc-editable-text-wording {
	color: $black;
	font-size: 1.4rem;
	font-weight: 900;
}
```


<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
