### PR TITLE
feat(Scripts): option to disable css modules

### DIFF
--- a/packages/scripts/webapp/preset/README.md
+++ b/packages/scripts/webapp/preset/README.md
@@ -20,7 +20,9 @@ This preset allows some customisation through specific entry points. The configu
       "$brand-primary-t7": "#00A1B3",
       "$brand-secondary-t7": "#168AA6"
     },
-    "theme": "tdp",
+    "theme": "tdp"
+  },
+  "css": {
     "modules": false
   },
   "webpack": {
@@ -123,7 +125,7 @@ By default, css modules are activated. To deactivate them,
 ```json
 {
   "preset": "talend",
-  "sass": {
+  "css": {
     "modules": false
   }
 }

--- a/packages/scripts/webapp/preset/README.md
+++ b/packages/scripts/webapp/preset/README.md
@@ -20,7 +20,8 @@ This preset allows some customisation through specific entry points. The configu
       "$brand-primary-t7": "#00A1B3",
       "$brand-secondary-t7": "#168AA6"
     },
-    "theme": "tdp"
+    "theme": "tdp",
+    "modules": false
   },
   "webpack": {
     "debug": true,
@@ -113,6 +114,17 @@ In case you want to load one of T7+ @talend/bootstrap-theme variation, you can p
   "preset": "talend",
   "sass": {
     "theme": "tdp"
+  }
+}
+```
+
+By default, css modules are activated. To deactivate them,
+
+```json
+{
+  "preset": "talend",
+  "sass": {
+    "modules": false
   }
 }
 ```

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -108,7 +108,13 @@ module.exports = ({ getUserConfig, mode }) => {
 				{
 					test: /\.scss$/,
 					use: getSassLoaders(true, sassData, mode),
+					include: /@talend/,
 					exclude: /bootstrap-theme/,
+				},
+				{
+					test: /\.scss$/,
+					use: getSassLoaders(getUserConfig(['sass', 'modules'], true), sassData, mode),
+					exclude: /@talend/,
 				},
 				{
 					test: /\.woff(2)?(\?v=\d+\.\d+\.\d+)?$/,
@@ -135,9 +141,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				loadCSSAsync: true,
 				appLoaderIcon: getUserConfig(['html', 'appLoaderIcon'], DEFAULT_APP_LOADER_ICON),
 			}),
-			new CopyWebpackPlugin([
-				{ from: 'src/assets' },
-			]),
+			new CopyWebpackPlugin([{ from: 'src/assets' }]),
 			new webpack.BannerPlugin({
 				banner: LICENSE_BANNER,
 			}),

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -113,7 +113,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				},
 				{
 					test: /\.scss$/,
-					use: getSassLoaders(getUserConfig(['sass', 'modules'], true), sassData, mode),
+					use: getSassLoaders(getUserConfig(['css', 'modules'], true), sassData, mode),
 					exclude: /@talend/,
 				},
 				{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some app don't use css modules, but talend/scripts default preset use css modules and there is no way to disable it.

**What is the chosen solution to this problem?**
Add an option to disable it in talend preset

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
