### PR TITLE
fix(container/uiform): onTrigger update properties only if function

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -143,6 +143,15 @@ export class TCompForm extends React.Component {
 					type: TCompForm.ON_TRIGGER_END,
 					...payload,
 				});
+				// Today there is a need to give control to the trigger to modify the properties
+				// But this will override what user change in the meantime
+				// need to rethink that, there are lots of potential issues :
+				// - race conditions,
+				// - trigger result that is does not fit user entry anymore,
+				// - erase a good value put by the enduser
+				if (data.properties) {
+					this.setState({ properties: data.properties });
+				}
 				if (data.jsonSchema || data.uiSchema) {
 					this.props.setState(data);
 				}

--- a/packages/containers/src/ComponentForm/ComponentForm.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.test.js
@@ -386,6 +386,22 @@ describe('ComponentForm', () => {
 				expect(trigger.isCalled).toBe(true);
 			});
 
+			it('should register trigger result properties in state', () => {
+				// given
+				const wrapper = shallow(<TCompForm state={state} dispatch={jest.fn()} />);
+				const properties = { type: selectedType.value };
+				const trigger = wrapper.instance().trigger;
+				trigger.mockReturnWith({ properties });
+
+				// when
+				return wrapper
+					.instance()
+					.onTrigger(event, changePayload)
+					.then(() => {
+						expect(wrapper.state().properties).toBe(properties);
+					});
+			});
+
 			it('should set cmf state with schemas', () => {
 				// given
 				const setState = jest.fn();

--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -151,11 +151,9 @@ export default class UIForm extends React.Component {
 				}
 				this.setErrors(event, errors);
 			}
-			if (data.properties) {
+			if (typeof data.properties === 'function') {
 				let properties = data.properties;
-				if (typeof data.properties === 'function') {
-					properties = data.properties(liveState.properties);
-				}
+				properties = data.properties(liveState.properties);
 				this.onChange(event, { properties });
 			}
 			return data;

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -226,7 +226,7 @@ describe('UIForm container', () => {
 			});
 		});
 
-		it('should update state properties', done => {
+		it('should not update state properties', done => {
 			const properties = { firstname: 'my firstname is invalid' };
 			const onTrigger = jest.fn(() => Promise.resolve({ properties }));
 			const wrapper = shallow(<UIForm data={data} {...props} onTrigger={onTrigger} />);
@@ -235,7 +235,7 @@ describe('UIForm container', () => {
 			const triggerPromise = instance.onTrigger();
 
 			triggerPromise.then(() => {
-				expect(instance.state.liveState.properties).toBe(properties);
+				expect(instance.state.liveState.properties).not.toBe(properties);
 				done();
 			});
 		});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a breaking change introduced by #2024

The UIForm triggers is now handling the `properties` the trigger returns, overriding the current `properties`.

Before the PR, this was done only in ComponentForm.

**What is the chosen solution to this problem?**

* Revert this trigger `properties` return management from UIForm back to ComponentForm.
* we let the properties as modifier in UIForm
* another PR will set it back from ComponentForm to UIForm with a breaking change, scheduled for 3.x

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
