### PR TITLE
Fix(scripts):  testRegex in jest.config.js for Windows users

### DIFF
--- a/packages/scripts/webapp/preset/config/jest.config.js
+++ b/packages/scripts/webapp/preset/config/jest.config.js
@@ -12,6 +12,6 @@ module.exports = {
 	rootDir: process.cwd(),
 	setupFilesAfterEnv: [path.join(__dirname, 'test', 'test-setup.js')],
 	testEnvironment: 'jest-environment-jsdom-global',
-	testRegex: path.join('src', '.*\\.test.js$'),
+	testRegex: 'src/.*\\.test.js$',
 	transform: { '^.+\\.js$': path.join(__dirname, 'test', 'jest-preprocess.js') },
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Windows users can't launch unit tests anymore, due to wrong value for testRegex in jest.config.js.
![image](https://user-images.githubusercontent.com/35027619/57530473-9a432d00-7337-11e9-96ff-f1d7635e2944.png)

**What is the chosen solution to this problem?**
Fix regex.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
