### PR TITLE
fix(component/MultiSelect): clear searchTerm on dropdown close

### DIFF
--- a/packages/components/src/MultiSelect/MultiSelect.container.js
+++ b/packages/components/src/MultiSelect/MultiSelect.container.js
@@ -83,7 +83,7 @@ class MultiSelect extends React.Component {
 
 	closeOnOutsideClick(event) {
 		if (this.containerRef !== null && !isIn(event.target, this.containerRef)) {
-			this.setState({ showDropdown: false });
+			this.setState({ showDropdown: false, searchTerm: '' });
 		}
 	}
 
@@ -290,7 +290,7 @@ class MultiSelect extends React.Component {
 					autoFocus={this.props.autoFocus}
 					placeholder={this.props.placeholder}
 					readOnly={this.props.readOnly}
-					value={this.state.value}
+					value={this.state.searchTerm}
 					ref={ref => {
 						this.inputRef = ref;
 					}}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
searchTerm is not cleared when the form props change, so it's misleading for a user that is switching between multiple entity with the same type and so same form.

**What is the chosen solution to this problem?**
Automatically clear the searchTerm when the dropdown close.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
