### PR TITLE
fix(forms/validation): Fix errors entry generated by validation func

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -10,6 +10,12 @@ src/Drawer/Drawer.scss
 src/FilterBar/FilterBar.scss
   48:6  warning  Vendor prefixes should not be used  no-vendor-prefixes
 
+src/List/Toolbar/SelectSortBy/SelectSortBy.scss
+  16:10  error  Strings must use single quotes  quotes
+
+src/List/Toolbar/Toolbar.scss
+  31:10  error  Strings must use single quotes  quotes
+
 src/Typeahead/Typeahead.scss
   34:5  error  Mixins should come before declarations  mixins-before-declarations
   91:5  error  Nesting depth 4 greater than max of 3   nesting-depth
@@ -17,5 +23,5 @@ src/Typeahead/Typeahead.scss
 src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
   2:24  error  Strings must use single quotes  quotes
 
-✖ 6 problems (4 errors, 2 warnings)
+✖ 8 problems (6 errors, 2 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,5 +5,10 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
-✖ 1 problem (1 error, 0 warnings)
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/validation.test.js
+  223:10  error  'customValidationFn' is already declared in the upper scope    no-shadow
+  236:29  error  Unnecessarily computed property ['fieldsets,someField'] found  no-useless-computed-key
+
+✖ 3 problems (3 errors, 0 warnings)
+  1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -114,12 +114,12 @@ export function validateSimple(
 	const results = {};
 	const { key, items } = mergedSchema;
 
-	results[key] = validateValue(mergedSchema, value, properties, customValidationFn);
-
 	if (deepValidation && items) {
 		// eslint-disable-next-line no-use-before-define
 		const subResults = validateAll(items, properties, customValidationFn);
 		Object.assign(results, subResults);
+	} else {
+		results[key] = validateValue(mergedSchema, value, properties, customValidationFn);
 	}
 
 	return results;

--- a/packages/forms/src/UIForm/utils/validation.test.js
+++ b/packages/forms/src/UIForm/utils/validation.test.js
@@ -202,6 +202,39 @@ describe('Validation utils', () => {
 			// then
 			expect(errors).toEqual({ [schema.key]: 'Missing required property: firstname' });
 		});
+		it('should validate fieldsets/object', () => {
+			// given
+			const schema = {
+				key: ['fieldsets'],
+				items: [
+					{
+						key: ['fieldsets', 'someField'],
+						required: true,
+						schema: {
+							type: 'string'
+						}
+					}
+				],
+				schema: {
+					type: 'object',
+					required: ['someField']
+				}
+			};
+			const customValidationFn = undefined;
+			const deepValidation = true;
+			const value = '';
+			const properties = {
+				fieldsets: {
+					someField: value,
+				}
+			};
+
+			// when
+			const errors = validateSimple(schema, value, properties, customValidationFn, deepValidation);
+
+			// then
+			expect(errors).toEqual({ ['fieldsets,someField']: 'Missing required property: someField' });
+		})
 	});
 
 	describe('#validateSingle', () => {

--- a/packages/forms/src/UIForm/utils/validation.test.js
+++ b/packages/forms/src/UIForm/utils/validation.test.js
@@ -211,14 +211,14 @@ describe('Validation utils', () => {
 						key: ['fieldsets', 'someField'],
 						required: true,
 						schema: {
-							type: 'string'
-						}
-					}
+							type: 'string',
+						},
+					},
 				],
 				schema: {
 					type: 'object',
-					required: ['someField']
-				}
+					required: ['someField'],
+				},
 			};
 			const customValidationFn = undefined;
 			const deepValidation = true;
@@ -226,7 +226,7 @@ describe('Validation utils', () => {
 			const properties = {
 				fieldsets: {
 					someField: value,
-				}
+				},
 			};
 
 			// when
@@ -234,7 +234,7 @@ describe('Validation utils', () => {
 
 			// then
 			expect(errors).toEqual({ ['fieldsets,someField']: 'Missing required property: someField' });
-		})
+		});
 	});
 
 	describe('#validateSingle', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Consider there's a fieldset eg `fields` in form, and inside there's a required field 'madatoryField'.
When user provides no value for it, form validation functionality will generate 2 entries in `props.errors`:
```
{
  "fields": "Missing required property",
  "fields, madatoryField": "Missing required property"
}
```
and then user input this value, only the second entry will be removed. then form is always in error state and enable to submit.
Related issue in TMC: https://jira.talendforge.org/browse/TMC-16637
**What is the chosen solution to this problem?**
Make changes to validate function so it only generate a single entry for nested objects.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
