### PR TITLE
feat(VirtualizedList): custom actions by item in collection actions hook

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
@@ -5,8 +5,9 @@ export default function useCollectionActions(collection, actions = [], persisten
 		() =>
 			collection.map(item => ({
 				...item,
-				actions,
-				persistentActions,
+				actions: typeof actions === 'function' ? actions(item) : actions,
+				persistentActions:
+					typeof persistentActions === 'function' ? persistentActions(item) : persistentActions,
 			})),
 		[collection, actions, persistentActions],
 	);

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
@@ -86,4 +86,48 @@ describe('useCollectionFilter', () => {
 			expect(item.persistentActions).toBe(persistentActions);
 		});
 	});
+
+	it('should insert item-configured actions', () => {
+		// given
+		const getActions = item => [
+			{
+				id: 'edit',
+				label: `Edit ${item.firstName}`,
+				onClick: () => {},
+			},
+			{
+				id: 'delete',
+				label: `Delete ${item.firstName}`,
+				onClick: () => {},
+			},
+		];
+		const getPersistentActions = item => [
+			{
+				label: `Set ${item.firstName} as favorite`,
+				icon: 'talend-star',
+				onClick: () => {},
+			},
+			{
+				label: `Request ${item.firstName} certification`,
+				icon: 'talend-badge',
+				onClick: () => {},
+			},
+		];
+
+		// when
+		const wrapper = mount(
+			<ActionComponent
+				collection={collection}
+				actions={getActions}
+				persistentActions={getPersistentActions}
+			/>,
+		);
+
+		// then
+		const hookCollection = wrapper.find('#mainChild').prop('collection');
+		expect(hookCollection[0].actions[0].label).toBe('Edit Watkins');
+		expect(hookCollection[0].actions[1].label).toBe('Delete Watkins');
+		expect(hookCollection[0].persistentActions[0].label).toBe('Set Watkins as favorite');
+		expect(hookCollection[0].persistentActions[1].label).toBe('Request Watkins certification');
+	});
 });

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.test.js
@@ -124,10 +124,10 @@ describe('useCollectionFilter', () => {
 		);
 
 		// then
-		const hookCollection = wrapper.find('#mainChild').prop('collection');
-		expect(hookCollection[0].actions[0].label).toBe('Edit Watkins');
-		expect(hookCollection[0].actions[1].label).toBe('Delete Watkins');
-		expect(hookCollection[0].persistentActions[0].label).toBe('Set Watkins as favorite');
-		expect(hookCollection[0].persistentActions[1].label).toBe('Request Watkins certification');
+		const firstItem = wrapper.find('#mainChild').prop('collection')[0];
+		expect(firstItem.actions[0].label).toBe('Edit Watkins');
+		expect(firstItem.actions[1].label).toBe('Delete Watkins');
+		expect(firstItem.persistentActions[0].label).toBe('Set Watkins as favorite');
+		expect(firstItem.persistentActions[1].label).toBe('Request Watkins certification');
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the list, each item can have specificities, and we want to activate/deactivate some item actions depending on the item.
Example: share action in shareable items, and not in other.

**What is the chosen solution to this problem?**
In hook that insert the actions in the items, allow to pass a function

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
