### PR TITLE
fix(tui-97/filterbar): set padding in tc-list-toolbar

### DIFF
--- a/packages/components/src/FilterBar/FilterBar.scss
+++ b/packages/components/src/FilterBar/FilterBar.scss
@@ -83,7 +83,7 @@ $tc-filter-bar-width: 250px !default;
 	background-color: $tc-filter-bar-highlight-color;
 }
 
-:global(.tc-list-toolbar) .filter{
+:global(.tc-list-toolbar) .filter {
 	margin-top: 9px;
 	margin-bottom: 9px;
 }

--- a/packages/components/src/FilterBar/FilterBar.scss
+++ b/packages/components/src/FilterBar/FilterBar.scss
@@ -83,6 +83,11 @@ $tc-filter-bar-width: 250px !default;
 	background-color: $tc-filter-bar-highlight-color;
 }
 
+:global(.tc-list-toolbar) .filter{
+	margin-top: 9px;
+	margin-bottom: 9px;
+}
+
 @keyframes reveal {
 	0% {
 		opacity: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The filterbar in the the list toolbar is not well aligned.
It create in some case an ugly visual effect.

**What is the chosen solution to this problem?**

update the margin when in the list toolbar

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
