### PR TITLE
chore(Forms): fixing validation when using array type with checkboxes

### DIFF
--- a/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.component.js
@@ -43,7 +43,12 @@ export default function CheckBoxes(props) {
 							value: getValues(value, item.value, payload.value),
 						})
 					}
-					onFinish={onFinish}
+					onFinish={(event, payload) =>
+						onFinish(event, {
+							schema: payload.schema,
+							value: getValues(value, item.value, payload.value),
+						})
+					}
 					schema={schema}
 					value={value && value.includes(item.value)}
 				/>

--- a/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.test.js
@@ -208,6 +208,6 @@ describe('CheckBoxes field', () => {
 			.simulate('change', event);
 
 		// then
-		expect(onFinish).toBeCalledWith(expect.anything(), { schema, value: true });
+		expect(onFinish).toBeCalledWith(expect.anything(), { schema, value: ['foo', 'bar', 'lol'] });
 	});
 });

--- a/packages/forms/src/UIForm/fields/CheckBox/__snapshots__/CheckBoxes.test.js.snap
+++ b/packages/forms/src/UIForm/fields/CheckBox/__snapshots__/CheckBoxes.test.js.snap
@@ -15,7 +15,7 @@ exports[`CheckBoxes field should render checkboxes 1`] = `
     isValid={true}
     label="My foo title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -45,7 +45,7 @@ exports[`CheckBoxes field should render checkboxes 1`] = `
     isValid={true}
     label="My bar title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -75,7 +75,7 @@ exports[`CheckBoxes field should render checkboxes 1`] = `
     isValid={true}
     label="My lol title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -117,7 +117,7 @@ exports[`CheckBoxes field should render checkboxes with no values 1`] = `
     isValid={true}
     label="My foo title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -147,7 +147,7 @@ exports[`CheckBoxes field should render checkboxes with no values 1`] = `
     isValid={true}
     label="My bar title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -177,7 +177,7 @@ exports[`CheckBoxes field should render checkboxes with no values 1`] = `
     isValid={true}
     label="My lol title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -220,7 +220,7 @@ exports[`CheckBoxes field should render disabled checkboxes 1`] = `
     isValid={true}
     label="My foo title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -252,7 +252,7 @@ exports[`CheckBoxes field should render disabled checkboxes 1`] = `
     isValid={true}
     label="My bar title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",
@@ -284,7 +284,7 @@ exports[`CheckBoxes field should render disabled checkboxes 1`] = `
     isValid={true}
     label="My lol title"
     onChange={[Function]}
-    onFinish={[MockFunction]}
+    onFinish={[Function]}
     schema={
       Object {
         "description": "my checkbox input hint",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently checkboxes onFinish receive a boolean as a value instead of the array of value like the onChange callback which results in the following error: 
![image](https://user-images.githubusercontent.com/14272767/57581606-149bba80-74ba-11e9-8640-073f4c6a01d3.png)

**What is the chosen solution to this problem?**
passing the array of checked values as value for onFinish
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
