### PR TITLE
fix(TUI-355/forms): improve displayMode=text

### DIFF
--- a/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import { TextMode as FieldTemplate } from '../../FieldTemplate';
+import TextModeArrayTemplate from '../../../fieldsets/Array/displayMode/TextModeArrayTemplate.component';
+
+export default function TextMode(props) {
+	if (Array.isArray(props.value)) {
+		return <TextModeArrayTemplate {...props} />;
+	}
+	const { id, schema, value } = props;
+	const { title } = schema;
+	return (
+		<FieldTemplate id={id} label={title}>
+			{value}
+		</FieldTemplate>
+	);
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	TextMode.propTypes = {
+		id: PropTypes.string,
+		schema: PropTypes.shape({
+			title: PropTypes.string,
+		}),
+		value: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+	};
+}
+
+TextMode.defaultProps = {
+	schema: {},
+	value: '',
+};

--- a/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.test.js
+++ b/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.test.js
@@ -19,9 +19,7 @@ describe('Text field text display mode', () => {
 
 	it('should render array input', () => {
 		// when
-		const wrapper = shallow(
-			<TextMode id={'myForm'} schema={schema} value={['toto']} />,
-		);
+		const wrapper = shallow(<TextMode id={'myForm'} schema={schema} value={['toto']} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.test.js
+++ b/packages/forms/src/UIForm/fields/Select/displayMode/TextMode.component.test.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TextMode from './TextMode.component';
+
+describe('Text field text display mode', () => {
+	const schema = {
+		title: 'My input title',
+		type: 'select',
+	};
+
+	it('should render input', () => {
+		// when
+		const wrapper = shallow(<TextMode id={'myForm'} schema={schema} value="toto" />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render array input', () => {
+		// when
+		const wrapper = shallow(
+			<TextMode id={'myForm'} schema={schema} value={['toto']} />,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/forms/src/UIForm/fields/Select/displayMode/__snapshots__/TextMode.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Select/displayMode/__snapshots__/TextMode.component.test.js.snap
@@ -1,0 +1,27 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Text field text display mode should render array input 1`] = `
+<TextModeArrayTemplate
+  id="myForm"
+  schema={
+    Object {
+      "title": "My input title",
+      "type": "select",
+    }
+  }
+  value={
+    Array [
+      "toto",
+    ]
+  }
+/>
+`;
+
+exports[`Text field text display mode should render input 1`] = `
+<FieldTemplate
+  id="myForm"
+  label="My input title"
+>
+  toto
+</FieldTemplate>
+`;

--- a/packages/forms/src/UIForm/fields/Select/index.js
+++ b/packages/forms/src/UIForm/fields/Select/index.js
@@ -1,3 +1,5 @@
 import Select from './Select.component';
 
+export { default as TextModeSelect } from './displayMode/TextMode.component';
+
 export default Select;

--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -47,6 +47,8 @@ const widgets = {
 	fieldset_text: FieldsetTextMode,
 
 	// fields: text mode
+	button_text: () => null,
+	buttons_text: () => null,
 	checkbox_text: TextModeCheckBox,
 	checkboxes_text: ArrayWidget,
 	code_text: CodeTextMode,

--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -17,7 +17,7 @@ import NestedListView from '../fields/NestedListView';
 import Radios from '../fields/Radios';
 import RadioOrSelect from '../fields/RadioOrSelect';
 import ResourcePicker from '../fields/ResourcePicker';
-import Select from '../fields/Select';
+import Select, { TextModeSelect } from '../fields/Select';
 import Text, { TextTextMode } from '../fields/Text';
 import TextArea, { TextAreaTextMode } from '../fields/TextArea';
 import Toggle, { ToggleTextMode } from '../fields/Toggle';
@@ -53,9 +53,12 @@ const widgets = {
 	checkboxes_text: ArrayWidget,
 	code_text: CodeTextMode,
 	datalist_text: DatalistTextMode,
+	file_text: () => null,
 	multiSelectTag_text: MultiSelectTagTextMode,
 	number_text: TextTextMode,
 	password_text: TextTextMode,
+	radios_text: TextTextMode,
+	select_text: TextModeSelect,
 	text_text: TextTextMode,
 	textarea_text: TextAreaTextMode,
 	toggle_text: ToggleTextMode,

--- a/packages/forms/stories-core/customDisplayMode.js
+++ b/packages/forms/stories-core/customDisplayMode.js
@@ -1,0 +1,234 @@
+import React from 'react';
+import IconsProvider from '@talend/react-components/lib/IconsProvider';
+import { action } from '@storybook/addon-actions';
+import { UIForm } from '../src/UIForm';
+
+const schema = {
+	jsonSchema: {
+		type: 'object',
+		title: 'Comment',
+		properties: {
+			arrayOfObjects: {
+				type: 'array',
+				items: {
+					type: 'object',
+					properties: {
+						string: {
+							type: 'string',
+						},
+						number: {
+							type: 'number',
+						},
+					},
+					required: ['string', 'number'],
+				},
+			},
+			root: {
+				type: 'object',
+				properties: {
+					string: {
+						type: 'string',
+					},
+					number: {
+						type: 'number',
+					},
+					textarea: {
+						type: 'string',
+					},
+					checkbox: {
+						type: 'boolean',
+					},
+					multicheckbox: {
+						type: 'array',
+						items: {
+							type: 'string',
+							enum: ['foo', 'bar', 'fuzz', 'qux'],
+						},
+					},
+					code: {
+						type: 'string',
+					},
+					datalist: {
+						type: 'string',
+						enum: ['Apple', 'Pine[apple]', 'Banana', 'Cher[ry', 'Lemo}n', 'Grapefruit'],
+					},
+					date: {
+						type: 'string',
+					},
+					file: {
+						type: 'string',
+					},
+					multiSelectTag: {
+						type: 'array',
+						items: {
+							type: 'string',
+							enum: ['Apple'],
+						},
+					},
+					radios: {
+						type: 'string',
+						enum: ['foo', 'bar', 'fuzz', 'qux'],
+					},
+					toggle: {
+						type: 'boolean',
+					},
+					select: {
+						type: 'string',
+						enum: ['foo', 'bar', 'fuzz', 'qux'],
+					},
+					selectmulti: {
+						type: 'array',
+						items: {
+							type: 'string',
+							enum: ['foo', 'bar', 'fuzz', 'qux'],
+						},
+						uniqueItems: true,
+					},
+				},
+			},
+		},
+	},
+	uiSchema: [
+		{
+			key: 'arrayOfObjects',
+			itemTitle: 'item title',
+			items: [
+				{
+					key: 'arrayOfObjects[].string',
+					title: 'string',
+				},
+				{
+					key: 'arrayOfObjects[].number',
+					title: 'number',
+				},
+			],
+		},
+		{
+			key: 'root.string',
+			title: 'string',
+		},
+		{
+			key: 'root.number',
+			title: 'number',
+		},
+		{
+			key: 'root.textarea',
+			widget: 'textarea',
+			title: 'textarea',
+			rows: 5,
+		},
+		{
+			key: 'root.checkbox',
+			title: 'checkbox',
+		},
+		{
+			key: 'root.multicheckbox',
+			title: 'multicheckbox',
+		},
+		{
+			key: 'root.code',
+			widget: 'code',
+			title: 'code',
+			options: {
+				language: 'javascript',
+				height: '100px',
+			},
+		},
+		{
+			key: 'root.datalist',
+			restricted: true,
+			title: 'datalist',
+			widget: 'datalist',
+		},
+		{
+			key: 'root.date',
+			title: 'date',
+			widget: 'date',
+			options: {
+				dateFormat: 'DD/MM/YYYY',
+			},
+		},
+		{
+			key: 'root.file',
+			title: 'file',
+			widget: 'file',
+		},
+		{
+			key: 'root.multiSelectTag',
+			title: 'multiSelectTag',
+			widget: 'multiSelectTag',
+			titleMap: [
+				{
+					name: 'Apple12',
+					value: 'Apple',
+				},
+			],
+		},
+		{
+			key: 'root.toggle',
+			title: 'toggle',
+			widget: 'toggle',
+		},
+		{
+			key: 'root.radios',
+			title: 'radios',
+			widget: 'radios',
+		},
+		{
+			key: 'root.select',
+			title: 'select',
+		},
+		{
+			key: 'root.selectmulti',
+			title: 'Multiple choices list',
+			widget: 'select',
+		},
+		{
+			widget: 'button',
+			bsStyle: 'primary',
+			label: 'I am a button',
+			type: 'button',
+		},
+	],
+	properties: {
+		arrayOfObjects: [{ string: 'string', number: 3 }],
+		root: {
+			string: 'I am a string',
+			number: 2,
+			textarea: `I am a multiline text.
+            proof !`,
+			checkbox: true,
+			multicheckbox: ['foo', 'bar'],
+			code: 'console.log("Hello World")',
+			datalist: 'Apple',
+			date: '02/06/2018',
+			// file: ?
+			multiSelectTag: ['Apple'],
+			radios: 'foo',
+			toggle: true,
+			select: 'foo',
+			selectmulti: ['foo', 'bar'],
+		},
+	},
+};
+
+function story() {
+	return (
+		<div>
+			<IconsProvider />
+			<h2>displayMode="text"</h2>
+			<p>Form can be used to display data in read only</p>
+			<UIForm
+				data={schema}
+				onChange={action('Change')}
+				onSubmit={action('onSubmit')}
+				displayMode="text"
+			/>
+		</div>
+	);
+}
+
+export default {
+	name: 'Core Concept displayMode text',
+	story,
+};

--- a/packages/forms/stories-core/index.js
+++ b/packages/forms/stories-core/index.js
@@ -6,6 +6,7 @@ import customTemplateStory from './customTemplateStory';
 import customWidgetStory from './customWidgetStory';
 import customActionsStory from './customActionsStory';
 import customUpdating from './customUpdating';
+import customDisplayMode from './customDisplayMode';
 
 const coreConceptsStories = storiesOf('Core concepts', module);
 
@@ -41,3 +42,4 @@ coreConceptsStories.add(customTemplateStory.name, customTemplateStory.story);
 coreConceptsStories.add(customWidgetStory.name, customWidgetStory.story);
 coreConceptsStories.add(customActionsStory.name, customActionsStory.story);
 coreConceptsStories.add(customUpdating.name, customUpdating.story);
+coreConceptsStories.add(customDisplayMode.name, customDisplayMode.story);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Issues on displayMode=text
* radios are not supported
* select is not supported
* button not supported

**What is the chosen solution to this problem?**

Add storybook with all field in text mode.
Add support for all existing fields

Demo: http://2057.talend.surge.sh/forms/?selectedKind=Core%20concepts&selectedStory=Core%20Concept%20displayMode%20text

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
