### PR TITLE
feat(components/VirtualizedList): Loading state for collapsible panel

### DIFF
--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
@@ -3,18 +3,41 @@ import React from 'react';
 import get from 'lodash/get';
 import classNames from 'classnames';
 import { CellMeasurer, CellMeasurerCache } from 'react-virtualized';
+import isEmpty from 'lodash/isEmpty';
 
+import Skeleton from '../../Skeleton';
 import CollapsiblePanel from '../../CollapsiblePanel/CollapsiblePanel.component';
 import { getId, getRowData } from '../utils/gridrow';
 
 import withListGesture from '../../Gesture/withListGesture';
-import './RowCollapsiblePanel.scss';
+import theme from './RowCollapsiblePanel.scss';
 
 const cache = new CellMeasurerCache({ fixedWidth: true });
 const options = {
 	deferredMeasurementCache: cache,
 	rowHeight: cache.rowHeight,
 };
+
+function LoadingCollapsiblePanel() {
+	return (
+		<div className={theme['loading-collapsible-panel']}>
+			<span>
+				<Skeleton type={Skeleton.TYPES.circle} size={Skeleton.SIZES.small} />
+				<Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.xlarge} />
+			</span>
+			<span>
+				<Skeleton type={Skeleton.TYPES.circle} size={Skeleton.SIZES.small} />
+				<Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.medium} />
+			</span>
+			<span>
+				<Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.small} />
+			</span>
+			<span>
+				<Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.medium} />
+			</span>
+		</div>
+	);
+}
 
 /**
  * Row renderer that displays a Collapsible Panel
@@ -55,12 +78,18 @@ class RowCollapsiblePanel extends React.Component {
 						aria-label={get(rowData, 'header[0].label')}
 						style={style}
 					>
-						<CollapsiblePanel
-							onEntered={measure}
-							onExited={measure}
-							onToggle={this.onToggle}
-							{...rowData}
-						/>
+						{isEmpty(rowData)
+							? <LoadingCollapsiblePanel />
+							: (
+								<CollapsiblePanel
+									onEntered={measure}
+									onExited={measure}
+									onToggle={this.onToggle}
+									{...rowData}
+								/>
+							)
+						}
+
 					</div>
 				)}
 			</CellMeasurer>

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
@@ -39,6 +39,8 @@ function LoadingCollapsiblePanel() {
 	);
 }
 
+const MemoLoadingCollapsiblePanel = React.memo(LoadingCollapsiblePanel);
+
 /**
  * Row renderer that displays a Collapsible Panel
  */
@@ -79,7 +81,7 @@ class RowCollapsiblePanel extends React.Component {
 						style={style}
 					>
 						{isEmpty(rowData) ? (
-							<LoadingCollapsiblePanel />
+							<MemoLoadingCollapsiblePanel />
 						) : (
 							<CollapsiblePanel
 								onEntered={measure}

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.component.js
@@ -78,18 +78,16 @@ class RowCollapsiblePanel extends React.Component {
 						aria-label={get(rowData, 'header[0].label')}
 						style={style}
 					>
-						{isEmpty(rowData)
-							? <LoadingCollapsiblePanel />
-							: (
-								<CollapsiblePanel
-									onEntered={measure}
-									onExited={measure}
-									onToggle={this.onToggle}
-									{...rowData}
-								/>
-							)
-						}
-
+						{isEmpty(rowData) ? (
+							<LoadingCollapsiblePanel />
+						) : (
+							<CollapsiblePanel
+								onEntered={measure}
+								onExited={measure}
+								onToggle={this.onToggle}
+								{...rowData}
+							/>
+						)}
 					</div>
 				)}
 			</CellMeasurer>

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
@@ -19,7 +19,6 @@
 		margin-bottom: $padding-small;
 
 		display: flex;
-		flex-direction: row;
 		align-items: center;
 
 		> * {

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
@@ -13,7 +13,7 @@
 	}
 
 	.loading-collapsible-panel {
-		height: 40px;
+		height: 4rem;
 		background-color: $gallery;
 		border-radius: $border-radius-base;
 		margin-bottom: $padding-small;

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.scss
@@ -11,4 +11,25 @@
 		margin-bottom: $padding-small;
 		margin-top: $padding-small;
 	}
+
+	.loading-collapsible-panel {
+		height: 40px;
+		background-color: $gallery;
+		border-radius: $border-radius-base;
+		margin-bottom: $padding-small;
+
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+
+		> * {
+			display: inline-block;
+			flex: 1;
+		}
+
+		:first-child {
+			flex: 2;
+			margin: 0 $padding-small;
+		}
+	}
 }

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
@@ -103,7 +103,7 @@ describe('RowCollapsiblePanel', () => {
 		).toMatchSnapshot();
 	});
 
