### PR TITLE
fix(forms): display tooltips as block

### DIFF
--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -146,7 +146,7 @@ function TooltipTrigger(props) {
 		// eslint-disable-next-line jsx-a11y/no-static-element-interactions
 		<div
 			{...omit(props, Object.keys(TooltipTrigger.propTypes))}
-			className={theme['tc-tooltip']}
+			className={classNames(theme['tc-tooltip'], props.className)}
 			onFocus={show}
 			onBlur={hide}
 			onKeyPress={hide}
@@ -181,6 +181,7 @@ function TooltipTrigger(props) {
 TooltipTrigger.displayName = 'TooltipTrigger';
 
 TooltipTrigger.propTypes = {
+	className: PropTypes.string,
 	label: PropTypes.oneOfType([PropTypes.string, PropTypes.element]),
 	tooltipPlacement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 	tooltipHeight: PropTypes.number,

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -72,7 +72,11 @@ export default function Widget(props) {
 
 	if (tooltip) {
 		return (
-			<TooltipTrigger className={theme.tooltip} label={tooltip} tooltipPlacement={tooltipPlacement || 'left'}>
+			<TooltipTrigger
+				className={theme.tooltip}
+				label={tooltip}
+				tooltipPlacement={tooltipPlacement || 'left'}
+			>
 				<div>
 					<WidgetImpl {...all} />
 				</div>

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -1,12 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { sfPath } from '@talend/json-schema-form-core';
-import { TooltipTrigger } from '@talend/react-components';
+import TooltipTrigger from '@talend/react-components/lib/TooltipTrigger';
 
 import defaultWidgets from '../utils/widgets';
 import { getError } from '../utils/errors';
 import { getValue } from '../utils/properties';
 import shouldRender from '../utils/condition';
+
+import theme from './Widget.component.scss';
 
 function getWidget(displayMode, widgetId, customWidgets) {
 	// resolve the widget id depending on the display mode
@@ -70,7 +72,7 @@ export default function Widget(props) {
 
 	if (tooltip) {
 		return (
-			<TooltipTrigger label={tooltip} tooltipPlacement={tooltipPlacement || 'left'}>
+			<TooltipTrigger className={theme.tooltip} label={tooltip} tooltipPlacement={tooltipPlacement || 'left'}>
 				<div>
 					<WidgetImpl {...all} />
 				</div>

--- a/packages/forms/src/UIForm/Widget/Widget.component.scss
+++ b/packages/forms/src/UIForm/Widget/Widget.component.scss
@@ -1,0 +1,3 @@
+.tooltip {
+  display: block;
+}

--- a/packages/forms/src/UIForm/Widget/Widget.component.scss
+++ b/packages/forms/src/UIForm/Widget/Widget.component.scss
@@ -1,3 +1,3 @@
 .tooltip {
-  display: block;
+	display: block;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Form tooltip triggers are displayed as `inline-block` which it breaks Form layout
 
**What is the chosen solution to this problem?**
In the forms, display them as `block`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
