### PR TITLE
feat(components/datepicker): fixed position

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -56,6 +56,7 @@
     "react-draggable": "^3.3.0",
     "react-grid-layout": "0.16.6",
     "react-immutable-proptypes": "^2.1.0",
+    "react-popper": "^1.3.3",
     "react-transition-group": "^2.3.1",
     "react-virtualized": "9.21.0",
     "reactour": "^1.13.4",

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -2,9 +2,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
-import { Overlay, Popover } from 'react-bootstrap';
 import keycode from 'keycode';
 import uuid from 'uuid';
+import { Popper } from 'react-popper';
 
 import FocusManager from '../../FocusManager';
 import { DateTimeContext } from '../DateTime/Context';
@@ -133,7 +133,11 @@ class InputDateTimePicker extends React.Component {
 			if (showPicker === isShown) {
 				return extra;
 			}
-			return { showPicker: isShown, ...extra };
+			return {
+				showPicker: isShown,
+				style: this.inputRef ? { width: this.inputRef.getBoundingClientRect().width } : {},
+				...extra,
+			};
 		});
 	}
 
@@ -148,21 +152,38 @@ class InputDateTimePicker extends React.Component {
 					this.inputRef = ref;
 				}}
 			/>,
-			<div
-				className={theme['dropdown-wrapper']}
-				key="dropdown"
-				ref={ref => {
-					this.dropdownWrapperRef = ref;
-				}}
-			>
-				<Overlay container={this.dropdownWrapperRef} show={this.state.showPicker}>
-					<Popover className={theme.popover} id={this.popoverId}>
-						<DateTime.Picker />
-						{this.props.formMode && <DateTime.Validation />}
-					</Popover>
-				</Overlay>
-			</div>,
-		];
+			this.state.showPicker && (
+				<Popper
+					key="popper"
+					referenceElement={this.inputRef}
+					placement="bottom-end"
+					modifiers={{
+						hide: {
+							enabled: false,
+						},
+						preventOverflow: {
+							enabled: false,
+						},
+					}}
+					positionFixed
+				>
+					{({ ref, style }) => (
+						<div
+							id={this.popoverId}
+							className={theme.popper}
+							style={{
+								...this.state.style,
+								...style,
+							}}
+							ref={ref}
+						>
+							<DateTime.Picker />
+							{this.props.formMode && <DateTime.Validation />}
+						</div>
+					)}
+				</Popper>
+			),
+		].filter(Boolean);
 
 		return (
 			<DateTime.Manager

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -124,6 +124,17 @@ class InputDateTimePicker extends React.Component {
 		}
 	}
 
+	getPopperPlacement() {
+		const input = this.inputRef;
+		if (input) {
+			const inputDimensions = input.getBoundingClientRect();
+			if (inputDimensions.left > window.innerWidth / 2) {
+				return 'bottom-end';
+			}
+		}
+		return 'bottom-start';
+	}
+
 	setPickerVisibility(isShown, extra = {}) {
 		if (this.props.readOnly) {
 			return;
@@ -135,7 +146,6 @@ class InputDateTimePicker extends React.Component {
 			}
 			return {
 				showPicker: isShown,
-				style: this.inputRef ? { width: this.inputRef.getBoundingClientRect().width } : {},
 				...extra,
 			};
 		});
