### PR TITLE
fix(frontend): add form mode to Date component widget

### DIFF
--- a/packages/forms/src/UIForm/fields/Date/Date.component.js
+++ b/packages/forms/src/UIForm/fields/Date/Date.component.js
@@ -90,6 +90,7 @@ class DateWidget extends React.Component {
 					useTime={useTime}
 					useSeconds={useSeconds}
 					useUTC={options.useUTC}
+					formMode={options.formMode}
 					// eslint-disable-next-line jsx-a11y/aria-proptypes
 					aria-invalid={!isValid}
 					aria-required={schema.required}
@@ -114,6 +115,7 @@ if (process.env.NODE_ENV !== 'production') {
 		onFinish: PropTypes.func.isRequired,
 		options: PropTypes.shape({
 			dateFormat: PropTypes.string,
+			formMode: PropTypes.bool,
 		}),
 		schema: PropTypes.shape({
 			autoFocus: PropTypes.bool,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When calling the Date and Datetime widget the formMode prop is not being taken in consideration in the Date component, therefore we can't use this option from a form configuration.

**What is the chosen solution to this problem?**
I have added the prop to the Date component.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
