### PR TITLE
fix(ActionIconToggle): align in ActionBar

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -62,3 +62,7 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 		}
 	}
 }
+
+:global(.tc-actionbar-container) .tc-icon-toggle svg {
+	margin: 0 0.3rem 0.3rem;
+}

--- a/packages/components/stories/ActionBar.js
+++ b/packages/components/stories/ActionBar.js
@@ -68,6 +68,7 @@ const actions = {
 		{
 			label: 'Secondary5',
 			icon: 'talend-cog',
+			displayMode: 'iconToggle',
 			onClick: action('You clicked me'),
 		},
 	],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

iconToggle in action bar is not well aligned

<img width="358" alt="Screenshot 2019-06-11 at 09 30 47" src="https://user-images.githubusercontent.com/19857479/59252122-a7e81d00-8c2b-11e9-9709-74da8e6e3a74.png">


**What is the chosen solution to this problem?**

update margin when in action bar

<img width="356" alt="Screenshot 2019-06-11 at 09 52 28" src="https://user-images.githubusercontent.com/19857479/59253540-c13e9880-8c2e-11e9-9ec0-ce55d9cdd16b.png">



**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->