### PR TITLE
feat(ListComposition): hook to insert actions into collection

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -30,9 +30,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
    9:2   warning  Unexpected console statement  no-console
   10:16  error    Unexpected require()          global-require
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/ListManager.component.js
-  1:17  error  'useState' is defined but never used  no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/MultiSelect/ItemOption.component.js
   57:9  error  'index' PropType is defined but prop is never used  react/no-unused-prop-types
 
@@ -51,6 +48,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   41:3  warning  Unexpected console statement  no-console
 
-✖ 25 problems (22 errors, 3 warnings)
+✖ 24 problems (21 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import PropTypes from 'prop-types';
 import { withTranslation } from 'react-i18next';
 import useLocalStorage from 'react-use/lib/useLocalStorage';

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
@@ -1,0 +1,13 @@
+import { useMemo } from 'react';
+
+export default function useCollectionActions(collection, actions = [], persistentActions = []) {
+	return useMemo(
+		() =>
+			collection.map(item => ({
+				...item,
+				actions,
+				persistentActions,
+			})),
+		[collection, actions, persistentActions],
+	);
+}

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
@@ -1,0 +1,89 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { mount } from 'enzyme';
+import useCollectionActions from './useCollectionActions.hook';
+
+const Div = () => <div />;
+function ActionComponent({ collection, actions, persistentActions }) {
+	const hookCollection = useCollectionActions(collection, actions, persistentActions);
+	return <Div id="mainChild" collection={hookCollection} />;
+}
+ActionComponent.propTypes = {
+	collection: PropTypes.array,
+	actions: PropTypes.array,
+	persistentActions: PropTypes.array,
+};
+
+const collection = [
+	{
+		firstName: 'Watkins',
+		lastName: 'Fry',
+		number: 0,
+	},
+	{
+		firstName: 'Fannie',
+		lastName: 'Carver',
+		number: 1,
+	},
+	{
+		firstName: 'Madden',
+		lastName: 'Silva',
+		number: 2,
+	},
+	{
+		firstName: 'Ferrell',
+		lastName: 'Jacobs',
+		number: 3,
+	},
+	{
+		firstName: 'Carly',
+		lastName: 'Dorsey',
+		number: 4,
+	},
+];
+
+export const actions = [
+	{
+		id: 'edit',
+		label: 'Edit',
+		onClick: () => {},
+	},
+	{
+		id: 'delete',
+		label: 'Delete',
+		onClick: () => {},
+	},
+];
+
+export const persistentActions = [
+	{
+		label: 'favorite',
+		icon: 'talend-star',
+		onClick: () => {},
+	},
+	{
+		label: 'certify',
+		icon: 'talend-badge',
+		onClick: () => {},
+	},
+];
+
+describe('useCollectionFilter', () => {
+	it('should insert actions in collection items', () => {
+		// when
+		const wrapper = mount(
+			<ActionComponent
+				collection={collection}
+				actions={actions}
+				persistentActions={persistentActions}
+			/>,
+		);
+
+		// then
+		const hookCollection = wrapper.find('#mainChild').prop('collection');
+		hookCollection.forEach(item => {
+			expect(item.actions).toBe(actions);
+			expect(item.persistentActions).toBe(persistentActions);
+		});
+	});
+});

--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -7,6 +7,7 @@ import TextFilter from './TextFilter';
 import Toolbar from './Toolbar';
 import VList from './VList';
 import useCollectionSort from './Manager/hooks/useCollectionSort.hook';
+import useCollectionActions from './Manager/hooks/useCollectionActions.hook';
 
 export default {
 	DisplayMode,
@@ -20,6 +21,7 @@ export default {
 };
 
 export const hooks = {
+	useCollectionActions,
 	useCollectionSort,
 	useDisplayMode: useLocalStorage,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Collections always comes without actions. The actions are defined afterward, and List container insert them into the each item.
For list composition, let's avoid writing that too.

**What is the chosen solution to this problem?**
Create a hook to insert actions (also called title actions), and persistent actions.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
