### PR TITLE
fix(forms/number): Emptying number input result in NaN error

### DIFF
--- a/npm-audit/audit.json
+++ b/npm-audit/audit.json
@@ -1,4 +1,18 @@
 === npm audit security report ===                        
                                                                                 
-found 0 vulnerabilities
- in 66653 scanned packages
+# Run  npm install webpack-dev-server@3.1.14  to resolve 1 vulnerability
+┌───────────────┬──────────────────────────────────────────────────────────────┐
+│ High          │ Missing Origin Validation                                    │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Package       │ webpack-dev-server                                           │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Dependency of │ webpack-dev-server                                           │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ Path          │ webpack-dev-server                                           │
+├───────────────┼──────────────────────────────────────────────────────────────┤
+│ More info     │ https://nodesecurity.io/advisories/725                       │
+└───────────────┴──────────────────────────────────────────────────────────────┘
+
+
+found 1 high severity vulnerability in 66653 scanned packages
+  run `npm audit fix` to fix 1 of them.

--- a/packages/forms/src/UIForm/utils/properties.js
+++ b/packages/forms/src/UIForm/utils/properties.js
@@ -19,6 +19,9 @@ export function getValue(properties, schema) {
  */
 export function convertValue(type, value) {
 	if (type === 'number') {
+		if (value === '') {
+			return undefined;
+		}
 		return parseFloat(value);
 	}
 	return value;

--- a/packages/forms/src/UIForm/utils/properties.test.js
+++ b/packages/forms/src/UIForm/utils/properties.test.js
@@ -58,6 +58,14 @@ describe('Properties utils', () => {
 			// then
 			expect(convertedValue).toBe(3.5);
 		});
+
+		it('should convert empty string to undefined value', () => {
+			const value = '';
+
+			const convertedValue = convertValue('number', value);
+
+			expect(convertedValue).toBeUndefined();
+		});
 	});
 
 	describe('#mutateValue', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Emptying an input (type something then remove it) of type "number" result to the following error : 
![screenshot from 2019-01-03 11-37-45](https://user-images.githubusercontent.com/38074242/50633643-5d5fc780-0f4c-11e9-9479-a87740b129d1.png)
Whenever the field is required or not.

**What is the chosen solution to this problem?**
Convert empty string input value to `undefined` to avoid converting it to `NaN`.
The conversion occurs after each input `onChange`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
