### PR TITLE
fix(VirtualizedList): cell title propTypes

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
@@ -108,26 +108,29 @@ CellTitle.propTypes = {
 	// The cell value : props.rowData[props.dataKey]
 	cellData: PropTypes.string,
 	// The custom props passed to <VirtualizedList.Content columnData={}>.
-	columnData: PropTypes.shape({
-		// The List id. This is used as the title parts ids prefix.
-		id: PropTypes.string,
-		// The onClick callback triggered on title main button click.
-		onClick: PropTypes.func,
-		// The actions property key. Actions = props.rowData[props.actionsKey]
-		actionsKey: PropTypes.string,
-		// The persistent actions property key. Actions = props.rowData[props.persistentActionsKey]
-		persistentActionsKey: PropTypes.string,
-		// The display mode property key. DisplayMode = props.rowData[props.displayModeKey]
-		displayModeKey: PropTypes.string,
-		// The icon property key. Icon = props.rowData[props.iconKey]
-		iconKey: PropTypes.string,
-		// The icon tooltip label key. tooltiplabel = props.rowData[iconLabelKey]
-		iconLabelKey: PropTypes.string,
-		// Input mode : the cancel callback on ESC keydown.
-		onEditCancel: PropTypes.func,
-		// Input mode : the submit callback on ENTER keydown or blur.
-		onEditSubmit: PropTypes.func,
-	}),
+	columnData: PropTypes.oneOfType([
+		PropTypes.func,
+		PropTypes.shape({
+			// The List id. This is used as the title parts ids prefix.
+			id: PropTypes.string,
+			// The onClick callback triggered on title main button click.
+			onClick: PropTypes.func,
+			// The actions property key. Actions = props.rowData[props.actionsKey]
+			actionsKey: PropTypes.string,
+			// The persistent actions property key. Actions = props.rowData[props.persistentActionsKey]
+			persistentActionsKey: PropTypes.string,
+			// The display mode property key. DisplayMode = props.rowData[props.displayModeKey]
+			displayModeKey: PropTypes.string,
+			// The icon property key. Icon = props.rowData[props.iconKey]
+			iconKey: PropTypes.string,
+			// The icon tooltip label key. tooltiplabel = props.rowData[iconLabelKey]
+			iconLabelKey: PropTypes.string,
+			// Input mode : the cancel callback on ESC keydown.
+			onEditCancel: PropTypes.func,
+			// Input mode : the submit callback on ENTER keydown or blur.
+			onEditSubmit: PropTypes.func,
+		}),
+	]),
 	getComponent: PropTypes.func,
 	// The collection item.
 	rowData: PropTypes.object, // eslint-disable-line


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
CellTitle columnData props can now be a function but the proptypes haven't been updated.

**What is the chosen solution to this problem?**
Fix the proptypes

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
