### PR TITLE
feat(router): add support for registerFunctions

### DIFF
--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -10,7 +10,11 @@ First add it to your bootstrap app
 import cmf from '@talend/react-cmf';
 import getRouter from '@talend/react-cmf-router';
 
-const router = getRouter({ history, sagaRouterConfig });
+const routerFunctions = {
+    // key for OnEnter/onLeave in router config: value is the function
+};
+
+const router = getRouter({ history, sagaRouterConfig, routerFunctions });
 
 cmf.bootstrap({
     modules: [router.cmfModule],

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -8,9 +8,18 @@ import expressions from './expressions';
 import sagaRouter from './sagaRouter';
 import * as selectors from './selectors';
 import documentTitle from './sagas/documentTitle';
+import { REGISTRY_HOOK_PREFIX } from './route';
 
 function getModule(options = {}) {
 	const history = options.history || hashHistory;
+	const registry = {};
+	if (options.routerFunctions) {
+		Object.keys(options.routerFunctions).reduce((acc, key) => {
+			// eslint-disable-next-line no-param-reassign
+			acc[`${REGISTRY_HOOK_PREFIX}:${key}`] = options.routerFunctions[key];
+			return acc;
+		}, registry);
+	}
 	function* saga() {
 		yield fork(documentTitle);
 		if (options.sagaRouterConfig) {
@@ -36,6 +45,7 @@ function getModule(options = {}) {
 			middlewares,
 			saga,
 			storeCallback,
+			registry,
 		},
 		RootComponent: Router,
 	};

--- a/packages/router/src/index.test.js
+++ b/packages/router/src/index.test.js
@@ -1,0 +1,11 @@
+import getModule from './index';
+
+describe('getModule', () => {
+	it('should support routerFunctions', () => {
+		const routerFunctions = {
+			foo: jest.fn(),
+		};
+		const mod = getModule({ routerFunctions });
+		expect(mod.cmfModule.registry).toEqual({ '_.route.hook:foo': routerFunctions.foo });
+	});
+});

--- a/packages/router/src/route.js
+++ b/packages/router/src/route.js
@@ -10,7 +10,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import cmf, { cmfConnect } from '@talend/react-cmf';
 
-const REGISTRY_HOOK_PREFIX = '_.route.hook';
+export const REGISTRY_HOOK_PREFIX = '_.route.hook';
 
 /**
  * register a function for the router configuration


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

@sgendre report he can t use registerFunctions.

**What is the chosen solution to this problem?**

add new routerFunctions entry in getRouter main function

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->