### PR TITLE
feat(DatePicker): validation button when we want date and time

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,6 +2,9 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+  195:1  error  Line 195 exceeds the maximum line length of 100  max-len
+
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   105:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role
 
@@ -23,5 +26,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   33:3  warning  Unexpected console statement  no-console
 
-✖ 7 problems (5 errors, 2 warnings)
+✖ 8 problems (6 errors, 2 warnings)
 

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -191,8 +191,8 @@ class InputDateTimePicker extends React.Component {
 export default InputDateTimePicker;
 
 /*
-* Scenarios to check
-* - focus on input + ESC (close picker), we don't have the validation button anymore. Then on blur, value is reset
-* - type in input, do I really have to press validation button ?
-* - if we want that, we have to consider dropdown and input as separated entities
-* */
+ * Scenarios to check
+ * - focus on input + ESC (close picker), we don't have the validation button anymore. Then on blur, value is reset
+ * - type in input, do I really have to press validation button ?
+ * - if we want that, we have to consider dropdown and input as separated entities
+ * */

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -133,30 +133,6 @@ class InputDateTimePicker extends React.Component {
 	render() {
 		const inputProps = omit(this.props, PROPS_TO_OMIT_FOR_INPUT);
 
-		const dateTimePicker = [
-			<DateTime.Input
-				{...inputProps}
-				key="input"
-				inputRef={ref => {
-					this.inputRef = ref;
-				}}
-			/>,
-			<div
-				className={theme['dropdown-wrapper']}
-				key="dropdown"
-				ref={ref => {
-					this.dropdownWrapperRef = ref;
-				}}
-			>
-				<Overlay container={this.dropdownWrapperRef} show={this.state.showPicker}>
-					<Popover className={theme.popover} id={this.popoverId}>
-						<DateTime.Picker />
-						{this.props.formMode && <DateTime.Validation />}
-					</Popover>
-				</Overlay>
-			</div>,
-		];
-
 		return (
 			<DateTime.Manager
 				dateFormat={this.props.dateFormat}
@@ -172,9 +148,6 @@ class InputDateTimePicker extends React.Component {
 				<DateTimeContext.Consumer>
 					{({ formManagement }) => (
 						<FocusManager
-							divRef={ref => {
-								this.containerRef = ref;
-							}}
 							onFocusIn={this.onFocus}
 							onFocusOut={event => {
 								this.onBlur(event, formManagement);
@@ -183,13 +156,31 @@ class InputDateTimePicker extends React.Component {
 								this.onKeyDown(event, formManagement);
 							}}
 						>
-							{this.props.formMode ? (
-								<form key="form" onSubmit={formManagement.onSubmit}>
-									{dateTimePicker}
-								</form>
-							) : (
-								dateTimePicker
-							)}
+							<DateTime.Input
+								{...inputProps}
+								key="input"
+								inputRef={ref => {
+									this.inputRef = ref;
+								}}
+							/>
+							<Overlay target={this.inputRef} show={this.state.showPicker} placement="bottom">
+								<Popover className={theme.popover} id={this.popoverId}>
+									<div
+										ref={ref => {
+											this.containerRef = ref;
+										}}
+									>
+										{this.props.formMode ? (
+											<form key="form" onSubmit={formManagement.onSubmit}>
+												<DateTime.Picker />
+												<DateTime.Validation />
+											</form>
+										) : (
+											<DateTime.Picker />
+										)}
+									</div>
+								</Popover>
+							</Overlay>
 						</FocusManager>
 					)}
 				</DateTimeContext.Consumer>
@@ -198,3 +189,10 @@ class InputDateTimePicker extends React.Component {
 	}
 }
 export default InputDateTimePicker;
+
+/*
+* Scenarios to check
+* - focus on input + ESC (close picker), we don't have the validation button anymore. Then on blur, value is reset
+* - type in input, do I really have to press validation button ?
+* - if we want that, we have to consider dropdown and input as separated entities
+* */

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
@@ -1,11 +1,5 @@
-.dropdown-wrapper {
-	position: relative;
-}
-
 .popover {
-	min-width: 310px;
-	max-width: 700px;
-	width: 100%;
+	width: 310px;
 	padding: 0;
 	border-radius: 0;
 

--- a/packages/forms/src/UIForm/fields/Date/Date.component.js
+++ b/packages/forms/src/UIForm/fields/Date/Date.component.js
@@ -92,6 +92,7 @@ class DateWidget extends React.Component {
 					autoFocus={schema.autoFocus}
 					dateFormat={options.dateFormat}
 					disabled={schema.disabled || valueIsUpdating}
+					formMode={useTime}
 					id={id}
 					onChange={this.onChange}
 					onBlur={this.onBlur}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Test to set the validation button everytime we need a date and time

Issues to solve : 
- no form in form: invalid html
- accessibility

Possible solution
Dropdown is mounted in a completely separated overlay.
- we have to consider input and picker as completely separated entities.
- wee need to manage focus (focus trap on dropdown)

Issues to solve
- focus on input + ESC (close picker), we don't have the validation button anymore. Then on blur, value is reset
- type in input, do I really have to press validation button ?

**What is the chosen solution to this problem?**


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
