### PR TITLE
feat(ActionBar): Mass Actions: add support for app multi-select actions

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -12,6 +12,7 @@ const DISPLAY_MODES = {
 	DROPDOWN: 'dropdown',
 	SPLIT_DROPDOWN: 'splitDropdown',
 	BTN_GROUP: 'btnGroup',
+	DIVIDER: 'divider',
 };
 const TAG_TYPES = {
 	DIV: 'div',
@@ -37,13 +38,17 @@ const actionsShape = {
 	children: PropTypes.node,
 };
 
-function getActionsToRender({ selected, actions, multiSelectActions, appMultiSelectActions }) {
+function getActionsToRender({ selected, actions, multiSelectActions = {}, appMultiSelectActions }) {
 	if (selected > 0) {
 		if (appMultiSelectActions) {
 			return ['left', 'center', 'right'].reduce((result, type) => {
 				if (multiSelectActions[type] && appMultiSelectActions[type]) {
 					return Object.assign({}, result, {
-						[type]: [multiSelectActions[type], appMultiSelectActions[type]],
+						[type]: [
+							...multiSelectActions[type],
+							{ displayMode: 'divider' },
+							...appMultiSelectActions[type],
+						],
 					});
 				}
 				return Object.assign({}, result, {
@@ -98,6 +103,8 @@ function getActionsFromRenderers(actions, getComponent) {
 	function getActionsElements(action, index) {
 		const { displayMode, ...rest } = action;
 		switch (displayMode) {
+			case DISPLAY_MODES.DIVIDER:
+				return <span className="divider">|</span>;
 			case DISPLAY_MODES.DROPDOWN:
 				return <Renderers.ActionDropdown key={index} {...rest} />;
 			case DISPLAY_MODES.SPLIT_DROPDOWN:
@@ -110,16 +117,6 @@ function getActionsFromRenderers(actions, getComponent) {
 				}
 				return <Renderers.Action key={index} {...rest} />;
 		}
-	}
-	if (actions.length > 0 && Array.isArray(actions[0])) {
-		return actions.reduce((result, action, index) => {
-			if (index === 0) {
-				return result.concat(action.map(getActionsElements));
-			}
-			return result
-				.concat(<span className="divider">|</span>)
-				.concat(action.map(getActionsElements));
-		}, []);
 	}
 	return actions.map(getActionsElements);
 }

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -37,8 +37,24 @@ const actionsShape = {
 	children: PropTypes.node,
 };
 
-function getActionsToRender({ selected, actions, multiSelectActions }) {
+function getActionsToRender({ selected, actions, multiSelectActions, appMultiSelectActions }) {
 	if (selected > 0) {
+		if (appMultiSelectActions) {
+			return ['left', 'center', 'right'].reduce((result, type) => {
+				if (multiSelectActions[type] && appMultiSelectActions[type]) {
+					return Object.assign(
+						{},
+						result,
+						{ [type]: [multiSelectActions[type], appMultiSelectActions[type]] }
+					);
+				}
+				return Object.assign(
+					{},
+					result,
+					{ [type]: multiSelectActions[type] || appMultiSelectActions[type] }
+				);
+			}, {});
+		}
 		return multiSelectActions || {};
 	}
 	return actions || {};
@@ -127,12 +143,7 @@ function SwitchActions({ actions, left, right, center, getComponent, components 
 	);
 }
 SwitchActions.propTypes = {
-	actions: PropTypes.arrayOf(
-		PropTypes.oneOfType([
-			PropTypes.shape(actionsShape),
-			PropTypes.arrayOf(PropTypes.shape(actionsShape)),
-		])
-	).isRequired,
+	actions: PropTypes.arrayOf(PropTypes.shape(actionsShape)).isRequired,
 	left: PropTypes.bool,
 	right: PropTypes.bool,
 	center: PropTypes.bool,

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -42,17 +42,13 @@ function getActionsToRender({ selected, actions, multiSelectActions, appMultiSel
 		if (appMultiSelectActions) {
 			return ['left', 'center', 'right'].reduce((result, type) => {
 				if (multiSelectActions[type] && appMultiSelectActions[type]) {
-					return Object.assign(
-						{},
-						result,
-						{ [type]: [multiSelectActions[type], appMultiSelectActions[type]] }
-					);
+					return Object.assign({}, result, {
+						[type]: [multiSelectActions[type], appMultiSelectActions[type]],
+					});
 				}
-				return Object.assign(
-					{},
-					result,
-					{ [type]: multiSelectActions[type] || appMultiSelectActions[type] }
-				);
+				return Object.assign({}, result, {
+					[type]: multiSelectActions[type] || appMultiSelectActions[type],
+				});
 			}, {});
 		}
 		return multiSelectActions || {};
@@ -120,7 +116,8 @@ function getActionsFromRenderers(actions, getComponent) {
 			if (index === 0) {
 				return result.concat(action.map(getActionsElements));
 			}
-			return result.concat(<span className="divider">|</span>)
+			return result
+				.concat(<span className="divider">|</span>)
 				.concat(action.map(getActionsElements));
 		}, []);
 	}

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -83,7 +83,7 @@ function getActionsFromRenderers(actions, getComponent) {
 		ActionDropdown,
 		ActionSplitDropdown,
 	});
-	return actions.map((action, index) => {
+	function getActionsElements(action, index) {
 		const { displayMode, ...rest } = action;
 		switch (displayMode) {
 			case DISPLAY_MODES.DROPDOWN:
@@ -98,7 +98,17 @@ function getActionsFromRenderers(actions, getComponent) {
 				}
 				return <Renderers.Action key={index} {...rest} />;
 		}
-	});
+	}
+	if (actions.length > 0 && Array.isArray(actions[0])) {
+		return actions.reduce((result, action, index) => {
+			if (index === 0) {
+				return result.concat(action.map(getActionsElements));
+			}
+			return result.concat(<span className="divider">|</span>)
+				.concat(action.map(getActionsElements));
+		}, []);
+	}
+	return actions.map(getActionsElements);
 }
 
 function SwitchActions({ actions, left, right, center, getComponent, components }) {
@@ -117,7 +127,12 @@ function SwitchActions({ actions, left, right, center, getComponent, components 
 	);
 }
 SwitchActions.propTypes = {
-	actions: PropTypes.arrayOf(PropTypes.shape(actionsShape)).isRequired,
+	actions: PropTypes.arrayOf(
+		PropTypes.oneOfType([
+			PropTypes.shape(actionsShape),
+			PropTypes.arrayOf(PropTypes.shape(actionsShape)),
+		])
+	).isRequired,
 	left: PropTypes.bool,
 	right: PropTypes.bool,
 	center: PropTypes.bool,

--- a/packages/components/src/ActionBar/ActionBar.scss
+++ b/packages/components/src/ActionBar/ActionBar.scss
@@ -56,6 +56,12 @@ $tc-action-bar-margin: $padding-small $padding-larger $padding-small 0 !default;
 	:global(.btn-icon-text) {
 		margin: $padding-small $padding-normal $padding-small 0;
 		text-transform: capitalize;
+
+		&:global(.separated):after {
+			content: '|';
+			color: $silver;
+			margin-left: $padding-large;
+		}
 	}
 
 	:global(.divider) {

--- a/packages/components/src/ActionBar/ActionBar.scss
+++ b/packages/components/src/ActionBar/ActionBar.scss
@@ -56,12 +56,11 @@ $tc-action-bar-margin: $padding-small $padding-larger $padding-small 0 !default;
 	:global(.btn-icon-text) {
 		margin: $padding-small $padding-normal $padding-small 0;
 		text-transform: capitalize;
+	}
 
-		&:global(.separated):after {
-			content: '|';
-			color: $silver;
-			margin-left: $padding-large;
-		}
+	:global(.divider) {
+		color: $silver;
+		margin-right: $padding-normal;
 	}
 }
 

--- a/packages/components/stories/ActionBar.js
+++ b/packages/components/stories/ActionBar.js
@@ -244,8 +244,12 @@ const multiCertify = {
 	className: 'btn-icon-text',
 };
 const massActions = {
-	left: [[multiDelete, multiDuplicate, multiUpdate], [multiFavorite, multiCertify]],
+	left: [multiDelete, multiDuplicate, multiUpdate],
 };
+
+const appMassActions = {
+	left:  [multiFavorite, multiCertify],
+}
 
 const icons = {
 	'talend-badge': talendIcons['talend-badge'],
@@ -292,7 +296,11 @@ storiesOf('ActionBar', module)
 			</div>
 			<p>3 items selected, with mass/bulk Actions</p>
 			<div id="mass-actions">
-				<ActionBar selected={3} multiSelectActions={massActions} />
+				<ActionBar
+					selected={3}
+					multiSelectActions={massActions}
+					appMultiSelectActions={appMassActions}
+				/>
 			</div>
 		</nav>
 	))

--- a/packages/components/stories/ActionBar.js
+++ b/packages/components/stories/ActionBar.js
@@ -229,7 +229,7 @@ const multiUpdate = {
 	label: 'Update',
 	icon: 'talend-file-move',
 	onClick: action('multiple update'),
-	className: 'btn-icon-text separated',
+	className: 'btn-icon-text',
 };
 const multiFavorite = {
 	label: 'Favorite',
@@ -244,7 +244,7 @@ const multiCertify = {
 	className: 'btn-icon-text',
 };
 const massActions = {
-	left: [multiDelete, multiDuplicate, multiUpdate, multiFavorite, multiCertify],
+	left: [[multiDelete, multiDuplicate, multiUpdate], [multiFavorite, multiCertify]],
 };
 
 const icons = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add app specific multi-select actions.
if app specifical actions provided, show them right to common multi-select actions with a divider
![image](https://user-images.githubusercontent.com/3214228/57358985-296e0a80-71a9-11e9-8bea-e72e9ca71b44.png)

**What is the chosen solution to this problem?**
add prop `appMultiSelectActions` of actions list.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
