### PR TITLE
fix(icons) use baseSelector option to generate talend webicon css file properly

### DIFF
--- a/packages/icons/src/talendicons.font.js
+++ b/packages/icons/src/talendicons.font.js
@@ -1,5 +1,5 @@
 module.exports = {
-  "baseClass": "icon",
+  "baseSelector": ".icon",
   "classPrefix": "icon-",
   "cssTemplate": "./talendicons.template.css",
   "fileName": "[fontname][ext]",

--- a/packages/icons/src/talendicons.template.css
+++ b/packages/icons/src/talendicons.template.css
@@ -3,7 +3,7 @@
     src: {{{src}}};
 }
 
-.{{baseClass}} {
+{{baseSelector}} {
     display: inline-block;
     font: normal normal normal 14px/1 {{fontName}};
     font-size: inherit;
@@ -13,7 +13,7 @@
     vertical-align: middle;
 }
 
-.{{baseClass}}:before {
+{{baseSelector}}:before {
     display: block;
 }
 


### PR DESCRIPTION


**What is the problem this PR is trying to solve?**

The `packages/icons/dist/talend-icons-webfont.css` file is badly generated as the build process misses to replace a selector.

**What is the chosen solution to this problem?**
Looking at the [documentation](https://www.npmjs.com/package/webfonts-loader#all-font-configuration-options) I saw that we were relying on a bad font configuration options. So I replaced it according to the documentation from the lib.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
