### PR TITLE
chore(talend-html-webpack-plugin): webpack 4 support

### DIFF
--- a/packages/html-webpack-plugin/index.js
+++ b/packages/html-webpack-plugin/index.js
@@ -1,45 +1,59 @@
+const htmlWebpackPlugin = require('html-webpack-plugin');
 const AppLoader = require('@talend/react-components/lib/AppLoader/constant').default;
 
 function TalendHTMLOptimize(options) {
 	this.options = options;
 }
 
-TalendHTMLOptimize.prototype.apply = function myapply(compiler) {
+TalendHTMLOptimize.prototype.process = function process(data) {
 	const options = this.options || {};
-	compiler.plugin('compilation', compilation => {
-		compilation.plugin('html-webpack-plugin-alter-asset-tags', data => {
-			if (options.bodyBefore) {
-				data.body = options.bodyBefore.concat(data.body);
+	if (options.bodyBefore) {
+		data.body = options.bodyBefore.concat(data.body);
+	}
+	if (options.loadCSSAsync) {
+		data.head = data.head.map(head => {
+			if (head.tagName !== 'link') {
+				return head;
 			}
-			if (options.loadCSSAsync) {
-				data.head = data.head.map(head => {
-					if (head.tagName !== 'link') {
-						return head;
-					}
-					const media = head.attributes.media || 'all';
-					head.attributes.media = 'none';
-					head.attributes.onload = `if(media!='${media}')media='${media}'`;
-					return head;
-				});
-			}
-			if (options.versions) {
-				data.body.splice(0, 0, {
-					tagName: 'script',
-					closeTag: true,
-					innerHTML: `TALEND_APP_INFO=${JSON.stringify(options.versions)}`,
-					attributes: { type: 'text/javascript' },
-				});
-			}
-			if (options.appLoaderIcon) {
-				data.head.splice(0, 0, {
-					tagName: 'style',
-					closeTag: true,
-					innerHTML: AppLoader.getLoaderStyle(options.appLoaderIcon),
-				});
-			}
-			return data;
+			const media = head.attributes.media || 'all';
+			head.attributes.media = 'none';
+			head.attributes.onload = `if(media!='${media}')media='${media}'`;
+			return head;
 		});
-	});
+	}
+	if (options.versions) {
+		data.body.splice(0, 0, {
+			tagName: 'script',
+			closeTag: true,
+			innerHTML: `TALEND_APP_INFO=${JSON.stringify(options.versions)}`,
+			attributes: { type: 'text/javascript' },
+		});
+	}
+	if (options.appLoaderIcon) {
+		data.head.splice(0, 0, {
+			tagName: 'style',
+			closeTag: true,
+			innerHTML: AppLoader.getLoaderStyle(options.appLoaderIcon),
+		});
+	}
+	return data;
+};
+
+TalendHTMLOptimize.prototype.apply = function myapply(compiler) {
+	if (compiler.hooks) {
+		compiler.hooks.compilation.tap('TalendHtmlWebpackPlugin', compilation => {
+			if (htmlWebpackPlugin.getHooks) {
+				// htmlWebpackPlugin @Next
+				const hooks = htmlWebpackPlugin.getHooks(compilation);
+				return (
+					hooks &&
+					hooks.alterAssetTags &&
+					hooks.alterAssetTags.tap('TalendHtmlWebpackPlugin', data => this.process(data))
+				);
+			}
+			return compilation.plugin('html-webpack-plugin-alter-asset-tags', data => this.process(data));
+		});
+	}
 };
 
 module.exports = TalendHTMLOptimize;

--- a/packages/html-webpack-plugin/package.json
+++ b/packages/html-webpack-plugin/package.json
@@ -19,7 +19,8 @@
     "eslint": "^4.0.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.16.0",
-    "jest": "^23.6.0"
+    "jest": "^23.6.0",
+    "html-webpack-plugin": "3.2.0"
   },
   "peerDependencies": {
     "@talend/react-components": "1.10.0"

--- a/packages/html-webpack-plugin/package.json
+++ b/packages/html-webpack-plugin/package.json
@@ -19,8 +19,8 @@
     "eslint": "^4.0.0",
     "eslint-config-airbnb": "^11.1.0",
     "eslint-plugin-import": "^1.16.0",
-    "jest": "^23.6.0",
-    "html-webpack-plugin": "3.2.0"
+    "html-webpack-plugin": "3.2.0",
+    "jest": "^23.6.0"
   },
   "peerDependencies": {
     "@talend/react-components": "1.10.0"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Our `talend-html-webpack-plugin` uses `html-webpack-plugin` hook but it's not compatible with Webpack 4.

**What is the chosen solution to this problem?**
Add Webpack 4 support as proposed [here](https://github.com/hxlniada/webpack-concat-plugin/pull/71/files#diff-168726dbe96b3ce427e7fedce31bb0bcR346)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
