### PR TITLE
fix(Scripts): output public path

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talend/scripts",
   "description": "Set of scripts",
-  "version": "0.12.0",
+  "version": "0.12.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "mainSrc": "index.js",

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -85,6 +85,7 @@ module.exports = ({ getUserConfig, mode }) => {
 		entry: ['@babel/polyfill', 'whatwg-fetch', `${process.cwd()}/src/app/index.js`],
 		output: {
 			filename: '[name]-[hash].js',
+			publicPath: '/',
 		},
 		module: {
 			rules: [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
From non "/" path, the refresh produce a bad path for assets (style, ...), including the non root context.

**What is the chosen solution to this problem?**
Add the missing public path in webpack output config to produce url with / context.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
