### PR TITLE
fix(UIForm): trigger properties modifier calls onChange with proper info

### DIFF
--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -154,7 +154,15 @@ export default class UIForm extends React.Component {
 			if (typeof data.properties === 'function') {
 				let properties = data.properties;
 				properties = data.properties(liveState.properties);
-				this.onChange(event, { properties });
+
+				const { schema, value, oldProperties } = payload;
+				this.onChange(event, {
+					schema,
+					value,
+					oldProperties,
+					properties,
+					formData: properties,
+				});
 			}
 			return data;
 		});

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -209,16 +209,18 @@ describe('UIForm container', () => {
 		});
 
 		it('should call errors updater if given', done => {
+			// given
 			const updater = jest.fn(() => ({ test: 42 }));
 			const onTrigger = jest.fn(() => Promise.resolve({ errors: updater }));
 			const wrapper = shallow(<UIForm data={data} {...props} onTrigger={onTrigger} />);
 			const instance = wrapper.instance();
 
-			const triggerPromise = instance.onTrigger();
-			instance.state.liveState.errors = {
-				test: 666,
-			};
+			instance.state.liveState.errors = { test: 666 };
 
+			// when
+			const triggerPromise = instance.onTrigger();
+
+			// then
 			triggerPromise.then(() => {
 				expect(updater).toHaveBeenCalledWith({ test: 666 });
 				expect(instance.state.liveState.errors).toEqual({ test: 42 });
@@ -227,13 +229,16 @@ describe('UIForm container', () => {
 		});
 
 		it('should not update state properties', done => {
+			// given
 			const properties = { firstname: 'my firstname is invalid' };
 			const onTrigger = jest.fn(() => Promise.resolve({ properties }));
 			const wrapper = shallow(<UIForm data={data} {...props} onTrigger={onTrigger} />);
 			const instance = wrapper.instance();
 
+			// when
 			const triggerPromise = instance.onTrigger();
 
+			// then
 			triggerPromise.then(() => {
 				expect(instance.state.liveState.properties).not.toBe(properties);
 				done();
@@ -241,18 +246,34 @@ describe('UIForm container', () => {
 		});
 
 		it('should call properties updater if given', done => {
+			// given
+			const onChange = jest.fn();
 			const updater = jest.fn(() => ({ test: 42 }));
 			const onTrigger = jest.fn(() => Promise.resolve({ properties: updater }));
-			const wrapper = shallow(<UIForm data={data} {...props} onTrigger={onTrigger} />);
+			const wrapper = shallow(
+				<UIForm data={data} {...props} onTrigger={onTrigger} onChange={onChange} />,
+			);
 			const instance = wrapper.instance();
 
-			const triggerPromise = instance.onTrigger();
-			instance.state.liveState.properties = {
-				test: 666,
-			};
+			instance.state.liveState.properties = { test: 666 };
+
+			const event = { target: {} };
+			const schema = { key: ['test'] };
+			const value = 666;
+			const oldProperties = { test: 777 };
+
+			// when
+			const triggerPromise = instance.onTrigger(event, { schema, value, oldProperties });
 
 			triggerPromise.then(() => {
 				expect(updater).toHaveBeenCalledWith({ test: 666 });
+				expect(onChange).toBeCalledWith(event, {
+					schema,
+					value,
+					oldProperties,
+					properties: { test: 42 },
+					formData: { test: 42 },
+				});
 				expect(instance.state.liveState.properties).toEqual({ test: 42 });
 				done();
 			});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UIForm trigger properties modifier calls onChange, but with only the properties.
That doesn't follow the classical onChange call.

**What is the chosen solution to this problem?**
Add the missing info

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
