### PR TITLE
fix(containers/HeaderBar): Broken saga on Edge

### DIFF
--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.js
@@ -37,7 +37,6 @@ export function handleOpenProduct(action) {
 		const opened = window.open(action.payload.url, '_blank');
 		// security fix:
 		opened.opener = null;
-		opened.location = action.payload.url;
 	}
 }
 

--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
@@ -83,7 +83,6 @@ describe('HeaderBar sagas', () => {
 			handleOpenProduct(action);
 			expect(global.open).toHaveBeenCalled();
 			expect(result.opened).toEqual({
-				location: 'productUrl',
 				opener: null,
 			});
 		});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`HeaderBar`'s `handleOpenProduct` breaks after it's used once under Edge. This causes the applications list in the header bar to only work once (saga is killed due to the error).

**What is the chosen solution to this problem?**
Remove the instruction that breaks under Edge, it doesn't seem to be useful and is not impeding the new window's opening.
Fix was picked from https://www.jitbit.com/alexblog/256-targetblank---the-most-underestimated-vulnerability-ever/ (courtesy of @jmfrancois) but the instruction is not mentionned there.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