-	it('should render a row with no data', () => {
+	it('should render a row with no data (loading)', () => {
 		// given
 		const noDataParent = {
 			...parent,
@@ -114,16 +114,9 @@ describe('RowCollapsiblePanel', () => {
 		};
 
 		// when
-		const wrapper = mount(
-			<RowCollapsiblePanel
-				className={'my-class-names'}
-				index={1}
-				key={18}
-				parent={noDataParent}
-				style={{ background: 'red' }}
-			/>,
-		);
+		const wrapper = mount(<RowCollapsiblePanel index={1} parent={noDataParent} />);
 
-		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
+		// then
+		expect(toJsonWithoutI18n(wrapper.find('.tc-collapsible-row')).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
@@ -117,6 +117,6 @@ describe('RowCollapsiblePanel', () => {
 		const wrapper = mount(<RowCollapsiblePanel index={1} parent={noDataParent} />);
 
 		// then
-		expect(toJsonWithoutI18n(wrapper.find('.tc-collapsible-row')).toMatchSnapshot();
+		expect(toJsonWithoutI18n(wrapper.find('.tc-collapsible-row'))).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.test.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
+
+import toJsonWithoutI18n from '../../../test/props-without-i18n';
 import RowCollapsiblePanel from './RowCollapsiblePanel.component';
 
 const collection = [
@@ -99,5 +101,29 @@ describe('RowCollapsiblePanel', () => {
 				.getElement()
 				.props.children({ measure: jest.fn() }),
 		).toMatchSnapshot();
+	});
+
+	it('should render a row with no data', () => {
+		// given
+		const noDataParent = {
+			...parent,
+			props: {
+				...parent.props,
+				rowGetter: () => ({}),
+			},
+		};
+
+		// when
+		const wrapper = mount(
+			<RowCollapsiblePanel
+				className={'my-class-names'}
+				index={1}
+				key={18}
+				parent={noDataParent}
+				style={{ background: 'red' }}
+			/>,
+		);
+
+		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
@@ -1,8 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`RowCollapsiblePanel should render a row with no data 1`] = `
+exports[`RowCollapsiblePanel should render a row with no data (loading) 1`] = `
 <ListGesture(VirtualizedList(RowCollapsiblePanel))
-  className="my-class-names"
   index={1}
   parent={
     Object {
@@ -81,14 +80,8 @@ exports[`RowCollapsiblePanel should render a row with no data 1`] = `
       },
     }
   }
-  style={
-    Object {
-      "background": "red",
-    }
-  }
 >
   <VirtualizedList(RowCollapsiblePanel)
-    className="my-class-names"
     index={1}
     onKeyDown={[Function]}
     parent={
@@ -166,11 +159,6 @@ exports[`RowCollapsiblePanel should render a row with no data 1`] = `
           "id": "my-list",
           "rowGetter": [Function],
         },
-      }
-    }
-    style={
-      Object {
-        "background": "red",
       }
     }
   >
@@ -283,15 +271,10 @@ exports[`RowCollapsiblePanel should render a row with no data 1`] = `
     >
       <div
         aria-posinset={2}
-        className="tc-collapsible-row my-class-names"
+        className="tc-collapsible-row"
         id="my-list-1"
         onKeyDown={[Function]}
         role="listitem"
-        style={
-          Object {
-            "background": "red",
-          }
-        }
         tabIndex="0"
       >
         <LoadingCollapsiblePanel>

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
@@ -1,5 +1,583 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`RowCollapsiblePanel should render a row with no data 1`] = `
+<ListGesture(VirtualizedList(RowCollapsiblePanel))
+  className="my-class-names"
+  index={1}
+  parent={
+    Object {
+      "props": Object {
+        "children": Array [],
+        "collection": Array [
+          Object {
+            "content": Array [
+              Object {
+                "description": "Description1",
+                "label": "Content1",
+              },
+              Object {
+                "description": "Description2",
+                "label": "Content2",
+              },
+            ],
+            "expanded": true,
+            "header": Array [
+              Object {
+                "actions": Array [],
+                "displayMode": "status",
+                "icon": "talend-check",
+                "label": "Successful",
+                "status": "successful",
+              },
+            ],
+          },
+          Object {
+            "content": Array [
+              Object {
+                "description": "Description1",
+                "label": "Content1",
+              },
+              Object {
+                "description": "Description2",
+                "label": "Content2",
+              },
+            ],
+            "expanded": true,
+            "header": Array [
+              Object {
+                "actions": Array [],
+                "displayMode": "status",
+                "icon": "talend-cross",
+                "label": "Canceled",
+                "status": "canceled",
+              },
+            ],
+          },
+          Object {
+            "content": Array [
+              Object {
+                "description": "Description1",
+                "label": "Content1",
+              },
+              Object {
+                "description": "Description2",
+                "label": "Content2",
+              },
+            ],
+            "expanded": true,
+            "header": Array [
+              Object {
+                "actions": Array [],
+                "displayMode": "status",
+                "icon": "talend-cross",
+                "label": "Failure",
+                "status": "failed",
+              },
+            ],
+          },
+        ],
+        "id": "my-list",
+        "rowGetter": [Function],
+      },
+    }
+  }
+  style={
+    Object {
+      "background": "red",
+    }
+  }
+>
+  <VirtualizedList(RowCollapsiblePanel)
+    className="my-class-names"
+    index={1}
+    onKeyDown={[Function]}
+    parent={
+      Object {
+        "props": Object {
+          "children": Array [],
+          "collection": Array [
+            Object {
+              "content": Array [
+                Object {
+                  "description": "Description1",
+                  "label": "Content1",
+                },
+                Object {
+                  "description": "Description2",
+                  "label": "Content2",
+                },
+              ],
+              "expanded": true,
+              "header": Array [
+                Object {
+                  "actions": Array [],
+                  "displayMode": "status",
+                  "icon": "talend-check",
+                  "label": "Successful",
+                  "status": "successful",
+                },
+              ],
+            },
+            Object {
+              "content": Array [
+                Object {
+                  "description": "Description1",
+                  "label": "Content1",
+                },
+                Object {
+                  "description": "Description2",
+                  "label": "Content2",
+                },
+              ],
+              "expanded": true,
+              "header": Array [
+                Object {
+                  "actions": Array [],
+                  "displayMode": "status",
+                  "icon": "talend-cross",
+                  "label": "Canceled",
+                  "status": "canceled",
+                },
+              ],
+            },
+            Object {
+              "content": Array [
+                Object {
+                  "description": "Description1",
+                  "label": "Content1",
+                },
+                Object {
+                  "description": "Description2",
+                  "label": "Content2",
+                },
+              ],
+              "expanded": true,
+              "header": Array [
+                Object {
+                  "actions": Array [],
+                  "displayMode": "status",
+                  "icon": "talend-cross",
+                  "label": "Failure",
+                  "status": "failed",
+                },
+              ],
+            },
+          ],
+          "id": "my-list",
+          "rowGetter": [Function],
+        },
+      }
+    }
+    style={
+      Object {
+        "background": "red",
+      }
+    }
+  >
+    <CellMeasurer
+      cache={
+        CellMeasurerCache {
+          "_cellHeightCache": Object {
+            "1-0": 0,
+          },
+          "_cellWidthCache": Object {
+            "1-0": 0,
+          },
+          "_columnCount": 1,
+          "_columnWidthCache": Object {},
+          "_defaultHeight": 30,
+          "_defaultWidth": 100,
+          "_hasFixedHeight": false,
+          "_hasFixedWidth": true,
+          "_keyMapper": [Function],
+          "_minHeight": 0,
+          "_minWidth": 0,
+          "_rowCount": 2,
+          "_rowHeightCache": Object {
+            "1-0": 0,
+          },
+          "columnWidth": [Function],
+          "rowHeight": [Function],
+        }
+      }
+      columnIndex={0}
+      key="1"
+      parent={
+        Object {
+          "props": Object {
+            "children": Array [],
+            "collection": Array [
+              Object {
+                "content": Array [
+                  Object {
+                    "description": "Description1",
+                    "label": "Content1",
+                  },
+                  Object {
+                    "description": "Description2",
+                    "label": "Content2",
+                  },
+                ],
+                "expanded": true,
+                "header": Array [
+                  Object {
+                    "actions": Array [],
+                    "displayMode": "status",
+                    "icon": "talend-check",
+                    "label": "Successful",
+                    "status": "successful",
+                  },
+                ],
+              },
+              Object {
+                "content": Array [
+                  Object {
+                    "description": "Description1",
+                    "label": "Content1",
+                  },
+                  Object {
+                    "description": "Description2",
+                    "label": "Content2",
+                  },
+                ],
+                "expanded": true,
+                "header": Array [
+                  Object {
+                    "actions": Array [],
+                    "displayMode": "status",
+                    "icon": "talend-cross",
+                    "label": "Canceled",
+                    "status": "canceled",
+                  },
+                ],
+              },
+              Object {
+                "content": Array [
+                  Object {
+                    "description": "Description1",
+                    "label": "Content1",
+                  },
+                  Object {
+                    "description": "Description2",
+                    "label": "Content2",
+                  },
+                ],
+                "expanded": true,
+                "header": Array [
+                  Object {
+                    "actions": Array [],
+                    "displayMode": "status",
+                    "icon": "talend-cross",
+                    "label": "Failure",
+                    "status": "failed",
+                  },
+                ],
+              },
+            ],
+            "id": "my-list",
+            "rowGetter": [Function],
+          },
+        }
+      }
+      rowIndex={1}
+    >
+      <div
+        aria-posinset={2}
+        className="tc-collapsible-row my-class-names"
+        id="my-list-1"
+        onKeyDown={[Function]}
+        role="listitem"
+        style={
+          Object {
+            "background": "red",
+          }
+        }
+        tabIndex="0"
+      >
+        <LoadingCollapsiblePanel>
+          <div
+            className="theme-loading-collapsible-panel"
+          >
+            <span>
+              <Translate(Skeleton)
+                size="small"
+                type="circle"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="small"
+                  translateFuncName="t"
+                  type="circle"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="small"
+                    t={[Function]}
+                    tReady={false}
+                    type="circle"
+                  >
+                    <span
+                      aria-label="circle (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+              <Translate(Skeleton)
+                size="xlarge"
+                type="text"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="xlarge"
+                  translateFuncName="t"
+                  type="text"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="xlarge"
+                    t={[Function]}
+                    tReady={false}
+                    type="text"
+                  >
+                    <span
+                      aria-label="text (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-xlarge theme-tc-skeleton-text-xlarge tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+            </span>
+            <span>
+              <Translate(Skeleton)
+                size="small"
+                type="circle"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="small"
+                  translateFuncName="t"
+                  type="circle"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="small"
+                    t={[Function]}
+                    tReady={false}
+                    type="circle"
+                  >
+                    <span
+                      aria-label="circle (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+              <Translate(Skeleton)
+                size="medium"
+                type="text"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="medium"
+                  translateFuncName="t"
+                  type="text"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="medium"
+                    t={[Function]}
+                    tReady={false}
+                    type="text"
+                  >
+                    <span
+                      aria-label="text (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+            </span>
+            <span>
+              <Translate(Skeleton)
+                size="small"
+                type="text"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="small"
+                  translateFuncName="t"
+                  type="text"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="small"
+                    t={[Function]}
+                    tReady={false}
+                    type="text"
+                  >
+                    <span
+                      aria-label="text (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-small theme-tc-skeleton-text-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+            </span>
+            <span>
+              <Translate(Skeleton)
+                size="medium"
+                type="text"
+              >
+                <I18n
+                  bindI18n="languageChanged loaded"
+                  bindStore="added removed"
+                  i18n={Object {}}
+                  ns={
+                    Array [
+                      "tui-components",
+                    ]
+                  }
+                  nsMode="default"
+                  omitBoundRerender={true}
+                  size="medium"
+                  translateFuncName="t"
+                  type="text"
+                  usePureComponent={false}
+                  wait={false}
+                  withRef={false}
+                >
+                  <Skeleton
+                    heartbeat={true}
+                    i18n={Object {}}
+                    lng="en"
+                    size="medium"
+                    t={[Function]}
+                    tReady={false}
+                    type="text"
+                  >
+                    <span
+                      aria-label="text (loading)"
+                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                      style={
+                        Object {
+                          "height": undefined,
+                          "width": undefined,
+                        }
+                      }
+                    />
+                  </Skeleton>
+                </I18n>
+              </Translate(Skeleton)>
+            </span>
+          </div>
+        </LoadingCollapsiblePanel>
+      </div>
+    </CellMeasurer>
+  </VirtualizedList(RowCollapsiblePanel)>
+</ListGesture(VirtualizedList(RowCollapsiblePanel))>
+`;
+
 exports[`RowCollapsiblePanel should render collapsible panel row 1`] = `
 <div
   aria-label="Canceled"

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/__snapshots__/RowCollapsiblePanel.test.js.snap
@@ -1,564 +1,293 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RowCollapsiblePanel should render a row with no data (loading) 1`] = `
-<ListGesture(VirtualizedList(RowCollapsiblePanel))
-  index={1}
-  parent={
-    Object {
-      "props": Object {
-        "children": Array [],
-        "collection": Array [
-          Object {
-            "content": Array [
-              Object {
-                "description": "Description1",
-                "label": "Content1",
-              },
-              Object {
-                "description": "Description2",
-                "label": "Content2",
-              },
-            ],
-            "expanded": true,
-            "header": Array [
-              Object {
-                "actions": Array [],
-                "displayMode": "status",
-                "icon": "talend-check",
-                "label": "Successful",
-                "status": "successful",
-              },
-            ],
-          },
-          Object {
-            "content": Array [
-              Object {
-                "description": "Description1",
-                "label": "Content1",
-              },
-              Object {
-                "description": "Description2",
-                "label": "Content2",
-              },
-            ],
-            "expanded": true,
-            "header": Array [
-              Object {
-                "actions": Array [],
-                "displayMode": "status",
-                "icon": "talend-cross",
-                "label": "Canceled",
-                "status": "canceled",
-              },
-            ],
-          },
-          Object {
-            "content": Array [
-              Object {
-                "description": "Description1",
-                "label": "Content1",
-              },
-              Object {
-                "description": "Description2",
-                "label": "Content2",
-              },
-            ],
-            "expanded": true,
-            "header": Array [
-              Object {
-                "actions": Array [],
-                "displayMode": "status",
-                "icon": "talend-cross",
-                "label": "Failure",
-                "status": "failed",
-              },
-            ],
-          },
-        ],
-        "id": "my-list",
-        "rowGetter": [Function],
-      },
-    }
-  }
+<div
+  aria-posinset={2}
+  className="tc-collapsible-row"
+  id="my-list-1"
+  onKeyDown={[Function]}
+  role="listitem"
+  tabIndex="0"
 >
-  <VirtualizedList(RowCollapsiblePanel)
-    index={1}
-    onKeyDown={[Function]}
-    parent={
-      Object {
-        "props": Object {
-          "children": Array [],
-          "collection": Array [
-            Object {
-              "content": Array [
-                Object {
-                  "description": "Description1",
-                  "label": "Content1",
-                },
-                Object {
-                  "description": "Description2",
-                  "label": "Content2",
-                },
-              ],
-              "expanded": true,
-              "header": Array [
-                Object {
-                  "actions": Array [],
-                  "displayMode": "status",
-                  "icon": "talend-check",
-                  "label": "Successful",
-                  "status": "successful",
-                },
-              ],
-            },
-            Object {
-              "content": Array [
-                Object {
-                  "description": "Description1",
-                  "label": "Content1",
-                },
-                Object {
-                  "description": "Description2",
-                  "label": "Content2",
-                },
-              ],
-              "expanded": true,
-              "header": Array [
-                Object {
-                  "actions": Array [],
-                  "displayMode": "status",
-                  "icon": "talend-cross",
-                  "label": "Canceled",
-                  "status": "canceled",
-                },
-              ],
-            },
-            Object {
-              "content": Array [
-                Object {
-                  "description": "Description1",
-                  "label": "Content1",
-                },
-                Object {
-                  "description": "Description2",
-                  "label": "Content2",
-                },
-              ],
-              "expanded": true,
-              "header": Array [
-                Object {
-                  "actions": Array [],
-                  "displayMode": "status",
-                  "icon": "talend-cross",
-                  "label": "Failure",
-                  "status": "failed",
-                },
-              ],
-            },
-          ],
-          "id": "my-list",
-          "rowGetter": [Function],
-        },
-      }
-    }
-  >
-    <CellMeasurer
-      cache={
-        CellMeasurerCache {
-          "_cellHeightCache": Object {
-            "1-0": 0,
-          },
-          "_cellWidthCache": Object {
-            "1-0": 0,
-          },
-          "_columnCount": 1,
-          "_columnWidthCache": Object {},
-          "_defaultHeight": 30,
-          "_defaultWidth": 100,
-          "_hasFixedHeight": false,
-          "_hasFixedWidth": true,
-          "_keyMapper": [Function],
-          "_minHeight": 0,
-          "_minWidth": 0,
-          "_rowCount": 2,
-          "_rowHeightCache": Object {
-            "1-0": 0,
-          },
-          "columnWidth": [Function],
-          "rowHeight": [Function],
-        }
-      }
-      columnIndex={0}
-      key="1"
-      parent={
-        Object {
-          "props": Object {
-            "children": Array [],
-            "collection": Array [
-              Object {
-                "content": Array [
-                  Object {
-                    "description": "Description1",
-                    "label": "Content1",
-                  },
-                  Object {
-                    "description": "Description2",
-                    "label": "Content2",
-                  },
-                ],
-                "expanded": true,
-                "header": Array [
-                  Object {
-                    "actions": Array [],
-                    "displayMode": "status",
-                    "icon": "talend-check",
-                    "label": "Successful",
-                    "status": "successful",
-                  },
-                ],
-              },
-              Object {
-                "content": Array [
-                  Object {
-                    "description": "Description1",
-                    "label": "Content1",
-                  },
-                  Object {
-                    "description": "Description2",
-                    "label": "Content2",
-                  },
-                ],
-                "expanded": true,
-                "header": Array [
-                  Object {
-                    "actions": Array [],
-                    "displayMode": "status",
-                    "icon": "talend-cross",
-                    "label": "Canceled",
-                    "status": "canceled",
-                  },
-                ],
-              },
-              Object {
-                "content": Array [
-                  Object {
-                    "description": "Description1",
-                    "label": "Content1",
-                  },
-                  Object {
-                    "description": "Description2",
-                    "label": "Content2",
-                  },
-                ],
-                "expanded": true,
-                "header": Array [
-                  Object {
-                    "actions": Array [],
-                    "displayMode": "status",
-                    "icon": "talend-cross",
-                    "label": "Failure",
-                    "status": "failed",
-                  },
-                ],
-              },
-            ],
-            "id": "my-list",
-            "rowGetter": [Function],
-          },
-        }
-      }
-      rowIndex={1}
+  <LoadingCollapsiblePanel>
+    <div
+      className="theme-loading-collapsible-panel"
     >
-      <div
-        aria-posinset={2}
-        className="tc-collapsible-row"
-        id="my-list-1"
-        onKeyDown={[Function]}
-        role="listitem"
-        tabIndex="0"
-      >
-        <LoadingCollapsiblePanel>
-          <div
-            className="theme-loading-collapsible-panel"
+      <span>
+        <Translate(Skeleton)
+          size="small"
+          type="circle"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="small"
+            translateFuncName="t"
+            type="circle"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
           >
-            <span>
-              <Translate(Skeleton)
-                size="small"
-                type="circle"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="small"
+              t={[Function]}
+              tReady={false}
+              type="circle"
+            >
+              <span
+                aria-label="circle (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="small"
-                  translateFuncName="t"
-                  type="circle"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="small"
-                    t={[Function]}
-                    tReady={false}
-                    type="circle"
-                  >
-                    <span
-                      aria-label="circle (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-              <Translate(Skeleton)
-                size="xlarge"
-                type="text"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+        <Translate(Skeleton)
+          size="xlarge"
+          type="text"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="xlarge"
+            translateFuncName="t"
+            type="text"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
+          >
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="xlarge"
+              t={[Function]}
+              tReady={false}
+              type="text"
+            >
+              <span
+                aria-label="text (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-xlarge theme-tc-skeleton-text-xlarge tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="xlarge"
-                  translateFuncName="t"
-                  type="text"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="xlarge"
-                    t={[Function]}
-                    tReady={false}
-                    type="text"
-                  >
-                    <span
-                      aria-label="text (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-xlarge theme-tc-skeleton-text-xlarge tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-            </span>
-            <span>
-              <Translate(Skeleton)
-                size="small"
-                type="circle"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+      </span>
+      <span>
+        <Translate(Skeleton)
+          size="small"
+          type="circle"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="small"
+            translateFuncName="t"
+            type="circle"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
+          >
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="small"
+              t={[Function]}
+              tReady={false}
+              type="circle"
+            >
+              <span
+                aria-label="circle (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="small"
-                  translateFuncName="t"
-                  type="circle"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="small"
-                    t={[Function]}
-                    tReady={false}
-                    type="circle"
-                  >
-                    <span
-                      aria-label="circle (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-              <Translate(Skeleton)
-                size="medium"
-                type="text"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+        <Translate(Skeleton)
+          size="medium"
+          type="text"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="medium"
+            translateFuncName="t"
+            type="text"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
+          >
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="medium"
+              t={[Function]}
+              tReady={false}
+              type="text"
+            >
+              <span
+                aria-label="text (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="medium"
-                  translateFuncName="t"
-                  type="text"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="medium"
-                    t={[Function]}
-                    tReady={false}
-                    type="text"
-                  >
-                    <span
-                      aria-label="text (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-            </span>
-            <span>
-              <Translate(Skeleton)
-                size="small"
-                type="text"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+      </span>
+      <span>
+        <Translate(Skeleton)
+          size="small"
+          type="text"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="small"
+            translateFuncName="t"
+            type="text"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
+          >
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="small"
+              t={[Function]}
+              tReady={false}
+              type="text"
+            >
+              <span
+                aria-label="text (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-small theme-tc-skeleton-text-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="small"
-                  translateFuncName="t"
-                  type="text"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="small"
-                    t={[Function]}
-                    tReady={false}
-                    type="text"
-                  >
-                    <span
-                      aria-label="text (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-small theme-tc-skeleton-text-small tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-            </span>
-            <span>
-              <Translate(Skeleton)
-                size="medium"
-                type="text"
-              >
-                <I18n
-                  bindI18n="languageChanged loaded"
-                  bindStore="added removed"
-                  i18n={Object {}}
-                  ns={
-                    Array [
-                      "tui-components",
-                    ]
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+      </span>
+      <span>
+        <Translate(Skeleton)
+          size="medium"
+          type="text"
+        >
+          <I18n
+            bindI18n="languageChanged loaded"
+            bindStore="added removed"
+            i18n={Object {}}
+            ns={
+              Array [
+                "tui-components",
+              ]
+            }
+            nsMode="default"
+            omitBoundRerender={true}
+            size="medium"
+            translateFuncName="t"
+            type="text"
+            usePureComponent={false}
+            wait={false}
+            withRef={false}
+          >
+            <Skeleton
+              heartbeat={true}
+              i18n={Object {}}
+              lng="en"
+              size="medium"
+              t={[Function]}
+              tReady={false}
+              type="text"
+            >
+              <span
+                aria-label="text (loading)"
+                className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+                style={
+                  Object {
+                    "height": undefined,
+                    "width": undefined,
                   }
-                  nsMode="default"
-                  omitBoundRerender={true}
-                  size="medium"
-                  translateFuncName="t"
-                  type="text"
-                  usePureComponent={false}
-                  wait={false}
-                  withRef={false}
-                >
-                  <Skeleton
-                    heartbeat={true}
-                    i18n={Object {}}
-                    lng="en"
-                    size="medium"
-                    t={[Function]}
-                    tReady={false}
-                    type="text"
-                  >
-                    <span
-                      aria-label="text (loading)"
-                      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-medium theme-tc-skeleton-text-medium tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
-                      style={
-                        Object {
-                          "height": undefined,
-                          "width": undefined,
-                        }
-                      }
-                    />
-                  </Skeleton>
-                </I18n>
-              </Translate(Skeleton)>
-            </span>
-          </div>
-        </LoadingCollapsiblePanel>
-      </div>
-    </CellMeasurer>
-  </VirtualizedList(RowCollapsiblePanel)>
-</ListGesture(VirtualizedList(RowCollapsiblePanel))>
+                }
+              />
+            </Skeleton>
+          </I18n>
+        </Translate(Skeleton)>
+      </span>
+    </div>
+  </LoadingCollapsiblePanel>
+</div>
 `;
 
 exports[`RowCollapsiblePanel should render collapsible panel row 1`] = `

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -332,5 +332,41 @@ storiesOf('List Composition', module)
 					/>
 				</List.Manager>
 			</section>
+
+			<h2>Collapsible panel mode</h2>
+			<section style={{ height: '30vh' }}>
+				<List.Manager
+					id="my-collapsible-panels-list"
+					collection={[{
+						header: [
+							{
+								displayMode: 'status',
+								actions: [],
+								status: 'successful',
+								label: 'Successful',
+								icon: 'talend-check',
+							},
+						],
+						content: [
+							{
+								label: 'Content1',
+								description: 'Description1',
+							},
+							{
+								label: 'Content2',
+								description: 'Description2',
+							},
+						],
+						expanded: true,
+						children: <div>HELLO WORLD</div>,
+					}]}
+				>
+					<CustomListInfiniteScroll
+						type="COLLAPSIBLE_PANEL"
+						loadMoreRows={action('onLoadMoreRows')}
+						rowCount={50}
+					/>
+				</List.Manager>
+			</section>
 		</div>
 	));

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -338,6 +338,7 @@ storiesOf('List Composition', module)
 				<List.Manager
 					id="my-collapsible-panels-list"
 					collection={[{
+						id: 'status-header',
 						header: [
 							{
 								displayMode: 'status',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
"Collapsible panel" mode of lists currently does not support having unloaded data in a row (it shows an empty element).

**What is the chosen solution to this problem?**
As for the "table" mode, assume that if data is missing, it is being loaded (used for infinite scroll feature) and show its loading state (built with skeletons).
See guidelines here : https://company-57688.frontify.com/document/92132#/navigation-layout/expandable-collapsible-panels/skeleton-loading (_Skeleton loading_ section)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
