### PR TITLE
fix(containers): add withComponentRegistry to RichLayout

### DIFF
--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -6,7 +6,7 @@ import * as containers from './containers';
 const components = Object.keys(allComponents).reduce((acc, key) => {
 	if (!acc[key] && typeof allComponents[key] === 'function') {
 		const options = {};
-		if (['ActionList', 'Layout'].includes(key)) {
+		if (['ActionList', 'Layout', 'RichLayout'].includes(key)) {
 			options.withComponentRegistry = true;
 		}
 		if (!allComponents[key].displayName) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
get component is not here anymore by default with cmf connect
![image](https://user-images.githubusercontent.com/2909671/51115126-9c710100-1807-11e9-8f12-c5c409c53f58.png)

**What is the chosen solution to this problem?**
Add withCompoentRegistry to have content back 
![image](https://user-images.githubusercontent.com/2909671/51115148-a561d280-1807-11e9-9d00-8c730e6a8acb.png)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
