### PR TITLE
fix(Typeahead): dropdown display

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -12,7 +12,7 @@ src/FilterBar/FilterBar.scss
 
 src/Typeahead/Typeahead.scss
   34:5  error  Mixins should come before declarations  mixins-before-declarations
-  83:5  error  Nesting depth 4 greater than max of 3   nesting-depth
+  90:5  error  Nesting depth 4 greater than max of 3   nesting-depth
 
 src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
   2:24  error  Strings must use single quotes  quotes

--- a/packages/components/src/Datalist/Datalist.scss
+++ b/packages/components/src/Datalist/Datalist.scss
@@ -1,8 +1,5 @@
-$tc-datalist-items-background-color: $white !default;
-$tc-datalist-items-max-height: 320px !default;
-$tc-datalist-items-shadow-color: $shadow !default;
-$tc-typeahead-input-width: 260px !default;
-$tc-datalist-item-height: 40px !default;
+$tc-datalist-items-max-height: 32rem !default;
+$tc-datalist-item-height: 4rem !default;
 
 .tc-datalist-form {
 	width: 100%;
@@ -17,19 +14,7 @@ $tc-datalist-item-height: 40px !default;
 }
 
 .items-container {
-	display: flex;
-	flex-direction: column;
-	position: absolute;
-	top: 100%;
-	right: 0;
-	left: 0;
 	max-height: $tc-datalist-items-max-height;
-	min-width: $tc-typeahead-input-width;
-	font-size: 1.5rem;
-	background-color: $tc-datalist-items-background-color;
-	border-radius: $border-radius-base;
-	box-shadow: 0 1px 3px 0 $tc-datalist-items-shadow-color;
-	overflow-y: auto;
 	z-index: 999;
 
 	:global(.tc-typeahead-section-container) {

--- a/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
+++ b/packages/components/src/HeaderBar/__snapshots__/HeaderBar.snapshot.test.js.snap
@@ -1782,7 +1782,7 @@ exports[`Storyshots HeaderBar while searching 1`] = `
               />
             </div>
             <div
-              className="theme-items-container tc-typeahead-items-container theme-item-container"
+              className="theme-items-container tc-typeahead-items-container theme-items-container theme-container-open"
               id="react-autowhatever-42"
               role="listbox"
             >
@@ -4961,7 +4961,7 @@ exports[`Storyshots HeaderBar with no search result 1`] = `
               />
             </div>
             <div
-              className="theme-items-container tc-typeahead-items-container theme-item-container"
+              className="theme-items-container tc-typeahead-items-container theme-items-container theme-container-open"
               id="react-autowhatever-42"
               role="listbox"
             >
@@ -6532,7 +6532,7 @@ exports[`Storyshots HeaderBar with search input 1`] = `
               />
             </div>
             <div
-              className="theme-items-container tc-typeahead-items-container theme-item-container"
+              className="theme-items-container tc-typeahead-items-container theme-items-container"
               id="react-autowhatever-42"
               role="listbox"
             />
@@ -7309,7 +7309,7 @@ exports[`Storyshots HeaderBar with search results 1`] = `
               />
             </div>
             <div
-              className="theme-items-container tc-typeahead-items-container theme-item-container"
+              className="theme-items-container tc-typeahead-items-container theme-items-container"
               id="react-autowhatever-42"
               role="listbox"
             >

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -68,7 +68,9 @@ export function renderItemsContainerFactory(
 		const { id, ref, containerProps, children } = props;
 		const { className, ...restProps } = containerProps;
 
-		const containerClassName = classNames(className, theme['item-container'], {});
+		const containerClassName = classNames(className, theme['items-container'], {
+			[theme['container-open']]: searching || noResult,
+		});
 
 		let content;
 		if (searching) {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -1,7 +1,7 @@
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 $tc-typeahead-input-color: #000 !default;
-$tc-typeahead-input-width: 262px !default;
+$tc-typeahead-input-width: 26rem !default;
 
 $tc-typeahead-opened-items-container-color: #aaa !default;
 $tc-typeahead-opened-items-container-background-color: #fff !default;
@@ -28,7 +28,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 
 	&.loading {
 		.typeahead-input-icon,
-		.item-container {
+		.items-container {
 			> * {
 				color: inherit;
 				@include heartbeat(object-blink);
@@ -59,6 +59,13 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 			left: auto;
 		}
 	}
+
+	.container-open,
+	 &.container-open .items-container {
+		 display: block;
+		 padding-top: 1px;
+		 padding-bottom: 1px;
+	 }
 }
 
 .typeahead-input {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -61,11 +61,11 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 	}
 
 	.container-open,
-	 &.container-open .items-container {
-		 display: block;
-		 padding-top: 1px;
-		 padding-bottom: 1px;
-	 }
+	&.container-open .items-container {
+		display: block;
+		padding-top: 1px;
+		padding-bottom: 1px;
+	}
 }
 
 .typeahead-input {

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -33,7 +33,7 @@ exports[`Typeahead injection should use render props to inject extra components 
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -137,7 +137,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -370,7 +370,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container theme-container-open"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -416,7 +416,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -591,7 +591,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -675,7 +675,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container theme-container-open"
     id="react-autowhatever-my-search"
     role="listbox"
   >
@@ -722,7 +722,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   />
@@ -765,7 +765,7 @@ exports[`Typeahead should pass input extra props 1`] = `
     />
   </div>
   <div
-    className="theme-items-container tc-typeahead-items-container theme-item-container"
+    className="theme-items-container tc-typeahead-items-container theme-items-container"
     id="react-autowhatever-my-search"
     role="listbox"
   />

--- a/packages/forms/src/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -54,7 +54,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget 1`] = `
 
 exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = `
 <div
-  className="theme-items-container items-container theme-item-container"
+  className="theme-items-container items-container theme-items-container"
   id="react-autowhatever-42"
   key="react-autowhatever-42-items-container"
   role="listbox"
@@ -90,7 +90,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
 
 exports[`MultiSelectTagWidget should render section title when items has category 1`] = `
 <div
-  className="theme-items-container items-container theme-item-container"
+  className="theme-items-container items-container theme-items-container"
   id="react-autowhatever-42"
   key="react-autowhatever-42-items-container"
   role="listbox"
@@ -145,7 +145,7 @@ exports[`MultiSelectTagWidget should render section title when items has categor
 
 exports[`MultiSelectTagWidget should take default message when there isnt items 1`] = `
 <div
-  className="theme-items-container items-container theme-item-container"
+  className="theme-items-container items-container theme-items-container theme-container-open"
   id="react-autowhatever-42"
   key="react-autowhatever-42-items-container"
   role="listbox"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Typeahead doesn't display the dropdown anymore.
It's a regression, du to an unwanted css removal.

**What is the chosen solution to this problem?**
Restore that, when
- react-autowhatever opens it
- when there is no result (no result message)
- when it is searching (searching message)

Remove duplicated style in datalist css

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