@@ -155,8 +165,6 @@ class InputDateTimePicker extends React.Component {
 			this.state.showPicker && (
 				<Popper
 					key="popper"
-					referenceElement={this.inputRef}
-					placement="bottom-end"
 					modifiers={{
 						hide: {
 							enabled: false,
@@ -165,18 +173,12 @@ class InputDateTimePicker extends React.Component {
 							enabled: false,
 						},
 					}}
+					placement={this.getPopperPlacement()}
 					positionFixed
+					referenceElement={this.inputRef}
 				>
 					{({ ref, style }) => (
-						<div
-							id={this.popoverId}
-							className={theme.popper}
-							style={{
-								...this.state.style,
-								...style,
-							}}
-							ref={ref}
-						>
+						<div id={this.popoverId} className={theme.popper} style={style} ref={ref}>
 							<DateTime.Picker />
 							{this.props.formMode && <DateTime.Validation />}
 						</div>

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
@@ -7,7 +7,7 @@ import InputDateTimePicker from './InputDateTimePicker.component';
 import Manager from '../DateTime/Manager';
 
 function getOverlay(wrapper) {
-	return wrapper.find('Overlay').first();
+	return wrapper.find('Popper').first();
 }
 
 describe('InputDateTimePicker', () => {
@@ -15,13 +15,13 @@ describe('InputDateTimePicker', () => {
 		it('should open picker on focus', () => {
 			// given
 			const wrapper = mount(<InputDateTimePicker id="my-picker" />);
-			expect(getOverlay(wrapper).prop('show')).toBeFalsy();
+			expect(getOverlay(wrapper).exists()).toBe(false);
 
 			// when
 			wrapper.simulate('focus');
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 		});
 
 		it('should close picker on blur', () => {
@@ -29,7 +29,7 @@ describe('InputDateTimePicker', () => {
 			jest.useFakeTimers();
 			const wrapper = mount(<InputDateTimePicker id="my-picker" />);
 			wrapper.simulate('focus');
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 
 			// when
 			wrapper.simulate('blur');
@@ -37,7 +37,7 @@ describe('InputDateTimePicker', () => {
 			wrapper.update();
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(false);
+			expect(getOverlay(wrapper).exists()).toBe(false);
 		});
 
 		it('should trigger props.onBlur', () => {
@@ -61,27 +61,27 @@ describe('InputDateTimePicker', () => {
 			// given
 			const wrapper = mount(<InputDateTimePicker id="my-picker" />);
 			wrapper.simulate('focus');
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 			const event = { keyCode: keycode.codes.esc };
 
 			// when
 			wrapper.simulate('keydown', event);
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(false);
+			expect(getOverlay(wrapper).exists()).toBe(false);
 		});
 
 		it('should open picker if it is closed with DOWN on input', () => {
 			// given
 			const wrapper = mount(<InputDateTimePicker id="my-picker" />);
-			expect(getOverlay(wrapper).prop('show')).toBeFalsy();
+			expect(getOverlay(wrapper).exists()).toBe(false);
 			const event = { keyCode: keycode.codes.down };
 
 			// when
 			wrapper.find('input').simulate('keydown', event);
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 		});
 
 		it('should focus on calendar day if it is open with input DOWN', () => {
@@ -136,7 +136,7 @@ describe('InputDateTimePicker', () => {
 					/>,
 				);
 				wrapper.simulate('focus');
-				expect(getOverlay(wrapper).prop('show')).toBe(true);
+				expect(getOverlay(wrapper).exists()).toBe(true);
 
 				// when
 				wrapper
@@ -145,7 +145,7 @@ describe('InputDateTimePicker', () => {
 					.simulate('click');
 
 				// then
-				expect(getOverlay(wrapper).prop('show')).toBe(expectedOverlay);
+				expect(getOverlay(wrapper).exists()).toBe(expectedOverlay);
 			},
 			[
 				{
@@ -173,20 +173,20 @@ describe('InputDateTimePicker', () => {
 			// given
 			const wrapper = mount(<InputDateTimePicker id="my-picker" onChange={jest.fn()} />);
 			wrapper.simulate('focus');
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 
 			// when
 			wrapper.find('DebounceInput').simulate('change');
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 		});
 
 		it('should close in form mode submit', () => {
 			// given
 			const wrapper = mount(<InputDateTimePicker id="my-picker" onChange={jest.fn()} formMode />);
 			wrapper.simulate('focus');
-			expect(getOverlay(wrapper).prop('show')).toBe(true);
+			expect(getOverlay(wrapper).exists()).toBe(true);
 
 			// when
 			wrapper
@@ -196,7 +196,7 @@ describe('InputDateTimePicker', () => {
 			wrapper.find('form').simulate('submit');
 
 			// then
-			expect(getOverlay(wrapper).prop('show')).toBe(false);
+			expect(getOverlay(wrapper).exists()).toBe(false);
 		});
 	});
 });

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
@@ -1,8 +1,9 @@
+$tc-datetimepicker-width: 31rem !default;
 $tc-datetimepicker-background: $white !default;
+$tc-datetimepicker-box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2) !default;
 
 .popper {
-	min-width: 310px;
-	max-width: 700px;
+	width: $tc-datetimepicker-width;
 	background: $tc-datetimepicker-background;
-	box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2);
+	box-shadow: $tc-datetimepicker-box-shadow;
 }

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.scss
@@ -1,23 +1,8 @@
-.dropdown-wrapper {
-	position: relative;
-}
+$tc-datetimepicker-background: $white !default;
 
-.popover {
+.popper {
 	min-width: 310px;
 	max-width: 700px;
-	width: 100%;
-	padding: 0;
-	border-radius: 0;
-
-	&:global(.popover) {
-		margin: 0;
-	}
-
-	:global(.arrow) {
-		display: none;
-	}
-
-	:global(.popover-content) {
-		padding: 0;
-	}
+	background: $tc-datetimepicker-background;
+	box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2);
 }

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.snapshot.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.snapshot.test.js.snap
@@ -51,24 +51,6 @@ exports[`InputDateTimePicker should render 1`] = `
             />
           </Mock>
         </Component>
-        <div
-          className="theme-dropdown-wrapper"
-          key="dropdown"
-        >
-          <Overlay
-            animation={[Function]}
-            placement="right"
-            rootClose={false}
-            show={false}
-          >
-            <Overlay
-              placement="right"
-              rootClose={false}
-              show={false}
-              transition={[Function]}
-            />
-          </Overlay>
-        </div>
       </div>
     </FocusManager>
   </DateTime.Manager>

--- a/packages/components/stories/DatePicker.js
+++ b/packages/components/stories/DatePicker.js
@@ -288,48 +288,51 @@ storiesOf('DatePicker', module)
 			</div>
 		);
 	})
-	.add('Date picker - parent with fixed height', () => (
-		<div>
-			<IconsProvider />
-			<h1>DatePicker with fixed-height parent</h1>
-			<div style={{ height: 300, overflow: 'auto', border: 'solid' }}>
-				<form style={{ width: 320, float: 'left' }}>
-					<InputDateTimePicker
-						id="my-date-picker-top-left"
-						name="Datetime"
-						onBlur={action('onBlur')}
-						onChange={action('onChange')}
-						useTime
-					/>
-				</form>
-				<form style={{ width: 160, float: 'right' }}>
-					<InputDateTimePicker
-						id="my-date-picker-top-right"
-						name="Datetime"
-						onBlur={action('onBlur')}
-						onChange={action('onChange')}
-						useTime
-					/>
-				</form>
-				<div style={{ height: 600 }} />
-				<form style={{ width: 320, float: 'left' }}>
-					<InputDateTimePicker
-						id="my-date-picker-bottom-left"
-						name="Datetime"
-						onBlur={action('onBlur')}
-						onChange={action('onChange')}
-						useTime
-					/>
-				</form>
-				<form style={{ width: 160, float: 'right' }}>
-					<InputDateTimePicker
-						id="my-date-picker-bottom-right"
-						name="Datetime"
-						onBlur={action('onBlur')}
-						onChange={action('onChange')}
-						useTime
-					/>
-				</form>
+	.add('Date picker - parent with fixed height', () => {
+		const width = 150;
+		return (
+			<div>
+				<IconsProvider />
+				<h1>DatePicker with fixed-height parent</h1>
+				<div style={{ height: 300, overflow: 'auto', border: 'solid' }}>
+					<form style={{ width, float: 'left' }}>
+						<InputDateTimePicker
+							id="my-date-picker-top-left"
+							name="Datetime"
+							onBlur={action('onBlur')}
+							onChange={action('onChange')}
+							useTime
+						/>
+					</form>
+					<form style={{ width, float: 'right' }}>
+						<InputDateTimePicker
+							id="my-date-picker-top-right"
+							name="Datetime"
+							onBlur={action('onBlur')}
+							onChange={action('onChange')}
+							useTime
+						/>
+					</form>
+					<div style={{ height: 600 }} />
+					<form style={{ width, float: 'left' }}>
+						<InputDateTimePicker
+							id="my-date-picker-bottom-left"
+							name="Datetime"
+							onBlur={action('onBlur')}
+							onChange={action('onChange')}
+							useTime
+						/>
+					</form>
+					<form style={{ width, float: 'right' }}>
+						<InputDateTimePicker
+							id="my-date-picker-bottom-right"
+							name="Datetime"
+							onBlur={action('onBlur')}
+							onChange={action('onChange')}
+							useTime
+						/>
+					</form>
+				</div>
 			</div>
-		</div>
-	));
+		);
+	});

--- a/packages/components/stories/DatePicker.js
+++ b/packages/components/stories/DatePicker.js
@@ -287,4 +287,50 @@ storiesOf('DatePicker', module)
 				</div>
 			</div>
 		);
-	});
+	})
+	.add('Date picker - parent with fixed height', () => (
+		<div>
+			<IconsProvider />
+			<h1>DatePicker with time</h1>
+			<p>You can require time with a simple "useTime" props.</p>
+			<div style={{ height: 300, overflow: 'auto', border: 'solid' }}>
+				<form style={{ width: 320, float: 'left' }}>
+					<InputDateTimePicker
+						id="my-date-picker-top-left"
+						name="Datetime"
+						onBlur={action('onBlur')}
+						onChange={action('onChange')}
+						useTime
+					/>
+				</form>
+				<form style={{ width: 160, float: 'right' }}>
+					<InputDateTimePicker
+						id="my-date-picker-top-right"
+						name="Datetime"
+						onBlur={action('onBlur')}
+						onChange={action('onChange')}
+						useTime
+					/>
+				</form>
+				<div style={{ height: 600 }} />
+				<form style={{ width: 320, float: 'left' }}>
+					<InputDateTimePicker
+						id="my-date-picker-bottom-left"
+						name="Datetime"
+						onBlur={action('onBlur')}
+						onChange={action('onChange')}
+						useTime
+					/>
+				</form>
+				<form style={{ width: 160, float: 'right' }}>
+					<InputDateTimePicker
+						id="my-date-picker-bottom-right"
+						name="Datetime"
+						onBlur={action('onBlur')}
+						onChange={action('onChange')}
+						useTime
+					/>
+				</form>
+			</div>
+		</div>
+	));

--- a/packages/components/stories/DatePicker.js
+++ b/packages/components/stories/DatePicker.js
@@ -291,8 +291,7 @@ storiesOf('DatePicker', module)
 	.add('Date picker - parent with fixed height', () => (
 		<div>
 			<IconsProvider />
-			<h1>DatePicker with time</h1>
-			<p>You can require time with a simple "useTime" props.</p>
+			<h1>DatePicker with fixed-height parent</h1>
 			<div style={{ height: 300, overflow: 'auto', border: 'solid' }}>
 				<form style={{ width: 320, float: 'left' }}>
 					<InputDateTimePicker


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Datepicker has `position: absolute` so it's quickly hidden when its parents have fixed height

**What is the chosen solution to this problem?**
Choose `position: fixed` to deal with parents overflow

To do so, I added a new dependency : [Popper.js](https://popper.js.org)
https://github.com/FezVrasta/react-popper
https://bundlephobia.com/result?p=react-popper@1.3.3

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
