### PR TITLE
fix(DatePicker): stop propagation of mouse down in the whole picker

### DIFF
--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -26,6 +26,10 @@ const PROPS_TO_OMIT_FOR_INPUT = [
 	'onChange',
 ];
 
+function onMouseDown(event) {
+	event.stopPropagation();
+}
+
 class InputDateTimePicker extends React.Component {
 	static propTypes = {
 		id: PropTypes.string.isRequired,
@@ -178,7 +182,13 @@ class InputDateTimePicker extends React.Component {
 					referenceElement={this.inputRef}
 				>
 					{({ ref, style }) => (
-						<div id={this.popoverId} className={theme.popper} style={style} ref={ref}>
+						<div
+							id={this.popoverId}
+							className={theme.popper}
+							style={style}
+							ref={ref}
+							onMouseDown={onMouseDown}
+						>
 							<DateTime.Picker />
 							{this.props.formMode && <DateTime.Validation />}
 						</div>

--- a/packages/components/stories/GridLayout.js
+++ b/packages/components/stories/GridLayout.js
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import talendIcons from '@talend/icons/dist/react';
+import { action } from '@storybook/addon-actions';
 
 import ActionIconToggle from '../src/Actions/ActionIconToggle';
+import InputDateTimePicker, { DateTime } from '../src/DateTimePickers';
 import { GridLayout, IconsProvider } from '../src/';
 import Tile from '../src/GridLayout/Tile/index';
 import Action from '../src/Actions/Action';
@@ -28,31 +30,38 @@ function TdsTileContent() {
 	};
 
 	switch (displayMode) {
-		case 'chart':
-			return (
-				<React.Fragment>
-					<div>
-						'my chart'
-					</div>
-				</React.Fragment>
-			);
-		case 'filter':
-			return (
-				<React.Fragment>
-					<div>my filter</div>
-					<Action {...submitAction} />
-				</React.Fragment>
-			);
-		case 'filterUser': {
-			return (
-				<React.Fragment>
-					<div>'user list'</div>
-					<Action {...submitAction} />
-				</React.Fragment>
-			);
-		}
-		default:
-			return null;
+	case 'chart':
+		return (
+			<React.Fragment>
+				<div>
+					'my chart'
+					<InputDateTimePicker
+						id="my-date-picker"
+						name="Datetime"
+						onBlur={action('onBlur')}
+						onChange={action('onChange')}
+						useTime
+					/>
+				</div>
+			</React.Fragment>
+		);
+	case 'filter':
+		return (
+			<React.Fragment>
+				<div>my filter</div>
+				<Action {...submitAction} />
+			</React.Fragment>
+		);
+	case 'filterUser': {
+		return (
+			<React.Fragment>
+				<div>'user list'</div>
+				<Action {...submitAction} />
+			</React.Fragment>
+		);
+	}
+	default:
+		return null;
 	}
 }
 
@@ -97,10 +106,10 @@ function ChartTile({ tile }) {
 		<Tile.Container>
 			{
 				tile.header ? (
-					<Tile.Header>
-						{ tile.header.label }
-						<ViewSelector></ViewSelector>
-					</Tile.Header> )
+						<Tile.Header>
+							{ tile.header.label }
+							<ViewSelector></ViewSelector>
+						</Tile.Header> )
 					: null
 			}
 			<Tile.Body>
@@ -108,6 +117,11 @@ function ChartTile({ tile }) {
 			</Tile.Body>
 		</Tile.Container>
 	);
+}
+
+function dragStart(event, something, tata, toto) {
+	// event.persist();
+	return
 }
 
 function GridContainer({ isLoading = false, skeletonConfiguration }) {
@@ -156,6 +170,7 @@ function GridContainer({ isLoading = false, skeletonConfiguration }) {
 	return (
 		<div className="App">
 			<GridLayout
+				onDragStart={dragStart}
 				isResizable
 				isLoading={isLoading}
 				skeletonConfiguration={skeletonConfiguration}>

--- a/packages/components/stories/GridLayout.js
+++ b/packages/components/stories/GridLayout.js
@@ -40,7 +40,6 @@ function TdsTileContent() {
 						name="Datetime"
 						onBlur={action('onBlur')}
 						onChange={action('onChange')}
-						useTime
 					/>
 				</div>
 			</React.Fragment>

--- a/packages/components/stories/GridLayout.js
+++ b/packages/components/stories/GridLayout.js
@@ -4,7 +4,7 @@ import talendIcons from '@talend/icons/dist/react';
 import { action } from '@storybook/addon-actions';
 
 import ActionIconToggle from '../src/Actions/ActionIconToggle';
-import InputDateTimePicker, { DateTime } from '../src/DateTimePickers';
+import InputDateTimePicker from '../src/DateTimePickers';
 import { GridLayout, IconsProvider } from '../src/';
 import Tile from '../src/GridLayout/Tile/index';
 import Action from '../src/Actions/Action';
@@ -119,11 +119,6 @@ function ChartTile({ tile }) {
 	);
 }
 
-function dragStart(event, something, tata, toto) {
-	// event.persist();
-	return
-}
-
 function GridContainer({ isLoading = false, skeletonConfiguration }) {
 	const [tiles, setTiles] = useState([
 		{
@@ -170,7 +165,6 @@ function GridContainer({ isLoading = false, skeletonConfiguration }) {
 	return (
 		<div className="App">
 			<GridLayout
-				onDragStart={dragStart}
 				isResizable
 				isLoading={isLoading}
 				skeletonConfiguration={skeletonConfiguration}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the picker button were not clickable when used in react-grid-layout because, mousedown is used for the drag feature whereas we use click in the picker.

**What is the chosen solution to this problem?**
stopping propagatin of the mousedown event

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
