### PR TITLE
chore(Typeahead): adding data-feature to items

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -87,7 +87,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 	};
 
 	const defaultRenderersProps = {
-		renderItem,
+		renderItem: renderItem(rest.additionalOptions),
 		renderItemsContainer: renderItemsContainerFactory(
 			rest.items,
 			rest.noResultText,

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -129,25 +129,27 @@ export function renderSectionTitle(section) {
 	return null;
 }
 
-export function renderItem(item, { value }) {
-	let title;
-	let description;
-	if (typeof item === 'string') {
-		title = item;
-	} else {
-		title = (item.title || item.name || '').trim();
-		description = item.description;
-	}
-	return (
-		<div className={theme.item} title={title}>
+export function renderItem(additionalOptions = {}) {
+	return (item, { value }) => {
+		let title;
+		let description;
+		if (typeof item === 'string') {
+			title = item;
+		} else {
+			title = (item.title || item.name || '').trim();
+			description = item.description;
+		}
+		return (
+			<div className={theme.item} title={title} data-feature={additionalOptions['data-feature']}>
 			<span className={classNames(theme['item-title'], 'tc-typeahead-item-title')}>
-				<Emphasis value={value} text={title} />
+				<Emphasis value={value} text={title}/>
 			</span>
-			{description && (
-				<p className={classNames(theme['item-description'], 'tc-typeahead-item-description')}>
-					<Emphasis value={value} text={description} />
-				</p>
-			)}
-		</div>
-	);
+				{description && (
+					<p className={classNames(theme['item-description'], 'tc-typeahead-item-description')}>
+						<Emphasis value={value} text={description}/>
+					</p>
+				)}
+			</div>
+		);
+	}
 }

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -141,15 +141,15 @@ export function renderItem(additionalOptions = {}) {
 		}
 		return (
 			<div className={theme.item} title={title} data-feature={additionalOptions['data-feature']}>
-			<span className={classNames(theme['item-title'], 'tc-typeahead-item-title')}>
-				<Emphasis value={value} text={title}/>
-			</span>
+				<span className={classNames(theme['item-title'], 'tc-typeahead-item-title')}>
+					<Emphasis value={value} text={title} />
+				</span>
 				{description && (
 					<p className={classNames(theme['item-description'], 'tc-typeahead-item-description')}>
-						<Emphasis value={value} text={description}/>
+						<Emphasis value={value} text={description} />
 					</p>
 				)}
 			</div>
 		);
-	}
+	};
 }

--- a/packages/components/src/Typeahead/Typeahead.snapshot.test.js
+++ b/packages/components/src/Typeahead/Typeahead.snapshot.test.js
@@ -88,7 +88,7 @@ describe('Typeahead', () => {
 				id: 'my-search',
 				items: itemsString,
 				multiSection: false,
-				additionalOptions: { 'data-feature': 'my-feature'},
+				additionalOptions: { 'data-feature': 'my-feature' },
 			};
 			// when
 			const wrapper = renderer.create(<Typeahead {...props} />).toJSON();

--- a/packages/components/src/Typeahead/Typeahead.snapshot.test.js
+++ b/packages/components/src/Typeahead/Typeahead.snapshot.test.js
@@ -88,6 +88,7 @@ describe('Typeahead', () => {
 				id: 'my-search',
 				items: itemsString,
 				multiSection: false,
+				additionalOptions: { 'data-feature': 'my-feature'},
 			};
 			// when
 			const wrapper = renderer.create(<Typeahead {...props} />).toJSON();

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -607,6 +607,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       >
         <div
           className="theme-item"
+          data-feature="my-feature"
           title="category 1"
         >
           <span
@@ -626,6 +627,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       >
         <div
           className="theme-item"
+          data-feature="my-feature"
           title="category 2"
         >
           <span

--- a/packages/components/stories/Typeahead.js
+++ b/packages/components/stories/Typeahead.js
@@ -118,6 +118,7 @@ storiesOf('Typeahead', module)
 		const props = {
 			value: 'le',
 			items,
+			additionalOptions: { 'data-feature': 'data-feature-typeahead' },
 			onBlur: action('onBlur'),
 			onChange: action('onChange'),
 			onSelect: action('onSelect'),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No data-feature available on typeahead's items

**What is the chosen solution to this problem?**
Passing additionalOptions to typeahead and use it in renderItem in order to pass the data-feature attribut to the render method.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
