### PR TITLE
feat(Scripts): remove eslint from webpack build

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -42,7 +42,6 @@
     "enzyme-to-json": "^3.0.0",
     "eslint": "^4.0.0",
     "eslint-config-airbnb": "^11.1.0",
-    "eslint-loader": "^2.0.0",
     "eslint-plugin-import": "^1.16.0",
     "eslint-plugin-jsx-a11y": "^2.2.2",
     "eslint-plugin-react": "^6.3.0",

--- a/packages/scripts/webapp/preset/config/webpack.config.dev.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.dev.js
@@ -10,15 +10,6 @@ module.exports = ({ getUserConfig }) => {
 
 	return {
 		mode: 'development',
-		module: {
-			rules: [{
-				test:	/.*\.js$/,
-				enforce: 'pre',
-				loader: 'eslint-loader',
-				exclude: /node_modules/,
-				options: { configFile: path.resolve(__dirname, '.eslintrc') },
-			}],
-		},
 		watchOptions: {
 			aggregateTimeout: 300,
 			poll: 1000,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Talend/scripts has eslint loader in dev mode. But it makes it hard to read the console and takes more time to build.

**What is the chosen solution to this problem?**
Remove it from build. Eslint should be enforced via IDE plugins and CI run.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
