### PR TITLE
fix(components/GuidedTour): valid html

### DIFF
--- a/packages/components/src/GuidedTour/GuidedTour.component.js
+++ b/packages/components/src/GuidedTour/GuidedTour.component.js
@@ -14,9 +14,9 @@ function getTooltipContent({ header, body }) {
 	return reactourCallbacks => (
 		<React.Fragment>
 			{header && <h2 className={classNames(theme.header, 'tc-guided-tour__header')}>{header}</h2>}
-			<p className={classNames(theme.body, 'tc-guided-tour__body')}>
-				{typeof body === 'function' ? body(reactourCallbacks) : body}
-			</p>
+			<div className={classNames(theme.body, 'tc-guided-tour__body')}>
+				{typeof body === 'function' ? body(reactourCallbacks) : (<p>body</p>)}
+			</div>
 		</React.Fragment>
 	);
 }

--- a/packages/components/src/GuidedTour/GuidedTour.component.js
+++ b/packages/components/src/GuidedTour/GuidedTour.component.js
@@ -15,7 +15,7 @@ function getTooltipContent({ header, body }) {
 		<React.Fragment>
 			{header && <h2 className={classNames(theme.header, 'tc-guided-tour__header')}>{header}</h2>}
 			<div className={classNames(theme.body, 'tc-guided-tour__body')}>
-				{typeof body === 'function' ? body(reactourCallbacks) : (<p>body</p>)}
+				{typeof body === 'function' ? body(reactourCallbacks) : <p>body</p>}
 			</div>
 		</React.Fragment>
 	);

--- a/packages/components/stories/GuidedTour.js
+++ b/packages/components/stories/GuidedTour.js
@@ -97,7 +97,7 @@ function getSteps({ hideControls, showControls, t }) {
 			content: {
 				header: 'Hello world',
 				body: () => (
-					<div
+					<p
 						dangerouslySetInnerHTML={{
 							__html: t('GUIDEDTOUR_HELLO_WORD_HTML', {
 								defaultValue: 'Hello world<br>You can switch language',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
I tried to inject `div` into `p`

**What is the chosen solution to this problem?**
Render valid html by wrapping it with a `div`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
