### PR TITLE
fix(forms): onSubmitEnter should be passed all of the time

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,10 +5,5 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/deprecated/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
-  284:26  error  Arrow function used ambiguously with a conditional expression  no-confusing-arrow
-  290:2   error  Mixed spaces and tabs                                          no-mixed-spaces-and-tabs
-
-✖ 3 problems (3 errors, 0 warnings)
-  1 error, 0 warnings potentially fixable with the `--fix` option.
+✖ 1 problem (1 error, 0 warnings)
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,5 +5,10 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/deprecated/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
-✖ 1 problem (1 error, 0 warnings)
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
+  284:26  error  Arrow function used ambiguously with a conditional expression  no-confusing-arrow
+  290:2   error  Mixed spaces and tabs                                          no-mixed-spaces-and-tabs
+
+✖ 3 problems (3 errors, 0 warnings)
+  1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -281,11 +281,11 @@ export class UIFormComponent extends React.Component {
 		}
 
 		if (onSubmitEnter) {
-			actions = actions.map(a => (a.type === 'submit' ? {
-				...a,
-				onMouseEnter: onSubmitEnter && (event => onSubmitEnter(event, properties)),
+			actions = actions.map(action => (action.type === 'submit' ? {
+				...action,
+				onMouseEnter: event => onSubmitEnter(event, properties),
 				onMouseLeave: onSubmitLeave,
-			} : a));
+			} : action));
 		}
 
 

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -281,13 +281,16 @@ export class UIFormComponent extends React.Component {
 		}
 
 		if (onSubmitEnter) {
-			actions = actions.map(action => (action.type === 'submit' ? {
-				...action,
-				onMouseEnter: event => onSubmitEnter(event, properties),
-				onMouseLeave: onSubmitLeave,
-			} : action));
+			actions = actions.map(action =>
+				action.type === 'submit'
+					? {
+							...action,
+							onMouseEnter: event => onSubmitEnter(event, properties),
+							onMouseLeave: onSubmitLeave,
+					  }
+					: action,
+			);
 		}
-
 
 		const formTemplate =
 			this.props.displayMode === 'text' ? TextModeFormTemplate : DefaultFormTemplate;

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -281,15 +281,16 @@ export class UIFormComponent extends React.Component {
 		}
 
 		if (onSubmitEnter) {
-			actions = actions.map(action =>
-				action.type === 'submit'
-					? {
-							...action,
-							onMouseEnter: event => onSubmitEnter(event, properties),
-							onMouseLeave: onSubmitLeave,
-					  }
-					: action,
-			);
+			actions = actions.map(action => {
+				if (action.type === 'submit') {
+					return {
+						...action,
+						onMouseEnter: event => onSubmitEnter(event, properties),
+						onMouseLeave: onSubmitLeave,
+					};
+				}
+				return action;
+			});
 		}
 
 		const formTemplate =

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -267,20 +267,27 @@ export class UIFormComponent extends React.Component {
 
 	render() {
 		const { onSubmitEnter, onSubmitLeave, properties } = this.props;
-		const actions = this.props.actions || [
+		let actions = this.props.actions || [
 			{
 				bsStyle: 'primary',
 				label: 'Submit',
 				type: 'submit',
 				widget: 'button',
 				position: 'right',
-				onMouseEnter: onSubmitEnter && (event => onSubmitEnter(event, properties)),
-				onMouseLeave: onSubmitLeave,
 			},
 		];
 		if (!this.state.mergedSchema) {
 			return null;
 		}
+
+		if (onSubmitEnter) {
+			actions = actions.map(a => (a.type === 'submit' ? {
+				...a,
+				onMouseEnter: onSubmitEnter && (event => onSubmitEnter(event, properties)),
+				onMouseLeave: onSubmitLeave,
+			} : a));
+		}
+
 
 		const formTemplate =
 			this.props.displayMode === 'text' ? TextModeFormTemplate : DefaultFormTemplate;

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -113,8 +113,6 @@ exports[`UIForm component should render form 1`] = `
             Object {
               "bsStyle": "primary",
               "label": "Submit",
-              "onMouseEnter": undefined,
-              "onMouseLeave": undefined,
               "position": "right",
               "type": "submit",
               "widget": "button",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If actions are passed to an `UIForm`, `onSubmitEnter` is ignored.

**What is the chosen solution to this problem?**

If `onSubmitEnter` is given to the `UIForm`, add it to the submit action.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->