### PR TITLE
fix(TPSVC-7304): add min and max attributes to text input

### DIFF
--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -15,8 +15,6 @@ export default function Text(props) {
 		readOnly = false,
 		title,
 		type,
-		minimum,
-		maximum,
 	} = schema;
 
 	if (type === 'hidden') {
@@ -50,8 +48,8 @@ export default function Text(props) {
 				readOnly={readOnly}
 				type={type}
 				value={value}
-				min={minimum}
-				max={maximum}
+				min={schema.schema.minimum}
+				max={schema.schema.maximum}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes
 				aria-invalid={!isValid}
 				aria-required={schema.required}
@@ -76,8 +74,7 @@ if (process.env.NODE_ENV !== 'production') {
 			readOnly: PropTypes.bool,
 			title: PropTypes.string,
 			type: PropTypes.string,
-			minimum: PropTypes.number,
-			maximum: PropTypes.number,
+			schema: PropTypes.object,
 		}),
 		value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	};

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -15,6 +15,8 @@ export default function Text(props) {
 		readOnly = false,
 		title,
 		type,
+		minimum,
+		maximum,
 	} = schema;
 
 	if (type === 'hidden') {
@@ -48,6 +50,8 @@ export default function Text(props) {
 				readOnly={readOnly}
 				type={type}
 				value={value}
+				min={minimum}
+				max={maximum}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes
 				aria-invalid={!isValid}
 				aria-required={schema.required}
@@ -72,6 +76,8 @@ if (process.env.NODE_ENV !== 'production') {
 			readOnly: PropTypes.bool,
 			title: PropTypes.string,
 			type: PropTypes.string,
+			minimum: PropTypes.number,
+			maximum: PropTypes.number,
 		}),
 		value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	};

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -11,6 +11,9 @@ describe('Text field', () => {
 		required: true,
 		title: 'My input title',
 		type: 'text',
+		schema: {
+			type: 'string',
+		},
 	};
 
 	it('should render input', () => {
@@ -101,7 +104,11 @@ describe('Text field', () => {
 		// given
 		const minSchema = {
 			...schema,
-			minimum: 0,
+			schema: {
+				...schema.schema,
+				type: 'number',
+				minimum: 0,
+			}
 		};
 
 		// when
@@ -125,7 +132,11 @@ describe('Text field', () => {
 		// given
 		const maxSchema = {
 			...schema,
-			maximum: 10,
+			schema: {
+				...schema.schema,
+				type: 'number',
+				maximum: 10,
+			}
 		};
 
 		// when

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -97,6 +97,54 @@ describe('Text field', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render input with min attribute', () => {
+		// given
+		const minSchema = {
+			...schema,
+			minimum: 0,
+		};
+
+		// when
+		const wrapper = shallow(
+			<Text
+				id={'myForm'}
+				isValid
+				errorMessage={'My error message'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={minSchema}
+				value={'toto'}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render input with max attribute', () => {
+		// given
+		const maxSchema = {
+			...schema,
+			maximum: 10,
+		};
+
+		// when
+		const wrapper = shallow(
+			<Text
+				id={'myForm'}
+				isValid
+				errorMessage={'My error message'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={maxSchema}
+				value={'toto'}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	it('should trigger onChange', () => {
 		// given
 		const onChange = jest.fn();

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -108,7 +108,7 @@ describe('Text field', () => {
 				...schema.schema,
 				type: 'number',
 				minimum: 0,
-			}
+			},
 		};
 
 		// when
@@ -136,7 +136,7 @@ describe('Text field', () => {
 				...schema.schema,
 				type: 'number',
 				maximum: 10,
-			}
+			},
 		};
 
 		// when

--- a/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
@@ -68,6 +68,68 @@ exports[`Text field should render input 1`] = `
 </FieldTemplate>
 `;
 
+exports[`Text field should render input with max attribute 1`] = `
+<FieldTemplate
+  description="my text input hint"
+  descriptionId="myForm-description"
+  errorId="myForm-error"
+  errorMessage="My error message"
+  id="myForm"
+  isValid={true}
+  label="My input title"
+  labelAfter={true}
+  required={true}
+>
+  <input
+    aria-describedby="myForm-description myForm-error"
+    aria-invalid={false}
+    aria-required={true}
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="myForm"
+    max={10}
+    onBlur={[Function]}
+    onChange={[Function]}
+    placeholder="Type something here"
+    readOnly={false}
+    type="text"
+    value="toto"
+  />
+</FieldTemplate>
+`;
+
+exports[`Text field should render input with min attribute 1`] = `
+<FieldTemplate
+  description="my text input hint"
+  descriptionId="myForm-description"
+  errorId="myForm-error"
+  errorMessage="My error message"
+  id="myForm"
+  isValid={true}
+  label="My input title"
+  labelAfter={true}
+  required={true}
+>
+  <input
+    aria-describedby="myForm-description myForm-error"
+    aria-invalid={false}
+    aria-required={true}
+    autoFocus={true}
+    className="form-control"
+    disabled={false}
+    id="myForm"
+    min={0}
+    onBlur={[Function]}
+    onChange={[Function]}
+    placeholder="Type something here"
+    readOnly={false}
+    type="text"
+    value="toto"
+  />
+</FieldTemplate>
+`;
+
 exports[`Text field should render password input 1`] = `
 <FieldTemplate
   description="my text input hint"

--- a/packages/forms/stories-core/json/fields/core-text.json
+++ b/packages/forms/stories-core/json/fields/core-text.json
@@ -10,6 +10,11 @@
       "number": {
         "type": "number"
       },
+      "numberMinMax": {
+        "type": "number",
+        "minimum": 1,
+        "maximum": 10
+      },
       "password": {
         "type": "string"
       }
@@ -23,6 +28,10 @@
     {
       "key": "number",
       "title": "Number"
+    },
+    {
+      "key": "numberMinMax",
+      "title": "Number (with min and max)"
     },
     {
       "key": "password",

--- a/packages/forms/stories-core/json/fields/core-text.json
+++ b/packages/forms/stories-core/json/fields/core-text.json
@@ -12,8 +12,8 @@
       },
       "numberMinMax": {
         "type": "number",
-        "minimum": 1,
-        "maximum": 10
+        "minimum": 0,
+        "maximum": 7
       },
       "password": {
         "type": "string"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
restrict user input by using arrows on the text field input with type number
https://jira.talendforge.org/browse/TPSVC-7304

**What is the chosen solution to this problem?**
min and max attributes can solve this problems in native html way.
It allows manually set any number, but restrict setting numbers out of min and max boundaries.