### PR TITLE
feat(Dialog): remove specific title style

### DIFF
--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -35,7 +35,6 @@
 		}
 
 		.modal-title {
-			text-transform: none;
 			line-height: 1;
 		}
 

--- a/packages/theme/src/theme/_modals.scss
+++ b/packages/theme/src/theme/_modals.scss
@@ -31,13 +31,6 @@
 		}
 
 		.modal {
-			&-title {
-				font-size: 16px;
-				color: $modal-header-color;
-				font-weight: 900;
-				text-transform: uppercase;
-			}
-
 			&-subtitle {
 				font-size: 14px;
 				color: $dark-silver;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The new guideline on headings impacts Dialog boxes too.
But they have specific style defined in the theme and components.

**What is the chosen solution to this problem?**
Remove all those dialog title style, letting the headings style application.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
