### PR TITLE
fix: all target blank and window.open

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -160,6 +160,10 @@ export function ActionButton(props) {
 	if (hasPopup) {
 		buttonProps['aria-haspopup'] = true;
 	}
+	// enforce security on target="_blank"
+	if (buttonProps.target === '_blank') {
+		buttonProps.rel = 'noopener noreferrer';
+	}
 	let btn = (
 		<Button
 			onMouseDown={!overlayComponent ? rMouseDown : null}

--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.js
@@ -34,7 +34,10 @@ export function* fetchProducts(action) {
  */
 export function handleOpenProduct(action) {
 	if ('url' in action.payload) {
-		window.open(action.payload.url, '_blank');
+		const opened = window.open(action.payload.url, '_blank');
+		// security fix:
+		opened.opener = null;
+		opened.location = action.payload.url;
 	}
 }
 

--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
@@ -70,8 +70,7 @@ describe('HeaderBar sagas', () => {
 	});
 
 	describe('handleOpenProduct', () => {
-		const result = { opened: {} };
-		global.open = jest.fn(() => result.opened);
+		const result = {};
 
 		beforeEach(() => {
 			result.opened = {};

--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
@@ -70,10 +70,12 @@ describe('HeaderBar sagas', () => {
 	});
 
 	describe('handleOpenProduct', () => {
-		global.open = jest.fn();
+		const result = { opened: {} };
+		global.open = jest.fn(() => result.opened);
 
 		beforeEach(() => {
-			global.open.mockReset();
+			result.opened = {};
+			global.open = jest.fn(() => result.opened);
 		});
 
 		it("should open a product's page when an URL is provided", () => {
@@ -81,6 +83,10 @@ describe('HeaderBar sagas', () => {
 
 			handleOpenProduct(action);
 			expect(global.open).toHaveBeenCalled();
+			expect(result.opened).toEqual({
+				location: 'productUrl',
+				opener: null,
+			});
 		});
 
 		it('should do nothing if no product URI is provided', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

https://dev.to/ben/the-targetblank-vulnerability-by-example

`target="_blank"` must be followed by `rel="noopener noreferrer"`

The ActionButton do not enforce that.


window.open must also be followed by

```
		opened.opener = null;
		opened.location = action.payload.url;
```

The HeaderBar is impacted

**What is the chosen solution to this problem?**

Fix HeaderBar
Enforce this pattern in ActionButton

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->