### PR TITLE
doc(cmf/bootstrap): fix preReducers entry types

### DIFF
--- a/packages/cmf/src/bootstrap.md
+++ b/packages/cmf/src/bootstrap.md
@@ -29,7 +29,7 @@ cmf.bootstrap({
 | saga | function | the main saga to start  |
 | sagas | Object | undefined | Same as `components`  |
 | httpMiddleware | function | undefined | Override the default http middleware |
-| preReducer | function | undefined | Redux preReducer, called on every actions before reducer |
+| preReducer | Array or function | undefined | Redux preReducer, called on every actions before reducer |
 | enhancer | function | undefined |Redux enhancer |
 | reducer | Object or function | undefined | Redux reducer. This is added with the internal reducers. |
 | preloadedState | Object | undefined | Redux state to preload. This is the initial state on Redux bootstrap. |


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`preReducers` entry has incomplete type documentation

**What is the chosen solution to this problem?**
Complete it 

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
