### PR TITLE
fix(TUI-380): Tooltip not shown for actions with overlay

### DIFF
--- a/packages/components/src/OverlayTrigger/OverlayTrigger.component.js
+++ b/packages/components/src/OverlayTrigger/OverlayTrigger.component.js
@@ -93,6 +93,11 @@ export default class OverlayTrigger extends React.Component {
 			rootClose: true,
 			trigger: 'click',
 		};
+		const tooltipProps = {
+			onMouseOver: this.props.onMouseOver,
+			onMouseOut: this.props.onMouseOut,
+			onFocus: this.props.onFocus,
+		};
 
 		if (this.props.preventScrolling) {
 			props.container = this;
@@ -105,6 +110,7 @@ export default class OverlayTrigger extends React.Component {
 					theme['tc-action-button-positionned'],
 					'tc-action-button-positionned',
 				)}
+				{...tooltipProps}
 			>
 				<BaseOverlayTrigger {...props}>{this.props.children}</BaseOverlayTrigger>
 			</span>

--- a/packages/components/src/OverlayTrigger/OverlayTrigger.component.js
+++ b/packages/components/src/OverlayTrigger/OverlayTrigger.component.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import BaseOverlayTrigger from 'react-bootstrap/lib/OverlayTrigger';
 import Popover from 'react-bootstrap/lib/Popover';
@@ -97,6 +97,7 @@ export default class OverlayTrigger extends React.Component {
 			onMouseOver: this.props.onMouseOver,
 			onMouseOut: this.props.onMouseOut,
 			onFocus: this.props.onFocus,
+			onBlur: this.props.onBlur,
 		};
 
 		if (this.props.preventScrolling) {
@@ -110,9 +111,10 @@ export default class OverlayTrigger extends React.Component {
 					theme['tc-action-button-positionned'],
 					'tc-action-button-positionned',
 				)}
-				{...tooltipProps}
 			>
-				<BaseOverlayTrigger {...props}>{this.props.children}</BaseOverlayTrigger>
+				<BaseOverlayTrigger {...props}>
+					{cloneElement(this.props.children, tooltipProps)}
+				</BaseOverlayTrigger>
 			</span>
 		);
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Tooltip not displayed for actions with overlay on mouse over
https://jira.talendforge.org/browse/TUI-380

**What is the chosen solution to this problem?**
**Cause:**
The OverlayTriggerComponent is created to show PopOver on click **{ trigger: 'click' }** so the events 
onMouseOver and onFocus provided from TooltipTrigger is overridden by the Bootstrap OverlayTrigger.
**Solution:**
Attach those events manually to the OverlayTrigger
**Demo:**
Action with popover ->
http://2139.talend.surge.sh/components/?selectedKind=Action&selectedStory=default&full=0&addons=1&stories=1&panelRight=0&addonPanel=storybook%2Factions%2Factions-panel

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
