### PR TITLE
fix(router): trigger sagas on init

### DIFF
--- a/packages/router/src/sagaRouter.js
+++ b/packages/router/src/sagaRouter.js
@@ -156,8 +156,6 @@ export default function* sagaRouter(history, routes) {
 	const sagas = {};
 	const routeFragments = Object.keys(routes);
 	while (true) {
-		// eslint-disable-line no-constant-condition
-		yield take('@@router/LOCATION_CHANGE');
 		const shouldStart = [];
 		const currentLocation = history.getCurrentLocation();
 		for (let index = 0; index < routeFragments.length; ) {
@@ -186,5 +184,7 @@ export default function* sagaRouter(history, routes) {
 			};
 			index += 1;
 		}
+		// eslint-disable-line no-constant-condition
+		yield take('@@router/LOCATION_CHANGE');
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Router sagas is only triggered when we navigate in the app.
If we have a saga attached to the route we land when the app is opened, the saga is not launched.
**What is the chosen solution to this problem?**
Wait the _@@router/LOCATION_CHANGE_ after a first round of sagas path evaluations

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
