### PR TITLE
Frassinier/fix/components/typeahead/zindex

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -50,6 +50,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 		border-radius: $tc-typeahead-items-border-radius;
 		box-shadow: $tc-typeahead-items-box-shadow;
 		overflow-y: auto;
+		z-index: $zindex-dropdown + 1;
 	}
 
 	&.right {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -50,7 +50,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 		border-radius: $tc-typeahead-items-border-radius;
 		box-shadow: $tc-typeahead-items-box-shadow;
 		overflow-y: auto;
-		z-index: $zindex-dropdown + 1;
+		z-index: $zindex-dropdown;
 	}
 
 	&.right {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Typeahead result container has an absolute position and no z-index
 
**What is the chosen solution to this problem?**
Just add the z-index than dropdowns

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
