### PR TITLE
fix(datagrid): js error when onFocusColumns is not defined

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -10,6 +10,12 @@ src/Drawer/Drawer.scss
 src/FilterBar/FilterBar.scss
   48:6  warning  Vendor prefixes should not be used  no-vendor-prefixes
 
+src/List/Toolbar/SelectSortBy/SelectSortBy.scss
+  16:10  error  Strings must use single quotes  quotes
+
+src/List/Toolbar/Toolbar.scss
+  31:10  error  Strings must use single quotes  quotes
+
 src/Typeahead/Typeahead.scss
   34:5  error  Mixins should come before declarations  mixins-before-declarations
   91:5  error  Nesting depth 4 greater than max of 3   nesting-depth
@@ -17,5 +23,5 @@ src/Typeahead/Typeahead.scss
 src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
   2:24  error  Strings must use single quotes  quotes
 
-✖ 6 problems (4 errors, 2 warnings)
+✖ 8 problems (6 errors, 2 warnings)
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -131,7 +131,9 @@ export default class DataGrid extends React.Component {
 		this.setCurrentFocusedColumn(colId);
 		this.updateStyleFocusColumn();
 
-		this.props.onFocusedColumn({ colId });
+		if (this.props.onFocusedColumn) {
+			this.props.onFocusedColumn({ colId });
+		}
 	}
 
 	onKeyDownHeaderColumn(event, colId) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
js errors occurs when the user clicks on the header and no onFocusColumn defined on the Datagrid props
**What is the chosen solution to this problem?**
fix that
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
