### PR TITLE
feat(Scripts): add images and svg loaders

### DIFF
--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -120,7 +120,7 @@ module.exports = ({ getUserConfig, mode }) => {
 					},
 				},
 				{
-					test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+					test: /\.svg$/,
 					loader: 'url-loader',
 					options: {
 						name: 'assets/svg/[name].[ext]',

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -131,7 +131,11 @@ module.exports = ({ getUserConfig, mode }) => {
 				{
 					test: /\.(png|jpg|jpeg|gif)$/,
 					loader: 'url-loader',
-					options: { mimetype: 'image/png' },
+					options: {
+						name: 'assets/img/[name].[ext]',
+						limit: 10000,
+						mimetype: 'image/png',
+					},
 				},
 			],
 		},

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -123,7 +123,7 @@ module.exports = ({ getUserConfig, mode }) => {
 					test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
 					loader: 'url-loader',
 					options: {
-						name: 'assets/fonts/[name].[ext]',
+						name: 'assets/svg/[name].[ext]',
 						limit: 10000,
 						mimetype: 'image/svg+xml',
 					},

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -119,6 +119,20 @@ module.exports = ({ getUserConfig, mode }) => {
 						mimetype: 'application/font-woff',
 					},
 				},
+				{
+					test: /\.svg(\?v=\d+\.\d+\.\d+)?$/,
+					loader: 'url-loader',
+					options: {
+						name: 'assets/fonts/[name].[ext]',
+						limit: 10000,
+						mimetype: 'image/svg+xml',
+					},
+				},
+				{
+					test: /\.(png|jpg|jpeg|gif)$/,
+					loader: 'url-loader',
+					options: { mimetype: 'image/png' },
+				},
 			],
 		},
 		plugins: [
@@ -135,9 +149,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				loadCSSAsync: true,
 				appLoaderIcon: getUserConfig(['html', 'appLoaderIcon'], DEFAULT_APP_LOADER_ICON),
 			}),
-			new CopyWebpackPlugin([
-				{ from: 'src/assets' },
-			]),
+			new CopyWebpackPlugin([{ from: 'src/assets' }]),
 			new webpack.BannerPlugin({
 				banner: LICENSE_BANNER,
 			}),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No loaders for images and svg

**What is the chosen solution to this problem?**
Add the loaders

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
