### PR TITLE
feat(theme): forms input ellipsis

### DIFF
--- a/output/theme.sasslint.txt
+++ b/output/theme.sasslint.txt
@@ -16,13 +16,13 @@ src/theme/_forms.scss
     6:24  error    Parenthesis should be removed                            empty-args
    33:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
    68:7   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  119:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  134:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  196:4   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  120:8   error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  135:6   warning  Vendor prefixes should not be used                       no-vendor-prefixes
   197:4   warning  Vendor prefixes should not be used                       no-vendor-prefixes
-  335:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  348:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  439:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  198:4   warning  Vendor prefixes should not be used                       no-vendor-prefixes
+  336:23  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  349:10  error    Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  440:8   warning  Vendor prefixes should not be used                       no-vendor-prefixes
 
 src/theme/_navbar.scss
   18:6  warning  Expected indentation of 4 tabs but found 5  indentation

--- a/packages/theme/src/theme/_forms.scss
+++ b/packages/theme/src/theme/_forms.scss
@@ -83,6 +83,7 @@ form {
 		font-size: $form-input-font-size;
 		font-weight: $form-base-font-weight;
 		box-shadow: $form-shadow;
+		text-overflow: ellipsis;
 
 		&:focus {
 			box-shadow: $form-focus-shadow;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Guideline has evolved and we need to add an ellipsis on input value.

**What is the chosen solution to this problem?**
Add a ellispsis rule in the theme.

<img width="352" alt="capture d ecran 2019-01-30 a 09 56 54" src="https://user-images.githubusercontent.com/10761073/51969716-6e312980-2475-11e9-9f69-a3533514679d.png">

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
