### PR TITLE
fix(drawer): do not override theme for cancel Action

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -97,7 +97,7 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 		},
 		onCancelAction,
 	);
-	return <ActionComponent className={theme['tc-drawer-close-action']} {...enhancedCancelAction} />;
+	return <ActionComponent {...enhancedCancelAction} className={classnames(theme['tc-drawer-close-action'], enhancedCancelAction.className)} />;
 }
 
 export function subtitleComponent(subtitle) {

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -97,7 +97,12 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 		},
 		onCancelAction,
 	);
-	return <ActionComponent {...enhancedCancelAction} className={classnames(theme['tc-drawer-close-action'], enhancedCancelAction.className)} />;
+	return (
+		<ActionComponent
+			{...enhancedCancelAction}
+			className={classnames(theme['tc-drawer-close-action'], enhancedCancelAction.className)}
+		/>
+	);
 }
 
 export function subtitleComponent(subtitle) {

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -349,4 +349,9 @@ describe('Drawer', () => {
 		expect(combinedFooterActions(onCancelAction, footerActions)).toEqual(result);
 		expect(combinedFooterActions(onCancelAction, footerActions)).toEqual(result);
 	});
+
+	it('should render cancelActionComponent with passed in className', () => {
+		const wrapper = mount(cancelActionComponent({ className: 'btn-inverse' }));
+		expect(wrapper.find('Action').prop('className')).toEqual('theme-tc-drawer-close-action btn-inverse');
+	});
 });

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -352,6 +352,8 @@ describe('Drawer', () => {
 
 	it('should render cancelActionComponent with passed in className', () => {
 		const wrapper = mount(cancelActionComponent({ className: 'btn-inverse' }));
-		expect(wrapper.find('Action').prop('className')).toEqual('theme-tc-drawer-close-action btn-inverse');
+		expect(wrapper.find('Action').prop('className')).toEqual(
+			'theme-tc-drawer-close-action btn-inverse',
+		);
 	});
 });

--- a/packages/components/stories/Drawer.js
+++ b/packages/components/stories/Drawer.js
@@ -59,6 +59,8 @@ const primary = {
 const onCancelAction = {
 	label: 'Cancel',
 	onClick: action('You clicked on cancel action'),
+	bsStyle: 'default',
+	className: 'btn-inverse',
 };
 
 const panelActions = {

--- a/packages/components/stories/Drawer.js
+++ b/packages/components/stories/Drawer.js
@@ -48,6 +48,7 @@ const actions = [
 const cancel = {
 	label: 'Cancel',
 	onClick: action('You clicked me'),
+	className: 'btn-inverse',
 };
 
 const primary = {
@@ -59,8 +60,6 @@ const primary = {
 const onCancelAction = {
 	label: 'Cancel',
 	onClick: action('You clicked on cancel action'),
-	bsStyle: 'default',
-	className: 'btn-inverse',
 };
 
 const panelActions = {
@@ -400,13 +399,15 @@ storiesOf('Drawer', module)
 		);
 	})
 	.add('Custom stacked', () => {
+		// Use same cancel action props with className for Title and Footer
+		const sameCancelAction = panelActions.left[0];
 		const customDrawers = [
 			<Drawer.Container stacked>
 				<Tab.Container defaultActiveKey="info">
 					<div style={{ flexGrow: 1, display: 'flex', flexDirection: 'column' }}>
 						<Drawer.Title
 							title="Custom drawer with tabs and a super long name that breaks the drawer title"
-							onCancelAction={onCancelAction}
+							onCancelAction={sameCancelAction}
 						/>
 						<Tab.Content>
 							<Drawer.Content>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On drawer, cancel button style also applies to the cross in the header.
And if you set a className on the cancel Action, it will override the default className from the Action in the header, and theme will not be applied.

**What is the chosen solution to this problem?**
Do not override theme in the Cancel action component, even if user add className in the CancelAction.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
