### PR TITLE
feat(Scripts): remove devServer proxy definition

### DIFF
--- a/packages/scripts/webapp/preset/README.md
+++ b/packages/scripts/webapp/preset/README.md
@@ -160,17 +160,6 @@ By default, css modules are activated. To deactivate them,
 
 ## Webpack
 
-By default, a devServer proxy is in place, mapping all `/api` urls to `http://localhost`. You can change it to adapt to your backend api url.
-
-```json
-{
-  "preset": "talend",
-  "webpack": {
-    "api-url": "http://localhost:3000"
-  }
-}
-```
-
 You can add the debug option to true so the webpack configuration will be printed to the output.
 
 ```json

--- a/packages/scripts/webapp/preset/config/webpack.config.dev.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.dev.js
@@ -16,13 +16,6 @@ module.exports = ({ getUserConfig }) => {
 		},
 		devServer: {
 			port: 3000,
-			proxy: {
-				'/api': {
-					target: getUserConfig(['webpack', 'api-url'], 'http://localhost'),
-					changeOrigin: true,
-					secure: false,
-				},
-			},
 			stats: 'errors-only',
 			historyApiFallback: true,
 			contentBase: path.join(process.cwd(), '/dist'),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In @talend/script talend preset, we define a devServer proxy, but it doesn't make sense, it's app specific.

**What is the chosen solution to this problem?**
Remove it. App will have to define their proxy in custom conf.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
