### PR TITLE
fix(scripts): Update path for eslint in IDE

### DIFF
--- a/packages/scripts/webapp/preset/README.md
+++ b/packages/scripts/webapp/preset/README.md
@@ -277,7 +277,7 @@ To use the eslint configuration in your IDE
 
 ```json
 {
-  "extends": "@talend/scritps/preset/config/.eslintrc"
+  "extends": "./node_modules/@talend/scripts/webapp/preset/config/.eslintrc"
 }
 ```
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When trying to enable eslint in the IDE (with talend-scripts eslint config) the `extends` path will try to fetch an npm module prefixed with `eslint-config-` resulting in `@talend/eslint-config-scripts/preset/config/.eslintrc` (which doesn't exist). 

**What is the chosen solution to this problem?**
Update documentation to use relative path into node_modules to get the correct path `./node_modules/@talend/scripts/webapp/preset/config/.eslintrc`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
