### PR TITLE
fix(components/subheaderbar): title edition does not work

### DIFF
--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -22,22 +22,22 @@ function TitleSubHeader({
 	...rest
 }) {
 	const [isEditMode, setIsEditMode] = React.useState(false);
-	function handleEdit() {
+	function handleEdit(...args) {
 		setIsEditMode(true);
 		if (onEdit) {
-			onEdit();
+			onEdit(...args);
 		}
 	}
-	function handleCancel() {
+	function handleCancel(...args) {
 		setIsEditMode(false);
 		if (onCancel) {
-			onCancel();
+			onCancel(...args);
 		}
 	}
-	function handleSubmit() {
+	function handleSubmit(...args) {
 		setIsEditMode(false);
 		if (onSubmit) {
-			onSubmit();
+			onSubmit(...args);
 		}
 	}
 	if (loading) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Since this PR https://github.com/Talend/ui/pull/2199/files, title edition does not work anymore.

**What is the chosen solution to this problem?**

Spread args to `onSubmit` and other handlers.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->