### PR TITLE
feat(scripts/i18n): accept token instead of password

### DIFF
--- a/packages/scripts/internationalization/README.md
+++ b/packages/scripts/internationalization/README.md
@@ -124,21 +124,17 @@ There are 4 methods of extraction
 You need to pass xtm information as environment variables
 
 ```shell
-> API_URL=https://XXX \
-  CLIENT=YYY \
-  CUSTOMER_ID=ZZZ \
-  USER_ID=AAA \
-  PASSWORD=BBB \
+> XTM_API_URL=https://XXX \
+  XTM_CUSTOMER_ID=YYY \
+  XTM_TOKEN=ZZZ \
   talend-scripts <i18n-upload|i18n-download>
 ```
 
 | Variable | Description |
 |---|---|
-| API_URL | The XTM api url |
-| CLIENT | The XTM client name |
-| CUSTOMER_ID | The XTM customer ID |
-| USER_ID | The XTM user id used to log in |
-| PASSWORD | The XTM user password to log in |
+| XTM_API_URL | The XTM api url |
+| XTM_CUSTOMER_ID | The XTM customer ID |
+| XTM_TOKEN | The XTM authentication token |
 
 ### Upload
 This step will upload previously created i18n zip to XTM.

--- a/packages/scripts/internationalization/common/xtm.js
+++ b/packages/scripts/internationalization/common/xtm.js
@@ -11,36 +11,26 @@ const { printRunning, printSuccess } = require('./log');
 function throwError(missingVar) {
 	error(`
 		In order to connect to XTM, you need to pass the ${missingVar} env variable.
-		> API_URL=http://XXX CLIENT=YYY USER_ID=ZZZ PASSWORD=AAA talend-scripts i18n-upload
+		> XTM_API_URL=http://XXX XTM_CUSTOMER_ID=YYY XTM_TOKEN=ZZZ talend-scripts i18n-upload
 	`);
 }
 
-let authToken;
 function getXTMVariables() {
-	const { API_URL, CLIENT, CUSTOMER_ID, USER_ID, PASSWORD } = process.env;
-	if (!API_URL) {
-		throwError('API_URL');
+	const { XTM_API_URL, XTM_CUSTOMER_ID, XTM_TOKEN } = process.env;
+	if (!XTM_API_URL) {
+		throwError('XTM_API_URL');
 	}
-	if (!CLIENT) {
-		throwError('CLIENT');
+	if (!XTM_CUSTOMER_ID) {
+		throwError('XTM_CUSTOMER_ID');
 	}
-	if (!CUSTOMER_ID) {
-		throwError('CUSTOMER_ID');
-	}
-	if (!USER_ID) {
-		throwError('API_URL');
-	}
-	if (!PASSWORD) {
-		throwError('PASSWORD');
+	if (!XTM_TOKEN) {
+		throwError('XTM_TOKEN');
 	}
 
 	return {
-		apiUrl: API_URL,
-		client: CLIENT,
-		customerId: CUSTOMER_ID,
-		userId: USER_ID,
-		password: PASSWORD,
-		token: authToken,
+		apiUrl: XTM_API_URL,
+		customerId: XTM_CUSTOMER_ID,
+		token: XTM_TOKEN,
 	};
 }
 
@@ -51,24 +41,6 @@ function handleError(res) {
 		});
 	}
 	return res;
-}
-
-function login(data) {
-	const xtm = getXTMVariables();
-
-	printRunning(`Login with user ${xtm.userId}...`);
-
-	const body = { client: xtm.client, userId: xtm.userId, password: xtm.password };
-	return fetch(`${xtm.apiUrl}/auth/token`, {
-		method: 'POST',
-		body: JSON.stringify(body),
-		headers: { 'Content-Type': 'application/json', 'Cache-Control': 'no-cache' },
-	})
-		.then(handleError)
-		.then(res => res.json())
-		.then(res => (authToken = res.token))
-		.then(() => printSuccess('Logged in successfully.'))
-		.then(() => data);
 }
 
 function getProject(data) {
@@ -197,7 +169,6 @@ function downloadFiles(data) {
 
 module.exports = {
 	getFilesToDownload,
-	login,
 	getProject,
 	uploadFile,
 	downloadFiles,

--- a/packages/scripts/internationalization/scripts/download.js
+++ b/packages/scripts/internationalization/scripts/download.js
@@ -54,8 +54,7 @@ function download({ load }) {
 		version: getPossibleVersion(),
 	};
 	printSection('XTM');
-	return login(data)
-		.then(getProject)
+	return getProject(data)
 		.then(getFilesToDownload)
 		.then(downloadFiles)
 		.then(unzip)

--- a/packages/scripts/internationalization/scripts/upload.js
+++ b/packages/scripts/internationalization/scripts/upload.js
@@ -7,8 +7,7 @@ function upload({ extract, load }) {
 		filePath: path.join(process.cwd(), extract.target, 'i18n.zip'),
 		projectName: load.project,
 	};
-	return login(data)
-		.then(getProject)
+	return getProject(data)
 		.then(uploadFile)
 		.catch(e => {
 			error(e.message);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
i18n scripts accept login/password as env var to login to XTM.

**What is the chosen solution to this problem?**
Replace that with token in en var

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
