### PR TITLE
fix(List): toolbar menu text capitalisation

### DIFF
--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.scss
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.scss
@@ -11,6 +11,17 @@ $tc-list-toolbar-display-color: $dove-gray !default;
 		margin: 0;
 		letter-spacing: 0;
 	}
+
+	&:global(.navbar-nav) li {
+		a[role="menuitem"],
+		a:global(.dropdown-toggle) {
+			text-transform: lowercase;
+			display: inline-block;
+			&::first-letter {
+				text-transform: uppercase;
+			}
+		}
+	}
 }
 
 .sort-by-items {

--- a/packages/components/src/List/Toolbar/Toolbar.scss
+++ b/packages/components/src/List/Toolbar/Toolbar.scss
@@ -28,13 +28,10 @@ $tc-list-toolbar-background-color: $concrete !default;
 	}
 
 	:global(.navbar-nav) {
-		li a {
+		a[role="menuitem"],
+		a:global(.dropdown-toggle) {
 			color: $black;
-			text-transform: lowercase;
-			display: inline-block;
-			&::first-letter {
-				text-transform: uppercase;
-			}
+			text-transform: capitalize;
 		}
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Visual Regression from #2012, display menu in toolbar are in lower case

<img width="364" alt="capture d ecran 2019-03-01 a 16 08 14" src="https://user-images.githubusercontent.com/10761073/53646741-4089fc80-3c3c-11e9-8d86-3e7712c27fa2.png">

This is du to the svg element before the test, the first-letter is not applied.

**What is the chosen solution to this problem?**

Restore capitalize + add specific first letter in sort menu that has no icon.

<img width="369" alt="capture d ecran 2019-03-01 a 16 07 27" src="https://user-images.githubusercontent.com/10761073/53646748-44b61a00-3c3c-11e9-8212-c16743d49aae.png">


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
