### PR TITLE
fix(components/titlesubheader): fix warning when using non string subtitle

### DIFF
--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -125,7 +125,7 @@ function SubTitle({ subTitleLoading, subTitle }) {
 }
 
 SubTitle.propTypes = {
-	subTitle: PropTypes.string,
+	subTitle: PropTypes.node,
 	subTitleLoading: PropTypes.bool,
 };
 
@@ -135,7 +135,7 @@ TitleSubHeader.propTypes = {
 	loading: PropTypes.bool,
 	inProgress: PropTypes.bool,
 	editable: PropTypes.bool,
-	subTitle: PropTypes.string,
+	subTitle: PropTypes.node,
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
 	onCancel: PropTypes.func,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- It's not possible to display a non string subtitle (for example, a link) without warning

**What is the chosen solution to this problem?**
- Changed the proptype to node

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
