### PR TITLE
fix(components/SubHeaderBar): subheader edit icon should only be visible when hover on title

### DIFF
--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
@@ -58,8 +58,24 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 
 				.tc-editable-text-form-buttons-submit:hover {
 					background: $scooter;
+
 					& svg {
 						background: $scooter;
+					}
+				}
+
+				.tc-editable-text-pencil {
+					opacity: 0;
+
+					&:focus,
+					&:active {
+						opacity: 1;
+					}
+				}
+
+				:hover {
+					.tc-editable-text-pencil {
+						opacity: 1;
 					}
 				}
 			}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
http://guidelines.talend.com/document/92132#/navigation-layout/sub-header/details
> Edition
> The user can edit the file title by clicking on the 'edit icon' which is visible on hover. 

**What is the chosen solution to this problem?**
Added a display none on the icon

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
