### PR TITLE
Revert "fix(forms): handle restricted option on the widget Datalist (#2029)

### DIFF
--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -160,7 +160,6 @@ class Datalist extends Component {
 					placeholder={this.props.schema.placeholder}
 					readOnly={this.props.schema.readOnly || false}
 					titleMap={this.getTitleMap()}
-					restricted={this.props.schema.restricted}
 					inputProps={{
 						'aria-invalid': !this.props.isValid,
 						'aria-required': this.props.schema.required,

--- a/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -27,7 +27,7 @@ exports[`Datalist component should render 1`] = `
     onFocus={[Function]}
     placeholder="Type here"
     readOnly={false}
-    restricted={true}
+    restricted={false}
     t={[Function]}
     titleMap={
       Array [
@@ -77,7 +77,7 @@ exports[`Datalist component should render with multisection 1`] = `
     onFocus={[Function]}
     placeholder="Type here"
     readOnly={false}
-    restricted={true}
+    restricted={false}
     t={[Function]}
     titleMap={
       Array [

--- a/packages/forms/stories-core/json/fields/core-datalist.json
+++ b/packages/forms/stories-core/json/fields/core-datalist.json
@@ -95,7 +95,6 @@
     },
     {
       "key": "restrictedDatalist",
-			"restricted": true,
       "title": "Datalist with restricted options",
       "description": "This datalist does not allow other values than the possible choices",
       "widget": "datalist"
@@ -153,7 +152,7 @@
     {
       "key": "restrictedAsyncTitleMap",
       "restricted": true,
-      "title": "Datalist with async options and restricted value",
+      "title": "Datalist with async options ans restricted value",
       "widget": "datalist",
       "triggers": [
         {
@@ -173,7 +172,6 @@
       "key": "datalistWithCategoryRestricted",
       "title": "Datalist With category and restricted value",
       "widget": "datalist",
-			"restricted": true,
       "options": {
         "isMultiSection": true,
         "titleMap": [


### PR DESCRIPTION
This reverts commit cc7a1fc3c44f07bf833dc55412c64b006baf8c76.

**What is the problem this PR is trying to solve?**
This behavior is not requested by UX guideline, and introduces issues in all form containing datalists.

**What is the chosen solution to this problem?**
Revert

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
