### PR TITLE
fix(frontend): TMC-15611 allow spaces (%20) on GIT url validation

### DIFF
--- a/packages/forms/src/UIForm/customFormats.js
+++ b/packages/forms/src/UIForm/customFormats.js
@@ -1,14 +1,14 @@
 const emailRegExp = /^[a-zA-Z][a-zA-Z0-9-.]+@[a-zA-Z-]+\.[a-zA-Z-]+$/;
-const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_]+)?$/;
+const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%+]+)?$/;
 /* eslint-disable max-len */
 // Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_]+)(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
-const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_]+)(\.git)?(\/)?$/;
+const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%+]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
+const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
+const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
-const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~]+)(\.git)?(\/)?$/;
+const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
 /* eslint-disable max-len */
 
 const urlGit = new RegExp(

--- a/packages/forms/src/UIForm/customFormats.js
+++ b/packages/forms/src/UIForm/customFormats.js
@@ -1,13 +1,13 @@
 const emailRegExp = /^[a-zA-Z][a-zA-Z0-9-.]+@[a-zA-Z-]+\.[a-zA-Z-]+$/;
 const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%]+)?$/;
 /* eslint-disable max-len */
-// Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_]+)(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
+// Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_%]+)(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
 const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%]+)(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
+// Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~%]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
 const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
+// Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~%]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
 const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
-// Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
+// Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~%]+)(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
 const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
 /* eslint-disable max-len */
 

--- a/packages/forms/src/UIForm/customFormats.js
+++ b/packages/forms/src/UIForm/customFormats.js
@@ -1,14 +1,14 @@
 const emailRegExp = /^[a-zA-Z][a-zA-Z0-9-.]+@[a-zA-Z-]+\.[a-zA-Z-]+$/;
-const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%+]+)?$/;
+const urlHttpOrHttpsRegExp = /^(http(s)?:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%]+)?$/;
 /* eslint-disable max-len */
 // Format usable in regex101 : (?<http>^http(s)?\:\/\/)(?<userHTTP>[a-zA-Z0-9\.\-_]+\@)?(?<hostHTTP>[a-zA-Z0-9\.\-_]+)(?<portHTTP>:[0-9]+)?(?<pathHTTP>\/[a-zA-Z0-9\/\.\-_]+)(?<extensionHTTP>\.git)?(?<slashHTTP>\/)?$
