### PR TITLE
chore(container): fix dependency

### DIFF
--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -46,7 +46,7 @@
     "@talend/bootstrap-theme": "^2.1.0",
     "@talend/icons": "^2.1.0",
     "@talend/react-cmf": "^2.1.0",
-    "@talend/react-cmf-router": "3.0.0",
+    "@talend/react-cmf-router": "^3.2.0",
     "@talend/react-components": "^2.1.0",
     "@talend/react-forms": "^2.1.0",
     "@talend/react-storybook-cmf": "^2.1.0",
@@ -108,7 +108,7 @@
   "peerDependencies": {
     "@talend/icons": "^2.1.0",
     "@talend/react-cmf": "^2.1.0",
-    "@talend/react-cmf-router": "3.0.0",
+    "@talend/react-cmf-router": "3.2.0",
     "@talend/react-components": "^2.1.0",
     "@talend/react-forms": "^2.1.0",
     "bson-objectid": "^1.1.5",
@@ -146,7 +146,6 @@
   },
   "version": "2.1.0",
   "dependencies": {
-    "@talend/react-cmf-router": "3.0.0",
     "memoize-one": "^4.0.0",
     "react-immutable-proptypes": "^2.1.0",
     "react-router": "^3.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1170,10 +1170,10 @@
     objectpath "^1.2.1"
     tv4 "^1.3.0"
 
-"@talend/react-cmf-router@3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-cmf-router/-/react-cmf-router-3.0.0.tgz#32213452abd181093790bf5c147724216ccc7ca2"
-  integrity sha512-F25YsRSiZ9h1L8keGRgI7EucwlOjPl+yqYHAEF6aVv9pqLFOguMPtIcho1bELHfKDURZ/sXaeaNS94SdFI7ujQ==
+"@talend/react-cmf-router@^3.2.0":
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-cmf-router/-/react-cmf-router-3.2.0.tgz#8e26eb51a0808bcee8f27dcdab35adf1ddfa9c20"
+  integrity sha512-z57OxZ9KOIG6NvewA6fBgERGcLmg6b4RxQbXPbmNiTuZ3edxSD2CGVNB717LVBI8wBRA71BImjSPpBb92BcqAg==
   dependencies:
     "@babel/polyfill" "^7.0.0"
     lodash "^4.17.4"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If you try to update the package @talend/react-cmf-router you will have it twice.
This is due to the package.json dependencies of container.

**What is the chosen solution to this problem?**

Move it to peerDependencies so the project decide which version to use.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
