### PR TITLE
fix(Intercom): remove cross from button to avoid double cross

### DIFF
--- a/packages/components/src/ActionIntercom/Intercom.component.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.js
@@ -16,20 +16,26 @@ function Intercom({ id, className, config, t }) {
 	const ref = useRef(null);
 
 	// init intercom messenger, attaching it to the custom button
-	useEffect(() => {
-		IntercomService.boot(`#${id}`, config);
-		IntercomService.onShow(setShow.bind(null, true));
-		IntercomService.onHide(setShow.bind(null, false));
+	useEffect(
+		() => {
+			IntercomService.boot(`#${id}`, config);
+			IntercomService.onShow(setShow.bind(null, true));
+			IntercomService.onHide(setShow.bind(null, false));
 
-		return IntercomService.shutdown;
-	}, [id, config, setShow]);
+			return IntercomService.shutdown;
+		},
+		[id, config, setShow],
+	);
 
 	// a11y: on intercom dropdown close, focus on the trigger button
-	useEffect(() => {
-		if (!show) {
-			ref.current.focus();
-		}
-	}, [show]);
+	useEffect(
+		() => {
+			if (!show) {
+				ref.current.focus();
+			}
+		},
+		[show],
+	);
 
 	// place intercom messenger dropdown depending on the button
 	useLayoutEffect(() => IntercomService.setPosition(ref.current), [ref.current]);
@@ -38,7 +44,6 @@ function Intercom({ id, className, config, t }) {
 		? t('TC_INTERCOM_CLOSE', { defaultValue: 'Close support messenger.' })
 		: t('TC_INTERCOM_OPEN', { defaultValue: 'Open support messenger.' });
 
-	const icon = show ? 'talend-cross' : 'talend-bubbles';
 	return (
 		<TooltipTrigger label={label} tooltipPlacement="bottom">
 			<button
@@ -48,7 +53,7 @@ function Intercom({ id, className, config, t }) {
 					[theme.open]: show,
 				})}
 			>
-				<Icon name={icon} />
+				<Icon name="talend-bubbles" />
 			</button>
 		</TooltipTrigger>
 	);

--- a/packages/components/src/ActionIntercom/Intercom.component.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.js
@@ -16,26 +16,20 @@ function Intercom({ id, className, config, t }) {
 	const ref = useRef(null);
 
 	// init intercom messenger, attaching it to the custom button
-	useEffect(
-		() => {
-			IntercomService.boot(`#${id}`, config);
-			IntercomService.onShow(setShow.bind(null, true));
-			IntercomService.onHide(setShow.bind(null, false));
+	useEffect(() => {
+		IntercomService.boot(`#${id}`, config);
+		IntercomService.onShow(setShow.bind(null, true));
+		IntercomService.onHide(setShow.bind(null, false));
 
-			return IntercomService.shutdown;
-		},
-		[id, config, setShow],
-	);
+		return IntercomService.shutdown;
+	}, [id, config, setShow]);
 
 	// a11y: on intercom dropdown close, focus on the trigger button
-	useEffect(
-		() => {
-			if (!show) {
-				ref.current.focus();
-			}
-		},
-		[show],
-	);
+	useEffect(() => {
+		if (!show) {
+			ref.current.focus();
+		}
+	}, [show]);
 
 	// place intercom messenger dropdown depending on the button
 	useLayoutEffect(() => IntercomService.setPosition(ref.current), [ref.current]);

--- a/packages/components/src/ActionIntercom/Intercom.component.test.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.test.js
@@ -100,7 +100,7 @@ describe('Intercom button', () => {
 		expect(IntercomService.shutdown).toBeCalled();
 	});
 
-	it('should change icon and label on open/close', () => {
+	it('should change label on open/close', () => {
 		// given
 		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
@@ -109,7 +109,6 @@ describe('Intercom button', () => {
 		const onHide = IntercomService.onHide.mock.calls[0][0];
 
 		expect(wrapper.find('TooltipTrigger').prop('label')).toBe('Open support messenger.');
-		expect(wrapper.find('Icon').prop('name')).toBe('talend-bubbles');
 
 		// when/then show
 		act(() => {
@@ -117,7 +116,6 @@ describe('Intercom button', () => {
 		});
 		wrapper.update();
 		expect(wrapper.find('TooltipTrigger').prop('label')).toBe('Close support messenger.');
-		expect(wrapper.find('Icon').prop('name')).toBe('talend-cross');
 
 		// when/then hide
 		act(() => {
@@ -125,7 +123,6 @@ describe('Intercom button', () => {
 		});
 		wrapper.update();
 		expect(wrapper.find('TooltipTrigger').prop('label')).toBe('Open support messenger.');
-		expect(wrapper.find('Icon').prop('name')).toBe('talend-bubbles');
 	});
 
 	it('should set messenger position', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The intercom button switch the icon from bubbles to a cross when it's open.
But the intercom window already has a cross.
To avoid the double cross, UX team ask us to remove the cross from the button as the one in intercom window is not controlled by us.

**What is the chosen solution to this problem?**
The icon doesn't change on open/close, it's still the bubbles.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
