### PR TITLE
feat(Containers/DeleteResource): pass action property to sucessful action

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -5,16 +5,12 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/containers/src/ActionBar/ActionBar.test.js
   90:1  error  Expected indentation of 3 tabs but found 2  indent
 
-/home/travis/build/Talend/ui/packages/containers/src/DeleteResource/sagas.test.js
-  177:15  error  Missing trailing comma  comma-dangle
-  192:5   error  Missing semicolon       semi
-
 /home/travis/build/Talend/ui/packages/containers/src/EditableText/EditableText.selectors.js
   8:1  error  Prefer default export  import/prefer-default-export
 
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:80  error  'notifications' is missing in props validation  react/prop-types
 
-✖ 5 problems (5 errors, 0 warnings)
-  3 errors, 0 warnings potentially fixable with the `--fix` option.
+✖ 3 problems (3 errors, 0 warnings)
+  1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -75,6 +75,7 @@ export function* deleteResourceValidate(
 			yield put({
 				type: deleteResourceConst.DIALOG_BOX_DELETE_RESOURCE_SUCCESS,
 				model: {
+					...get(action, 'data.model', {}),
 					id: safeId,
 					labelResource: resource.get('label') || resource.get('name', ''),
 				},

--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -11,7 +11,6 @@ import deleteResourceConst from './constants';
  * @param {Array<String>} [resourcePath]
  * @return {String || Array<String>}
  */
-
 export function getResourceLocator(resourceType, resourcePath) {
 	if (resourcePath) {
 		if (Array.isArray(resourcePath)) {

--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -11,6 +11,7 @@ import deleteResourceConst from './constants';
  * @param {Array<String>} [resourcePath]
  * @return {String || Array<String>}
  */
+
 export function getResourceLocator(resourceType, resourcePath) {
 	if (resourcePath) {
 		if (Array.isArray(resourcePath)) {

--- a/packages/containers/src/DeleteResource/sagas.test.js
+++ b/packages/containers/src/DeleteResource/sagas.test.js
@@ -67,8 +67,19 @@ describe('internals', () => {
 			expect(httpAction.fn).toBe(cmf.sagas.http.delete);
 			expect(httpAction.args[0]).toBe('/api/datasets/123');
 			effect = gen.next({ response: { ok: true } }).value;
-			expect(effect.PUT.action.type).toBe(CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_SUCCESS);
-			expect(effect.PUT.action.model.labelResource).toBe('Foo');
+			expect(effect).toEqual(
+				put({
+					type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_SUCCESS,
+					model: {
+						id: '123',
+						labelResource: 'Foo',
+						redirectUrl: '/resources',
+						resourceType: 'datasets',
+						uri: '/api',
+					},
+				}),
+			);
+
 			effect = gen.next().value;
 			expect(effect.CALL.fn).toBe(internals.redirect);
 			expect(effect.CALL.args[0]).toBe('/resources');
@@ -174,10 +185,10 @@ describe('internals', () => {
 			};
 			const failedRequest = {
 				response: {
-					ok: false
+					ok: false,
 				},
 				data: {
-					error: 'can\'t delete resource in use',
+					error: "can't delete resource in use",
 				},
 			};
 
@@ -185,11 +196,13 @@ describe('internals', () => {
 			gen.next();
 			gen.next(action);
 			gen.next(resource);
-			expect(gen.next(failedRequest).value).toEqual(put({
-				type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_ERROR,
-				error: failedRequest.data,
-			}));
-		})
+			expect(gen.next(failedRequest).value).toEqual(
+				put({
+					type: CONSTANTS.DIALOG_BOX_DELETE_RESOURCE_ERROR,
+					error: failedRequest.data,
+				}),
+			);
+		});
 	});
 	describe('deleteResourceCancel', () => {
 		it('should call redirect ', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
when the webapp catches the action DELETE_SUCESSFUl, we haven't no information about the model

**What is the chosen solution to this problem?**
pass the model to the action

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
