### PR TITLE
chore(ci): use openJDK8 instead of oracleJDK8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ matrix:
         - .travis/after_success_git.sh
 
     - language: java
-      jdk: oraclejdk8
+      jdk: openjdk8
       env:
         - NAME=demo NODE_VERSION=8 CC=clang CXX=clang++
       before_install:


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`oracleJDK8` is not supported anymore in travis.

**What is the chosen solution to this problem?**
Use openJDK to stay in jdk 8

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
