### PR TITLE
fix: stories with i18n, removing provider

### DIFF
--- a/packages/components/stories/Enumeration.js
+++ b/packages/components/stories/Enumeration.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { I18nextProvider } from 'react-i18next';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
@@ -300,11 +299,9 @@ storiesOf('Enumeration', module)
 			<button onClick={() => i18n.changeLanguage('fr')}>fr</button>
 			<button onClick={() => i18n.changeLanguage('it')}>it</button>
 			<IconsProvider />
-			<I18nextProvider i18n={i18n}>
-				<Enumeration
-					{...defaultEmptyListProps}
-				/>
-			</I18nextProvider>
+			<Enumeration
+				{...defaultEmptyListProps}
+			/>
 		</div>
 	))
 	.add('default - empty list', () => (

--- a/packages/components/stories/GuidedTour.js
+++ b/packages/components/stories/GuidedTour.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import { I18nextProvider, withTranslation } from 'react-i18next';
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { withTranslation } from 'react-i18next';
+import { LanguageSwitcher } from './config/i18n';
 
 import { GuidedTour } from '../src/index';
 import I18N_DOMAIN_COMPONENTS from '../src/constants';
@@ -277,12 +277,10 @@ storiesOf('GuidedTour', module)
 	.addDecorator(story => (
 		<React.Fragment>
 			<LanguageSwitcher />
-			<I18nextProvider i18n={i18n}>
-				<React.Fragment>
-					{story()}
-					{getLayoutWithLoremIpsum()}
-				</React.Fragment>
-			</I18nextProvider>
+			<React.Fragment>
+				{story()}
+				{getLayoutWithLoremIpsum()}
+			</React.Fragment>
 		</React.Fragment>
 	))
 	.add('default', () => <TranslatedGuidedTourContainer getSteps={getSteps} />);

--- a/packages/components/stories/HeaderBar.js
+++ b/packages/components/stories/HeaderBar.js
@@ -6,8 +6,7 @@ import { makeDecorator } from '@storybook/addons';
 import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-dependencies
 import talendIcons from '@talend/icons/dist/react';
 
-import { I18nextProvider } from 'react-i18next';
-import i18n from './config/i18n';
+import './config/i18n';
 
 import { HeaderBar, IconsProvider } from '../src';
 
@@ -177,13 +176,11 @@ const withIcons = makeDecorator({
 	wrapper: (getStory, context) => {
 		const story = getStory(context);
 		return (
-			<I18nextProvider i18n={i18n}>
-				<div>
-					<IconsProvider defaultIcons={icons} />
-					{story}
-					<div className="container" style={{ paddingTop: 40 }} />
-				</div>
-			</I18nextProvider>
+			<div>
+				<IconsProvider defaultIcons={icons} />
+				{story}
+				<div className="container" style={{ paddingTop: 40 }} />
+			</div>
 		);
 	},
 });

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -4,11 +4,10 @@ import PropTypes from 'prop-types';
 import { action } from '@storybook/addon-actions';
 import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-dependencies
 import talendIcons from '@talend/icons/dist/react';
-import { I18nextProvider } from 'react-i18next';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { List, IconsProvider } from '../src/index';
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { LanguageSwitcher } from './config/i18n';
 import MyCustomRow from './List/MyCustomRow.component';
 /**
  * Cell renderer that displays hello + text
@@ -473,7 +472,7 @@ storiesOf('List', module)
 		<div>
 			<LanguageSwitcher />
 			<IconsProvider defaultIcons={icons} />
-			<I18nextProvider i18n={i18n}>{story()}</I18nextProvider>
+			{story()}
 		</div>
 	))
 	.add('Table display', () => (
@@ -651,10 +650,10 @@ storiesOf('List', module)
 			<div style={{ height: '70vh' }} className="virtualized-list">
 				<h1>List</h1>
 				<p>
-				For table view, user toggle column header to select/disselect all items.
+					For table view, user toggle column header to select/disselect all items.
 					<br />
-				When List displayed in large view,
-				there's a one-line checkbox of "Select All" above the list.
+					When List displayed in large view, there's a one-line checkbox of "Select All" above the
+					list.
 					<br />
 				</p>
 				<List {...selectedItemsProps} rowHeight={140} displayMode="large" />
@@ -736,9 +735,7 @@ storiesOf('List', module)
 		return (
 			<div style={{ height: '70vh' }} className="virtualized-list">
 				<h1>List</h1>
-				<p>
-					Show Sort widgets on List toolbar when display in large view
-				</p>
+				<p>Show Sort widgets on List toolbar when display in large view</p>
 				<List {...tprops} rowHeight={140} displayMode="large" />
 			</div>
 		);

--- a/packages/components/stories/ListView.js
+++ b/packages/components/stories/ListView.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { I18nextProvider } from 'react-i18next';
 
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { LanguageSwitcher } from './config/i18n';
 import { ListView, IconsProvider } from '../src/index';
 
 const filterAction = {
@@ -116,14 +115,12 @@ const withNestedItems = {
 
 storiesOf('ListView', module)
 	.addDecorator(story => (
-		<I18nextProvider i18n={i18n}>
-			<div>
-				<LanguageSwitcher />
-				<IconsProvider />
-				<h1>ListView</h1>
-				<form>{story()}</form>
-			</div>
-		</I18nextProvider>
+		<div>
+			<LanguageSwitcher />
+			<IconsProvider />
+			<h1>ListView</h1>
+			<form>{story()}</form>
+		</div>
 	))
 	.add('empty', () => {
 		const emptyProps = { ...props };

--- a/packages/components/stories/SidePanel.js
+++ b/packages/components/stories/SidePanel.js
@@ -1,9 +1,8 @@
 import React from 'react';
-import { I18nextProvider } from 'react-i18next';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import talendIcons from '@talend/icons/dist/react';
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { LanguageSwitcher } from './config/i18n';
 import { IconsProvider, Layout, SidePanel } from '../src/index';
 
 import { TALEND_T7_THEME_APPS as apps, TALEND_T7_THEME_CLASSNAME } from '../src/Layout/constants';
@@ -80,7 +79,7 @@ stories
 		<div>
 			<LanguageSwitcher />
 			<IconsProvider defaultIcons={icons} />
-			<I18nextProvider i18n={i18n}>{story()}</I18nextProvider>
+			{story()}
 		</div>
 	))
 	.add('default', () => (
@@ -175,9 +174,9 @@ stories
 				return (
 					<Layout mode="TwoColumns" one={panel}>
 						<ol>
-							{new Array(100)
-								.fill('This is some random content')
-								.map((item, num) => <li key={num}>{item}</li>)}
+							{new Array(100).fill('This is some random content').map((item, num) => (
+								<li key={num}>{item}</li>
+							))}
 						</ol>
 					</Layout>
 				);
@@ -214,9 +213,9 @@ stories
 				return (
 					<Layout mode="TwoColumns" one={panel}>
 						<ol>
-							{new Array(100)
-								.fill('This is some random content')
-								.map((item, num) => <li key={num}>{item}</li>)}
+							{new Array(100).fill('This is some random content').map((item, num) => (
+								<li key={num}>{item}</li>
+							))}
 						</ol>
 					</Layout>
 				);

--- a/packages/components/stories/config/i18n.js
+++ b/packages/components/stories/config/i18n.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import I18N_DOMAIN_COMPONENTS from '../../src/constants';
 
-i18n.init({
+i18n.use(initReactI18next).init({
 	resources: {
 		fr: {
 			[I18N_DOMAIN_COMPONENTS]: {

--- a/packages/containers/examples/ExampleDeleteResource.js
+++ b/packages/containers/examples/ExampleDeleteResource.js
@@ -1,6 +1,5 @@
 import React from 'react';
-import { I18nextProvider } from 'react-i18next';
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { LanguageSwitcher } from './config/i18n';
 import { DeleteResource } from '../src';
 
 /*
@@ -58,11 +57,9 @@ export default {
 		</div>
 	),
 	translated: () => (
-		<I18nextProvider i18n={i18n}>
-			<div>
-				<LanguageSwitcher />
-				<DeleteResource {...props} />
-			</div>
-		</I18nextProvider>
+		<div>
+			<LanguageSwitcher />
+			<DeleteResource {...props} />
+		</div>
 	),
 };

--- a/packages/containers/examples/ExampleList.js
+++ b/packages/containers/examples/ExampleList.js
@@ -3,7 +3,6 @@ import PropTypes from 'prop-types';
 import { IconsProvider } from '@talend/react-components';
 import api from '@talend/react-cmf';
 import Immutable from 'immutable';
-import { I18nextProvider } from 'react-i18next';
 import cloneDeep from 'lodash/cloneDeep';
 
 import { List } from '../src';
@@ -216,11 +215,7 @@ const ExampleList = {
 		<div>
 			<IconsProvider />
 			<div className="list-container">
-				<List
-					{...props}
-					actions={actionsWithPersistent}
-					items={items}
-				/>
+				<List {...props} actions={actionsWithPersistent} items={items} />
 			</div>
 		</div>
 	),
@@ -347,17 +342,15 @@ const ExampleList = {
 		</div>
 	),
 	i18n: () => (
-		<I18nextProvider i18n={i18n}>
-			<div>
-				<p>Change language on the toolbar</p>
-				<button onClick={() => i18n.changeLanguage('fr')}>fr</button>
-				<button onClick={() => i18n.changeLanguage('it')}>it</button>
-				<IconsProvider />
-				<div className="list-container">
-					<List {...props} items={items} />
-				</div>
+		<div>
+			<p>Change language on the toolbar</p>
+			<button onClick={() => i18n.changeLanguage('fr')}>fr</button>
+			<button onClick={() => i18n.changeLanguage('it')}>it</button>
+			<IconsProvider />
+			<div className="list-container">
+				<List {...props} items={items} />
 			</div>
-		</I18nextProvider>
+		</div>
 	),
 	'sort on timestamps': () => (
 		<div>

--- a/packages/containers/examples/config/i18n.js
+++ b/packages/containers/examples/config/i18n.js
@@ -1,9 +1,10 @@
 import React from 'react';
 import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import { I18N_DOMAIN_COMPONENTS } from '@talend/react-components';
 import I18N_DOMAIN_CONTAINERS from '../../src/constant';
 
-i18n.init({
+i18n.use(initReactI18next).init({
 	lng: 'en',
 	resources: {
 		en: {

--- a/packages/datagrid/stories/config/i18n.js
+++ b/packages/datagrid/stories/config/i18n.js
@@ -1,8 +1,9 @@
 import React from 'react';
 import i18n from 'i18next';
+import { initReactI18next } from 'react-i18next';
 import I18N_DOMAIN_DATAGRID from '../../src/constant';
 
-i18n.init({
+i18n.use(initReactI18next).init({
 	lng: 'en',
 	resources: {
 		en: {

--- a/packages/datagrid/stories/datagrid.component.js
+++ b/packages/datagrid/stories/datagrid.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { IconsProvider } from '@talend/react-components';
 
+import './config/i18n';
 import DataGrid from '../src/components/';
 import DefaultRenderer from '../src/components/DefaultCellRenderer/DefaultRenderer.component';
 import DefaultIntCellRenderer from '../src/components/DefaultIntCellRenderer';

--- a/packages/datagrid/stories/datagrid.container.js
+++ b/packages/datagrid/stories/datagrid.container.js
@@ -2,7 +2,6 @@ import React from 'react';
 import get from 'lodash/get';
 import { storiesOf } from '@storybook/react';
 import withCMF from '@talend/react-storybook-cmf';
-import { I18nextProvider } from 'react-i18next';
 import mock from '@talend/react-cmf/lib/mock';
 import { IconsProvider } from '@talend/react-components';
 import api from '@talend/react-cmf';
@@ -10,7 +9,7 @@ import api from '@talend/react-cmf';
 import DataGrid from '../src/';
 import register from '../src/register';
 import theme from '../src/components/DataGrid/DataGrid.scss';
-import i18n, { LanguageSwitcher } from './config/i18n';
+import { LanguageSwitcher } from './config/i18n';
 import sample from './sample.json';
 import sampleRenderer from './sampleRenderer.json';
 
@@ -219,7 +218,7 @@ storiesOf('Container Datagrid', module)
 	.addDecorator(story => (
 		<div>
 			<LanguageSwitcher />
-			<I18nextProvider i18n={i18n}>{story()}</I18nextProvider>
+			{story()}
 		</div>
 	))
 	.addDecorator(withCMF)

--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { configure, addDecorator } from '@storybook/react';
 import { withA11y } from '@storybook/addon-a11y';
 import IconsProvider from '@talend/react-components/lib/IconsProvider';
-import { I18nextProvider } from 'react-i18next';
 
 import '@talend/bootstrap-theme/src/theme/theme.scss';
 import i18n from '../stories/config/i18n';
@@ -16,32 +15,28 @@ const withFormLayout = (story, options) => {
 		return story();
 	}
 	return (
-		<I18nextProvider i18n={i18n}>
-			<div className="container-fluid">
-				<IconsProvider />
-				<nav
-					style={{ position: 'fixed', bottom: 0, width: '100vw', textAlign: 'center', zIndex: 1 }}
-				>
-					<div className="btn-group">
-						<button className="btn" onClick={() => i18n.changeLanguage('en')}>
-							Default (en)
-						</button>
-						<button className="btn" onClick={() => i18n.changeLanguage('fr')}>
-							fr
-						</button>
-						<button className="btn" onClick={() => i18n.changeLanguage('it')}>
-							it
-						</button>
-					</div>
-				</nav>
-				<div
-					className="col-md-offset-1 col-md-10"
-					style={{ marginTop: '20px', marginBottom: '20px' }}
-				>
-					{story()}
+		<div className="container-fluid">
+			<IconsProvider />
+			<nav style={{ position: 'fixed', bottom: 0, width: '100vw', textAlign: 'center', zIndex: 1 }}>
+				<div className="btn-group">
+					<button className="btn" onClick={() => i18n.changeLanguage('en')}>
+						Default (en)
+					</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('fr')}>
+						fr
+					</button>
+					<button className="btn" onClick={() => i18n.changeLanguage('it')}>
+						it
+					</button>
 				</div>
+			</nav>
+			<div
+				className="col-md-offset-1 col-md-10"
+				style={{ marginTop: '20px', marginBottom: '20px' }}
+			>
+				{story()}
 			</div>
-		</I18nextProvider>
+		</div>
 	);
 };
 

--- a/packages/forms/stories-core/index.js
+++ b/packages/forms/stories-core/index.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { withKnobs } from '@storybook/addon-knobs';
-import { I18nextProvider } from 'react-i18next';
 import i18n from 'i18next';
 
 import jsonStories from './jsonStories';
@@ -15,9 +14,7 @@ import customErrors from './customErrors';
 import customDisplayMode from './customDisplayMode';
 import customHoverSubmitStory from './customHoverSubmitStory';
 
-const coreConceptsStories = storiesOf('Core concepts', module).addDecorator(story => (
-	<I18nextProvider i18n={i18n}>{story()}</I18nextProvider>
-));
+const coreConceptsStories = storiesOf('Core concepts', module);
 
 const coreFieldsetsStories = storiesOf('Core fieldsets', module);
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an issue with react-i18next, described here : https://github.com/i18next/react-i18next/issues/750#issuecomment-508092824

Some stories use i18next provider, others don't, which introduce a bug, trying to destructure undefined.

**What is the chosen solution to this problem?**
Remove react-i18next provider from stories, and configure i18next, exposing the configuration.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
