### PR TITLE
chore(CQRS): remove componentWillReceiveProps

### DIFF
--- a/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.connect.js
+++ b/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.connect.js
@@ -3,14 +3,13 @@ import { cmfConnect } from '@talend/react-cmf';
 import Container, { DEFAULT_STATE } from './ACKDispatcher.container';
 
 export function mapStateToProps(state) {
-	const props = {
+	return {
 		acks: state.ack,
 	};
-	return props;
 }
 
 export default cmfConnect({
-	componentId: 'ACKDispatcher',  // can be a function
+	componentId: 'ACKDispatcher', // can be a function
 	defaultState: DEFAULT_STATE,
 	mapStateToProps,
 })(Container);

--- a/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.container.js
+++ b/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.container.js
@@ -39,18 +39,6 @@ class ACKDispatcher extends React.Component {
 		this.state = { dispatchedAck: [] };
 	}
 
-	componentDidMount() {
-		if (this.props.acks) {
-			this.processACK(this.props.acks);
-		}
-	}
-
-	componentWillReceiveProps(nextProps) {
-		if (nextProps.acks) {
-			this.processACK(nextProps.acks);
-		}
-	}
-
 	shouldComponentUpdate(nextProps) {
 		return this.props.acks !== nextProps.acks;
 	}
@@ -67,8 +55,8 @@ class ACKDispatcher extends React.Component {
 		});
 	}
 
-	processACK(acks) {
-		acks
+	processACK() {
+		this.props.acks
 			.filter(ack => ack.get('received') === true && ack.get('actionCreator'))
 			.forEach((ack, requestId) => {
 				let data = ack.get('data');
@@ -79,8 +67,10 @@ class ACKDispatcher extends React.Component {
 			});
 	}
 
-	// eslint-disable-next-line class-methods-use-this
 	render() {
+		if (this.props.acks) {
+			this.processACK();
+		}
 		return null;
 	}
 }

--- a/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.test.js
+++ b/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.test.js
@@ -1,12 +1,10 @@
 import React from 'react';
 import { Map } from 'immutable';
 import { shallow, mount } from 'enzyme';
-import { Provider, store } from '@talend/react-cmf/lib/mock';
+import { store } from '@talend/react-cmf/lib/mock';
 
 import Container, { DEFAULT_STATE } from './ACKDispatcher.container';
-import Connected, {
-	mapStateToProps,
-} from './ACKDispatcher.connect';
+import Connected, { mapStateToProps } from './ACKDispatcher.connect';
 
 describe('Container ACKDispatcher', () => {
 	let mockProcessACK;
@@ -44,11 +42,8 @@ describe('Container ACKDispatcher', () => {
 		}
 
 		registry['actionCreator:myActionCreator'] = myActionCreator;
-		mount(
-			<Container acks={Map()} />,
-			{ context: { registry } });
+		mount(<Container acks={Map()} />, { context: { registry } });
 		expect(mockProcessACK).toHaveBeenCalled();
-		expect(mockProcessACK.mock.calls[0][0]).toEqual(Map());
 	});
 	it('should processACK call dispatch', () => {
 		const dispatch = jest.fn();
@@ -75,9 +70,7 @@ describe('Container ACKDispatcher', () => {
 
 		registry['actionCreator:actionCreator'] = myActionCreator;
 		registry['actionCreator:actionCreatorBis'] = myActionCreator;
-		mount(
-			<Container acks={acks} dispatch={dispatch} />,
-			{ context: { registry } });
+		mount(<Container acks={acks} dispatch={dispatch} />, { context: { registry } });
 		expect(mockDispatchAndUpdateAck).toHaveBeenCalled();
 		const calls = mockDispatchAndUpdateAck.mock.calls;
 		expect(calls.length).toBe(1);
@@ -96,10 +89,12 @@ describe('Container ACKDispatcher', () => {
 
 		const registry = store.registry();
 		registry['actionCreator:myActionCreator'] = myActionCreator;
-		const wrapper = shallow(
-			<Container dispatch={dispatch} acks={Map()} />,
-			{ context: { registry } });
-		wrapper.setProps({ acks: Map({ id1: Map({ actionCreator: 'myActionCreator', received: true }) }) });
+		const wrapper = shallow(<Container dispatch={dispatch} acks={Map()} />, {
+			context: { registry },
+		});
+		wrapper.setProps({
+			acks: Map({ id1: Map({ actionCreator: 'myActionCreator', received: true }) }),
+		});
 		expect(dispatch).toHaveBeenCalled();
 		const calls = dispatch.mock.calls;
 		const action = calls[0][0];
@@ -141,9 +136,7 @@ describe('Container ACKDispatcher', () => {
 
 		registry['actionCreator:actionCreator'] = myActionCreator;
 		registry['actionCreator:actionCreatorBis'] = myActionCreator;
-		mount(
-			<Container dispatch={dispatch} acks={acks} />,
-			{ context: { registry } });
+		mount(<Container dispatch={dispatch} acks={acks} />, { context: { registry } });
 		expect(mockDispatchAndUpdateAck).toHaveBeenCalled();
 		const calls = mockDispatchAndUpdateAck.mock.calls;
 		expect(calls.length).toBe(1);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We need to remove deprecated react 15 lifecycle methods.
This PR is only on cmf-cqrs package.

**What is the chosen solution to this problem?**
- Remove the call from `componentDidMount()`
- Remove the call from `componentWillReceiveProps()`
- Replace them with a call in `render()` instead. There is already a `componentShouldUpdate()` that checks if the props.acks has changed. So `render()` is only called on new props.acks, and will process them.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
