### PR TITLE
fix(cmf): http saga options documentation

### DIFF
--- a/packages/cmf/src/sagas/index.md
+++ b/packages/cmf/src/sagas/index.md
@@ -88,8 +88,8 @@ Example
 
 ```javascript
 const options = {
-    notify: false,
-    redirect: false,
+    toto: false,
+    tata: false,
 };
 
 const { data, response } = yield call(http.get, `${API['dataset-sample']}/${datasetId}`, config, options);

--- a/packages/cmf/src/sagas/index.md
+++ b/packages/cmf/src/sagas/index.md
@@ -68,32 +68,33 @@ const options = {
 
 const { data, response } = yield call(http.get, `${API['dataset-sample']}/${datasetId}`, config, options);
 ```
-* The config object allow you to customize your http request
+
+#### Config
+
+The config object allow you to customize your http request
  + ```headers```, ```credentials```, ```method```, ```body``` will be merged recursively against other provided arguments and override those values.
  + ```security``` will be resolved and then merged
 
-* The options object allow you to configure cmf behavior.
+#### Options
+
+The options object allow you to configure cmf behavior.
 
   + The ```silent``` property to ```true``` avoid that cmf dispatch an action of type ```@@HTTP/ERRORS```.<br/>
   It could be usefull if you want to treat the request error on a specific way only and deal with it within your own saga.
 
-#### Advanced silent options
+  + The other properties are passed in the dispatched error action. You can pass whatever option you want, to pass them to you app error handler.
+
+Example
 
 ```javascript
 const options = {
-	silent: {
-		notify: false,
-		redirect: false,
-	},
+    notify: false,
+    redirect: false,
 };
 
 const { data, response } = yield call(http.get, `${API['dataset-sample']}/${datasetId}`, config, options);
 ```
-Passing an object instead of a boolean will make cmf dispatch an action of type ```@@HTTP/ERRORS``` and allow you to deal with it in your redirect and notification sagas.
-
-If ```notify``` is ```false```, your onHttpErrorNotification saga should send the notification as it is within a ```silent```, if ```true``` it should not.
-
-If ```redirect``` is ```false```, your onHttpErrorRedirect saga should redirect to dedicated error page base on the status code as it is within a ```silent```, if ```true``` it should do nothing.
+On error, cmf will dispatch an action of type `@@HTTP/ERRORS`. Your onHttpErrorNotification saga will get the options object, and perform any action accordingly.
 
 
 ### http.create


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The cmf http saga documentation describes options that are not cmf related.

**What is the chosen solution to this problem?**
Change this part to explain that you can pass any options that is given back to the app on http error dispatch.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
