### PR TITLE
chore(Scripts): set enzyme as peer dep

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -39,7 +39,7 @@
     "core-js": "^2.6.5",
     "cross-spawn": "^6.0.4",
     "css-loader": "^1.0.1",
-    "enzyme": "^3.7.0",
+    "enzyme": "^3.7.0"
     "enzyme-adapter-react-16": "^1.7.0",
     "enzyme-to-json": "^3.0.0",
     "eslint": "^4.0.0",
@@ -73,8 +73,9 @@
     "which": "^1.3.0"
   },
   "peerDependencies": {
-    "@talend/bootstrap-theme": "1.10.0",
-    "@talend/react-components": "1.10.0"
+    "@talend/bootstrap-theme": ">=1.10.0",
+    "@talend/react-components": ">=1.10.0",
+    "enzyme": "^3.7.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Enzyme is a dependency but it is not really used.
And having this dep, projects won't request it, but eslint will output an issue because the tests import enzyme explicitly without being a dependency.

**What is the chosen solution to this problem?**
Migrate as peer dep. It makes sense that apps import enzyme because it use it in tests, not in talend/scripts code.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
