### PR TITLE
fix(Datalist): updated datalist titlemapping function title check

### DIFF
--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -220,7 +220,7 @@ class Datalist extends Component {
 	 */
 	buildTitleMapping(titleMap) {
 		return titleMap.reduce((obj, item) => {
-			if (this.props.multiSection && item.title && item.suggestions) {
+			if (this.props.multiSection && item.title !== undefined && item.suggestions) {
 				const children = this.buildTitleMapping(item.suggestions);
 				return { ...obj, ...children };
 			}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If we have datalist with multiSection: true, and a section with an empty-line title '' then it treating titlemap like it regular single-section title map.

**What is the chosen solution to this problem?**

Added additional undefined check.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
