### PR TITLE
fix(icons) generate webfont with [fontname].[ext] format

### DIFF
--- a/packages/icons/src/talendicons.font.js
+++ b/packages/icons/src/talendicons.font.js
@@ -1,12 +1,10 @@
 module.exports = {
-  "baseSelector": ".icon",
-  "classPrefix": "icon-",
-  "cssTemplate": "./talendicons.template.css",
-  'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
-  "fileName": "[fontname].[ext]",
-  "files": [
-    "svg/*.svg"
-  ],
-  "fixedWidth": true,
-  "fontName": "talendicons"
+	baseSelector: '.icon',
+	classPrefix: 'icon-',
+	cssTemplate: './talendicons.template.css',
+	types: ['eot', 'woff', 'woff2', 'ttf', 'svg'],
+	fileName: '[fontname].[ext]',
+	files: ['svg/*.svg'],
+	fixedWidth: true,
+	fontName: 'talendicons',
 };

--- a/packages/icons/src/talendicons.font.js
+++ b/packages/icons/src/talendicons.font.js
@@ -2,7 +2,8 @@ module.exports = {
   "baseSelector": ".icon",
   "classPrefix": "icon-",
   "cssTemplate": "./talendicons.template.css",
-  "fileName": "[fontname][ext]",
+  'types': ['eot', 'woff', 'woff2', 'ttf', 'svg'],
+  "fileName": "[fontname].[ext]",
   "files": [
     "svg/*.svg"
   ],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The format we use to generate the webfont files is incorrect and we generate things that the browser can't parse. See below screenshot:

<img width="1038" alt="screenshot 2019-01-29 at 15 16 27" src="https://user-images.githubusercontent.com/1674329/51914359-f6152600-23d8-11e9-8b1e-28d14295b97d.png">

**What is the chosen solution to this problem?**

Just changing the webfont generation file format:

<img width="1047" alt="screenshot 2019-01-29 at 15 12 01" src="https://user-images.githubusercontent.com/1674329/51914088-5061b700-23d8-11e9-8413-2263fe4f1ad7.png">

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
