### PR TITLE
fix(components/Headerbar): dropdowns with drawer

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -5,7 +5,7 @@ src/DateTimePickers/pickers/TimePicker/TimePicker.scss
   26:9  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
 
 src/Drawer/Drawer.scss
-  14:4  warning  Statement must begin on a new line  brace-style
+  15:4  warning  Statement must begin on a new line  brace-style
 
 src/FilterBar/FilterBar.scss
   48:6  warning  Vendor prefixes should not be used  no-vendor-prefixes

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -7,6 +7,7 @@ $tc-drawer-transition-easing: cubic-bezier(0.18, 0.89, 0.32, 1.28) !default;
 $tc-action-bar-background-color: $concrete !default;
 $tc-drawer-content-max-width: 650px !default;
 $tc-drawer-tabs-background: tint($brand-primary, 90) !default;
+$tc-drawer-z-index: $drawer-z-index !default;
 
 @function set-text-color($color) {
 	@if (lightness($color) > 60) {
@@ -25,8 +26,7 @@ $tc-drawer-tabs-background: tint($brand-primary, 90) !default;
 	right: 0;
 	bottom: 0;
 	width: 50vw;
-	// should always stay lower than dialog z-index which is set to 1040
-	z-index: 100;
+	z-index: $tc-drawer-z-index;
 }
 
 @media (min-width: $screen-md-min) and (max-width: $screen-md-max) {

--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -5,9 +5,10 @@
 
 /// Layout height of the header
 /// @type Number (Unit)
-$tc-layout-header-height: $navbar-height;
-$tc-layout-skip-links-z-index: 20;
-$tc-layout-header-z-index: 10;
+$tc-drawer-z-index: $drawer-z-index !default;
+$tc-layout-header-height: $navbar-height !default;
+$tc-layout-skip-links-z-index:  $tc-drawer-z-index + 20 !default;
+$tc-layout-header-z-index: $tc-drawer-z-index + 10 !default;
 
 .layout {
 	display: flex;

--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -7,7 +7,7 @@
 /// @type Number (Unit)
 $tc-drawer-z-index: $drawer-z-index !default;
 $tc-layout-header-height: $navbar-height !default;
-$tc-layout-skip-links-z-index:  $tc-drawer-z-index + 20 !default;
+$tc-layout-skip-links-z-index: $tc-drawer-z-index + 20 !default;
 $tc-layout-header-z-index: $tc-drawer-z-index + 10 !default;
 
 .layout {

--- a/packages/theme/src/theme/_guidelines.scss
+++ b/packages/theme/src/theme/_guidelines.scss
@@ -52,6 +52,11 @@ $modal-header-color: $black !default;
 $navbar-brand-logo-height: 20px !default;
 $navbar-brand-logo-width: 75px !default;
 
+/// Drawer z-index
+/// should always stay lower than dialog z-index which is set to 1040
+/// @type Number (Unitless)
+$drawer-z-index: 100 !default;
+
 /// Navbar form top and bottom width
 /// @type Number (Unit)
 $navbar-form-margin: 0 !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Since #1777, we cannot see `HeaderbBar` dropdowns while `Drawer` is opened anymore.

![image](https://user-images.githubusercontent.com/18534166/52870372-fb4bd200-3147-11e9-8127-41f7ac90ebe4.png)

**What is the chosen solution to this problem?**
Adapt _z-index_ regarding the `Drawer` one.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
