### PR TITLE
fix(Scripts): use path to build file path forw windows compat

### DIFF
--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@talend/scripts",
   "description": "Set of scripts",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "license": "Apache-2.0",
   "main": "index.js",
   "mainSrc": "index.js",

--- a/packages/scripts/webapp/preset/config/webpack.config.js
+++ b/packages/scripts/webapp/preset/config/webpack.config.js
@@ -191,7 +191,7 @@ module.exports = ({ getUserConfig, mode }) => {
 	const { theme } = userSassData;
 
 	const sassData = getSassData(userSassData);
-	const indexTemplatePath = `${process.cwd()}/src/app/index.html`;
+	const indexTemplatePath = path.join(process.cwd(), 'src', 'app', 'index.html');
 
 	return {
 		entry: {
@@ -205,7 +205,7 @@ module.exports = ({ getUserConfig, mode }) => {
 		output: {
 			filename: '[name]-[hash].js',
 			publicPath: '/',
-			globalObject: 'this'
+			globalObject: 'this',
 		},
 		module: {
 			rules: [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Index.html is excluded from html loader, but the path to exclude it is slash separated, that makes it windows incompatible.

**What is the chosen solution to this problem?**
Use `path.join()`.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
