### PR TITLE
feat(form/resourcepicker): manage single selection

### DIFF
--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
@@ -55,8 +55,9 @@ class ResourcePicker extends Component {
 	onRowClick(event, { id }) {
 		let selected = [...this.state.filters.selected];
 		const index = selected.findIndex(i => i === id);
+		const { multi } = this.props.schema;
 
-		if (!this.props.schema.multi) {
+		if (!multi) {
 			selected = [];
 		}
 
@@ -67,7 +68,7 @@ class ResourcePicker extends Component {
 		}
 
 		this.setState({ filters: { ...this.state.filters, selected } });
-		this.onChange(event, selected);
+		this.onChange(event, multi ? selected : selected[0]);
 	}
 
 	isItemSelected({ id }) {

--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
@@ -10,7 +10,7 @@ import ResourcePicker from './ResourcePicker.component';
 describe('ResourcePicker field', () => {
 	const collection = [
 		{
-			id: 0,
+			id: '0',
 			name: 'Title with few actions',
 			modified: 1442880000000,
 			icon: 'talend-file-xls-o',
@@ -18,14 +18,14 @@ describe('ResourcePicker field', () => {
 			flags: ['CERTIFIED', 'FAVORITE'],
 		},
 		{
-			id: 1,
+			id: '1',
 			name: 'Title with lot of actions',
 			modified: 1537574400000,
 			icon: 'talend-file-xls-o',
 			author: 'Second Author',
 		},
 		{
-			id: 2,
+			id: '2',
 			name: 'Title with persistant actions',
 			modified: 1474502400000,
 			author: 'Jean-Pierre DUPONT',
@@ -33,7 +33,7 @@ describe('ResourcePicker field', () => {
 			flags: ['FAVORITE'],
 		},
 		{
-			id: 3,
+			id: '3',
 			name: 'Title with icon',
 			modified: 1506038400000,
 			author: 'Third Author',
@@ -41,14 +41,14 @@ describe('ResourcePicker field', () => {
 			flags: ['CERTIFIED'],
 		},
 		{
-			id: 4,
+			id: '4',
 			name: 'Title in input mode',
 			modified: 1506038400000,
 			author: 'Jean-Pierre DUPONT',
 			icon: 'talend-file-xls-o',
 		},
 		{
-			id: 5,
+			id: '5',
 			name: 'Title with long long long long long long long long long long long text',
 			modified: 1547478328552,
 			author: 'Jean-Pierre DUPONT with super super super long text',
@@ -131,7 +131,7 @@ describe('ResourcePicker field', () => {
 				},
 				title: 'My ResourcePicker title',
 			},
-			value: [0],
+			value: '0',
 		});
 	});
 
@@ -158,7 +158,7 @@ describe('ResourcePicker field', () => {
 			.simulate('click');
 		expect(props.onChange).toBeCalledWith(expect.anything(), {
 			schema: expect.anything(),
-			value: [0, 1],
+			value: ['0', '1'],
 		});
 	});
 
@@ -177,7 +177,7 @@ describe('ResourcePicker field', () => {
 			.simulate('click');
 		expect(props.onChange).toBeCalledWith(expect.anything(), {
 			schema: expect.anything(),
-			value: [],
+			value: undefined,
 		});
 	});
 
@@ -196,7 +196,7 @@ describe('ResourcePicker field', () => {
 			.simulate('click');
 		expect(props.onChange).toBeCalledWith(expect.anything(), {
 			schema: expect.anything(),
-			value: [1],
+			value: '1',
 		});
 	});
 

--- a/packages/forms/stories-core/json/fields/core-resource-picker.json
+++ b/packages/forms/stories-core/json/fields/core-resource-picker.json
@@ -5,14 +5,16 @@
     "title": "ResourcePicker",
     "properties": {
       "multiResourcePicker": {
-        "type": "enum",
-        "enum": []
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
       },
       "singleResourcePicker": {
-        "type": "enum",
-        "enum": []
+        "type": "string"
       }
-    }
+    },
+    "required": ["multiResourcePicker", "singleResourcePicker"]
   },
   "uiSchema": [
     {
@@ -20,7 +22,6 @@
       "title": "ResourcePicker with multi selection",
       "widget": "resourcePicker",
       "placeholder": "Select an existing resource",
-      "required": true,
       "multi": true
     },
     {

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -24,7 +24,7 @@ function getFilteredCollection({ name, selection, certified, favorites, selected
 	};
 	const collection = [
 		{
-			id: 0,
+			id: '0',
 			name: 'Title with few actions',
 			modified: 1442880000000,
 			icon: 'talend-file-xls-o',
@@ -32,14 +32,14 @@ function getFilteredCollection({ name, selection, certified, favorites, selected
 			flags: ['CERTIFIED', 'FAVORITE'],
 		},
 		{
-			id: 1,
+			id: '1',
 			name: 'Title with lot of actions',
 			modified: 1537574400000,
 			icon: 'talend-file-xls-o',
 			author: 'Second Author',
 		},
 		{
-			id: 2,
+			id: '2',
 			name: 'Title with persistant actions',
 			modified: 1474502400000,
 			author: 'Jean-Pierre DUPONT',
@@ -47,7 +47,7 @@ function getFilteredCollection({ name, selection, certified, favorites, selected
 			flags: ['FAVORITE'],
 		},
 		{
-			id: 3,
+			id: '3',
 			name: 'Title with icon',
 			modified: 1506038400000,
 			author: 'Third Author',
@@ -55,14 +55,14 @@ function getFilteredCollection({ name, selection, certified, favorites, selected
 			flags: ['CERTIFIED'],
 		},
 		{
-			id: 4,
+			id: '4',
 			name: 'Title in input mode',
 			modified: 1506038400000,
 			author: 'Jean-Pierre DUPONT',
 			icon: 'talend-file-xls-o',
 		},
 		{
-			id: 5,
+			id: '5',
 			name: 'Title with long long long long long long long long long long long text',
 			modified: 1547478328552,
 			author: 'Jean-Pierre DUPONT with super super super long text',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Validation fails on single selection (selected, then unselect => valid because an empty array is returned)

**What is the chosen solution to this problem?**

Return a single string if not multi

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->