### PR TITLE
fix(forms): fire onSubmitEnter only if form is valid

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -34,6 +34,7 @@ export class UIFormComponent extends React.Component {
 		this.onChange = this.onChange.bind(this);
 		this.onFinish = this.onFinish.bind(this);
 		this.onSubmit = this.onSubmit.bind(this);
+		this.onSubmitEnter = this.onSubmitEnter.bind(this);
 		this.onTrigger = this.onTrigger.bind(this);
 		this.onActionClick = this.onActionClick.bind(this);
 		this.focusFirstError = this.focusFirstError.bind(this);
@@ -216,6 +217,32 @@ export class UIFormComponent extends React.Component {
 			event.preventDefault();
 		}
 
+		const isValid = this.validate();
+
+		if (this.props.onSubmit && isValid) {
+			const { properties } = this.props;
+			if (this.props.moz) {
+				this.props.onSubmit(null, { formData: properties });
+			} else {
+				this.props.onSubmit(event, properties, this.state.mergedSchema);
+			}
+		}
+
+		return isValid;
+	}
+
+	onSubmitEnter(event) {
+		const { onSubmitEnter, properties } = this.props;
+		if (onSubmitEnter && this.validate()) {
+			onSubmitEnter(event, properties);
+		}
+	}
+
+	setFormRef(element) {
+		this.formRef = element;
+	}
+
+	validate() {
 		const { mergedSchema } = this.state;
 		const { properties, customValidation } = this.props;
 		const newErrors = validateAll(mergedSchema, properties, customValidation);
@@ -234,23 +261,9 @@ export class UIFormComponent extends React.Component {
 				accu[key] = value;
 				return accu;
 			}, {});
-
 		const isValid = !Object.keys(errors).length;
 		this.props.setErrors(event, errors, !isValid ? this.focusFirstError : undefined);
-
-		if (this.props.onSubmit && isValid) {
-			if (this.props.moz) {
-				this.props.onSubmit(null, { formData: properties });
-			} else {
-				this.props.onSubmit(event, properties, mergedSchema);
-			}
-		}
-
 		return isValid;
-	}
-
-	setFormRef(element) {
-		this.formRef = element;
 	}
 
 	focusFirstError() {
@@ -266,7 +279,7 @@ export class UIFormComponent extends React.Component {
 	}
 
 	render() {
-		const { onSubmitEnter, onSubmitLeave, properties } = this.props;
+		const { onSubmitEnter, onSubmitLeave } = this.props;
 		let actions = this.props.actions || [
 			{
 				bsStyle: 'primary',
@@ -285,7 +298,7 @@ export class UIFormComponent extends React.Component {
 				if (action.type === 'submit') {
 					return {
 						...action,
-						onMouseEnter: event => onSubmitEnter(event, properties),
+						onMouseEnter: this.onSubmitEnter,
 						onMouseLeave: onSubmitLeave,
 					};
 				}

--- a/packages/forms/stories-core/customHoverSubmitStory.js
+++ b/packages/forms/stories-core/customHoverSubmitStory.js
@@ -24,7 +24,12 @@ const schema = {
 	},
 };
 
-function UIFormWithOnSubmitHover() {
+const errors = schema.uiSchema.reduce((acc, current) => ({
+	...acc,
+	[current.key.split('.').join(',')]: 'There is an error',
+}), {});
+
+function UIFormWithOnSubmitHover(props) {
 	const [hover, setHover] = useState(0);
 	return (
 		<div
@@ -46,6 +51,7 @@ function UIFormWithOnSubmitHover() {
 					action('onSubmitLeave')(...args);
 					setHover(false);
 				}}
+				{...props}
 			/>
 		</div>
 	);
@@ -64,7 +70,26 @@ function story() {
 	);
 }
 
-export default {
-	name: 'Core Concept hover submit',
-	story,
-};
+function storyWithErrors() {
+	return (
+		<div>
+			<h2>Hover submit handler with errors</h2>
+			<p>
+				Submit can detect if mouse enters or leaves by using <code>onSubmitEnter</code> and{' '}
+				<code>onSubmitLeave</code>
+			</p>
+			<UIFormWithOnSubmitHover errors={errors} />
+		</div>
+	);
+}
+
+export default [
+	{
+		name: 'Core Concept hover submit',
+		story,
+	},
+	{
+		name: 'Core Concept hover submit with errors',
+		story: storyWithErrors,
+	},
+];

--- a/packages/forms/stories-core/customHoverSubmitStory.js
+++ b/packages/forms/stories-core/customHoverSubmitStory.js
@@ -76,7 +76,8 @@ function storyWithErrors() {
 			<h2>Hover submit handler with errors</h2>
 			<p>
 				Submit can detect if mouse enters or leaves by using <code>onSubmitEnter</code> and{' '}
-				<code>onSubmitLeave</code>
+				<code>onSubmitLeave</code> but it will never trigger <code>onSubmitEnter</code> since the form is{' '}
+				invalid
 			</p>
 			<UIFormWithOnSubmitHover errors={errors} />
 		</div>

--- a/packages/forms/stories-core/index.js
+++ b/packages/forms/stories-core/index.js
@@ -49,4 +49,4 @@ coreConceptsStories.add(customActionsStory.name, customActionsStory.story);
 coreConceptsStories.add(customUpdating.name, customUpdating.story);
 coreConceptsStories.add(customErrors.name, customErrors.story);
 coreConceptsStories.add(customDisplayMode.name, customDisplayMode.story);
-coreConceptsStories.add(customHoverSubmitStory.name, customHoverSubmitStory.story);
+customHoverSubmitStory.forEach(({ name, story }) => coreConceptsStories.add(name, story));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`onSubmitEnter` is fired even if the form has errors

**What is the chosen solution to this problem?**
Fire it only if the form is valid ofc 😏

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
