### PR TITLE
fix(Theme): follow guidelines on bold

### DIFF
--- a/packages/theme/src/theme/_breadcrumbs.scss
+++ b/packages/theme/src/theme/_breadcrumbs.scss
@@ -44,7 +44,7 @@
 		}
 
 		&.active span {
-			font-weight: 600;
+			font-weight: $font-weight-semi-bold;
 			color: $breadcrumb-items-active-color;
 		}
 	}

--- a/packages/theme/src/theme/_hyperlinks.scss
+++ b/packages/theme/src/theme/_hyperlinks.scss
@@ -4,7 +4,7 @@
 ////
 
 a {
-	font-weight: 600;
+	font-weight: $font-weight-semi-bold;
 	color: $lochmara;
 
 	&:hover {

--- a/packages/theme/src/theme/_labels.scss
+++ b/packages/theme/src/theme/_labels.scss
@@ -17,7 +17,7 @@
 	height: 1.5rem;
 	padding: 0 $padding-smaller;
 	font-size: 1.2rem;
-	font-weight: 600;
+	font-weight: $font-weight-semi-bold;
 	line-height: 1.2;
 	text-align: center;
 	white-space: nowrap;

--- a/packages/theme/src/theme/_type.scss
+++ b/packages/theme/src/theme/_type.scss
@@ -1,6 +1,6 @@
 h2,
 .h2 {
-	font-weight: 600;
+	font-weight: $font-weight-semi-bold;
 }
 
 h3,
@@ -8,5 +8,5 @@ h3,
 h4,
 .h4 {
 	color: #000;
-	font-weight: 600;
+	font-weight: $font-weight-semi-bold;
 }

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -64,7 +64,9 @@ $font-size-h4: $font-size-small;
 $font-size-h5: $font-size-small;
 $font-size-h6: $font-size-small;
 
-$font-weight-bold: 600;
+$font-weight-bold: 800;
+$font-weight-semi-bold: 600;
+$font-weight-regular: 400;
 
 //** Unit-less `line-height` for use in components like buttons.
 $line-height-base: 1.428571429 !default; // 20/14
@@ -72,7 +74,7 @@ $line-height-base: 1.428571429 !default; // 20/14
 $line-height-computed: floor(($font-size-base * $line-height-base)) !default; // ~20px
 
 $form-label-base-color: #888 !default;
-$form-base-font-weight: 400 !default;
+$form-base-font-weight: $font-weight-regular !default;
 $form-input-font-size: 16px !default;
 
 //** By default, this inherits from the `<body>`.
@@ -168,7 +170,7 @@ $btn-secondary-bg: $brand-secondary !default;
 $btn-secondary-border: darken($btn-secondary-bg, 5%) !default;
 
 $btn-tertiary-line-height: 2.5rem !default;
-$btn-tertiary-font-weight: 600 !default;
+$btn-tertiary-font-weight: $font-weight-semi-bold !default;
 
 $btn-validation-color: #fff !default;
 $btn-validation-bg: $rio-grande !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Guideline only define 3 font sizes
https://company-57688.frontify.com/document/92132#/design-principles/font-styles/weights

**What is the chosen solution to this problem?**
To follow the guideline, update `$font-weight-bold` and create `$font-weight-semi-bold` and `$font-weight-regular`.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
