### PR TITLE
fix(Notification): animation

### DIFF
--- a/packages/components/src/Notification/Notification.scss
+++ b/packages/components/src/Notification/Notification.scss
@@ -122,52 +122,47 @@ $tc-notification-icon-size: $svg-md-size !default;
 	}
 }
 
-:global {
-	@keyframes timer-bar {
-		from {
-			transform: translateX(0);
-		}
-
-		to {
-			transform: translateX(100%);
-		}
+@keyframes timer-bar {
+	from {
+		transform: translateX(0);
 	}
 
-	@keyframes tc-notification-slide-in {
-		from {
-			transform: translateY(-100%);
-			opacity: 0;
-			z-index: 1;
-		}
+	to {
+		transform: translateX(100%);
+	}
+}
 
-		to {
-			transform: translateY(0);
-			opacity: 1;
-			z-index: 1;
-		}
+@keyframes tc-notification-slide-in {
+	from {
+		transform: translateY(-100%);
+		opacity: 0;
+		z-index: 1;
 	}
 
-	@keyframes tc-notification-slide-out {
-		from {
-			transform: translateY(0);
-			opacity: 1;
-			z-index: 1;
-		}
+	to {
+		transform: translateY(0);
+		opacity: 1;
+		z-index: 1;
+	}
+}
 
-		to {
-			transform: translateY(-100%);
-			opacity: 0;
-			z-index: 1;
-		}
+@keyframes tc-notification-slide-out {
+	from {
+		transform: translateY(0);
+		opacity: 1;
+		z-index: 1;
 	}
 
-	.tc-notification {
-		&-enter {
-			animation: tc-notification-slide-in $tc-notification-animation-duration linear;
-		}
-
-		&-exit {
-			animation: tc-notification-slide-out $tc-notification-animation-duration linear;
-		}
+	to {
+		transform: translateY(-100%);
+		opacity: 0;
+		z-index: 1;
 	}
+}
+:global(.tc-notification-enter) {
+	animation: tc-notification-slide-in $tc-notification-animation-duration linear;
+}
+
+:global(.tc-notification-exit) {
+	animation: tc-notification-slide-out $tc-notification-animation-duration linear;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No animation in Notification due to a change #1972.
That's quite weird, because the 2 codes have a different behavior

```css
// css modules will transpile the name with the hash, and set it here.
// this uses tc-notification-slide-in as local variable (with transpiled name).
:global(.tc-notification-enter) {
	animation: tc-notification-slide-in $tc-notification-animation-duration linear;
}

// this sets tc-notification-slide-in as global name.
// but animation names are transpiled, even if wrapped within a :global{} 
:global {
	.tc-notification-enter {
		animation: tc-notification-slide-in $tc-notification-animation-duration linear;
	}
}
```

**What is the chosen solution to this problem?**
Use 1st format

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
