### PR TITLE
chore: set key and default translation to singular

### DIFF
--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -342,8 +342,8 @@ function UntranslatedComplexItem(props) {
 					<sup
 						key="badge"
 						className={`${theme.badge} badge`}
-						aria-label={t('TC_OBJECT_VIEWER_NB_CHILDREN', {
-							defaultValue: 'Contains {{count}} children',
+						aria-label={t('TC_OBJECT_VIEWER_NB_CHILD', {
+							defaultValue: 'Contains {{count}} child',
 							count: info.length,
 						})}
 					>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Translation team had an issue understanding if a key is singular or plural.
In ObjectViewer, we have a key: `TC_OBJECT_VIEWER_NB_CHILDREN`. It contains a `count` variable, i18next-scanner will extract 2 keys:
- `TC_OBJECT_VIEWER_NB_CHILDREN`
- `TC_OBJECT_VIEWER_NB_CHILDREN_plural`

It's quite confusing that the singular version is `children`. Furthermore, the default value contains `children`

**What is the chosen solution to this problem?**
Set the key and default translation to singular, so we'll have 2 keys : 
- `TC_OBJECT_VIEWER_NB_CHILD`
- `TC_OBJECT_VIEWER_NB_CHILD_plural`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
