### PR TITLE
fix(components/Drawer): close button color

### DIFF
--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -86,18 +86,18 @@ $tc-drawer-tabs-background: tint($brand-primary, 90) !default;
 			overflow: hidden;
 		}
 	}
+
+	.tc-drawer-close-action {
+		top: $padding-normal / 2;
+		right: 0;
+		position: absolute;
+		color: white;
+	}
 }
 
 .tc-drawer-header-with-tabs {
 	padding: 0;
 	background-color: $gray-lighter;
-}
-
-.tc-drawer-close-action {
-	top: $padding-normal / 2;
-	right: 0;
-	position: absolute;
-	color: white;
 }
 
 .tc-drawer-content {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Because of CSS weigth, theme style comes first. And Drawer close button color is set to gray.

**What is the chosen solution to this problem?**
Improve CSS weight to restore its color to white. 🎉 
Will fix [TUI-328](https://jira.talendforge.org/browse/TUI-328)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
