### PR TITLE
feat(component): TMC-13918 show full date in a tooltip when base date is relative in a column cell

### DIFF
--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -45,7 +45,7 @@ export class CellDatetimeComponent extends React.Component {
 			</div>
 		);
 
-		if (columnData.mode === 'ago' && columnData.fullDateInTooltip) {
+		if (columnData.mode === 'ago') {
 			return (
 				<TooltipTrigger
 					label={format(cellData, columnData.pattern || DATE_TIME_FORMAT)}

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -8,6 +8,7 @@ import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
 import getLocale from '../../DateFnsLocale/locale';
 import styles from './CellDatetime.scss';
+import TooltipTrigger from '../../TooltipTrigger';
 
 const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 
@@ -38,11 +39,24 @@ export class CellDatetimeComponent extends React.Component {
 	}
 	render() {
 		const { cellData, columnData, t } = this.props;
-		return (
+		const cell = (
 			<div className={classnames('cell-datetime-container', styles['cell-datetime-container'])}>
 				{computeValue(cellData, columnData, t)}
 			</div>
 		);
+
+		if (columnData.mode === 'ago' && columnData.fullDateInTooltip) {
+			return (
+				<TooltipTrigger
+					label={format(cellData, columnData.pattern || DATE_TIME_FORMAT)}
+					tooltipPlacement={columnData.tooltipPlacement || 'bottom'}
+				>
+					{cell}
+				</TooltipTrigger>
+			);
+		}
+
+		return cell;
 	}
 }
 

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -69,7 +69,6 @@ describe('CellDatetime', () => {
 		// when
 		const columnData = {
 			mode: 'ago',
-			fullDateInTooltip: true,
 		};
 
 		const wrapper = shallow(
@@ -78,17 +77,5 @@ describe('CellDatetime', () => {
 		expect(wrapper.find('TooltipTrigger').length).toBe(1);
 		expect(wrapper.find('TooltipTrigger').getElement().props.label).toBe('2016-09-22 09:00:00');
 		expect(wrapper.getElement()).toMatchSnapshot();
-	});
-
-	it('should test CellDatetime render without tooltip', () => {
-		// when
-		const columnData = {
-			mode: 'ago',
-		};
-
-		const wrapper = shallow(
-			<CellDatetimeComponent cellData={1474495200000} columnData={columnData} />,
-		);
-		expect(wrapper.find('TooltipTrigger').length).toBe(0);
 	});
 });

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -64,4 +64,31 @@ describe('CellDatetime', () => {
 		expect(computedStrOffset).toEqual(expectedStrDate);
 		expect(format).toHaveBeenCalledWith(cellDataWithOffset, columnData.pattern);
 	});
+
+	it('should test CellDatetime render with tooltip', () => {
+		// when
+		const columnData = {
+			mode: 'ago',
+			fullDateInTooltip: true,
+		};
+
+		const wrapper = shallow(
+			<CellDatetimeComponent cellData={1474495200000} columnData={columnData} />,
+		);
+		expect(wrapper.find('TooltipTrigger').length).toBe(1);
+		expect(wrapper.find('TooltipTrigger').getElement().props.label).toBe('2016-09-22 09:00:00');
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should test CellDatetime render without tooltip', () => {
+		// when
+		const columnData = {
+			mode: 'ago',
+		};
+
+		const wrapper = shallow(
+			<CellDatetimeComponent cellData={1474495200000} columnData={columnData} />,
+		);
+		expect(wrapper.find('TooltipTrigger').length).toBe(0);
+	});
 });

--- a/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
@@ -1,11 +1,16 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CellDatetime should render CellDatetime 1`] = `
-<div
-  className="cell-datetime-container theme-cell-datetime-container"
+<TooltipTrigger
+  label="2016-09-22 09:00:00"
+  tooltipPlacement="bottom"
 >
-  about 1 month ago
-</div>
+  <div
+    className="cell-datetime-container theme-cell-datetime-container"
+  >
+    about 1 month ago
+  </div>
+</TooltipTrigger>
 `;
 
 exports[`CellDatetime should test CellDatetime render with tooltip 1`] = `

--- a/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
@@ -7,3 +7,16 @@ exports[`CellDatetime should render CellDatetime 1`] = `
   about 1 month ago
 </div>
 `;
+
+exports[`CellDatetime should test CellDatetime render with tooltip 1`] = `
+<TooltipTrigger
+  label="2016-09-22 09:00:00"
+  tooltipPlacement="bottom"
+>
+  <div
+    className="cell-datetime-container theme-cell-datetime-container"
+  >
+    about 1 month ago
+  </div>
+</TooltipTrigger>
+`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a datetime cell shows a relative date it'd be useful to show the full date inside a tooltip.

**What is the chosen solution to this problem?**
Wrap the tooltip in the relative date div.

![image](https://user-images.githubusercontent.com/3025706/57936014-5023f380-78c3-11e9-8095-53226449b9a2.png)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
