### PR TITLE
feat(router): support multiple config

### DIFF
--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -100,16 +100,18 @@ const MERGE_FNS = {
 	actionCreators: mergeObjects,
 };
 
-export function reduceConfig(acc, config, mergeConfig = MERGE_FNS) {
-	return Object.keys(config).reduce((subacc, key) => {
-		if (!mergeConfig[key]) {
-			throw new Error(`${key} is not supported`);
-		}
-		return {
-			...subacc,
-			[key]: mergeConfig[key](acc[key], config[key], key),
-		};
-	}, acc);
+export function getReduceConfig(mergeConfig = MERGE_FNS) {
+	return function reduceConfig(acc, config) {
+		return Object.keys(config).reduce((subacc, key) => {
+			if (!mergeConfig[key]) {
+				throw new Error(`${key} is not supported`);
+			}
+			return {
+				...subacc,
+				[key]: mergeConfig[key](acc[key], config[key], key),
+			};
+		}, acc);
+	};
 }
 
 /**
@@ -117,7 +119,7 @@ export function reduceConfig(acc, config, mergeConfig = MERGE_FNS) {
  * before passing them to cmf.bootstrap
  */
 function merge(...configs) {
-	return configs.reduce(reduceConfig, {});
+	return configs.reduce(getReduceConfig(), {});
 }
 
 export default merge;

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -1,7 +1,7 @@
 import { spawn } from 'redux-saga/effects';
 import { assertValueTypeOf } from './assert';
 
-function mergeObjects(obj1, obj2) {
+export function mergeObjects(obj1, obj2) {
 	if (!obj2) {
 		return obj1;
 	}
@@ -23,7 +23,7 @@ function mergeObjects(obj1, obj2) {
 	}, Object.assign({}, obj1));
 }
 
-function mergeFns(fn1, fn2) {
+export function mergeFns(fn1, fn2) {
 	if (!fn2) {
 		return fn1;
 	}
@@ -44,7 +44,7 @@ function throwIfBothExists(obj1, obj2, name) {
 	}
 }
 
-function getUnique(obj1, obj2, name) {
+export function getUnique(obj1, obj2, name) {
 	throwIfBothExists(obj1, obj2, name);
 	if (obj1) {
 		return obj1;
@@ -52,7 +52,7 @@ function getUnique(obj1, obj2, name) {
 	return obj2;
 }
 
-function mergeSaga(saga, newSaga) {
+export function mergeSaga(saga, newSaga) {
 	assertValueTypeOf(saga, 'function');
 	assertValueTypeOf(newSaga, 'function');
 
@@ -68,7 +68,7 @@ function mergeSaga(saga, newSaga) {
 	return saga;
 }
 
-function mergeArrays(preReducer, newPreReducer) {
+export function mergeArrays(preReducer, newPreReducer) {
 	if (preReducer && newPreReducer) {
 		return [].concat(preReducer).concat(newPreReducer);
 	}
@@ -100,14 +100,14 @@ const MERGE_FNS = {
 	actionCreators: mergeObjects,
 };
 
-function reduceConfig(acc, config) {
+export function reduceConfig(acc, config, mergeConfig = MERGE_FNS) {
 	return Object.keys(config).reduce((subacc, key) => {
-		if (!MERGE_FNS[key]) {
+		if (!mergeConfig[key]) {
 			throw new Error(`${key} is not supported`);
 		}
 		return {
 			...subacc,
-			[key]: MERGE_FNS[key](acc[key], config[key], key),
+			[key]: mergeConfig[key](acc[key], config[key], key),
 		};
 	}, acc);
 }

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -22,6 +22,15 @@ cmf.bootstrap({
 });
 ```
 
+If your project has multiple module with routerConfig you can pass all of them to getRouter the following way:
+
+
+```javascript
+const router = getRouter(config1, config2, config3);
+```
+
+The `getRouter` function will merge all of them to build the router configuration.
+
 ## routerAPI
 
 routerAPI is an object which expose the following api:

--- a/packages/router/README.md
+++ b/packages/router/README.md
@@ -22,7 +22,7 @@ cmf.bootstrap({
 });
 ```
 
-If your project has multiple module with routerConfig you can pass all of them to getRouter the following way:
+If your project has multiple modules with `routerConfig` you can pass all of them to `getRouter()` the following way:
 
 
 ```javascript
@@ -30,6 +30,8 @@ const router = getRouter(config1, config2, config3);
 ```
 
 The `getRouter` function will merge all of them to build the router configuration.
+
+So be careful with the order since the next has a higher priority comparing to the previous config.
 
 ## routerAPI
 

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -18,10 +18,10 @@
   "peerDependencies": {
     "react": "^15.6.2 || ^16.0.0",
     "react-dom": "^15.6.2 || ^16.0.0",
-    "@talend/react-cmf": "1.12.0-0"
+    "@talend/react-cmf": "^2.0.1"
   },
   "devDependencies": {
-    "@talend/react-cmf": "1.12.0-0",
+    "@talend/react-cmf": "^2.0.1",
     "@babel/cli": "^7.2.0",
     "@babel/core": "^7.2.0",
     "@babel/plugin-proposal-class-properties": "^7.2.0",

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { hashHistory } from 'react-router';
 import { routerReducer, routerMiddleware, syncHistoryWithStore } from 'react-router-redux';
 import cmf from '@talend/react-cmf';
+import { reduceConfig, mergeObjects, getUnique } from '@talend/react-cmf/lib/cmfModule.merge';
 import { fork } from 'redux-saga/effects';
 import UIRouter from './UIRouter';
 import expressions from './expressions';
@@ -11,7 +12,18 @@ import documentTitle from './sagas/documentTitle';
 import cmfRouterMiddleware from './middleware';
 import { REGISTRY_HOOK_PREFIX } from './route';
 
-function getModule(options = {}) {
+const mergeConfig = {
+	history: getUnique,
+	sagaRouterConfig: mergeObjects,
+	routerFunctions: mergeObjects,
+};
+
+function mergeModule(...configs) {
+	return configs.reduce((acc, config) => reduceConfig(acc, config, mergeConfig), {});
+}
+
+function getModule(...args) {
+	const options = mergeModule(args);
 	const history = options.history || hashHistory;
 	const registry = {};
 	if (options.routerFunctions) {

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { hashHistory } from 'react-router';
 import { routerReducer, routerMiddleware, syncHistoryWithStore } from 'react-router-redux';
 import cmf from '@talend/react-cmf';
-import { reduceConfig, mergeObjects, getUnique } from '@talend/react-cmf/lib/cmfModule.merge';
+import { getReduceConfig, mergeObjects, getUnique } from '@talend/react-cmf/lib/cmfModule.merge';
 import { fork } from 'redux-saga/effects';
 import UIRouter from './UIRouter';
 import expressions from './expressions';
@@ -19,7 +19,7 @@ const mergeConfig = {
 };
 
 function mergeRouterConfig(...configs) {
-	return configs.reduce((acc, config) => reduceConfig(acc, config, mergeConfig), {});
+	return configs.reduce(getReduceConfig(mergeConfig), {});
 }
 
 function getModule(...args) {

--- a/packages/router/src/index.js
+++ b/packages/router/src/index.js
@@ -18,12 +18,12 @@ const mergeConfig = {
 	routerFunctions: mergeObjects,
 };
 
-function mergeModule(...configs) {
+function mergeRouterConfig(...configs) {
 	return configs.reduce((acc, config) => reduceConfig(acc, config, mergeConfig), {});
 }
 
 function getModule(...args) {
-	const options = mergeModule(args);
+	const options = mergeRouterConfig(...args);
 	const history = options.history || hashHistory;
 	const registry = {};
 	if (options.routerFunctions) {

--- a/packages/router/src/index.test.js
+++ b/packages/router/src/index.test.js
@@ -8,4 +8,27 @@ describe('getModule', () => {
 		const mod = getModule({ routerFunctions });
 		expect(mod.cmfModule.registry).toEqual({ '_.route.hook:foo': routerFunctions.foo });
 	});
+	it('should support multiple args', () => {
+		const config = {
+			routerFunctions: {
+				foo: jest.fn(),
+			},
+			sagaRouterConfig: {
+				'/foo': jest.fn(),
+			},
+		};
+		const configBis = {
+			routerFunctions: {
+				bar: jest.fn(),
+			},
+			sagaRouterConfig: {
+				'/foo/bar': jest.fn(),
+			},
+		};
+		const mod = getModule(config, configBis);
+		expect(mod.cmfModule.registry).toEqual({
+			'_.route.hook:foo': config.routerFunctions.foo,
+			'_.route.hook:bar': configBis.routerFunctions.bar,
+		});
+	});
 });

--- a/packages/router/src/index.test.js
+++ b/packages/router/src/index.test.js
@@ -30,5 +30,12 @@ describe('getModule', () => {
 			'_.route.hook:foo': config.routerFunctions.foo,
 			'_.route.hook:bar': configBis.routerFunctions.bar,
 		});
+		const generator = mod.cmfModule.saga();
+		generator.next();
+		const result = generator.next();
+		expect(result.value.FORK.args[1]).toEqual({
+			'/foo': config.sagaRouterConfig['/foo'],
+			'/foo/bar': configBis.sagaRouterConfig['/foo/bar'],
+		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

today some of our modules add routerConfig. So if you want to integrate a module you have to merge thoses config with yours.

The configuration pass to getRouter has `history`, `sagaRouterConfig` and `routerFunctions`

This can be tricky to merge (does the external addon use one or the other)

**What is the chosen solution to this problem?**

add the same mechanism as cmfModule inside the router.

//before
```javascript
import getRouterModule from '@talend/react-cmf-router';
import { sagaRouterConfig as extRouterConfig } from 'ext-module';
import { sagaRouterConfig as myRouterConfig } from './sagaRouter';
const myRouterModule = getRouterModule({ sagaRouterConfig: { ... extRouterConfig, ... myRouterConfig} });

cmf.bootstrap({ modules: [myRouterModule]});
```

//after
```javascript
import getRouterModule from '@talend/react-cmf-router';
import { routerConfig as extRouterConfig } from 'ext-module';
import { routerConfig as myRouterConfig } from './sagaRouter';
const myRouterModule = getRouterModule(extRouterConfig, myRouterConfig);

cmf.bootstrap({ modules: [myRouterModule]});
```

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->