### PR TITLE
fix(Dialog): Title cut off

### DIFF
--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -28,14 +28,13 @@
 
 		.modal-title,
 		.modal-subtitle {
-			display: inline-block;
 			text-overflow: ellipsis;
 			white-space: nowrap;
 			overflow: hidden;
 		}
 
 		.modal-title {
-			line-height: 1;
+			line-height: normal;
 		}
 
 		.modal-subtitle {

--- a/packages/components/stories/Dialog.js
+++ b/packages/components/stories/Dialog.js
@@ -8,7 +8,7 @@ const defaultProps = {
 	show: true,
 };
 const headerProps = {
-	header: 'Hello world',
+	header: 'Hellogougoug  world',
 	show: true,
 };
 const actionProps = {
@@ -21,7 +21,7 @@ const actionProps = {
 };
 const subtitle = {
 	show: true,
-	header: 'Hello world',
+	header: 'Gougougoug Hello world',
 	subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 	onHide: action('onHide'),
 	action: {

--- a/packages/components/stories/Dialog.js
+++ b/packages/components/stories/Dialog.js
@@ -8,7 +8,7 @@ const defaultProps = {
 	show: true,
 };
 const headerProps = {
-	header: 'Hellogougoug  world',
+	header: 'Hello world',
 	show: true,
 };
 const actionProps = {
@@ -21,7 +21,7 @@ const actionProps = {
 };
 const subtitle = {
 	show: true,
-	header: 'Gougougoug Hello world',
+	header: 'Hello world',
 	subtitle: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
 	onHide: action('onHide'),
 	action: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The bottom of the modals' titles is cut off like so :
![image](https://user-images.githubusercontent.com/38908846/51903372-4e89fa80-23bc-11e9-995c-b415630be6bb.png)

**What is the chosen solution to this problem?**
Update style 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
