### PR TITLE
fix(components): add FocusManager to handle focus in datalist component

### DIFF
--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -6,6 +6,7 @@ import keycode from 'keycode';
 import get from 'lodash/get';
 import Typeahead from '../Typeahead';
 import theme from './Datalist.scss';
+import FocusManager from '../FocusManager';
 
 export function escapeRegexCharacters(str) {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -59,7 +60,6 @@ class Datalist extends Component {
 	 * @param event The blur event
 	 */
 	onBlur(event) {
-		this.resetSuggestions();
 		const { value, previousValue } = this.state;
 
 		if (value !== previousValue) {
@@ -174,6 +174,8 @@ class Datalist extends Component {
 			event.preventDefault();
 			return;
 		}
+
+		this.resetSuggestions();
 		this.updateValue(event, newValue, true);
 	}
 
@@ -351,21 +353,27 @@ class Datalist extends Component {
 	render() {
 		const label = this.getSelectedLabel();
 		return (
-			<Typeahead
-				{...omit(this.props, PROPS_TO_OMIT)}
-				className={classNames('tc-datalist', this.props.className)}
-				focusedItemIndex={this.state.focusedItemIndex}
-				focusedSectionIndex={this.state.focusedSectionIndex}
-				items={this.state.suggestions}
-				onBlur={this.onBlur}
-				onChange={this.onChange}
-				onFocus={this.onFocus}
-				onKeyDown={this.onKeyDown}
-				onSelect={this.onSelect}
-				theme={this.theme}
-				value={label}
-				caret
-			/>
+			<FocusManager
+				onFocusOut={() => {
+					this.resetSuggestions();
+				}}
+			>
+				<Typeahead
+					{...omit(this.props, PROPS_TO_OMIT)}
+					className={classNames('tc-datalist', this.props.className)}
+					focusedItemIndex={this.state.focusedItemIndex}
+					focusedSectionIndex={this.state.focusedSectionIndex}
+					items={this.state.suggestions}
+					onBlur={this.onBlur}
+					onChange={this.onChange}
+					onFocus={this.onFocus}
+					onKeyDown={this.onKeyDown}
+					onSelect={this.onSelect}
+					theme={this.theme}
+					value={label}
+					caret
+				/>
+			</FocusManager>
 		);
 	}
 }

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -163,7 +163,6 @@ describe('Datalist component', () => {
 		// then
 		const payload = { value: 'foobar' };
 		expect(onChange).toBeCalledWith(expect.anything(), payload);
-		expect(wrapper.find(Typeahead).props().items).toBe(null);
 	});
 
 	it('should reset suggestions and change value on blur when not in restricted mode and value not in suggestions', () => {
@@ -190,7 +189,6 @@ describe('Datalist component', () => {
 		// then
 		const payload = { value: 'foooo' };
 		expect(onChange).toBeCalledWith(expect.anything(), payload);
-		expect(wrapper.find(Typeahead).props().items).toBe(null);
 	});
 
 	it('should reset suggestions and not change value on blur in restricted mode and value does not exist', () => {

--- a/packages/components/src/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/components/src/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -1,37 +1,41 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Datalist component should render a typeahead 1`] = `
-<Typeahead
-  autoFocus={true}
-  caret={true}
-  className="tc-datalist"
-  disabled={false}
-  docked={false}
-  errorMessage="This should be correct"
-  id="my-datalist"
-  isLoadingText="Loading..."
-  isValid={true}
-  items={null}
-  multiSection={false}
-  noResultText="there is nothing ..."
-  onBlur={[Function]}
-  onChange={[Function]}
-  onFocus={[Function]}
-  onKeyDown={[Function]}
-  onSelect={[Function]}
-  placeholder="Type here"
-  position="left"
-  readOnly={false}
-  searching={false}
-  searchingText="Searching for matches..."
-  theme={
-    Object {
-      "container": "theme-container tc-datalist-container",
-      "itemsContainer": "theme-items-container",
-      "itemsList": "theme-items",
+<FocusManager
+  onFocusOut={[Function]}
+>
+  <Typeahead
+    autoFocus={true}
+    caret={true}
+    className="tc-datalist"
+    disabled={false}
+    docked={false}
+    errorMessage="This should be correct"
+    id="my-datalist"
+    isLoadingText="Loading..."
+    isValid={true}
+    items={null}
+    multiSection={false}
+    noResultText="there is nothing ..."
+    onBlur={[Function]}
+    onChange={[Function]}
+    onFocus={[Function]}
+    onKeyDown={[Function]}
+    onSelect={[Function]}
+    placeholder="Type here"
+    position="left"
+    readOnly={false}
+    searching={false}
+    searchingText="Searching for matches..."
+    theme={
+      Object {
+        "container": "theme-container tc-datalist-container",
+        "itemsContainer": "theme-items-container",
+        "itemsList": "theme-items",
+      }
     }
-  }
-  title="My List"
-  value="foo"
-/>
+    title="My List"
+    value="foo"
+  />
+</FocusManager>
 `;

--- a/packages/components/src/FocusManager/FocusManager.component.js
+++ b/packages/components/src/FocusManager/FocusManager.component.js
@@ -1,0 +1,30 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+/**
+ * This component handle some specifics case like when we click in the datalist
+ * We loose the focus on the datalist field but we don't want to close the suggestions
+ * until we click outside of the component
+ */
+export default class FocusManager extends Component {
+	static propTypes = {
+		children: PropTypes.element.isRequired,
+		onFocusOut: PropTypes.func.isRequired,
+	};
+
+	onJSOFocus() {
+		clearTimeout(this.timeout);
+	}
+
+	onJSOBlur() {
+		this.timeout = setTimeout(() => this.props.onFocusOut());
+	}
+
+	render() {
+		return (
+			<div tabIndex={0} onBlur={() => this.onJSOBlur()} onFocus={() => this.onJSOFocus()}>
+				{this.props.children}
+			</div>
+		);
+	}
+}

--- a/packages/components/src/FocusManager/FocusManager.test.js
+++ b/packages/components/src/FocusManager/FocusManager.test.js
@@ -1,0 +1,30 @@
+import FocusManager from './FocusManager.component';
+
+describe('FocusManager', () => {
+	it('should call onFocusOut if there is no onJSOFocus called', done => {
+		// given
+		const onFocusOut = jest.fn();
+		const focusManager = new FocusManager({ onFocusOut });
+		// when
+		focusManager.onJSOBlur();
+		// then
+		setTimeout(() => {
+			expect(onFocusOut).toHaveBeenCalled();
+			done();
+		}, 10);
+	});
+
+	it('should not call onFocusOut if there is onJSOFocus is called', done => {
+		// given
+		const onFocusOut = jest.fn();
+		const focusManager = new FocusManager({ onFocusOut });
+		// when
+		focusManager.onJSOBlur();
+		focusManager.onJSOFocus();
+		// then
+		setTimeout(() => {
+			expect(onFocusOut).not.toHaveBeenCalled();
+			done();
+		}, 10);
+	});
+});

--- a/packages/components/src/FocusManager/index.js
+++ b/packages/components/src/FocusManager/index.js
@@ -1,0 +1,3 @@
+import FocusManager from './FocusManager.component';
+
+export default FocusManager;

--- a/packages/components/stories/Datalist.js
+++ b/packages/components/stories/Datalist.js
@@ -23,6 +23,19 @@ const propsMultiSection = {
 			suggestions: [{ name: 'My foobar', value: 'foobar', description: 'foobar description' }],
 		},
 		{ title: 'cat 4', suggestions: [{ name: 'My lol', value: 'lol' }] },
+		{
+			title: 'cat 1',
+			suggestions: [
+				{ name: 'My foo', value: 'foo', description: 'foo description' },
+				{ name: 'My faa', value: 'faa' },
+			],
+		},
+		{ title: 'cat 2', suggestions: [{ name: 'My bar', value: 'bar' }] },
+		{
+			title: 'cat 3',
+			suggestions: [{ name: 'My foobar', value: 'foobar', description: 'foobar description' }],
+		},
+		{ title: 'cat 4', suggestions: [{ name: 'My lol', value: 'lol' }] },
 	],
 	onFinish: action('onFinish'),
 	onChange: action('onChange'),

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -146,7 +146,6 @@ class Datalist extends Component {
 				isValid={this.props.isValid}
 				label={this.props.schema.title}
 				required={this.props.schema.required}
-				labelAfter
 			>
 				<DataListComponent
 					{...props}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The datalist automaticly close in some case :
![screen recording 2019-02-04 at 17 51 39](https://user-images.githubusercontent.com/2909671/52223467-f8c6be00-28a5-11e9-99be-1a4aa8cafe8d.gif)

**What is the chosen solution to this problem?**
Create a FocusManager component that wrap some behaviour to not close when the focus is inside him.
This component could be used in the date picker

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
