### PR TITLE
fix(Notification): set Notification above the other

### DIFF
--- a/packages/components/src/Notification/Notification.scss
+++ b/packages/components/src/Notification/Notification.scss
@@ -28,7 +28,7 @@ $tc-notification-icon-size: $svg-md-size !default;
 		position: absolute;
 		top: 48px;
 		right: $padding-normal;
-		z-index: 120;
+		z-index: $zindex-notification;
 		left: auto;
 
 		.tc-notification[pin='true'] {

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -289,11 +289,12 @@ $dropdown-header-color: $gray-light !default;
 
 $zindex-navbar: 1000 !default;
 $zindex-dropdown: 1000 !default;
-$zindex-popover: 1060 !default;
-$zindex-tooltip: 1070 !default;
 $zindex-navbar-fixed: 1030 !default;
 $zindex-modal-background: 1040 !default;
 $zindex-modal: 1050 !default;
+$zindex-popover: 1060 !default;
+$zindex-tooltip: 1070 !default;
+$zindex-notification: 1080 !default;
 
 //== Media queries breakpoints
 //


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Notification is below the modal, popover

**What is the chosen solution to this problem?**
Set a z-index more hight to set the component Notification above the others

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
