### PR TITLE
fix(Scripts): eslint remove List and Map from mandatory new

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talend/scripts",
   "description": "Set of scripts",
-  "version": "0.14.1",
+  "version": "0.14.2",
   "license": "Apache-2.0",
   "main": "index.js",
   "mainSrc": "index.js",

--- a/packages/scripts/webapp/preset/config/.eslintrc
+++ b/packages/scripts/webapp/preset/config/.eslintrc
@@ -16,7 +16,8 @@
     "react/jsx-indent-props": ["error", "tab"],
     "react/jsx-filename-extension": [1, { "extensions": [".js"] }],
     "react/no-unused-prop-types": [2, { "skipShapeProps": true }],
-    "react/forbid-prop-types": [0]
+    "react/forbid-prop-types": [0],
+    "new-cap": [2, { "capIsNewExceptions": ["List", "Map"] }]
   },
   "env": {
     "es6": true,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When using immutableJS, List and Map give a lint error because they are not used with new.

**What is the chosen solution to this problem?**
Exclude them from the lint rule.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
