### PR TITLE
fix(forms): filtered properties should not be submitted

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -220,8 +220,8 @@ export class UIFormComponent extends React.Component {
 		const { mergedSchema } = this.state;
 		const { properties, customValidation } = this.props;
 		const filtered = filterProperties(mergedSchema, properties);
-		console.log('[NC] mergedSchema: ', JSON.stringify(mergedSchema));
 		const newErrors = validateAll(mergedSchema, filtered, customValidation);
+
 		Object.entries(this.props.errors)
 			.filter(entry => entry[0] in newErrors)
 			.reduce((accu, [key, value]) => {

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -12,6 +12,7 @@ import Widget from './Widget';
 import Buttons from './fields/Button/Buttons.component';
 import { getValue, mutateValue } from './utils/properties';
 import { removeError, addError } from './utils/errors';
+import { filterProperties } from './utils/condition';
 import getLanguage from './lang';
 import customFormats from './customFormats';
 import { I18N_DOMAIN_FORMS } from '../constants';
@@ -218,7 +219,9 @@ export class UIFormComponent extends React.Component {
 
 		const { mergedSchema } = this.state;
 		const { properties, customValidation } = this.props;
-		const newErrors = validateAll(mergedSchema, properties, customValidation);
+		const filtered = filterProperties(mergedSchema, properties);
+		console.log('[NC] mergedSchema: ', JSON.stringify(mergedSchema));
+		const newErrors = validateAll(mergedSchema, filtered, customValidation);
 		Object.entries(this.props.errors)
 			.filter(entry => entry[0] in newErrors)
 			.reduce((accu, [key, value]) => {
@@ -240,9 +243,9 @@ export class UIFormComponent extends React.Component {
 
 		if (this.props.onSubmit && isValid) {
 			if (this.props.moz) {
-				this.props.onSubmit(null, { formData: properties });
+				this.props.onSubmit(null, { formData: filtered });
 			} else {
-				this.props.onSubmit(event, properties);
+				this.props.onSubmit(event, filtered);
 			}
 		}
 

--- a/packages/forms/src/UIForm/utils/condition.js
+++ b/packages/forms/src/UIForm/utils/condition.js
@@ -1,5 +1,6 @@
 /* eslint-disable no-use-before-define */
 import jsonLogic from 'json-logic-js';
+import omit from 'lodash/omit';
 
 function lowercase(a) {
 	return a.toLowerCase();
@@ -76,6 +77,19 @@ function resolveArrayNotation(condition, key) {
 		return acc;
 	});
 	return acc;
+}
+
+export function filterProperties(schema, properties) {
+	function getKeys(items) {
+		return items.reduce((acc, curr) => {
+			if (curr.items) {
+				return acc.concat(getKeys(curr.items));
+			}
+			return !shouldRender(curr.condition, properties, curr.key) ? acc.concat([curr.key]) : acc;
+		}, []);
+	}
+
+	return omit(properties, getKeys(schema));
 }
 
 /**

--- a/packages/forms/src/UIForm/utils/condition.test.js
+++ b/packages/forms/src/UIForm/utils/condition.test.js
@@ -20,12 +20,9 @@ const properties = {
 const schema = [
 	{
 		widget: 'fieldset',
-		title: 'Basic info',
 		items: [
 			{
 				key: ['entity', 'kind'],
-				title: 'Kind',
-				description: 'Select a value here, it changes the form locally',
 				schema: { type: 'string', enum: ['human', 'animal', 'thing'] },
 				type: 'select',
 				titleMap: [{ name: 'human', value: 'human' }, { name: 'animal', value: 'animal' }],
@@ -36,12 +33,9 @@ const schema = [
 				items: [
 					{
 						key: ['entity', 'civility'],
-						title: 'Civility',
-						description: 'This should be visible only for humans',
 						condition: { '===': [{ var: 'entity.kind' }, 'human'] },
 						schema: { type: 'string', enum: ['Mr', 'Mrs'] },
 						type: 'select',
-						titleMap: [{ name: 'Mr', value: 'Mr' }, { name: 'Mrs', value: 'Mrs' }],
 					},
 				],
 			},

--- a/packages/forms/src/UIForm/utils/condition.test.js
+++ b/packages/forms/src/UIForm/utils/condition.test.js
@@ -1,4 +1,4 @@
-import shouldRender from './condition';
+import shouldRender, { filterProperties } from './condition';
 
 const properties = {
 	string: 'foo',
@@ -16,6 +16,38 @@ const properties = {
 	arrayString: ['foo', 'bar'],
 	arrayObj: [{ foo: 'foo' }, { bar: 'bar' }],
 };
+
+const schema = [
+	{
+		widget: 'fieldset',
+		title: 'Basic info',
+		items: [
+			{
+				key: ['entity', 'kind'],
+				title: 'Kind',
+				description: 'Select a value here, it changes the form locally',
+				schema: { type: 'string', enum: ['human', 'animal', 'thing'] },
+				type: 'select',
+				titleMap: [{ name: 'human', value: 'human' }, { name: 'animal', value: 'animal' }],
+			},
+			{
+				widget: 'fieldset',
+				condition: { in: [{ var: 'entity.kind' }, ['human', 'animal']] },
+				items: [
+					{
+						key: ['entity', 'civility'],
+						title: 'Civility',
+						description: 'This should be visible only for humans',
+						condition: { '===': [{ var: 'entity.kind' }, 'human'] },
+						schema: { type: 'string', enum: ['Mr', 'Mrs'] },
+						type: 'select',
+						titleMap: [{ name: 'Mr', value: 'Mr' }, { name: 'Mrs', value: 'Mrs' }],
+					},
+				],
+			},
+		],
+	},
+];
 
 const TRUTHY_CONDITIONS = [
 	undefined,
@@ -137,6 +169,14 @@ describe('condition', () => {
 	FALSY_CONDITIONS.forEach(condition => {
 		it(`falsy: ${JSON.stringify(condition)}`, () => {
 			expect(shouldRender(condition, properties)).toBeFalsy();
+		});
+	});
+
+	it('should filter properties', () => {
+		expect(
+			filterProperties(schema, { entity: { kind: 'animal', civility: 'Mrs', nop: 42 } }),
+		).toEqual({
+			entity: { kind: 'animal', nop: 42 },
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If a field is hidden by a condition, it will be sent anyway.

**What is the chosen solution to this problem?**

Filter properties before calling `props.onSubmit`.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
