### PR TITLE
fix(components/Typeahead): import I18N_DOMAIN_COMPONENTS

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -13,7 +13,7 @@ import {
 	renderItem,
 } from './Typeahead.component.renderers';
 import { Action } from '../Actions';
-import { I18N_DOMAIN_COMPONENTS } from '../constants';
+import I18N_DOMAIN_COMPONENTS from '../constants';
 
 /**
  * Show suggestions for search bar


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The import is importing as if it's a named export, when in fact it's a default export

**What is the chosen solution to this problem?**
Change to "deafult import"

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
