### PR TITLE
feat(components/notification): pause/resume when mouse is entering/leaving

### DIFF
--- a/npm-audit/html-webpack-plugin.json
+++ b/npm-audit/html-webpack-plugin.json
@@ -1,10 +1,1 @@
-{
-  "type": "auditSummary",
-  "data": {
-    "vulnerabilities": { "info": 0, "low": 0, "moderate": 0, "high": 0, "critical": 0 },
-    "dependencies": 868838,
-    "devDependencies": 0,
-    "optionalDependencies": 0,
-    "totalDependencies": 868838
-  }
-}
+{"type":"auditSummary","data":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0},"dependencies":868838,"devDependencies":0,"optionalDependencies":0,"totalDependencies":868838}}

--- a/npm-audit/html-webpack-plugin.json
+++ b/npm-audit/html-webpack-plugin.json
@@ -1,1 +1,10 @@
-{"type":"auditSummary","data":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0},"dependencies":868838,"devDependencies":0,"optionalDependencies":0,"totalDependencies":868838}}
+{
+  "type": "auditSummary",
+  "data": {
+    "vulnerabilities": { "info": 0, "low": 0, "moderate": 0, "high": 0, "critical": 0 },
+    "dependencies": 868838,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 868838
+  }
+}

--- a/npm-audit/router.json
+++ b/npm-audit/router.json
@@ -1,1 +1,10 @@
-{"type":"auditSummary","data":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0},"dependencies":872888,"devDependencies":0,"optionalDependencies":0,"totalDependencies":872888}}
+{
+  "type": "auditSummary",
+  "data": {
+    "vulnerabilities": { "info": 0, "low": 0, "moderate": 0, "high": 0, "critical": 0 },
+    "dependencies": 872888,
+    "devDependencies": 0,
+    "optionalDependencies": 0,
+    "totalDependencies": 872888
+  }
+}

--- a/npm-audit/router.json
+++ b/npm-audit/router.json
@@ -1,10 +1,1 @@
-{
-  "type": "auditSummary",
-  "data": {
-    "vulnerabilities": { "info": 0, "low": 0, "moderate": 0, "high": 0, "critical": 0 },
-    "dependencies": 872888,
-    "devDependencies": 0,
-    "optionalDependencies": 0,
-    "totalDependencies": 872888
-  }
-}
+{"type":"auditSummary","data":{"vulnerabilities":{"info":0,"low":0,"moderate":0,"high":0,"critical":0},"dependencies":872888,"devDependencies":0,"optionalDependencies":0,"totalDependencies":872888}}

--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -134,38 +134,44 @@ function Timer(callback, delay) {
 	this.resume();
 }
 
+function Registry() {
+	const timerRegistry = {};
+
+	this.register = (notification, timer) => {
+		timerRegistry[notification.id] = timer;
+	};
+
+	this.isRegistered = notification => !!timerRegistry[notification.id];
+
+	this.pause = notification => {
+		if (this.isRegistered(notification)) {
+			timerRegistry[notification.id].pause();
+		}
+	};
+
+	this.resume = notification => {
+		if (this.isRegistered(notification)) {
+			timerRegistry[notification.id].resume();
+		}
+	};
+
+	this.cancel = notification => {
+		if (this.isRegistered(notification)) {
+			timerRegistry[notification.id].cancel();
+		}
+	};
+}
+
 class NotificationsContainer extends React.Component {
 	constructor(props) {
 		super(props);
 		this.state = {};
+		this.registry = new Registry();
 		this.onMouseEnter = this.onMouseEnter.bind(this);
 		this.onMouseOut = this.onMouseOut.bind(this);
 		this.onClick = this.onClick.bind(this);
 		this.onClose = this.onClose.bind(this);
 		this.register = this.register.bind(this);
-		this.timerRegistry = {};
-		const self = this;
-		this.registry = {
-			register: (notification, timer) => {
-				self.timerRegistry[notification.id] = timer;
-			},
-			isRegistered: notification => !!self.timerRegistry[notification.id],
-			pause(notification) {
-				if (this.isRegistered(notification)) {
-					self.timerRegistry[notification.id].pause();
-				}
-			},
-			resume(notification) {
-				if (this.isRegistered(notification)) {
-					self.timerRegistry[notification.id].resume();
-				}
-			},
-			cancel(notification) {
-				if (this.isRegistered(notification)) {
-					self.timerRegistry[notification.id].cancel();
-				}
-			},
-		};
 		this.register(props);
 	}
 

--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -111,55 +111,61 @@ export function Notification({ notification, leaveFn, ...props }) {
 	);
 }
 
