### PR TITLE
fix(GridLayout): issue with shrink when content is bigger than tile and changing compact type

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -3,8 +3,8 @@
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
 /home/travis/build/Talend/ui/packages/components/src/GridLayout/Grid.component.js
-  57:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
-  60:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
+  56:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
+  59:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   129:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role

--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -47,8 +47,7 @@ function Grid({
 			cols={columns}
 			measureBeforeMount={false}
 			margin={[MARGIN, MARGIN]}
-			compactType="vertical"
-			verticalCompact
+			compactType="horizontal"
 			isResizable={isResizable}
 			useCSSTransforms={false}
 		>

--- a/packages/components/src/GridLayout/Tile/Tile.scss
+++ b/packages/components/src/GridLayout/Tile/Tile.scss
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;
+	min-height: 0;
 
 	.tc-tile-body {
 		flex: 1;
@@ -9,7 +10,7 @@
 		height: 100%;
 		flex-direction: column;
 		padding: $padding-normal;
-		overflow: visible;
+		min-height: 0;
 	}
 
 	.tc-tile-footer {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Tile content wasn't shrinking which made it overflow from the tile container.
In addition we're changing compact type to horizontal, because the vertical one does'nt allow us to place an element under a blank space.
**What is the chosen solution to this problem?**
setting min-height to 0

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
