### PR TITLE
fix(Resourcepicker): order chooser color

### DIFF
--- a/packages/components/src/ResourcePicker/Toolbar/SortOptions/OrderChooser/OrderChooser.scss
+++ b/packages/components/src/ResourcePicker/Toolbar/SortOptions/OrderChooser/OrderChooser.scss
@@ -2,8 +2,8 @@ $tc-resource-picker-order-chooser-icon-size: 0.6rem !default;
 
 .tc-resource-picker-order-chooser {
 	display: flex;
-
 	padding: 0;
+	background: $white;
 
 	&:hover,
 	&:focus,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The background of the order buttons is gray, it should be white
![image](https://user-images.githubusercontent.com/14272767/59116214-5ac62b80-894b-11e9-9d00-bc3bb97c8387.png)
n.b : cannot be seen on mac/chrome but on others

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
