### PR TITLE
fix(forms): handle restricted option on the widget Datalist

### DIFF
--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -159,6 +159,7 @@ class Datalist extends Component {
 					placeholder={this.props.schema.placeholder}
 					readOnly={this.props.schema.readOnly || false}
 					titleMap={this.getTitleMap()}
+					restricted={this.props.schema.restricted}
 					inputProps={{
 						'aria-invalid': !this.props.isValid,
 						'aria-required': this.props.schema.required,

--- a/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -28,7 +28,7 @@ exports[`Datalist component should render 1`] = `
     onFocus={[Function]}
     placeholder="Type here"
     readOnly={false}
-    restricted={false}
+    restricted={true}
     t={[Function]}
     titleMap={
       Array [
@@ -79,7 +79,7 @@ exports[`Datalist component should render with multisection 1`] = `
     onFocus={[Function]}
     placeholder="Type here"
     readOnly={false}
-    restricted={false}
+    restricted={true}
     t={[Function]}
     titleMap={
       Array [

--- a/packages/forms/stories-core/json/fields/core-datalist.json
+++ b/packages/forms/stories-core/json/fields/core-datalist.json
@@ -95,6 +95,7 @@
     },
     {
       "key": "restrictedDatalist",
+			"restricted": true,
       "title": "Datalist with restricted options",
       "description": "This datalist does not allow other values than the possible choices",
       "widget": "datalist"
@@ -152,7 +153,7 @@
     {
       "key": "restrictedAsyncTitleMap",
       "restricted": true,
-      "title": "Datalist with async options ans restricted value",
+      "title": "Datalist with async options and restricted value",
       "widget": "datalist",
       "triggers": [
         {
@@ -172,6 +173,7 @@
       "key": "datalistWithCategoryRestricted",
       "title": "Datalist With category and restricted value",
       "widget": "datalist",
+			"restricted": true,
       "options": {
         "isMultiSection": true,
         "titleMap": [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

On [frontify](https://company-57688.frontify.com/document/92132#/ui-controls/dropdowns), the user experience defined this behavior 

- type a filter
- when the user click outside without select a value

the input should be reseted



**What is the chosen solution to this problem?**

fix that by passing restricted to the component

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
