### PR TITLE
feat(Scripts): add build timestamp

### DIFF
--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -122,6 +122,7 @@ module.exports = ({ getUserConfig, mode }) => {
 			],
 		},
 		plugins: [
+			new webpack.DefinePlugin({ BUILD_TIMESTAMP: Date.now() }),
 			new MiniCssExtractPlugin({
 				filename: '[name]-[hash].css',
 			}),
@@ -135,9 +136,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				loadCSSAsync: true,
 				appLoaderIcon: getUserConfig(['html', 'appLoaderIcon'], DEFAULT_APP_LOADER_ICON),
 			}),
-			new CopyWebpackPlugin([
-				{ from: 'src/assets' },
-			]),
+			new CopyWebpackPlugin([{ from: 'src/assets' }]),
 			new webpack.BannerPlugin({
 				banner: LICENSE_BANNER,
 			}),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some projects use the build timestamp as query params to download some settings.

**What is the chosen solution to this problem?**
Add the build timestamp via webpack configuration

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
