### PR TITLE
chore(version.js): Upgrades only option + downgrades highlights

### DIFF
--- a/versions/version.js
+++ b/versions/version.js
@@ -19,7 +19,6 @@ program
 		'-s, --stack [value]',
 		'[optional] stack version to use, by default the last published one',
 	)
-	.option('-u --upgrade-only')
 	.option('-f, --force');
 
 program.on('--help', () => {
@@ -109,20 +108,20 @@ function check(source, dep, version, category = 'dep') {
 				'WARNING: react and react-dom should always be added as peer dependencies in library',
 			);
 		}
+		if (!program.quiet) {
+			const willDowngrade = semver.gt(source[dep].replace('^', ''), safeVersion.replace('^', ''));
+			const message = `update ${dep}: '${safeVersion}' from ${source[dep]}`;
 
-		const willDowngrade = semver.gt(source[dep].replace('^', ''), safeVersion.replace('^', ''));
-
-		if (!willDowngrade || !program.upgradeOnly) {
-			// eslint-disable-next-line no-param-reassign
-			source[dep] = safeVersion;
-
-			modified = true;
-
-			if (!program.quiet) {
-				const message = `update ${dep}: '${safeVersion}' from ${source[dep]}`;
-				console.log(willDowngrade ? colors.yellow(message) : message);
+			if (willDowngrade) {
+				console.log(colors.yellow(message));
+				console.log(colors.yellow(`Feel free to propose a version upgrade on Talend/UI : ${dep} -> ${source[dep]}`));
+			} else {
+				console.log(message);
 			}
 		}
+		// eslint-disable-next-line no-param-reassign
+		source[dep] = safeVersion;
+		modified = true;
 	}
 	return modified;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When using Talend/UI's `version.js` script to upgrade dependencies, sometimes dependency will downgrade because they have already been upgraded on project's side.

**What is the chosen solution to this problem?**
Highlight downgraded packages and provide a new option (`-u --upgrade-only`) to only perform upgrades.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
