### PR TITLE
fix(CMFWebpackPlugin): cmfConfig set properly (typo cmfconfig)

### DIFF
--- a/packages/cmf-webpack-plugin/src/index.js
+++ b/packages/cmf-webpack-plugin/src/index.js
@@ -50,7 +50,7 @@ ReactCMFWebpackPlugin.prototype.apply = function reactCMFWebpackPluginApply(comp
 	if (!destination) {
 		cmfconfig.settings.destination = path.join(outputPath, 'settings.json');
 	}
-	this.options.cmfconfig = cmfconfig;
+	this.options.cmfConfig = cmfconfig;
 
 	/**
 	 * Runs at each webpack run.


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
cmf-webpack-plugin get the cmf merge config and modify it. But this modified config is not passed properly to the `merge()` function because of a typo.

**What is the chosen solution to this problem?**
Fix `options.cmfconfig` --> `props.cmfConfig` which is properly consumed by the merge function

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
