### PR TITLE
feat(forms): add hover handlers for the submit button

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -36,6 +36,7 @@ export class UIFormComponent extends React.Component {
 		this.onSubmit = this.onSubmit.bind(this);
 		this.onTrigger = this.onTrigger.bind(this);
 		this.onActionClick = this.onActionClick.bind(this);
+		this.onSubmitHover = this.onSubmitHover.bind(this);
 		this.focusFirstError = this.focusFirstError.bind(this);
 		this.setFormRef = this.setFormRef.bind(this);
 		// control the tv4 language here.
@@ -249,6 +250,15 @@ export class UIFormComponent extends React.Component {
 		return isValid;
 	}
 
+	onSubmitHover(event) {
+		const { properties } = this.props;
+		if (this.props.moz) {
+			this.props.onEnterSubmit(null, { formData: properties });
+		} else {
+			this.props.onEnterSubmit(event, properties);
+		}
+	}
+
 	setFormRef(element) {
 		this.formRef = element;
 	}
@@ -265,7 +275,9 @@ export class UIFormComponent extends React.Component {
 		}
 	}
 
+
 	render() {
+		const { onEnterSubmit, onLeaveSubmit } = this.props;
 		const actions = this.props.actions || [
 			{
 				bsStyle: 'primary',
@@ -273,6 +285,8 @@ export class UIFormComponent extends React.Component {
 				type: 'submit',
 				widget: 'button',
 				position: 'right',
+				onMouseEnter: onEnterSubmit && this.onSubmitHover,
+				onMouseLeave: onLeaveSubmit,
 			},
 		];
 		if (!this.state.mergedSchema) {
@@ -389,6 +403,8 @@ if (process.env.NODE_ENV !== 'production') {
 		/** State management impl: Set All fields validations errors */
 		setErrors: PropTypes.func,
 		getComponent: PropTypes.func,
+		onEnterSubmit: PropTypes.func,
+		onLeaveSubmit: PropTypes.func,
 	};
 	UIFormComponent.propTypes = I18NUIForm.propTypes;
 }

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -251,12 +251,7 @@ export class UIFormComponent extends React.Component {
 	}
 
 	onSubmitHover(event) {
-		const { properties } = this.props;
-		if (this.props.moz) {
-			this.props.onEnterSubmit(null, { formData: properties });
-		} else {
-			this.props.onEnterSubmit(event, properties);
-		}
+		this.props.onSubmitEnter(event, this.props.properties);
 	}
 
 	setFormRef(element) {
@@ -277,7 +272,7 @@ export class UIFormComponent extends React.Component {
 
 
 	render() {
-		const { onEnterSubmit, onLeaveSubmit } = this.props;
+		const { onSubmitEnter, onSubmitLeave } = this.props;
 		const actions = this.props.actions || [
 			{
 				bsStyle: 'primary',
@@ -285,8 +280,8 @@ export class UIFormComponent extends React.Component {
 				type: 'submit',
 				widget: 'button',
 				position: 'right',
-				onMouseEnter: onEnterSubmit && this.onSubmitHover,
-				onMouseLeave: onLeaveSubmit,
+				onMouseEnter: onSubmitEnter && this.onSubmitHover,
+				onMouseLeave: onSubmitLeave,
 			},
 		];
 		if (!this.state.mergedSchema) {
@@ -403,8 +398,8 @@ if (process.env.NODE_ENV !== 'production') {
 		/** State management impl: Set All fields validations errors */
 		setErrors: PropTypes.func,
 		getComponent: PropTypes.func,
-		onEnterSubmit: PropTypes.func,
-		onLeaveSubmit: PropTypes.func,
+		onSubmitEnter: PropTypes.func,
+		onSubmitLeave: PropTypes.func,
 	};
 	UIFormComponent.propTypes = I18NUIForm.propTypes;
 }

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -36,7 +36,6 @@ export class UIFormComponent extends React.Component {
 		this.onSubmit = this.onSubmit.bind(this);
 		this.onTrigger = this.onTrigger.bind(this);
 		this.onActionClick = this.onActionClick.bind(this);
-		this.onSubmitHover = this.onSubmitHover.bind(this);
 		this.focusFirstError = this.focusFirstError.bind(this);
 		this.setFormRef = this.setFormRef.bind(this);
 		// control the tv4 language here.
@@ -250,10 +249,6 @@ export class UIFormComponent extends React.Component {
 		return isValid;
 	}
 
-	onSubmitHover(event) {
-		this.props.onSubmitEnter(event, this.props.properties);
-	}
-
 	setFormRef(element) {
 		this.formRef = element;
 	}
@@ -271,7 +266,7 @@ export class UIFormComponent extends React.Component {
 	}
 
 	render() {
-		const { onSubmitEnter, onSubmitLeave } = this.props;
+		const { onSubmitEnter, onSubmitLeave, properties } = this.props;
 		const actions = this.props.actions || [
 			{
 				bsStyle: 'primary',
@@ -279,7 +274,7 @@ export class UIFormComponent extends React.Component {
 				type: 'submit',
 				widget: 'button',
 				position: 'right',
-				onMouseEnter: onSubmitEnter && this.onSubmitHover,
+				onMouseEnter: onSubmitEnter ? event => onSubmitEnter(event, properties) : undefined,
 				onMouseLeave: onSubmitLeave,
 			},
 		];

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -274,7 +274,7 @@ export class UIFormComponent extends React.Component {
 				type: 'submit',
 				widget: 'button',
 				position: 'right',
-				onMouseEnter: onSubmitEnter ? event => onSubmitEnter(event, properties) : undefined,
+				onMouseEnter: onSubmitEnter && (event => onSubmitEnter(event, properties)),
 				onMouseLeave: onSubmitLeave,
 			},
 		];

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -66,6 +66,30 @@ describe('UIForm component', () => {
 		expect(tv4.validate('def', { format: 'noABC' })).toBe(true);
 	});
 
+	describe('#onEnterSubmit & #onLeaveSubmit', () => {
+		it('should call onEnterSubmit and onLeaveSubmit when provided', () => {
+			const enter = jest.fn();
+			const leave = jest.fn();
+			const properties = { hihi: 'hoho' };
+			const wrapper = mount(
+				<UIFormComponent
+					{...data}
+					{...props}
+					properties={properties}
+					onEnterSubmit={enter}
+					onLeaveSubmit={leave}
+				/>,
+			);
+			const btn = wrapper.find('button').at(1);
+
+			btn.simulate('mouseenter');
+			expect(enter).toHaveBeenCalledWith(expect.anything(), properties);
+
+			btn.simulate('mouseleave');
+			expect(leave).toHaveBeenCalled();
+		});
+	});
+
 	describe('#onChange', () => {
 		it('should call onChange callback', () => {
 			// given

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -66,8 +66,8 @@ describe('UIForm component', () => {
 		expect(tv4.validate('def', { format: 'noABC' })).toBe(true);
 	});
 
-	describe('#onEnterSubmit & #onLeaveSubmit', () => {
-		it('should call onEnterSubmit and onLeaveSubmit when provided', () => {
+	describe('#onSubmitEnter & #onSubmitLeave', () => {
+		it('should call onSubmitEnter and onSubmitLeave when provided', () => {
 			const enter = jest.fn();
 			const leave = jest.fn();
 			const properties = { hihi: 'hoho' };
@@ -76,8 +76,8 @@ describe('UIForm component', () => {
 					{...data}
 					{...props}
 					properties={properties}
-					onEnterSubmit={enter}
-					onLeaveSubmit={leave}
+					onSubmitEnter={enter}
+					onSubmitLeave={leave}
 				/>,
 			);
 			const btn = wrapper.find('button').at(1);

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -113,6 +113,8 @@ exports[`UIForm component should render form 1`] = `
             Object {
               "bsStyle": "primary",
               "label": "Submit",
+              "onMouseEnter": undefined,
+              "onMouseLeave": undefined,
               "position": "right",
               "type": "submit",
               "widget": "button",

--- a/packages/forms/stories-core/customHoverSubmitStory.js
+++ b/packages/forms/stories-core/customHoverSubmitStory.js
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { action } from '@storybook/addon-actions';
+import { UIForm } from '../src/UIForm';
+
+const schema = {
+	jsonSchema: {
+		type: 'object',
+		title: 'Comment',
+		properties: {
+			name: {
+				type: 'string',
+			},
+		},
+		required: ['name'],
+	},
+	uiSchema: [
+		{
+			key: 'name',
+			title: 'Name',
+		},
+	],
+	properties: {
+		name: 'Chuck Norris',
+	},
+};
+
+function UIFormWithOnSubmitHover() {
+	const [hover, setHover] = useState(0);
+	return (
+		<div
+			style={{
+				margin: '-5px',
+				padding: '5px',
+				borderRadius: '5px',
+				background: hover ? '#EFEFEF' : 'transparent',
+			}}
+		>
+			<UIForm
+				data={schema}
+				onSubmit={action('onSubmit')}
+				onSubmitEnter={(...args) => {
+					action('onSubmitEnter')(...args);
+					setHover(true);
+				}}
+				onSubmitLeave={(...args) => {
+					action('onSubmitLeave')(...args);
+					setHover(false);
+				}}
+			/>
+		</div>
+	);
+}
+
+function story() {
+	return (
+		<div>
+			<h2>Hover submit handler</h2>
+			<p>
+				Submit can detect if mouse enters or leaves by using <code>onSubmitEnter</code> and{' '}
+				<code>onSubmitLeave</code>
+			</p>
+			<UIFormWithOnSubmitHover />
+		</div>
+	);
+}
+
+export default {
+	name: 'Core Concept hover submit',
+	story,
+};

--- a/packages/forms/stories-core/index.js
+++ b/packages/forms/stories-core/index.js
@@ -10,6 +10,7 @@ import customActionsStory from './customActionsStory';
 import customUpdating from './customUpdating';
 import customErrors from './customErrors';
 import customDisplayMode from './customDisplayMode';
+import customHoverSubmitStory from "./customHoverSubmitStory";
 
 const coreConceptsStories = storiesOf('Core concepts', module);
 
@@ -51,3 +52,4 @@ coreConceptsStories.add(customActionsStory.name, customActionsStory.story);
 coreConceptsStories.add(customUpdating.name, customUpdating.story);
 coreConceptsStories.add(customErrors.name, customErrors.story);
 coreConceptsStories.add(customDisplayMode.name, customDisplayMode.story);
+coreConceptsStories.add(customHoverSubmitStory.name, customHoverSubmitStory.story);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We need to detect hover on the UIForm submit button (this trigger a preview on TDP).

**What is the chosen solution to this problem?**

Add `onSubmitEnter` and `onSubmitLeave` props.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
