### PR TITLE
fix(toolbar): update composition list toolbar size

### DIFF
--- a/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
+++ b/packages/components/src/List/ListComposition/Toolbar/ListToolbar.scss
@@ -15,6 +15,12 @@ $tc-toolbar-height: 7rem;
 	border-top: 1px solid $alto;
 	border-bottom: 1px solid $alto;
 	margin-bottom: 0;
+	flex-shrink: 0;
+	flex-grow: 0;
+
+	:global(.tc-actionbar-container) {
+		padding: 0;
+	}
 
 	:global(.tc-display-mode-toggle) {
 		margin-left: auto;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
toolbar could shrink in composition mode
Also with an action bar inside, the action bar padding create a 40px left padding to get the first button
**What is the chosen solution to this problem?**
change the paddings & the flex-grow
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