-function Timer(callback, delay) {
-	let timerId;
-	let start;
-	let remaining = delay;
+class Timer {
+	constructor(callback, delay) {
+		this.timerId = null;
+		this.start = null;
+		this.callbackFn = callback;
+		this.remaining = delay;
+		this.resume();
+	}
 
-	this.pause = () => {
-		clearTimeout(timerId);
-		remaining -= Date.now() - start;
-	};
+	pause() {
+		clearTimeout(this.timerId);
+		this.remaining -= Date.now() - this.start;
+	}
 
-	this.resume = () => {
-		start = Date.now();
-		clearTimeout(timerId);
-		timerId = setTimeout(callback, remaining);
-	};
+	resume() {
+		this.start = Date.now();
+		clearTimeout(this.timerId);
+		this.timerId = setTimeout(this.callbackFn, this.remaining);
+	}
 
-	this.cancel = () => {
-		clearTimeout(timerId);
-	};
-
-	this.resume();
+	cancel() {
+		clearTimeout(this.timerId);
+	}
 }
 
-function Registry() {
-	const timerRegistry = {};
+class Registry {
+	constructor() {
+		this.timerRegistry = {};
+	}
 
-	this.register = (notification, timer) => {
-		timerRegistry[notification.id] = timer;
-	};
+	isRegistered(notification) {
+		return !!this.timerRegistry[notification.id];
+	}
 
-	this.isRegistered = notification => !!timerRegistry[notification.id];
+	register(notification, timer) {
+		this.timerRegistry[notification.id] = timer;
+	}
 
-	this.pause = notification => {
+	pause(notification) {
 		if (this.isRegistered(notification)) {
-			timerRegistry[notification.id].pause();
+			this.timerRegistry[notification.id].pause();
 		}
-	};
+	}
 
-	this.resume = notification => {
+	resume(notification) {
 		if (this.isRegistered(notification)) {
-			timerRegistry[notification.id].resume();
+			this.timerRegistry[notification.id].resume();
 		}
-	};
+	}
 
-	this.cancel = notification => {
+	cancel(notification) {
 		if (this.isRegistered(notification)) {
-			timerRegistry[notification.id].cancel();
+			this.timerRegistry[notification.id].cancel();
 		}
-	};
+	}
 }
 
 class NotificationsContainer extends React.Component {

--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -111,24 +111,24 @@ export function Notification({ notification, leaveFn, ...props }) {
 	);
 }
 
-export function Timer(callback, delay) {
+function Timer(callback, delay) {
 	let timerId;
 	let start;
 	let remaining = delay;
 
 	this.pause = () => {
-		window.clearTimeout(timerId);
+		clearTimeout(timerId);
 		remaining -= Date.now() - start;
 	};
 
 	this.resume = () => {
 		start = Date.now();
-		window.clearTimeout(timerId);
-		timerId = window.setTimeout(callback, remaining);
+		clearTimeout(timerId);
+		timerId = setTimeout(callback, remaining);
 	};
 
 	this.cancel = () => {
-		window.clearTimeout(timerId);
+		clearTimeout(timerId);
 	};
 
 	this.resume();

--- a/packages/components/src/Notification/Notification.test.js
+++ b/packages/components/src/Notification/Notification.test.js
@@ -125,7 +125,6 @@ describe('NotificationContainer', () => {
 			};
 			const instance = new NotificationsContainer({ notifications: [] });
 			instance.registry.register(notification, mockTimer);
-			expect(instance.timerRegistry[notification.id]).toEqual(mockTimer);
 			expect(instance.registry.isRegistered(notification)).toEqual(true);
 			instance.registry.pause(notification);
 			expect(mockTimer.pause).toHaveBeenCalled();
@@ -254,10 +253,10 @@ describe('NotificationContainer', () => {
 					leaveFn: mockLeaveFn,
 				};
 				const instance = new NotificationsContainer(props);
+				expect(instance).toBeDefined();
 				expect(mockLeaveFn).not.toHaveBeenCalled();
-				expect(Object.keys(instance.timerRegistry).length).toBe(3);
 				jest.runAllTimers();
-				expect(mockLeaveFn.mock.calls.length).toEqual(3);
+				expect(mockLeaveFn).toHaveBeenCalledTimes(3);
 			},
 		);
 	});

--- a/packages/components/src/Notification/Notification.test.js
+++ b/packages/components/src/Notification/Notification.test.js
@@ -7,7 +7,6 @@ import NotificationsContainer, {
 	CloseButton,
 	Message,
 	MessageAction,
-	Timer,
 } from './Notification.component';
 
 jest.useFakeTimers();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
_It refers to a TCCUI topic._

Notifications have a timer (except errors). At the end of the timer, the notification disappears. But when the user hovers on it, the timer stops.

On mouse/focus out, the timer doesn't start again.

**What is the chosen solution to this problem?**
On mouse/focus out, the timer should start from the paused state, closing the toaster when time is up.

Note that errors notifications are out of this rule if the notification center is not in use.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
