### PR TITLE
feat(forms/checkbox): data-feature

### DIFF
--- a/packages/forms/src/UIForm/fields/CheckBox/README.md
+++ b/packages/forms/src/UIForm/fields/CheckBox/README.md
@@ -58,6 +58,7 @@ This widget allows you to render checkboxes input.
 | autoFocus | Focus on input on render | `false` |
 | disabled | Disable the input | `false` |
 | titleMap | A mapping of value/label to display |  |
+| 'data-feature' | A data-feature value to set on the label |  |
 
 ```json
 [

--- a/packages/forms/src/UIForm/fields/CheckBox/README.md
+++ b/packages/forms/src/UIForm/fields/CheckBox/README.md
@@ -58,7 +58,7 @@ This widget allows you to render checkboxes input.
 | autoFocus | Focus on input on render | `false` |
 | disabled | Disable the input | `false` |
 | titleMap | A mapping of value/label to display |  |
-| 'data-feature' | A data-feature value to set on the label |  |
+| data-feature | A data-feature value to set on the label |  |
 
 ```json
 [

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
@@ -17,7 +17,7 @@ export default function SimpleCheckBox({
 	const { autoFocus } = schema;
 	return (
 		<div className={classnames('checkbox', { disabled })}>
-			<label>
+			<label data-feature={schema['data-feature']}>
 				<input
 					id={id}
 					autoFocus={autoFocus}

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
@@ -1,7 +1,8 @@
 /* eslint-disable jsx-a11y/label-has-for */
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, { useState } from 'react';
 import classnames from 'classnames';
+import { get } from 'lodash';
 
 export default function SimpleCheckBox({
 	describedby,
@@ -14,17 +15,30 @@ export default function SimpleCheckBox({
 	schema,
 	value,
 }) {
+	const [checked, setChecked] = useState(value);
+
 	const { autoFocus } = schema;
+
+	function getDataFeature() {
+		const dataFeature = get(schema, 'data-feature');
+		if (dataFeature) {
+			return `${dataFeature}.${checked ? 'uncheck' : 'check'}`;
+		}
+		return undefined;
+	}
+
 	return (
 		<div className={classnames('checkbox', { disabled })}>
-			<label data-feature={schema['data-feature']}>
+			<label data-feature={getDataFeature()}>
 				<input
 					id={id}
 					autoFocus={autoFocus}
 					disabled={disabled}
 					onChange={event => {
-						onChange(event, { schema, value: event.target.checked });
-						onFinish(event, { schema, value: event.target.checked });
+						const isChecked = event.target.checked;
+						setChecked(isChecked);
+						onChange(event, { schema, value: isChecked });
+						onFinish(event, { schema, value: isChecked });
 					}}
 					type="checkbox"
 					checked={value}

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
@@ -105,9 +105,9 @@ describe('SimpleCheckBox field', () => {
 	});
 
 	describe('data-feature', () => {
-		it('should render checkbox with specific data-feature while starting to be unchecked', () => {
-			const dataFeature = 'my.custom.feature';
+		const dataFeature = 'my.custom.feature';
 
+		it('should render checkbox with specific data-feature while starting to be unchecked', () => {
 			const wrapper = shallow(
 				<SimpleCheckBox
 					describedby={'myForm-description myForm-error'}
@@ -134,8 +134,6 @@ describe('SimpleCheckBox field', () => {
 		});
 
 		it('should render checkbox with specific data-feature while starting to be checked', () => {
-			const dataFeature = 'my.custom.feature';
-
 			const wrapper = shallow(
 				<SimpleCheckBox
 					describedby={'myForm-description myForm-error'}

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
@@ -28,6 +28,32 @@ describe('SimpleCheckBox field', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render input with specific data-feature on its label', () => {
+		const dataFeature = 'my.custom.feature';
+
+		const wrapper = shallow(
+			<SimpleCheckBox
+				describedby={'myForm-description myForm-error'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				id={'myForm'}
+				label={'My checkbox custom label'}
+				schema={{
+					...schema,
+					'data-feature': dataFeature,
+				}}
+				value
+			/>,
+		);
+
+		// then
+		expect(
+			wrapper
+				.find(`label[data-feature="${dataFeature}"]`)
+				.exists(),
+		).toBeTruthy();
+	});
+
 	it('should render disabled input', () => {
 		// given
 		const disabledSchema = {

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
@@ -28,28 +28,6 @@ describe('SimpleCheckBox field', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should render input with specific data-feature on its label', () => {
-		const dataFeature = 'my.custom.feature';
-
-		const wrapper = shallow(
-			<SimpleCheckBox
-				describedby={'myForm-description myForm-error'}
-				onChange={jest.fn()}
-				onFinish={jest.fn()}
-				id={'myForm'}
-				label={'My checkbox custom label'}
-				schema={{
-					...schema,
-					'data-feature': dataFeature,
-				}}
-				value
-			/>,
-		);
-
-		// then
-		expect(wrapper.find(`label[data-feature="${dataFeature}"]`).exists()).toBeTruthy();
-	});
-
 	it('should render disabled input', () => {
 		// given
 		const disabledSchema = {
@@ -124,5 +102,64 @@ describe('SimpleCheckBox field', () => {
 
 		// then
 		expect(onFinish).toBeCalledWith(event, { schema, value: false });
+	});
+
+	describe('data-feature', () => {
+		it('should render checkbox with specific data-feature while starting to be unchecked', () => {
+			const dataFeature = 'my.custom.feature';
+
+			const wrapper = shallow(
+				<SimpleCheckBox
+					describedby={'myForm-description myForm-error'}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
+					id={'myForm'}
+					label={'My checkbox custom label'}
+					schema={{
+						...schema,
+						'data-feature': dataFeature,
+					}}
+				/>,
+			);
+			expect(wrapper.find(`label[data-feature="${dataFeature}.check"]`).exists()).toBeTruthy();
+
+			// when
+			wrapper
+				.find('input')
+				.at(0)
+				.simulate('change', { target: { checked: true } });
+
+			// then
+			expect(wrapper.find(`label[data-feature="${dataFeature}.uncheck"]`).exists()).toBeTruthy();
+		});
+
+		it('should render checkbox with specific data-feature while starting to be checked', () => {
+			const dataFeature = 'my.custom.feature';
+
+			const wrapper = shallow(
+				<SimpleCheckBox
+					describedby={'myForm-description myForm-error'}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
+					id={'myForm'}
+					label={'My checkbox custom label'}
+					schema={{
+						...schema,
+						'data-feature': dataFeature,
+					}}
+					value
+				/>,
+			);
+			expect(wrapper.find(`label[data-feature="${dataFeature}.uncheck"]`).exists()).toBeTruthy();
+
+			// when
+			wrapper
+				.find('input')
+				.at(0)
+				.simulate('change', { target: { checked: false } });
+
+			// then
+			expect(wrapper.find(`label[data-feature="${dataFeature}.check"]`).exists()).toBeTruthy();
+		});
 	});
 });

--- a/packages/forms/stories-core/json/fields/core-checkbox.json
+++ b/packages/forms/stories-core/json/fields/core-checkbox.json
@@ -46,7 +46,8 @@
   "uiSchema": [
     {
       "key": "standard",
-      "title": "Check if you are happy (standard)"
+      "title": "Check if you are happy (standard)",
+      "data-feature": "my.custom.feature"
     },
     {
       "key": "autofocused",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UIForm does not deal with data-feature for each field

**What is the chosen solution to this problem?**
Be able to render data-feature attribute for Checkbox from `uiSchema`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
