### PR TITLE
feat(form): provide a skeleton while a trigger is loading

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -77,6 +77,7 @@ export class TCompForm extends React.Component {
 		this.onSubmit = this.onSubmit.bind(this);
 		this.onReset = this.onReset.bind(this);
 		this.getUISpec = this.getUISpec.bind(this);
+		this.addTriggerSkeleton = this.addTriggerSkeleton.bind(this);
 		this.setupTrigger = this.setupTrigger.bind(this);
 		this.setupTrigger(props);
 
@@ -87,7 +88,7 @@ export class TCompForm extends React.Component {
 
 	componentWillReceiveProps(nextProps) {
 		if (this.props.state.get('properties') !== nextProps.state.get('properties')) {
-			this.setState({ properties: nextProps.state.get('properties').toJS() });
+			this.setState({ properties: nextProps.state.get('properties', {}).toJS() });
 		}
 	}
 
@@ -129,6 +130,8 @@ export class TCompForm extends React.Component {
 			type: TCompForm.ON_TRIGGER_BEGIN,
 			...payload,
 		});
+		this.addTriggerSkeleton();
+
 		return this.trigger(event, payload).then(data => {
 			this.props.dispatch({
 				type: TCompForm.ON_TRIGGER_END,
@@ -193,6 +196,30 @@ export class TCompForm extends React.Component {
 			jsonSchema: this.getMemoizedJsonSchema(this.props.state.get('jsonSchema')),
 			uiSchema: this.getMemoizedUiSchema(this.props.state.get('uiSchema')),
 		};
+	}
+
+	/**
+	 * will be erased by the backend trigger response
+	 */
+	addTriggerSkeleton() {
+		const loadingJsonSchema = this.props.state.getIn(['initialState', 'jsonSchema']).setIn(
+			['properties', '$$loadingPlaceholder'],
+			new Map({
+				title: 'Loading placeholder',
+				type: 'string',
+			}),
+		);
+		const loadingUiSchema = this.props.state.getIn(['initialState', 'uiSchema']).push(
+			new Map({
+				key: '$$loadingPlaceholder',
+				title: 'Loading placeholder',
+				widget: 'loadingPlaceholder',
+			}),
+		);
+		this.props.setState({
+			jsonSchema: loadingJsonSchema,
+			uiSchema: loadingUiSchema,
+		});
 	}
 
 	render() {

--- a/packages/forms/src/FormSkeleton.js
+++ b/packages/forms/src/FormSkeleton.js
@@ -7,15 +7,15 @@ export default function FormSkeleton() {
 		<div className={`${theme.container} tc-skeleton-heartbeat`} aria-busy>
 			<div className={theme['form-content']}>
 				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={400} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
 				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={400} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
 				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={400} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
 				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={400} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
 				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={400} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
 			</div>
 			<div className={theme.submit}>
 				<div className={theme['submit-wrapper']}>

--- a/packages/forms/src/TriggerSkeleton.js
+++ b/packages/forms/src/TriggerSkeleton.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Skeleton } from '@talend/react-components';
+import theme from './FormSkeleton.scss';
+
+export default function TriggerSkeleton() {
+	return (
+		<div className={`${theme.container} tc-skeleton-heartbeat`} aria-busy>
+			<div className={theme['form-content']}>
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
+				<Skeleton heartbeat={false} type={Skeleton.TYPES.text} />
+			</div>
+		</div>
+	);
+}

--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -22,6 +22,8 @@ import Text, { TextTextMode } from '../fields/Text';
 import TextArea, { TextAreaTextMode } from '../fields/TextArea';
 import Toggle from '../fields/Toggle';
 
+import TriggerSkeleton from '../../TriggerSkeleton';
+
 const widgets = {
 	// fieldsets
 	array: ArrayWidget,
@@ -71,6 +73,7 @@ const widgets = {
 	radioOrSelect: RadioOrSelect,
 	resourcePicker: ResourcePicker,
 	toggle: Toggle,
+	loadingPlaceholder: TriggerSkeleton,
 };
 
 export default widgets;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
on a field with a trigger, the user doesn't have any feedback about the fact that smtg is going on (backend call), and then suddenly the rest of teh form is displayed
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**
provide a loading feedback as soon as a trigger is needed

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
