### PR TITLE
fix(components): make email a required prop

### DIFF
--- a/packages/components/src/ActionIntercom/Intercom.component.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.js
@@ -64,7 +64,7 @@ Intercom.propTypes = {
 	config: PropTypes.shape({
 		app_id: PropTypes.string.isRequired,
 		name: PropTypes.string,
-		email: PropTypes.string,
+		email: PropTypes.string.isRequired,
 		company: PropTypes.shape({
 			id: PropTypes.string.isRequired,
 			name: PropTypes.string,

--- a/packages/components/src/ActionIntercom/Intercom.component.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.js
@@ -58,19 +58,21 @@ Intercom.defaultProps = {
 	t: getDefaultT(),
 };
 
-Intercom.propTypes = {
-	id: PropTypes.string.isRequired,
-	className: PropTypes.string,
-	config: PropTypes.shape({
-		app_id: PropTypes.string.isRequired,
-		name: PropTypes.string,
-		email: PropTypes.string.isRequired,
-		company: PropTypes.shape({
-			id: PropTypes.string.isRequired,
+if (process.env.NODE_ENV !== 'production') {
+	Intercom.propTypes = {
+		id: PropTypes.string.isRequired,
+		className: PropTypes.string,
+		config: PropTypes.shape({
+			app_id: PropTypes.string.isRequired,
 			name: PropTypes.string,
-		}),
-	}).isRequired,
-	t: PropTypes.func,
-};
+			email: PropTypes.string.isRequired,
+			company: PropTypes.shape({
+				id: PropTypes.string.isRequired,
+				name: PropTypes.string,
+			}),
+		}).isRequired,
+		t: PropTypes.func,
+	};
+}
 
 export default translate(I18N_DOMAIN_COMPONENTS)(Intercom);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In a local environment we used the intercom component without an email. This worked fine, but only until you closed and reopened the widget. Then all messages sent **to** the user were not received anymore. 

In fact Intercom uses email as identifier and without this it will not be able to do the connection between the user in the app and the user in Intercom. name was provided but is not used as identifier. 

However there were no errors or warnings about this, and found no clear info about it in the docs. 

**What is the chosen solution to this problem?**
Lets at least make the prop required so we have some indication that we must have it. 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
