### PR TITLE
fix(components): Prevent intercom from rerendering with same props

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -263,7 +263,7 @@ function Intercom({ id, config }) {
 			<ActionIntercom
 				className="btn btn-link"
 				id={id}
-				config={{ ...config, vertical_padding: 70 }}
+				config={React.useMemo(() => ({ ...config, vertical_padding: 70 }), [config])}
 			/>
 		</li>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When headerbar rerenders it will _always_ rerender the Intercom too. This is a problem because in the Intercom component it will disconnect and reconnect with the new config object, resulting in unnecessary network requests (and rerenders). 

This is the useEffect that will always be triggered since `config` has changed https://github.com/Talend/ui/blob/master/packages/components/src/ActionIntercom/Intercom.component.js#L19

**What is the chosen solution to this problem?**
Memoize the `config` prop before sending it, so it doesn't create a new object if the config is the same

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
