### PR TITLE
fix(Scripts): custom .babelrc file load

### DIFF
--- a/packages/scripts/webapp/preset/config/babel-resolver.js
+++ b/packages/scripts/webapp/preset/config/babel-resolver.js
@@ -1,13 +1,8 @@
 const path = require('path');
 const fs = require('fs');
 
-function getBabelConfigPath() {
-	const userBabelrcPath = `${process.cwd()}/.babelrc`;
-	if (!fs.existsSync(userBabelrcPath)) {
-		return path.join(__dirname, '.babelrc.json');
-	}
-
-	const babelrc = JSON.parse(fs.readFileSync(userBabelrcPath, 'utf8'));
+function checkBabelJsonExtension(babelConfigJsonPath) {
+	const babelrc = JSON.parse(fs.readFileSync(babelConfigJsonPath, 'utf8'));
 	const babelrcExtends = '@talend/scripts/webapp/preset/config/.babelrc.json';
 	if (babelrc.extends !== babelrcExtends) {
 		throw new Error(`
@@ -15,12 +10,36 @@ function getBabelConfigPath() {
 				{ "extends": "${babelrcExtends}" }
 		`);
 	}
-	return userBabelrcPath;
+}
+
+function getBabelConfigPath() {
+	const userBabelrcPath = `${process.cwd()}/.babelrc`;
+	const userBabelrcJsonPath = `${process.cwd()}/.babelrc.json`;
+	const userBabelrcConfigJsPath = `${process.cwd()}/babelrc.config.js`;
+
+	if (fs.existsSync(userBabelrcPath)) {
+		checkBabelJsonExtension(userBabelrcPath);
+		return userBabelrcPath;
+	} else if (fs.existsSync(userBabelrcJsonPath)) {
+		checkBabelJsonExtension(userBabelrcJsonPath);
+		return userBabelrcJsonPath;
+	} else if (fs.existsSync(userBabelrcConfigJsPath)) {
+		return userBabelrcConfigJsPath;
+	} else {
+		return path.join(__dirname, '.babelrc.json');
+	}
 }
 
 function getBabelConfig() {
+	const babelConfigPath = getBabelConfigPath();
+
+	// .babelrc is a json, but without explicit .json extension, node require() tries to parse js
+	if (babelConfigPath.endsWith('.babelrc')) {
+		return JSON.parse(fs.readFileSync(babelConfigPath, 'utf8'));
+	}
+
 	// eslint-disable-next-line global-require
-	return require(getBabelConfigPath());
+	return require(babelConfigPath);
 }
 
 module.exports = {

--- a/packages/scripts/webapp/preset/config/babel-resolver.js
+++ b/packages/scripts/webapp/preset/config/babel-resolver.js
@@ -13,20 +13,21 @@ function checkBabelJsonExtension(babelConfigJsonPath) {
 }
 
 function getBabelConfigPath() {
-	const userBabelrcPath = `${process.cwd()}/.babelrc`;
-	const userBabelrcJsonPath = `${process.cwd()}/.babelrc.json`;
-	const userBabelrcConfigJsPath = `${process.cwd()}/babelrc.config.js`;
+	const userBabelrc = path.join(process.cwd(), '.babelrc');
+	const userBabelrcJson = path.join(process.cwd(), '.babelrc.json');
+	const userBabelJs = path.join(process.cwd(), 'babel.config.js');
+	const defaultBabelrc = path.join(__dirname, '.babelrc.json');
 
-	if (fs.existsSync(userBabelrcPath)) {
-		checkBabelJsonExtension(userBabelrcPath);
-		return userBabelrcPath;
-	} else if (fs.existsSync(userBabelrcJsonPath)) {
-		checkBabelJsonExtension(userBabelrcJsonPath);
-		return userBabelrcJsonPath;
-	} else if (fs.existsSync(userBabelrcConfigJsPath)) {
-		return userBabelrcConfigJsPath;
+	if (fs.existsSync(userBabelrc)) {
+		checkBabelJsonExtension(userBabelrc);
+		return userBabelrc;
+	} else if (fs.existsSync(userBabelrcJson)) {
+		checkBabelJsonExtension(userBabelrcJson);
+		return userBabelrcJson;
+	} else if (fs.existsSync(userBabelJs)) {
+		return userBabelJs;
 	} else {
-		return path.join(__dirname, '.babelrc.json');
+		return defaultBabelrc;
 	}
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
* Adding a custom .babelrc file fails because node relies on the file extension to parse js or json.
* Babel accepts `.babelrc` (json), `.babelrc.json`, `babelrc.config.js`, but we consider only `.babelrc` file.

**What is the chosen solution to this problem?**
* Add a specific case to load `.babelrc` file
* support the 3 types of user custom files

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
