### PR TITLE
fix(frontend): missing ID in UIForm default array template Action

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
@@ -36,6 +36,7 @@ function DefaultArrayTemplate(props) {
 		>
 			{schema.title && <legend className="sr-only">{schema.title}</legend>}
 			<Action
+				id={`${id || 'tf-array'}-btn`}
 				className={classNames(theme['tf-array-add'], 'tf-array-add')}
 				bsStyle={'info'}
 				onClick={onAdd}

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
@@ -13,6 +13,7 @@ exports[`Default Array Template component should render default array template 1
   <Action
     bsStyle="info"
     className="theme-tf-array-add tf-array-add"
+    id="my-template-btn"
     label="New Element"
     onClick={[MockFunction]}
   />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The QA members ask to have an ID missing in the Buttons of a default array template in UIForms.

**What is the chosen solution to this problem?**
I added the _id_ prop to the Action component inside the default array template in UIForms.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
