### PR TITLE
fix(i18n): filter active projects from xtm

### DIFF
--- a/packages/scripts/internationalization/common/xtm.js
+++ b/packages/scripts/internationalization/common/xtm.js
@@ -83,8 +83,7 @@ function getProject(data) {
 		}
 		return uiProject;
 	}
-
-	return fetch(`${xtm.apiUrl}/projects?customerIds=${xtm.customerId}`, {
+	return fetch(`${xtm.apiUrl}/projects?customerIds=${xtm.customerId}&status=STARTED`, {
 		headers: { Authorization: `XTM-Basic ${xtm.token}` },
 	})
 		.then(handleError)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
i18n scripts get projects from xtm, but even the inactive projects are returned.

**What is the chosen solution to this problem?**
Pass a param to xtm request to get only active ones

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
