### PR TITLE
fix(datagrid): miss ellipsis on the large header

### DIFF
--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.component.js
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.component.js
@@ -24,20 +24,22 @@ export default function DefaultHeaderRenderer({ column, displayName, onFocusedCo
 				onKeyDown={onHeaderKeyDown}
 				type="button"
 			>
-				<div className={classNames(theme['td-header-title'], 'td-header-title')}>
-					<span
-						className={classNames(theme['td-header-title-ellipse'], 'td-header-title-ellipse')}
-						title={displayName}
+				<span>
+					<div className={classNames(theme['td-header-title'], 'td-header-title')}>
+						<span
+							className={classNames(theme['td-header-title-ellipse'], 'td-header-title-ellipse')}
+							title={displayName}
+						>
+							{displayName}
+						</span>
+					</div>
+					<div
+						className={classNames(theme['td-header-type'], 'td-header-type')}
+						title={column.colDef.type}
 					>
-						{displayName}
-					</span>
-				</div>
-				<div
-					className={classNames(theme['td-header-type'], 'td-header-type')}
-					title={column.colDef.type}
-				>
-					{column.colDef.type}
-				</div>
+						{column.colDef.type}
+					</div>
+				</span>
 			</button>
 			{column.colDef[QUALITY_KEY] && (
 				<QualityBar

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
@@ -20,12 +20,6 @@ $td-grip-resize-width: 6px !default;
 .td-header-component {
 	height: 100%;
 
-	> span {
-		// https://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-or-fieldset-elements
-		display: flex;
-		flex-direction: column;
-	}
-
 	&:hover :global(.td-quality-bar) {
 		height: $td-quality-bar-hover-height;
 	}

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
@@ -20,6 +20,12 @@ $td-grip-resize-width: 6px !default;
 .td-header-component {
 	height: 100%;
 
+	> span {
+		// https://stackoverflow.com/questions/35464067/flexbox-not-working-on-button-or-fieldset-elements
+		display: flex;
+		flex-direction: column;
+	}
+
 	&:hover :global(.td-quality-bar) {
 		height: $td-quality-bar-hover-height;
 	}
@@ -31,8 +37,6 @@ $td-grip-resize-width: 6px !default;
 		text-align: left;
 		background-color: transparent;
 		border: none;
-		display: flex;
-		flex-direction: column;
 
 		&-title {
 			display: flex;

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
@@ -10,22 +10,24 @@ exports[`#DefaultHeaderGrid should render DefaultHeaderGrid 1`] = `
     onKeyDown={[Function]}
     type="button"
   >
-    <div
-      className="theme-td-header-title td-header-title"
-    >
-      <span
-        className="theme-td-header-title-ellipse td-header-title-ellipse"
-        title="Title"
+    <span>
+      <div
+        className="theme-td-header-title td-header-title"
       >
-        Title
-      </span>
-    </div>
-    <div
-      className="theme-td-header-type td-header-type"
-      title="string"
-    >
-      string
-    </div>
+        <span
+          className="theme-td-header-title-ellipse td-header-title-ellipse"
+          title="Title"
+        >
+          Title
+        </span>
+      </div>
+      <div
+        className="theme-td-header-type td-header-type"
+        title="string"
+      >
+        string
+      </div>
+    </span>
   </button>
   <Translate(QualityBarComponent)
     empty={33}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
we have regression with [Talend/ui#2022](https://github.com/Talend/ui/pull/2022). chrome don't handle flex on button element very well. The overflow hidden is not respected.

**What is the chosen solution to this problem?**
So, we remove button by div and restore accessibility action(press space and enter) to select the column

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
