### PR TITLE
fix(List): list title cell not centered

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -42,7 +42,6 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 		display: block;
 
 		padding: 0 $padding-normal;
-		height: 100%;
 
 		color: $tc-list-title-color;
 		font-size: inherit;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the List component, when the main column (title column) doesn't have any action associated, the label isn't centered.
See https://jira.talendforge.org/browse/TPSVC-10683
Problem can be seen here : http://talend.surge.sh/components/?path=/story/list--title-without-click

**What is the chosen solution to this problem?**
Remove `height: 100%;` from `.main-title`.
Fixed problem : http://2333.talend.surge.sh/components/?path=/story/list--title-without-click

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
