### PR TITLE
fix(forms): forms buttons ids generation

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -320,7 +320,7 @@ export class UIFormComponent extends React.Component {
 			return (
 				<div className={classNames(theme['form-actions'], 'tf-actions-wrapper')} key="form-buttons">
 					<Buttons
-						id={`${this.props.id}-${this.props.id}-actions`}
+						id={`${this.props.id}-actions`}
 						onTrigger={this.onTrigger}
 						className={this.props.buttonBlockClass}
 						schema={{ items: actions }}

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -104,7 +104,7 @@ exports[`UIForm component should render form 1`] = `
   >
     <Buttons
       className="form-actions"
-      id="myFormId-myFormId-actions"
+      id="myFormId-actions"
       onClick={[Function]}
       onTrigger={[Function]}
       schema={
@@ -334,7 +334,7 @@ exports[`UIForm component should render provided actions 1`] = `
   >
     <Buttons
       className="form-actions"
-      id="myFormId-myFormId-actions"
+      id="myFormId-actions"
       onClick={[Function]}
       onTrigger={[Function]}
       schema={


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Generated ids for forms buttons contain form id twice

**What is the chosen solution to this problem?**
Remove duplicate

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
