### PR TITLE
fix(form): call onSubmit with mergedSchema

### DIFF
--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -123,11 +123,12 @@ export default class UIForm extends React.Component {
 	 * On user submit change local state and call this.props.onSubmit
 	 * @param event submit event
 	 * @param {Object} properties
+	 * @param {Object} mergedSchema
 	 */
-	onSubmit(event, properties) {
+	onSubmit(event, properties, mergedSchema) {
 		this.setState(setLiveAsInitialState);
 		if (typeof this.props.onSubmit === 'function') {
-			this.props.onSubmit(event, properties);
+			this.props.onSubmit(event, properties, mergedSchema);
 		}
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In order to filter filtered properties on the project side (to avoid breaking changes on TUI), we've to pass the mergedSchema to props.onSubmit. The goal is to implement #2204 on TDP. Container was missing from my previous commit.

**What is the chosen solution to this problem?**

Pass the mergedSchema to props.onSubmit and close #2204.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