-const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%+]+)(\.git)?(\/)?$/;
+const urlGitProtocoltHttp = /(^http(s)?:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_%]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<ssh>^ssh\:\/\/)(?<userSSH>[a-zA-Z0-9\.\-_]+\@)?(?<hostSSH>[a-zA-Z0-9\.\-_]+)(?<portSSH>:[0-9]+)?(?<pathSSH>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
+const urlGitProtocolSsh = /(^ssh:\/\/)([a-zA-Z0-9.\-_]+@)?([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<userSSH>^[a-zA-Z0-9\.\-_]+\@)(?<hostSSH>[a-zA-Z0-9\.\-_]+)(:)(?<portSSH>[0-9]+)?(?<pathSSH>[a-zA-Z0-9\.\-_~]+)(?<pathSSH2>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionSSH>\.git)?(?<slashSSH>\/)?$
-const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
+const urlGitProtocolSshScpLike = /(^[a-zA-Z0-9.\-_]+@)([a-zA-Z0-9.\-_]+)(:)([0-9]+)?([a-zA-Z0-9.\-_~]+)(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
 // Format usable in regex101 : (?<git>^git\:\/\/)(?<hostGIT>[a-zA-Z0-9\.\-_]+)(?<portGIT>:[0-9]+)?(?<pathGIT>\/[a-zA-Z0-9\/\.\-_~]+)(?<extensionGIT>\.git)?(?<slashGIT>\/)?$
-const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%+]+)(\.git)?(\/)?$/;
+const urlGitProtocolGit = /(^git:\/\/)([a-zA-Z0-9.\-_]+)(:[0-9]+)?(\/[a-zA-Z0-9/.\-_~%]+)(\.git)?(\/)?$/;
 /* eslint-disable max-len */
 
 const urlGit = new RegExp(

--- a/packages/forms/src/UIForm/customFormats.test.js
+++ b/packages/forms/src/UIForm/customFormats.test.js
@@ -48,7 +48,7 @@ describe('custom formats', () => {
 		// then
 		expect(resultIpPortOK).toBe(null);
 
-		const resultSpaceOK = customValidation['url-http-https']('https://test.domain.com/path%20with%20space/and+plus+character');
+		const resultSpaceOK = customValidation['url-http-https']('https://test.domain.com/path%20with%20space');
 		// then
 		expect(resultSpaceOK).toBe(null);
 
@@ -104,7 +104,7 @@ describe('custom formats', () => {
 		const gitResultHttpOK11 = customValidation['url-git']('http://user@host.com:999/sd.git');
 		expect(gitResultHttpOK11).toBe(null);
 
-		const gitResultHttpOK12 = customValidation['url-git']('https://host.xz:999/path%20space/to%20space/repo+with+plus');
+		const gitResultHttpOK12 = customValidation['url-git']('https://host.xz:999/path%20space/to%20space');
 		expect(gitResultHttpOK12).toBe(null);
 
 		// TEST KO
@@ -216,7 +216,7 @@ describe('custom formats', () => {
 		const gitResultSshOK7 = customValidation['url-git']('user@host.xz:path/to/repo/');
 		expect(gitResultSshOK7).toBe(null);
 
-		const gitResultSshOK8 = customValidation['url-git']('user@host.xz:port/path%20with%20space/and+plus+character/repo/');
+		const gitResultSshOK8 = customValidation['url-git']('user@host.xz:port/path%20with%20space/more%20space/repo/');
 		expect(gitResultSshOK8).toBe(null);
 
 		// TEST KO
@@ -253,7 +253,7 @@ describe('custom formats', () => {
 		const gitResultGitOK6 = customValidation['url-git']('git://1.1.1.1:9999/path/to/repo/');
 		expect(gitResultGitOK6).toBe(null);
 
-		const gitResultGitOK7 = customValidation['url-git']('git://1.1.1.1:9999/path%20with%20space/and+plus+character/repo/');
+		const gitResultGitOK7 = customValidation['url-git']('git://1.1.1.1:9999/path%20with%20space/repo/');
 		expect(gitResultGitOK7).toBe(null);
 
 		// TEST KO

--- a/packages/forms/src/UIForm/customFormats.test.js
+++ b/packages/forms/src/UIForm/customFormats.test.js
@@ -48,12 +48,17 @@ describe('custom formats', () => {
 		// then
 		expect(resultIpPortOK).toBe(null);
 
+		const resultSpaceOK = customValidation['url-http-https']('https://test.domain.com/path%20with%20space/and+plus+character');
+		// then
+		expect(resultSpaceOK).toBe(null);
+
 		const resultKO1 = customValidation['url-http-https']('ssh://test.domain.com');
 		const resultKO2 = customValidation['url-http-https']('test.domain.com');
 		const resultKO3 = customValidation['url-http-https']('https://test. domain.com');
 		const resultKO4 = customValidation['url-http-https'](' https://test.domain.com');
 		const resultKO5 = customValidation['url-http-https']('https://test.domain.com ');
 		const resultKO6 = customValidation['url-http-https']('https://test.dom$ain.com ');
+		const resultKO7 = customValidation['url-http-https']('https://test.domain.com/path with space');
 		// then
 		expect(resultKO1).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
 		expect(resultKO2).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
@@ -61,6 +66,7 @@ describe('custom formats', () => {
 		expect(resultKO4).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
 		expect(resultKO5).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
 		expect(resultKO6).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
+		expect(resultKO7).toBe(mockedTranslation.FORMAT_URL_HTTP_HTTPS);
 	});
 
 	it('should validate a git url http', () => {
@@ -98,6 +104,9 @@ describe('custom formats', () => {
 		const gitResultHttpOK11 = customValidation['url-git']('http://user@host.com:999/sd.git');
 		expect(gitResultHttpOK11).toBe(null);
 
+		const gitResultHttpOK12 = customValidation['url-git']('https://host.xz:999/path%20space/to%20space/repo+with+plus');
+		expect(gitResultHttpOK12).toBe(null);
+
 		// TEST KO
 		const gitResultHttpKO1 = customValidation['url-git']('http://host.xz');
 		expect(gitResultHttpKO1).toBe(mockedTranslation.FORMAT_URL_GIT);
@@ -113,6 +122,9 @@ describe('custom formats', () => {
 
 		const gitResultHttpKO5 = customValidation['url-git']('http://host~host.xz/path/to/repo.git/');
 		expect(gitResultHttpKO5).toBe(mockedTranslation.FORMAT_URL_GIT);
+
+		const gitResultHttpKO6 = customValidation['url-git']('https://host.xz:999/path space/to space');
+		expect(gitResultHttpKO6).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate a git url ssh', () => {
@@ -155,6 +167,9 @@ describe('custom formats', () => {
 		const gitResultSshOK12 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo/');
 		expect(gitResultSshOK12).toBe(null);
 
+		const gitResultSshOK13 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo%20with%20space/');
+		expect(gitResultSshOK13).toBe(null);
+
 		// TEST KO
 		const gitResultSshKO1 = customValidation['url-git']('host.xz/~/path/to/repo.git');
 		expect(gitResultSshKO1).toBe(mockedTranslation.FORMAT_URL_GIT);
@@ -173,6 +188,9 @@ describe('custom formats', () => {
 
 		const gitResultSshKO6 = customValidation['url-git']('ssh://user@host.xz:999path/to/repo.git/');
 		expect(gitResultSshKO6).toBe(mockedTranslation.FORMAT_URL_GIT);
+
+		const gitResultSshKO7 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo with space/');
+		expect(gitResultSshKO7).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate a git url ssh 2', () => {
@@ -198,6 +216,9 @@ describe('custom formats', () => {
 		const gitResultSshOK7 = customValidation['url-git']('user@host.xz:path/to/repo/');
 		expect(gitResultSshOK7).toBe(null);
 
+		const gitResultSshOK8 = customValidation['url-git']('user@host.xz:port/path%20with%20space/and+plus+character/repo/');
+		expect(gitResultSshOK8).toBe(null);
+
 		// TEST KO
 		const gitResultSshKO1 = customValidation['url-git']('user@host.xz/path/to/repo.git/');
 		expect(gitResultSshKO1).toBe(mockedTranslation.FORMAT_URL_GIT);
@@ -207,6 +228,9 @@ describe('custom formats', () => {
 
 		const gitResultSshKO3 = customValidation['url-git']('user@host.xz:/path/to/repo.git/');
 		expect(gitResultSshKO3).toBe(mockedTranslation.FORMAT_URL_GIT);
+
+		const gitResultSshKO4 = customValidation['url-git']('user@host.xz:port/path with space/and plus character/repo/');
+		expect(gitResultSshKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate a git url git', () => {
@@ -229,6 +253,9 @@ describe('custom formats', () => {
 		const gitResultGitOK6 = customValidation['url-git']('git://1.1.1.1:9999/path/to/repo/');
 		expect(gitResultGitOK6).toBe(null);
 
+		const gitResultGitOK7 = customValidation['url-git']('git://1.1.1.1:9999/path%20with%20space/and+plus+character/repo/');
+		expect(gitResultGitOK7).toBe(null);
+
 		// TEST KO
 		const gitResultGitKO1 = customValidation['url-git']('git://host.xz.git/');
 		expect(gitResultGitKO1).toBe(mockedTranslation.FORMAT_URL_GIT);
@@ -241,6 +268,9 @@ describe('custom formats', () => {
 
 		const gitResultGitKO4 = customValidation['url-git']('git://user@1.1.1.1:9999/path/to/repo.git');
 		expect(gitResultGitKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
+
+		const gitResultGitKO5 = customValidation['url-git']('git://1.1.1.1:9999/path with space/and plus character/repo/');
+		expect(gitResultGitKO5).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
 	it('should validate string with no leading and trailing space', () => {

--- a/packages/forms/src/UIForm/customFormats.test.js
+++ b/packages/forms/src/UIForm/customFormats.test.js
@@ -48,7 +48,9 @@ describe('custom formats', () => {
 		// then
 		expect(resultIpPortOK).toBe(null);
 
-		const resultSpaceOK = customValidation['url-http-https']('https://test.domain.com/path%20with%20space');
+		const resultSpaceOK = customValidation['url-http-https'](
+			'https://test.domain.com/path%20with%20space',
+		);
 		// then
 		expect(resultSpaceOK).toBe(null);
 
@@ -104,7 +106,9 @@ describe('custom formats', () => {
 		const gitResultHttpOK11 = customValidation['url-git']('http://user@host.com:999/sd.git');
 		expect(gitResultHttpOK11).toBe(null);
 
-		const gitResultHttpOK12 = customValidation['url-git']('https://host.xz:999/path%20space/to%20space');
+		const gitResultHttpOK12 = customValidation['url-git'](
+			'https://host.xz:999/path%20space/to%20space',
+		);
 		expect(gitResultHttpOK12).toBe(null);
 
 		// TEST KO
@@ -167,7 +171,9 @@ describe('custom formats', () => {
 		const gitResultSshOK12 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo/');
 		expect(gitResultSshOK12).toBe(null);
 
-		const gitResultSshOK13 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo%20with%20space/');
+		const gitResultSshOK13 = customValidation['url-git'](
+			'ssh://190.22.21.12/~/path/to/repo%20with%20space/',
+		);
 		expect(gitResultSshOK13).toBe(null);
 
 		// TEST KO
@@ -189,7 +195,9 @@ describe('custom formats', () => {
 		const gitResultSshKO6 = customValidation['url-git']('ssh://user@host.xz:999path/to/repo.git/');
 		expect(gitResultSshKO6).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultSshKO7 = customValidation['url-git']('ssh://190.22.21.12/~/path/to/repo with space/');
+		const gitResultSshKO7 = customValidation['url-git'](
+			'ssh://190.22.21.12/~/path/to/repo with space/',
+		);
 		expect(gitResultSshKO7).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
@@ -216,7 +224,9 @@ describe('custom formats', () => {
 		const gitResultSshOK7 = customValidation['url-git']('user@host.xz:path/to/repo/');
 		expect(gitResultSshOK7).toBe(null);
 
-		const gitResultSshOK8 = customValidation['url-git']('user@host.xz:port/path%20with%20space/more%20space/repo/');
+		const gitResultSshOK8 = customValidation['url-git'](
+			'user@host.xz:port/path%20with%20space/more%20space/repo/',
+		);
 		expect(gitResultSshOK8).toBe(null);
 
 		// TEST KO
@@ -229,7 +239,9 @@ describe('custom formats', () => {
 		const gitResultSshKO3 = customValidation['url-git']('user@host.xz:/path/to/repo.git/');
 		expect(gitResultSshKO3).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultSshKO4 = customValidation['url-git']('user@host.xz:port/path with space/and plus character/repo/');
+		const gitResultSshKO4 = customValidation['url-git'](
+			'user@host.xz:port/path with space/and plus character/repo/',
+		);
 		expect(gitResultSshKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 
@@ -253,7 +265,9 @@ describe('custom formats', () => {
 		const gitResultGitOK6 = customValidation['url-git']('git://1.1.1.1:9999/path/to/repo/');
 		expect(gitResultGitOK6).toBe(null);
 
-		const gitResultGitOK7 = customValidation['url-git']('git://1.1.1.1:9999/path%20with%20space/repo/');
+		const gitResultGitOK7 = customValidation['url-git'](
+			'git://1.1.1.1:9999/path%20with%20space/repo/',
+		);
 		expect(gitResultGitOK7).toBe(null);
 
 		// TEST KO
@@ -269,7 +283,9 @@ describe('custom formats', () => {
 		const gitResultGitKO4 = customValidation['url-git']('git://user@1.1.1.1:9999/path/to/repo.git');
 		expect(gitResultGitKO4).toBe(mockedTranslation.FORMAT_URL_GIT);
 
-		const gitResultGitKO5 = customValidation['url-git']('git://1.1.1.1:9999/path with space/and plus character/repo/');
+		const gitResultGitKO5 = customValidation['url-git'](
+			'git://1.1.1.1:9999/path with space/and plus character/repo/',
+		);
 		expect(gitResultGitKO5).toBe(mockedTranslation.FORMAT_URL_GIT);
 	});
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-15611

We have had a case where the Azure repository urls can have a space between its name, this was not handled by the RegEx to validate the GIT urls in the UIForm custom formats.

**What is the chosen solution to this problem?**
I added the % character to the validation RegEx so that we allow it for this case.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
