### PR TITLE
feat(ListComposition/DisplayMode):  update design

### DIFF
--- a/packages/components/src/List/ListComposition/DisplayMode/DisplayModeToggle.scss
+++ b/packages/components/src/List/ListComposition/DisplayMode/DisplayModeToggle.scss
@@ -1,0 +1,11 @@
+$tc-display-button-icon-height: 2.4rem;
+
+.tc-display-mode-toggle {
+	display: flex;
+
+	:global(.tc-icon-toggle) {
+		height: $tc-display-button-icon-height;
+		min-height: $tc-display-button-icon-height;
+		margin: $padding-normal 0 $padding-normal $padding-normal;
+	}
+}

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
@@ -1,21 +1,10 @@
 import React, { useEffect } from 'react';
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import { Navbar, NavDropdown, Nav, MenuItem } from 'react-bootstrap';
 import uuid from 'uuid';
-
+import { ActionIconToggle } from '../../../Actions';
+import theme from './DisplayModeToggle.scss';
 import { useListContext } from '../context';
-import Icon from '../../../Icon';
-
-function getIcon(selected) {
-	switch (selected) {
-		case 'table':
-			return 'talend-table';
-		case 'large':
-			return 'talend-expanded';
-		default:
-			return 'talend-table';
-	}
-}
 
 function getLabel(option, t) {
 	switch (option) {
@@ -28,23 +17,40 @@ function getLabel(option, t) {
 	}
 }
 
-function ListDisplayMode(props) {
-	const { displayMode, setDisplayMode, t } = useListContext();
-	const {
-		id,
-		displayModes,
-		initialDisplayMode,
-		onChange,
-		selectedDisplayMode = displayMode,
-	} = props;
+const DisplayModeIcon = React.memo(({
+	displayMode,
+	displayModeOption,
+	id,
+	onSelect,
+}) => {
+	const { t } = useListContext();
+	return (
+		<ActionIconToggle
+			key={displayModeOption}
+			id={`${id}-${displayModeOption}`}
+			icon={displayModeOption === 'table' ? 'talend-table' : 'talend-expanded'}
+			label={t('LIST_SELECT_DISPLAY_MODE', {
+				defaultValue: 'Set {{displayMode}} as current display mode.',
+				displayMode: getLabel(displayModeOption, t),
+			})}
+			active={displayMode === displayModeOption}
+			disabled={displayMode === displayModeOption}
+			onClick={e => {
+				onSelect(e, displayModeOption);
+			}}
+		/>
+	);
+});
 
+function ListDisplayMode({ id, displayModes, initialDisplayMode, onChange, selectedDisplayMode }) {
+	const { displayMode, setDisplayMode } = useListContext();
 	useEffect(() => {
 		if (!onChange) {
 			setDisplayMode(initialDisplayMode);
 		}
 	}, []);
 
-	function onSelect(value, event) {
+	function onSelect(event, value) {
 		if (onChange) {
 			onChange(event, value);
 		} else {
@@ -53,39 +59,19 @@ function ListDisplayMode(props) {
 	}
 
 	return (
-		<React.Fragment>
-			<Navbar.Text>
-				<label htmlFor={id}>{t('LIST_TOOLBAR_DISPLAY', { defaultValue: 'Display:' })}</label>
-			</Navbar.Text>
-			<Nav>
-				<NavDropdown
+		<div className={classNames(theme['tc-display-mode-toggle'], 'tc-display-mode-toggle')}>
+			{displayModes.map(displayModeOption => (
+				<DisplayModeIcon
+					displayMode={selectedDisplayMode || displayMode}
+					displayModeOption={displayModeOption}
 					id={id}
-					title={<Icon name={getIcon(selectedDisplayMode)} />}
 					onSelect={onSelect}
-					aria-label={t('LIST_CHANGE_DISPLAY_MODE', {
-						defaultValue: 'Change display mode. Current display mode: {{displayMode}}.',
-						displayMode: selectedDisplayMode,
-					})}
-				>
-					{displayModes.map(option => (
-						<MenuItem
-							id={`${id}-${option}`}
-							key={option}
-							eventKey={option}
-							aria-label={t('LIST_SELECT_DISPLAY_MODE', {
-								defaultValue: 'Set {{displayMode}} as current display mode.',
-								displayMode: getLabel(option, t),
-							})}
-						>
-							<Icon name={getIcon(option)} />
-							{getLabel(option, t)}
-						</MenuItem>
-					))}
-				</NavDropdown>
-			</Nav>
-		</React.Fragment>
+				/>
+			))}
+		</div>
 	);
 }
+
 ListDisplayMode.defaultProps = {
 	id: uuid.v4(),
 	displayModes: ['table', 'large'],

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
@@ -43,7 +43,7 @@ export const DisplayModeIcon = React.memo(
 );
 
 DisplayModeIcon.propTypes = {
-	displayMode: PropTypes.string.isRequired,
+	displayMode: PropTypes.string,
 	displayModeOption: PropTypes.string.isRequired,
 	icon: PropTypes.string.isRequired,
 	id: PropTypes.string.isRequired,

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
@@ -17,32 +17,48 @@ function getLabel(option, t) {
 	}
 }
 
-const DisplayModeIcon = React.memo(({
-	displayMode,
-	displayModeOption,
-	id,
-	onSelect,
-}) => {
-	const { t } = useListContext();
-	return (
-		<ActionIconToggle
-			key={displayModeOption}
-			id={`${id}-${displayModeOption}`}
-			icon={displayModeOption === 'table' ? 'talend-table' : 'talend-expanded'}
-			label={t('LIST_SELECT_DISPLAY_MODE', {
-				defaultValue: 'Set {{displayMode}} as current display mode.',
-				displayMode: getLabel(displayModeOption, t),
-			})}
-			active={displayMode === displayModeOption}
-			disabled={displayMode === displayModeOption}
-			onClick={e => {
-				onSelect(e, displayModeOption);
-			}}
-		/>
-	);
-});
+export const DisplayModeIcon = React.memo(
+	({ displayMode, displayModeOption, icon, id, label, onSelect }) => {
+		const { t } = useListContext();
+		return (
+			<ActionIconToggle
+				key={displayModeOption}
+				id={`${id}-${displayModeOption}`}
+				icon={icon}
+				label={
+					label ||
+					t('LIST_SELECT_DISPLAY_MODE', {
+						defaultValue: 'Set {{displayMode}} as current display mode.',
+						displayMode: getLabel(displayModeOption, t),
+					})
+				}
+				active={displayMode === displayModeOption}
+				disabled={displayMode === displayModeOption}
+				onClick={e => {
+					onSelect(e, displayModeOption);
+				}}
+			/>
+		);
+	},
+);
 
-function ListDisplayMode({ id, displayModes, initialDisplayMode, onChange, selectedDisplayMode }) {
+DisplayModeIcon.propTypes = {
+	displayMode: PropTypes.string.isRequired,
+	displayModeOption: PropTypes.string.isRequired,
+	icon: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	label: PropTypes.string,
+	onSelect: PropTypes.func.isRequired,
+};
+
+function ListDisplayMode({
+	children,
+	displayModesOptions,
+	id,
+	initialDisplayMode,
+	onChange,
+	selectedDisplayMode,
+}) {
 	const { displayMode, setDisplayMode } = useListContext();
 	useEffect(() => {
 		if (!onChange) {
@@ -58,13 +74,18 @@ function ListDisplayMode({ id, displayModes, initialDisplayMode, onChange, selec
 		}
 	}
 
+	if (children) {
+		return children;
+	}
 	return (
 		<div className={classNames(theme['tc-display-mode-toggle'], 'tc-display-mode-toggle')}>
-			{displayModes.map(displayModeOption => (
+			{displayModesOptions.map(displayModeOption => (
 				<DisplayModeIcon
 					displayMode={selectedDisplayMode || displayMode}
 					displayModeOption={displayModeOption}
+					icon={displayModeOption === 'table' ? 'talend-table' : 'talend-expanded'}
 					id={id}
+					key={displayModeOption}
 					onSelect={onSelect}
 				/>
 			))}
@@ -74,11 +95,12 @@ function ListDisplayMode({ id, displayModes, initialDisplayMode, onChange, selec
 
 ListDisplayMode.defaultProps = {
 	id: uuid.v4(),
-	displayModes: ['table', 'large'],
+	displayModesOptions: ['table', 'large'],
 	initialDisplayMode: 'table',
 };
 ListDisplayMode.propTypes = {
-	displayModes: PropTypes.arrayOf(PropTypes.string),
+	children: PropTypes.node,
+	displayModesOptions: PropTypes.arrayOf(PropTypes.string),
 	id: PropTypes.string,
 	initialDisplayMode: PropTypes.string,
 	onChange: PropTypes.func,

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.test.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.test.js
@@ -4,7 +4,7 @@ import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
-import ListDisplayMode from './ListDisplayMode.component';
+import ListDisplayMode, { DisplayModeIcon } from './ListDisplayMode.component';
 import { ListContext } from '../context';
 import getDefaultT from '../../../translate';
 
@@ -35,12 +35,30 @@ describe('List DisplayMode', () => {
 		// when
 		const wrapper = mount(
 			<ListContext.Provider value={contextValue}>
-				<ListDisplayMode id="myDisplayMode" displayModes={['lol', 'mdr']} />
+				<ListDisplayMode id="myDisplayMode">
+					<DisplayModeIcon
+						displayMode="custom2"
+						displayModeOption="custom1"
+						icon="iconCustom1"
+						id="myId"
+						label="myCustomLabel1"
+						onSelect={jest.fn()}
+					/>
+					<DisplayModeIcon
+						displayMode="custom2"
+						displayModeOption="custom2"
+						icon="iconCustom2"
+						id="myId"
+						label="myCustomLabel2"
+						onSelect={jest.fn()}
+					/>
+				</ListDisplayMode>
 			</ListContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.find('a[role="menuitem"]').map(item => item.text())).toEqual(['lol', 'mdr']);
+		expect(wrapper.find('Button#myId-custom1').prop('aria-label')).toEqual('myCustomLabel1');
+		expect(wrapper.find('Button#myId-custom2').prop('aria-label')).toEqual('myCustomLabel2');
 	});
 
 	describe('uncontrolled mode', () => {
@@ -79,7 +97,7 @@ describe('List DisplayMode', () => {
 
 			// when: react-bootstrap use value-event instead of event-value
 			act(() => {
-				wrapper.find('MenuItem#myDisplayMode-large').prop('onSelect')('large', event);
+				wrapper.find('Button#myDisplayMode-large').prop('onClick')(event, 'large');
 			});
 
 			// then
@@ -101,9 +119,9 @@ describe('List DisplayMode', () => {
 			);
 
 			// then
-			expect(wrapper.find('a.dropdown-toggle').prop('aria-label')).toBe(
-				'Change display mode. Current display mode: large.',
-			);
+			const buttonLarge = wrapper.find('Button#myDisplayMode-large');
+			expect(buttonLarge.prop('aria-label')).toBe('Set Expanded as current display mode.');
+			expect(buttonLarge.prop('disabled')).toBe(true);
 		});
 
 		it('should call props.onChange with new display mode', () => {
@@ -122,7 +140,7 @@ describe('List DisplayMode', () => {
 
 			// when: react-bootstrap use value-event instead of event-value
 			act(() => {
-				wrapper.find('MenuItem#myDisplayMode-large').prop('onSelect')('large', event);
+				wrapper.find('Button#myDisplayMode-large').prop('onClick')(event, 'large');
 			});
 
 			// then

--- a/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`List DisplayMode should render 1`] = `
 <ListDisplayMode
-  displayModes={
+  displayModesOptions={
     Array [
       "table",
       "large",
@@ -11,250 +11,121 @@ exports[`List DisplayMode should render 1`] = `
   id="myDisplayMode"
   initialDisplayMode="table"
 >
-  <NavbarText
-    componentClass="p"
-    pullLeft={false}
-    pullRight={false}
+  <div
+    className="theme-tc-display-mode-toggle tc-display-mode-toggle"
   >
-    <p
-      className="navbar-text"
+    <Component
+      displayMode="table"
+      displayModeOption="table"
+      icon="talend-table"
+      id="myDisplayMode"
+      key="table"
+      onSelect={[Function]}
     >
-      <label
-        htmlFor="myDisplayMode"
+      <TooltipTrigger
+        label="Set Table as current display mode."
+        tooltipPlacement="top"
       >
-        Display:
-      </label>
-    </p>
-  </NavbarText>
-  <Nav
-    bsClass="nav"
-    justified={false}
-    pullLeft={false}
-    pullRight={false}
-    stacked={false}
-  >
-    <ul
-      className="nav"
-      role={null}
-    >
-      <NavDropdown
-        aria-label="Change display mode. Current display mode: table."
-        id="myDisplayMode"
-        key=".0"
-        onSelect={[Function]}
-        title={
-          <Icon
-            name="talend-table"
-          />
-        }
-      >
-        <Uncontrolled(Dropdown)
-          className=""
-          componentClass="li"
-          id="myDisplayMode"
-          onSelect={[Function]}
+        <Button
+          active={false}
+          aria-label="Set Table as current display mode."
+          aria-pressed={true}
+          block={false}
+          bsClass="btn"
+          bsStyle=""
+          className="tc-icon-toggle theme-tc-icon-toggle theme-active active"
+          disabled={true}
+          id="myDisplayMode-table"
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseOver={[Function]}
         >
-          <Dropdown
-            bsClass="dropdown"
-            className=""
-            componentClass="li"
-            id="myDisplayMode"
-            onSelect={[Function]}
-            onToggle={[Function]}
+          <button
+            aria-label="Set Table as current display mode."
+            aria-pressed={true}
+            className="tc-icon-toggle theme-tc-icon-toggle theme-active active btn"
+            disabled={true}
+            id="myDisplayMode-table"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOver={[Function]}
+            type="button"
           >
-            <li
-              className="dropdown"
+            <Icon
+              name="talend-table"
             >
-              <DropdownToggle
-                aria-label="Change display mode. Current display mode: table."
-                bsClass="dropdown-toggle"
-                bsRole="toggle"
-                id="myDisplayMode"
-                key=".0"
-                onClick={[Function]}
-                onKeyDown={[Function]}
-                open={false}
-                useAnchor={true}
+              <svg
+                aria-hidden="true"
+                className="theme-tc-svg-icon tc-svg-icon"
+                focusable="false"
+                name="talend-table"
+                title={null}
               >
-                <SafeAnchor
-                  aria-expanded={false}
-                  aria-haspopup={true}
-                  aria-label="Change display mode. Current display mode: table."
-                  className="dropdown-toggle"
-                  componentClass="a"
-                  id="myDisplayMode"
-                  onClick={[Function]}
-                  onKeyDown={[Function]}
-                  role="button"
-                >
-                  <a
-                    aria-expanded={false}
-                    aria-haspopup={true}
-                    aria-label="Change display mode. Current display mode: table."
-                    className="dropdown-toggle"
-                    href="#"
-                    id="myDisplayMode"
-                    onClick={[Function]}
-                    onKeyDown={[Function]}
-                    role="button"
-                  >
-                    <Icon
-                      name="talend-table"
-                    >
-                      <svg
-                        aria-hidden="true"
-                        className="theme-tc-svg-icon tc-svg-icon"
-                        focusable="false"
-                        name="talend-table"
-                        title={null}
-                      >
-                        <use
-                          xlinkHref="#talend-table"
-                        />
-                      </svg>
-                    </Icon>
-                     
-                    <span
-                      className="caret"
-                    />
-                  </a>
-                </SafeAnchor>
-              </DropdownToggle>
-              <DropdownMenu
-                bsClass="dropdown-menu"
-                bsRole="menu"
-                key=".1"
-                labelledBy="myDisplayMode"
-                onClose={[Function]}
-                onSelect={[Function]}
-                pullRight={false}
+                <use
+                  xlinkHref="#talend-table"
+                />
+              </svg>
+            </Icon>
+          </button>
+        </Button>
+      </TooltipTrigger>
+    </Component>
+    <Component
+      displayMode="table"
+      displayModeOption="large"
+      icon="talend-expanded"
+      id="myDisplayMode"
+      key="large"
+      onSelect={[Function]}
+    >
+      <TooltipTrigger
+        label="Set Expanded as current display mode."
+        tooltipPlacement="top"
+      >
+        <Button
+          active={false}
+          aria-label="Set Expanded as current display mode."
+          aria-pressed={false}
+          block={false}
+          bsClass="btn"
+          bsStyle=""
+          className="tc-icon-toggle theme-tc-icon-toggle"
+          disabled={false}
+          id="myDisplayMode-large"
+          onClick={[Function]}
+          onFocus={[Function]}
+          onMouseOver={[Function]}
+        >
+          <button
+            aria-label="Set Expanded as current display mode."
+            aria-pressed={false}
+            className="tc-icon-toggle theme-tc-icon-toggle btn"
+            disabled={false}
+            id="myDisplayMode-large"
+            onClick={[Function]}
+            onFocus={[Function]}
+            onMouseOver={[Function]}
+            type="button"
+          >
+            <Icon
+              name="talend-expanded"
+            >
+              <svg
+                aria-hidden="true"
+                className="theme-tc-svg-icon tc-svg-icon"
+                focusable="false"
+                name="talend-expanded"
+                title={null}
               >
-                <RootCloseWrapper
-                  disabled={true}
-                  event="click"
-                  onRootClose={[Function]}
-                >
-                  <ul
-                    aria-labelledby="myDisplayMode"
-                    className="dropdown-menu"
-                    role="menu"
-                  >
-                    <MenuItem
-                      aria-label="Set Table as current display mode."
-                      bsClass="dropdown"
-                      disabled={false}
-                      divider={false}
-                      eventKey="table"
-                      header={false}
-                      id="myDisplayMode-table"
-                      key=".$.$table"
-                      onKeyDown={[Function]}
-                      onSelect={[Function]}
-                    >
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <SafeAnchor
-                          aria-label="Set Table as current display mode."
-                          componentClass="a"
-                          id="myDisplayMode-table"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          <a
-                            aria-label="Set Table as current display mode."
-                            href="#"
-                            id="myDisplayMode-table"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <Icon
-                              name="talend-table"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                className="theme-tc-svg-icon tc-svg-icon"
-                                focusable="false"
-                                name="talend-table"
-                                title={null}
-                              >
-                                <use
-                                  xlinkHref="#talend-table"
-                                />
-                              </svg>
-                            </Icon>
-                            Table
-                          </a>
-                        </SafeAnchor>
-                      </li>
-                    </MenuItem>
-                    <MenuItem
-                      aria-label="Set Expanded as current display mode."
-                      bsClass="dropdown"
-                      disabled={false}
-                      divider={false}
-                      eventKey="large"
-                      header={false}
-                      id="myDisplayMode-large"
-                      key=".$.$large"
-                      onKeyDown={[Function]}
-                      onSelect={[Function]}
-                    >
-                      <li
-                        className=""
-                        role="presentation"
-                      >
-                        <SafeAnchor
-                          aria-label="Set Expanded as current display mode."
-                          componentClass="a"
-                          id="myDisplayMode-large"
-                          onClick={[Function]}
-                          onKeyDown={[Function]}
-                          role="menuitem"
-                          tabIndex="-1"
-                        >
-                          <a
-                            aria-label="Set Expanded as current display mode."
-                            href="#"
-                            id="myDisplayMode-large"
-                            onClick={[Function]}
-                            onKeyDown={[Function]}
-                            role="menuitem"
-                            tabIndex="-1"
-                          >
-                            <Icon
-                              name="talend-expanded"
-                            >
-                              <svg
-                                aria-hidden="true"
-                                className="theme-tc-svg-icon tc-svg-icon"
-                                focusable="false"
-                                name="talend-expanded"
-                                title={null}
-                              >
-                                <use
-                                  xlinkHref="#talend-expanded"
-                                />
-                              </svg>
-                            </Icon>
-                            Expanded
-                          </a>
-                        </SafeAnchor>
-                      </li>
-                    </MenuItem>
-                  </ul>
-                </RootCloseWrapper>
-              </DropdownMenu>
-            </li>
-          </Dropdown>
-        </Uncontrolled(Dropdown)>
-      </NavDropdown>
-    </ul>
-  </Nav>
+                <use
+                  xlinkHref="#talend-expanded"
+                />
+              </svg>
+            </Icon>
+          </button>
+        </Button>
+      </TooltipTrigger>
+    </Component>
+  </div>
 </ListDisplayMode>
 `;

--- a/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
@@ -22,53 +22,64 @@ exports[`List DisplayMode should render 1`] = `
       key="table"
       onSelect={[Function]}
     >
-      <TooltipTrigger
+      <ActionIconToggle
+        active={true}
+        disabled={true}
+        icon="talend-table"
+        id="myDisplayMode-table"
+        key="table"
         label="Set Table as current display mode."
+        onClick={[Function]}
         tooltipPlacement="top"
       >
-        <Button
-          active={false}
-          aria-label="Set Table as current display mode."
-          aria-pressed={true}
-          block={false}
-          bsClass="btn"
-          bsStyle=""
-          className="tc-icon-toggle theme-tc-icon-toggle theme-active active"
-          disabled={true}
-          id="myDisplayMode-table"
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOver={[Function]}
+        <TooltipTrigger
+          label="Set Table as current display mode."
+          tooltipPlacement="top"
         >
-          <button
+          <Button
+            active={false}
             aria-label="Set Table as current display mode."
             aria-pressed={true}
-            className="tc-icon-toggle theme-tc-icon-toggle theme-active active btn"
+            block={false}
+            bsClass="btn"
+            bsStyle=""
+            className="tc-icon-toggle theme-tc-icon-toggle theme-active active"
             disabled={true}
             id="myDisplayMode-table"
             onClick={[Function]}
             onFocus={[Function]}
             onMouseOver={[Function]}
-            type="button"
           >
-            <Icon
-              name="talend-table"
+            <button
+              aria-label="Set Table as current display mode."
+              aria-pressed={true}
+              className="tc-icon-toggle theme-tc-icon-toggle theme-active active btn"
+              disabled={true}
+              id="myDisplayMode-table"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOver={[Function]}
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                className="theme-tc-svg-icon tc-svg-icon"
-                focusable="false"
+              <Icon
                 name="talend-table"
-                title={null}
               >
-                <use
-                  xlinkHref="#talend-table"
-                />
-              </svg>
-            </Icon>
-          </button>
-        </Button>
-      </TooltipTrigger>
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon"
+                  focusable="false"
+                  name="talend-table"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-table"
+                  />
+                </svg>
+              </Icon>
+            </button>
+          </Button>
+        </TooltipTrigger>
+      </ActionIconToggle>
     </Component>
     <Component
       displayMode="table"
@@ -78,53 +89,64 @@ exports[`List DisplayMode should render 1`] = `
       key="large"
       onSelect={[Function]}
     >
-      <TooltipTrigger
+      <ActionIconToggle
+        active={false}
+        disabled={false}
+        icon="talend-expanded"
+        id="myDisplayMode-large"
+        key="large"
         label="Set Expanded as current display mode."
+        onClick={[Function]}
         tooltipPlacement="top"
       >
-        <Button
-          active={false}
-          aria-label="Set Expanded as current display mode."
-          aria-pressed={false}
-          block={false}
-          bsClass="btn"
-          bsStyle=""
-          className="tc-icon-toggle theme-tc-icon-toggle"
-          disabled={false}
-          id="myDisplayMode-large"
-          onClick={[Function]}
-          onFocus={[Function]}
-          onMouseOver={[Function]}
+        <TooltipTrigger
+          label="Set Expanded as current display mode."
+          tooltipPlacement="top"
         >
-          <button
+          <Button
+            active={false}
             aria-label="Set Expanded as current display mode."
             aria-pressed={false}
-            className="tc-icon-toggle theme-tc-icon-toggle btn"
+            block={false}
+            bsClass="btn"
+            bsStyle=""
+            className="tc-icon-toggle theme-tc-icon-toggle"
             disabled={false}
             id="myDisplayMode-large"
             onClick={[Function]}
             onFocus={[Function]}
             onMouseOver={[Function]}
-            type="button"
           >
-            <Icon
-              name="talend-expanded"
+            <button
+              aria-label="Set Expanded as current display mode."
+              aria-pressed={false}
+              className="tc-icon-toggle theme-tc-icon-toggle btn"
+              disabled={false}
+              id="myDisplayMode-large"
+              onClick={[Function]}
+              onFocus={[Function]}
+              onMouseOver={[Function]}
+              type="button"
             >
-              <svg
-                aria-hidden="true"
-                className="theme-tc-svg-icon tc-svg-icon"
-                focusable="false"
+              <Icon
                 name="talend-expanded"
-                title={null}
               >
-                <use
-                  xlinkHref="#talend-expanded"
-                />
-              </svg>
-            </Icon>
-          </button>
-        </Button>
-      </TooltipTrigger>
+                <svg
+                  aria-hidden="true"
+                  className="theme-tc-svg-icon tc-svg-icon"
+                  focusable="false"
+                  name="talend-expanded"
+                  title={null}
+                >
+                  <use
+                    xlinkHref="#talend-expanded"
+                  />
+                </svg>
+              </Icon>
+            </button>
+          </Button>
+        </TooltipTrigger>
+      </ActionIconToggle>
     </Component>
   </div>
 </ListDisplayMode>

--- a/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
+++ b/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
@@ -23,7 +23,7 @@ $tc-toolbar-height: 7rem;
 	> :global(.container-fluid) {
 		display: flex;
 		align-items: center;
-		width: 100vw;
+		width: 100%;
 		padding: 0;
 	}
 }

--- a/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
+++ b/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
@@ -1,36 +1,29 @@
 $tc-list-toolbar-display-color: $silver !default;
 $tc-list-toolbar-background-color: $concrete !default;
 
+$tc-toolbar-height: 7rem;
+
 .tc-list-toolbar {
+	display: flex;
+	height: $tc-toolbar-height;
+	max-height: $tc-toolbar-height;
+
+	padding-left: $padding-larger;
+	padding-right: $padding-larger;
+
 	background: $tc-list-toolbar-background-color;
 	border-top: 1px solid $alto;
 	border-bottom: 1px solid $alto;
 	margin-bottom: 0;
 
+	:global(.tc-display-mode-toggle) {
+		margin-left: auto;
+	}
+
 	> :global(.container-fluid) {
-		padding-left: 0;
-	}
-
-	:global(.navbar-btn) {
-		margin-top: 0;
-		margin-bottom: 0;
-	}
-
-	:global(.navbar-text) {
-		color: $tc-list-toolbar-display-color;
-		margin-right: 0;
-
-		label {
-			font-weight: 400;
-			margin: 0;
-		}
-	}
-
-	:global(.navbar-nav) {
-		a[role='menuitem'],
-		a:global(.dropdown-toggle) {
-			color: $black;
-			text-transform: capitalize;
-		}
+		display: flex;
+		align-items: center;
+		width: 100vw;
+		padding: 0;
 	}
 }

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -131,9 +131,10 @@ storiesOf('List Composition', module)
 			<IconsProvider />
 			<h1>List with display mode change</h1>
 			<p>
-				You can control the display mode by<br />
-				- passing the display mode to List.DisplayMode and List.VList<br />
-				- handling the display mode change via List.DisplayMode onChange prop
+				You can control the display mode by
+				<br />
+				- passing the display mode to List.DisplayMode and List.VList
+				<br />- handling the display mode change via List.DisplayMode onChange prop
 			</p>
 			<pre>{`
 <List.Manager
@@ -170,9 +171,7 @@ storiesOf('List Composition', module)
 		<div className="virtualized-list">
 			<IconsProvider />
 			<h1>Text Filter</h1>
-			<p>
-				You can filter the dataset with the text by adding the component and let it work itself
-			</p>
+			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<pre>{`<List.Manager
  	id="my-list"
  	collection={collection}
@@ -200,9 +199,10 @@ storiesOf('List Composition', module)
 			<IconsProvider />
 			<h1>Text Filter</h1>
 			<p>
-				You can control the filter feature by providing callbacks to<br />
-				- handle the text filter value change and filter data<br />
-				- handle the text filter's docked status
+				You can control the filter feature by providing callbacks to
+				<br />
+				- handle the text filter value change and filter data
+				<br />- handle the text filter's docked status
 			</p>
 			<pre>{`<List.Manager
  	id="my-list"
@@ -308,10 +308,11 @@ storiesOf('List Composition', module)
 			<h1>List supporting infinite scroll</h1>
 			<p>
 				The InfiniteScrollList list component allows to create lists that supports infinite scroll
-				feature.<br />
-				It requires :<br />
-				- <code>loadMoreRows</code> prop triggered when data loading is required<br />
-				- <code>rowCount</code> prop representing the collection's total number of items<br />
+				feature.
+				<br />
+				It requires :<br />- <code>loadMoreRows</code> prop triggered when data loading is required
+				<br />- <code>rowCount</code> prop representing the collection's total number of items
+				<br />
 				Skeleton rows are rendered when data is missing, while they are being fetched.
 			</p>
 			<pre>{`
@@ -331,4 +332,5 @@ storiesOf('List Composition', module)
 					/>
 				</List.Manager>
 			</section>
-		</div>));
+		</div>
+	));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Toolbar and display mode in list composition are not up to date.
Using what have been done in https://github.com/Talend/ui/pull/2162, in this pr we are gonna update the display mode
[Frontify](http://guidelines.talend.com/document/92132#/navigation-layout/list-toolbar)
**What is the chosen solution to this problem?**
Display mode is now represent by icon and toolbar is on a unique line.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
