### PR TITLE
feat(forms/TDC-876): pass formData in the result action

### DIFF
--- a/packages/containers/src/ComponentForm/ComponentForm.actions.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.actions.js
@@ -11,6 +11,7 @@ export function setComponentFormDirtyState(componentId, dirty) {
 			`ComponentForm dirty state should be a boolean, received "${dirty}"(${typeof dirty}) instead`,
 		);
 	}
+
 	return {
 		componentId,
 		dirty,

--- a/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
@@ -312,6 +312,7 @@ describe('ComponentForm saga', () => {
 				put({
 					type: TCompForm.ON_SUBMIT_SUCCEED,
 					data,
+					formData: action.properties,
 					response,
 					componentId,
 				}),
@@ -332,6 +333,7 @@ describe('ComponentForm saga', () => {
 				put({
 					type: TCompForm.ON_SUBMIT_FAILED,
 					data,
+					formData: action.properties,
 					response,
 					componentId,
 				}),

--- a/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
@@ -5,7 +5,6 @@ import cmf from '@talend/react-cmf';
 import * as sagas from './ComponentForm.sagas';
 import ConnectedTCompForm, { TCompForm } from './ComponentForm.component';
 
-
 describe('ComponentForm saga', () => {
 	describe('*checkFormComponentId', () => {
 		it('checkFormComponentId return true if provided componentId and action type match action', () => {

--- a/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.saga.test.js
@@ -5,6 +5,7 @@ import cmf from '@talend/react-cmf';
 import * as sagas from './ComponentForm.sagas';
 import ConnectedTCompForm, { TCompForm } from './ComponentForm.component';
 
+
 describe('ComponentForm saga', () => {
 	describe('*checkFormComponentId', () => {
 		it('checkFormComponentId return true if provided componentId and action type match action', () => {

--- a/packages/containers/src/ComponentForm/ComponentForm.sagas.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.sagas.js
@@ -78,6 +78,7 @@ export function* onFormSubmit(componentId, submitURL, action) {
 	yield put({
 		type: response.ok ? Component.ON_SUBMIT_SUCCEED : Component.ON_SUBMIT_FAILED,
 		data,
+		formData: action.properties,
 		response,
 		componentId,
 	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we have the submit result action, we have the response from the backend. Except this response is {id, requestId} and any information on the form. 

**What is the chosen solution to this problem?**
spread formData on the action

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
