### PR TITLE
chore(Badge): Add a props label to BadgeDelete

### DIFF
--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
@@ -26,7 +26,7 @@ BadgeDelete.propTypes = {
 	id: PropTypes.string.isRequired,
 	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
-	t: PropTypes.func.isRequired,
+	t: PropTypes.func,
 };
 
 export default BadgeDelete;

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
@@ -6,7 +6,7 @@ import { getTheme } from '../../../theme';
 
 const theme = getTheme(badgeCssModule);
 
-const BadgeDelete = ({ id, onClick, disabled, t }) => (
+const BadgeDelete = ({ disabled, id, label, onClick, t }) => (
 	<Action
 		className={theme('tc-badge-delete-icon')}
 		disabled={disabled}
@@ -14,7 +14,7 @@ const BadgeDelete = ({ id, onClick, disabled, t }) => (
 		icon={'talend-cross'}
 		id={id && `tc-badge-delete-${id}`}
 		key="delete"
-		label={t('BADGE_DELETE', { defaultValue: 'delete' })}
+		label={label || t('BADGE_DELETE', { defaultValue: 'Delete' })}
 		link
 		onClick={onClick}
 		role="button"
@@ -24,6 +24,7 @@ const BadgeDelete = ({ id, onClick, disabled, t }) => (
 BadgeDelete.propTypes = {
 	disabled: PropTypes.bool,
 	id: PropTypes.string.isRequired,
+	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	t: PropTypes.func.isRequired,
 };

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
@@ -1,15 +1,16 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import BadgeDelete from './BadgeDelete.component';
+import getDefaultT from '../../../translate';
 
 describe('BadgeDelete', () => {
 	it('should render', () => {
 		// given
 		const onClick = jest.fn();
 		const props = {
-			id: 'my id',
+			id: 'my-id',
 			onClick,
-			t: () => 'delete',
+			t: getDefaultT(),
 		};
 		// when
 		const wrapper = mount(<BadgeDelete {...props} />);
@@ -20,9 +21,9 @@ describe('BadgeDelete', () => {
 		// given
 		const onClick = jest.fn();
 		const props = {
-			id: 'my id',
+			id: 'my-id',
 			onClick,
-			t: () => 'delete',
+			t: getDefaultT(),
 		};
 		// when
 		const wrapper = mount(<BadgeDelete {...props} />);

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
@@ -31,4 +31,18 @@ describe('BadgeDelete', () => {
 		wrapper.find('button').simulate('click');
 		expect(onClick).toHaveBeenCalledTimes(1);
 	});
+	it('should pass the props label to the button', () => {
+		// given
+		const onClick = jest.fn();
+		const props = {
+			label: 'My custom label',
+			id: 'my-id',
+			onClick,
+			t: getDefaultT(),
+		};
+		// when
+		const wrapper = mount(<BadgeDelete {...props} />);
+		// then
+		expect(wrapper.find('button').prop('aria-label')).toBe('My custom label');
+	});
 });

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/__snapshots__/BadgeDelete.component.test.js.snap
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/__snapshots__/BadgeDelete.component.test.js.snap
@@ -5,7 +5,7 @@ exports[`BadgeDelete should render 1`] = `
      aria-describedby="42"
 >
   <button role="button"
-          aria-label="delete"
+          aria-label="Delete"
           id="tc-badge-delete-my-id"
           aria-describedby="42"
           type="button"

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/__snapshots__/BadgeDelete.component.test.js.snap
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/__snapshots__/BadgeDelete.component.test.js.snap
@@ -6,7 +6,7 @@ exports[`BadgeDelete should render 1`] = `
 >
   <button role="button"
           aria-label="delete"
-          id="tc-badge-delete-my id"
+          id="tc-badge-delete-my-id"
           aria-describedby="42"
           type="button"
           class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We want to add a label props to allow more precise information on tooltip thant "delete"
**What is the chosen solution to this problem?**
Add the props and fix a typo on the delete default value delete => Delete
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
