### PR TITLE
fix(TMC-18302): issue with drawer title

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -121,6 +121,7 @@ export function ActionButton(props) {
 		overlayPlacement,
 		overlayRef,
 		tooltipPlacement,
+		tooltipClassName,
 		tooltip,
 		tooltipLabel,
 		available,
@@ -202,9 +203,14 @@ export function ActionButton(props) {
 			</OverlayTrigger>
 		);
 	}
+
 	if (hideLabel || tooltip || tooltipLabel) {
 		btn = (
-			<TooltipTrigger label={tooltipLabel || label} tooltipPlacement={tooltipPlacement}>
+			<TooltipTrigger
+				label={tooltipLabel || label}
+				tooltipPlacement={tooltipPlacement}
+				className={tooltipClassName}
+			>
 				{btnIsDisabled ? (
 					<span
 						className={classNames(
@@ -241,6 +247,7 @@ ActionButton.propTypes = {
 	t: PropTypes.func,
 	tooltip: PropTypes.bool,
 	tooltipLabel: PropTypes.string,
+	tooltipClassName: PropTypes.string,
 	...overlayPropTypes,
 };
 

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -106,7 +106,7 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 				theme['tc-drawer-close-action'],
 				enhancedCancelAction.className,
 			)}
-			tooltipClassName={theme['drawer-cancel-action-tooltip']}
+			tooltipClassName={theme['drawer-close-action-tooltip']}
 		/>
 	);
 }

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -106,6 +106,7 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 				theme['tc-drawer-close-action'],
 				enhancedCancelAction.className,
 			)}
+			tooltipClassName={theme['drawer-cancel-action-tooltip']}
 		/>
 	);
 }

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -99,7 +99,7 @@ $tc-drawer-z-index: $drawer-z-index !default;
 			overflow: hidden;
 		}
 
-		.drawer-cancel-action-tooltip {
+		.drawer-close-action-tooltip {
 			position: absolute;
 			right: 0;
 			bottom: $padding-normal / 2;

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -99,15 +99,18 @@ $tc-drawer-z-index: $drawer-z-index !default;
 			overflow: hidden;
 		}
 
+		.drawer-cancel-action-tooltip {
+			position: absolute;
+			right: 0;
+			bottom: $padding-normal / 2;
+		}
+
 		& > .tc-editable-text {
 			width: unset;
 		}
 	}
 
 	.tc-drawer-close-action {
-		top: $padding-normal / 2;
-		right: 0;
-		position: absolute;
 		color: white;
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-18302

Previously TooltipTrigger used overlay, now after refactoring there is a div wrapper which is always rendered, and the tooltip content which is rendered using portal

The problem is that cancel button is absolutely positioned, and the tooltip div wrapper is inline block, so as a result tooltip wrapper increases drawer title height, button itself is out of the flow, and when hovering over the button tooltip appears under the title

**What is the chosen solution to this problem?**

Absolutely position the tooltip div wrapper


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

