### PR TITLE
fix(EditableText): disable submit on error

### DIFF
--- a/packages/components/src/EditableText/EditableText.test.js
+++ b/packages/components/src/EditableText/EditableText.test.js
@@ -226,4 +226,38 @@ describe('InlineForm', () => {
 		const wrapper = shallow(<InlineForm {...props} />);
 		expect(wrapper.find('input').getElement().props.placeholder).toBe(placeholder);
 	});
+	it('should have disabled submit button if required and empty', () => {
+		const props = { ...defaultProps, required: true, text: '' };
+		const wrapper = shallow(<InlineForm {...props} />);
+		expect(
+			wrapper
+				.find('Action')
+				.at(1)
+				.props().disabled,
+		).toBe(true);
+		wrapper.setState({ value: 'Some text' });
+		expect(
+			wrapper
+				.find('Action')
+				.at(1)
+				.props().disabled,
+		).toBe(false);
+	});
+	it('should have disabled submit button if not valid', () => {
+		const props = { ...defaultProps, errorMessage: 'Error here' };
+		const wrapper = shallow(<InlineForm {...props} />);
+		expect(
+			wrapper
+				.find('Action')
+				.at(1)
+				.props().disabled,
+		).toBe(true);
+		wrapper.setState({ errorMessage: '' });
+		expect(
+			wrapper
+				.find('Action')
+				.at(1)
+				.props().disabled,
+		).toBe(false);
+	});
 });

--- a/packages/components/src/EditableText/EditableText.test.js
+++ b/packages/components/src/EditableText/EditableText.test.js
@@ -244,7 +244,7 @@ describe('InlineForm', () => {
 		).toBe(false);
 	});
 	it('should have disabled submit button if not valid', () => {
-		const props = { ...defaultProps, errorMessage: 'Error here' };
+		const props = { ...defaultProps, required: false, errorMessage: 'Error here' };
 		const wrapper = shallow(<InlineForm {...props} />);
 		expect(
 			wrapper
@@ -252,7 +252,7 @@ describe('InlineForm', () => {
 				.at(1)
 				.props().disabled,
 		).toBe(true);
-		wrapper.setState({ errorMessage: '' });
+		wrapper.setProps({ errorMessage: '' });
 		expect(
 			wrapper
 				.find('Action')

--- a/packages/components/src/EditableText/InlineForm.component.js
+++ b/packages/components/src/EditableText/InlineForm.component.js
@@ -121,7 +121,7 @@ class InlineForm extends React.Component {
 							theme['tc-editable-text-form-buttons-submit'],
 							'tc-editable-text-form-buttons-submit',
 						)}
-						disabled={notFilled}
+						disabled={notValid}
 						hideLabel
 						data-feature={feature && `${feature}.submit`}
 					/>

--- a/packages/components/stories/EditableText.js
+++ b/packages/components/stories/EditableText.js
@@ -25,5 +25,11 @@ storiesOf('EditableText', module)
 	.add('in progress', () => <EditableText inProgress {...props} />)
 	.add('edit mode', () => <EditableText editMode {...props} />)
 	.add('not required', () => <EditableText required={false} editMode {...props} />)
-	.add('placeholder', () => <EditableText editMode placeholder="Enter your text here.." {...props} text="" />)
+	.add('required', () =>
+		<React.Fragment>
+			<p>Submit button is disabled as long as the content is empty or invalid.</p>
+			<EditableText placeholder="Content is required" required editMode {...props} text="" />
+		</React.Fragment>
+	)
+	.add('placeholder', () => <EditableText editMode placeholder="Enter your text here..." {...props} text="" />)
 	.add('with error', () => <EditableText editMode {...props} text="" errorMessage="custom error message" />);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, the submit button of the `EditableText` is disabled only if it is not filled.
But it's not disabled if the component is not valid.

**What is the chosen solution to this problem?**
Disable the submit button if `EditableText` is not valid.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
