### PR TITLE
feat(Scripts): disable cmf webpack plugin by default

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -29,7 +29,7 @@
     "@babel/preset-env": "^7.2.0",
     "@babel/preset-react": "^7.0.0",
     "@talend/html-webpack-plugin": "^1.0.0",
-    "@talend/react-cmf-webpack-plugin": "^2.3.0",
+    "@talend/react-cmf-webpack-plugin": "^2.6.2",
     "autoprefixer": "^7.1.4",
     "babel-eslint": "^10.0.1",
     "babel-jest": "^24.0.0",

--- a/packages/scripts/webapp/preset/README.md
+++ b/packages/scripts/webapp/preset/README.md
@@ -134,12 +134,12 @@ You can add the debug option to true so the webpack configuration will be printe
 
 ## CMF
 
-Talend preset integrates `cmf-webpack-plugin`. By default it is active, it is possible to disable the plugin with a flag
+Talend preset integrates `cmf-webpack-plugin`. By default it is deactived, to enable it:
 
 ```json
 {
   "preset": "talend",
-  "cmf": false
+  "cmf": true
 }
 ```
 

--- a/packages/scripts/webapp/preset/config/webpack.config.dev.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.dev.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = ({ getUserConfig }) => {
 	const plugins = [];
-	if (getUserConfig('cmf') === true) {
+	if (getUserConfig('cmf')) {
 		// eslint-disable-next-line global-require,import/newline-after-import
 		const ReactCMFWebpackPlugin = require('@talend/react-cmf-webpack-plugin');
 		plugins.push(new ReactCMFWebpackPlugin({ watch: true }));

--- a/packages/scripts/webapp/preset/config/webpack.config.dev.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.dev.js
@@ -2,7 +2,7 @@ const path = require('path');
 
 module.exports = ({ getUserConfig }) => {
 	const plugins = [];
-	if (getUserConfig('cmf') !== false) {
+	if (getUserConfig('cmf') === true) {
 		// eslint-disable-next-line global-require,import/newline-after-import
 		const ReactCMFWebpackPlugin = require('@talend/react-cmf-webpack-plugin');
 		plugins.push(new ReactCMFWebpackPlugin({ watch: true }));
@@ -11,13 +11,15 @@ module.exports = ({ getUserConfig }) => {
 	return {
 		mode: 'development',
 		module: {
-			rules: [{
-				test:	/.*\.js$/,
-				enforce: 'pre',
-				loader: 'eslint-loader',
-				exclude: /node_modules/,
-				options: { configFile: path.resolve(__dirname, '.eslintrc') },
-			}],
+			rules: [
+				{
+					test: /.*\.js$/,
+					enforce: 'pre',
+					loader: 'eslint-loader',
+					exclude: /node_modules/,
+					options: { configFile: path.resolve(__dirname, '.eslintrc') },
+				},
+			],
 		},
 		watchOptions: {
 			aggregateTimeout: 300,

--- a/packages/scripts/webapp/preset/config/webpack.config.prod.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.prod.js
@@ -3,7 +3,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = ({ getUserConfig }) => {
 	const plugins = [];
-	if (getUserConfig('cmf') !== false) {
+	if (getUserConfig('cmf') === true) {
 		// eslint-disable-next-line global-require,import/newline-after-import
 		const ReactCMFWebpackPlugin = require('@talend/react-cmf-webpack-plugin');
 		plugins.push(new ReactCMFWebpackPlugin({ quiet: true }));

--- a/packages/scripts/webapp/preset/config/webpack.config.prod.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.prod.js
@@ -3,7 +3,7 @@ const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 
 module.exports = ({ getUserConfig }) => {
 	const plugins = [];
-	if (getUserConfig('cmf') === true) {
+	if (getUserConfig('cmf')) {
 		// eslint-disable-next-line global-require,import/newline-after-import
 		const ReactCMFWebpackPlugin = require('@talend/react-cmf-webpack-plugin');
 		plugins.push(new ReactCMFWebpackPlugin({ quiet: true }));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an incompatibility between cmf-webpack-plugin and copy-webpack-plugin.  
This is not new, and well documented in talend/scripts doc.

But most of the time, projects use settings in the way that it's incompatible. They will have to set `cmf: false` option, that doesn't make sense.

**What is the chosen solution to this problem?**
Change the default to not include the cmf plugin. To enable it, the cmf option need to be set to true.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

But it's talend/scripts that is not in 1.0.

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
