### PR TITLE
fix(component): add missing translation

### DIFF
--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -18,7 +18,7 @@ function listviewClasses() {
 }
 
 function ListView(props) {
-	const noResultLabel = props.t('LISTVIEW_NO_RESULT', { defaultValue: 'No result found.' });
+	const noResultLabel = props.t('NO_RESULT_FOUND', { defaultValue: 'No result found.' });
 	const emptyLabel = props.t('LISTVIEW_EMPTY', { defaultValue: 'This list is empty.' });
 	const label = props.displayMode === DISPLAY_MODE_SEARCH ? noResultLabel : emptyLabel;
 	return (

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -3,6 +3,7 @@ import React from 'react';
 import uuid from 'uuid';
 import classNames from 'classnames';
 import Autowhatever from 'react-autowhatever';
+import { t } from 'i18next';
 
 import theme from './Typeahead.scss';
 import {
@@ -130,7 +131,7 @@ Typeahead.defaultProps = {
 	id: uuid.v4().toString(),
 	items: null,
 	multiSection: true, // TODO this is for compat, see if we can do the reverse :(
-	noResultText: 'No result.',
+	noResultText: t('tui-components:NO_RESULT_FOUND', { defaultValue: 'No result.' }),
 	position: 'left',
 	readOnly: false,
 	searching: false,

--- a/packages/components/src/VirtualizedList/NoRows/NoRows.component.js
+++ b/packages/components/src/VirtualizedList/NoRows/NoRows.component.js
@@ -15,7 +15,7 @@ export function NoRowsComponent(props) {
 			role="status"
 			aria-live="polite"
 		>
-			{props.t('VIRTUALIZEDLIST_NO_RESULT', { defaultValue: 'No result found' })}
+			{props.t('NO_RESULT_FOUND', { defaultValue: 'No result found' })}
 		</span>
 	);
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is no translation for the default value of the Typehead component
**What is the chosen solution to this problem?**
Add one & share the translation with same content

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
