### PR TITLE
feat(ListComposition): collection selection hook

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
@@ -1,0 +1,42 @@
+import { useState } from 'react';
+
+export default function useCollectionSelection(
+	collection = [],
+	initialSelectedIds = [],
+	idKey = 'id',
+) {
+	const [selectedIds, setSelectedIds] = useState(initialSelectedIds);
+
+	function isSelected(item) {
+		const itemId = item[idKey];
+		return selectedIds.some(itemKey => itemKey === itemId);
+	}
+
+	function onToggleItem(item) {
+		const itemId = item[idKey];
+		const dataIndex = selectedIds.indexOf(itemId);
+		const newSelectedIds = selectedIds.slice(0);
+		if (dataIndex > -1) {
+			newSelectedIds.splice(dataIndex, 1);
+		} else {
+			newSelectedIds.push(itemId);
+		}
+		setSelectedIds(newSelectedIds);
+	}
+
+	function onToggleAll() {
+		if (collection.length === selectedIds.length) {
+			setSelectedIds([]);
+		} else {
+			setSelectedIds(collection.map(item => item[idKey]));
+		}
+	}
+
+	return {
+		isSelected,
+		allIsSelected: selectedIds.length > 0 && selectedIds.length === collection.length,
+		selectedIds,
+		onToggleAll,
+		onToggleItem,
+	};
+}

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.test.js
@@ -1,0 +1,156 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import useCollectionSelection from './useCollectionSelection.hook';
+
+const Div = () => <div />;
+function SelectionComponent({ collection, initialSelectedIds, idKey }) {
+	const hookReturn = useCollectionSelection(collection, initialSelectedIds, idKey);
+	return <Div id="mainChild" {...hookReturn} />;
+}
+SelectionComponent.propTypes = {
+	collection: PropTypes.array,
+	initialSelectedIds: PropTypes.array,
+	idKey: PropTypes.string,
+};
+
+const collection = [
+	{
+		firstName: 'Watkins',
+		lastName: 'Fry',
+		number: 0,
+	},
+	{
+		firstName: 'Fannie',
+		lastName: 'Carver',
+		number: 1,
+	},
+	{
+		firstName: 'Madden',
+		lastName: 'Silva',
+		number: 2,
+	},
+	{
+		firstName: 'Ferrell',
+		lastName: 'Jacobs',
+		number: 3,
+	},
+	{
+		firstName: 'Carly',
+		lastName: 'Dorsey',
+		number: 4,
+	},
+];
+
+describe('useCollectionSelection', () => {
+	it('should set initial selection list', () => {
+		// given
+		const initialSelectedIds = [1, 4];
+
+		// when
+		const wrapper = mount(
+			<SelectionComponent
+				collection={collection}
+				initialSelectedIds={initialSelectedIds}
+				idKey="number"
+			/>,
+		);
+
+		// then
+		const selectedIds = wrapper.find('#mainChild').prop('selectedIds');
+		expect(selectedIds).toEqual([1, 4]);
+	});
+
+	it('should provide a function to check an item selection', () => {
+		// given
+		const initialSelectedIds = [1, 4];
+
+		// when
+		const wrapper = mount(
+			<SelectionComponent
+				collection={collection}
+				initialSelectedIds={initialSelectedIds}
+				idKey="number"
+			/>,
+		);
+
+		// then
+		const isSelected = wrapper.find('#mainChild').prop('isSelected');
+		expect(isSelected(collection[0])).toBe(false);
+		expect(isSelected(collection[1])).toBe(true);
+		expect(isSelected(collection[2])).toBe(false);
+		expect(isSelected(collection[3])).toBe(false);
+		expect(isSelected(collection[4])).toBe(true);
+	});
+
+	it('should set new item selection', () => {
+		// given
+		const wrapper = mount(<SelectionComponent collection={collection} idKey="number" />);
+
+		// when
+		let onToggleItem = wrapper.find('#mainChild').prop('onToggleItem');
+		act(() => onToggleItem(collection[0]));
+		wrapper.update();
+
+		// then
+		let selectedIds = wrapper.find('#mainChild').prop('selectedIds');
+		expect(selectedIds).toEqual([0]);
+
+		// when
+		onToggleItem = wrapper.find('#mainChild').prop('onToggleItem');
+		act(() => onToggleItem(collection[4]));
+		wrapper.update();
+
+		// then
+		selectedIds = wrapper.find('#mainChild').prop('selectedIds');
+		expect(selectedIds).toEqual([0, 4]);
+
+		// when
+		onToggleItem = wrapper.find('#mainChild').prop('onToggleItem');
+		act(() => onToggleItem(collection[0]));
+		wrapper.update();
+
+		// then
+		selectedIds = wrapper.find('#mainChild').prop('selectedIds');
+		expect(selectedIds).toEqual([4]);
+	});
+
+	it('should provide the "select all" status', () => {
+		// when
+		const wrapper = mount(
+			<SelectionComponent
+				collection={collection}
+				initialSelectedIds={[0, 1, 2, 3, 4]}
+				idKey="number"
+			/>,
+		);
+
+		// then
+		let allIsSelected = wrapper.find('#mainChild').prop('allIsSelected');
+		expect(allIsSelected).toBe(true);
+
+		// when
+		const onToggleItem = wrapper.find('#mainChild').prop('onToggleItem');
+		act(() => onToggleItem(collection[0]));
+		wrapper.update();
+
+		// then
+		allIsSelected = wrapper.find('#mainChild').prop('allIsSelected');
+		expect(allIsSelected).toBe(false);
+	});
+
+	it('should toggle all', () => {
+		// given
+		const wrapper = mount(<SelectionComponent collection={collection} idKey="number" />);
+
+		// when
+		const onToggleAll = wrapper.find('#mainChild').prop('onToggleAll');
+		act(() => onToggleAll());
+		wrapper.update();
+
+		// then
+		const allIsSelected = wrapper.find('#mainChild').prop('allIsSelected');
+		expect(allIsSelected).toBe(true);
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
_(This is part of a series of PR to improve api, and help to switch from List legacy component to List Composition)._
To help deal with selection, we had the container before. Let's drop that and externalize the selection management into a hook while composing the list.

**What is the chosen solution to this problem?**
Create a hook to deal with
- selection state
- item toggle management
- select all state
- select all toggle management
- predicate to check the selection status of an item

Those will be helpful to pass to the list parts props.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
