### PR TITLE
feat(VirtualizedList): title cell accepts functions as column data

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -42,12 +42,16 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
+/home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
+  65:3  warning  Unexpected console statement  no-console
+
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   41:3  warning  Unexpected console statement  no-console
+  69:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 24 problems (21 errors, 3 warnings)
+✖ 26 problems (22 errors, 4 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -42,9 +42,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
-/home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
-  65:3  warning  Unexpected console statement  no-console
-
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
@@ -52,6 +49,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   41:3  warning  Unexpected console statement  no-console
   69:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 26 problems (22 errors, 4 warnings)
+✖ 25 problems (22 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
@@ -32,6 +32,11 @@ class CellTitle extends React.Component {
 	}
 	render() {
 		const { cellData, columnData, getComponent, rowData, rowIndex, type } = this.props;
+
+		let cellColumnData = columnData;
+		if (typeof columnData === 'function') {
+			cellColumnData = columnData(rowData);
+		}
 		const {
 			id,
 			onClick,
@@ -43,7 +48,7 @@ class CellTitle extends React.Component {
 			onEditCancel,
 			onEditSubmit,
 			...columnDataRest
-		} = columnData;
+		} = cellColumnData;
 
 		const displayMode = rowData[displayModeKey] || TITLE_MODE_TEXT;
 		const titleId = id && `${id}-${rowIndex}-title-cell`;

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import CellTitle from './CellTitle.component';
 
@@ -34,6 +34,36 @@ describe('CellTitle', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should use column data as function', () => {
+		// given
+		const columnData = item => ({
+			id: 'my-title',
+			'data-feature': `list.click.${item.id}`,
+			onClick: jest.fn(),
+		});
+		const rowData = {
+			id: 1,
+			displayMode: 'text',
+			icon: 'talend-file-o',
+			title: 'my awesome title',
+		};
+
+		// when
+		const wrapper = mount(
+			<CellTitle
+				cellData={'my awesome title'}
+				columnData={columnData}
+				getComponent={jest.fn()}
+				rowData={rowData}
+				rowIndex={1}
+			/>,
+		);
+
+		// then
+		console.log(wrapper.find('button').debug());
+		expect(wrapper.find('button').prop('data-feature')).toBe('list.click.1');
 	});
 
 	it('should render without active class if no onClick on the title', () => {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.test.js
@@ -62,8 +62,12 @@ describe('CellTitle', () => {
 		);
 
 		// then
-		console.log(wrapper.find('button').debug());
-		expect(wrapper.find('button').prop('data-feature')).toBe('list.click.1');
+		expect(
+			wrapper
+				.find('button')
+				.at(0)
+				.prop('data-feature'),
+		).toBe('list.click.1');
 	});
 
 	it('should render without active class if no onClick on the title', () => {

--- a/packages/components/src/VirtualizedList/utils/tablerow.js
+++ b/packages/components/src/VirtualizedList/utils/tablerow.js
@@ -60,10 +60,13 @@ export function toColumns({ id, theme, children, columnsWidths }) {
 				'tc-header-resizable': columnWidth && columnWidth.resizable,
 			}),
 			className: classNames(field.props.className, theme.cell, colClassName),
-			columnData: {
-				...field.props.columnData,
-				id,
-			},
+			columnData:
+				typeof field.props.columnData === 'function'
+					? rowData => ({ ...field.props.columnData(rowData), id })
+					: {
+							...field.props.columnData,
+							id,
+					  },
 			...createColumnWidthProps(columnWidth),
 		};
 		return <Column key={index} {...colProps} />;

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -6,16 +6,16 @@ import { simpleCollection } from './collection';
 import { IconsProvider } from '../../src/index';
 import List from '../../src/List/ListComposition';
 
-const titleProps = {
+const titleProps = rowData => ({
 	onClick: action('onTitleClick'),
-	'data-feature': 'list.item.title',
+	'data-feature': `list.item.title.${rowData.id}`,
 	actionsKey: 'titleActions',
 	persistentActionsKey: 'persistentActions',
 	displayModeKey: 'display',
 	iconKey: 'icon',
 	onEditCancel: action('cancel-edit'),
 	onEditSubmit: action('submit-edit'),
-};
+});
 
 function CustomList(props) {
 	return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The need: we want to add different attributes on cell title button, depending on the row data.
For example: a `data-feature` with value `folder.open` or `preparation.open` if the item is a folder or a preparation.

**What is the chosen solution to this problem?**
Allow the columnData prop to be a function

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
