### PR TITLE
fix(TMC-18149) wrong dropdown arrow

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -199,6 +199,9 @@ class ActionDropdown extends React.Component {
 					{label}
 				</span>
 			),
+			<Icon name="talend-caret-down" className={classNames(theme['tc-dropdown-caret'], {
+				[theme['tc-dropdown-caret-open']]: this.state.isOpen,
+			})} />
 		];
 		const style = link ? 'link' : bsStyle;
 
@@ -219,6 +222,7 @@ class ActionDropdown extends React.Component {
 				{...omit(rest, 'tReady')}
 				onToggle={this.onToggle}
 				ref={ref => (this.ref = ref)}
+				noCaret
 			>
 				{!children && !items.length && !items.size && !loading && !components && (
 					<Renderers.MenuItem key="empty" disabled>

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
@@ -9,6 +9,21 @@ $tc-dropdown-loader-padding: $padding-small !default;
 		}
 	}
 
+	&-button {
+		padding-right: 8px;
+
+		.tc-dropdown-caret {
+			width: 0.8rem;
+			height: 0.8rem;
+			transition: transform .1s ease-in;
+			will-change: transform;
+
+			&.tc-dropdown-caret-open {
+				transform: rotate(-180deg);
+			}
+		}
+	}
+
 	&-item {
 		a svg {
 			margin: 0 $padding-smaller;

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -86,6 +86,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
     className="theme-tc-dropdown-button tc-dropdown-button"
     i18n={Object {}}
     id="dropdown-id"
+    noCaret={true}
     onSelect={[Function]}
     onToggle={[Function]}
     role="button"
@@ -97,6 +98,10 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
         >
           related items
         </span>,
+        <Icon
+          className="theme-tc-dropdown-caret"
+          name="talend-caret-down"
+        />,
       ]
     }
   >
@@ -136,6 +141,7 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
               i18n={Object {}}
               id="dropdown-id"
               key=".0"
+              noCaret={true}
               onClick={[Function]}
               onKeyDown={[Function]}
               open={false}
@@ -177,10 +183,22 @@ exports[`ActionDropdown should render a button dropdown with its menu 1`] = `
                   >
                     related items
                   </span>
-                   
-                  <span
-                    className="caret"
-                  />
+                  <Icon
+                    className="theme-tc-dropdown-caret"
+                    name="talend-caret-down"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+                      focusable="false"
+                      name="talend-caret-down"
+                      title={null}
+                    >
+                      <use
+                        xlinkHref="#talend-caret-down"
+                      />
+                    </svg>
+                  </Icon>
                 </button>
               </Button>
             </DropdownToggle>
@@ -332,6 +350,7 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
   className="theme-tc-dropdown-button tc-dropdown-button"
   i18n={Object {}}
   id="dropdown-id"
+  noCaret={true}
   onSelect={[Function]}
   onToggle={[Function]}
   role="button"
@@ -343,6 +362,10 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
       >
         related items
       </span>,
+      <Icon
+        className="theme-tc-dropdown-caret"
+        name="talend-caret-down"
+      />,
     ]
   }
 >
@@ -382,6 +405,7 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
             i18n={Object {}}
             id="dropdown-id"
             key=".0"
+            noCaret={true}
             onClick={[Function]}
             onKeyDown={[Function]}
             open={false}
@@ -423,10 +447,22 @@ exports[`ActionDropdown should render a button with "link" theme 1`] = `
                 >
                   related items
                 </span>
-                 
-                <span
-                  className="caret"
-                />
+                <Icon
+                  className="theme-tc-dropdown-caret"
+                  name="talend-caret-down"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+                    focusable="false"
+                    name="talend-caret-down"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-caret-down"
+                    />
+                  </svg>
+                </Icon>
               </button>
             </Button>
           </DropdownToggle>
@@ -577,6 +613,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
   className="theme-tc-dropdown-button tc-dropdown-button"
   i18n={Object {}}
   id="dropdown-id"
+  noCaret={true}
   onSelect={[Function]}
   onToggle={[Function]}
   role="button"
@@ -590,6 +627,10 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
       >
         related items
       </span>,
+      <Icon
+        className="theme-tc-dropdown-caret"
+        name="talend-caret-down"
+      />,
     ]
   }
 >
@@ -629,6 +670,7 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
             i18n={Object {}}
             id="dropdown-id"
             key=".0"
+            noCaret={true}
             onClick={[Function]}
             onKeyDown={[Function]}
             open={false}
@@ -681,10 +723,22 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
                 >
                   related items
                 </span>
-                 
-                <span
-                  className="caret"
-                />
+                <Icon
+                  className="theme-tc-dropdown-caret"
+                  name="talend-caret-down"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+                    focusable="false"
+                    name="talend-caret-down"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-caret-down"
+                    />
+                  </svg>
+                </Icon>
               </button>
             </Button>
           </DropdownToggle>
@@ -837,6 +891,7 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
   i18n={Object {}}
   id="dropdown-id"
   key=".0"
+  noCaret={true}
   onSelect={[Function]}
   onToggle={[Function]}
   role="button"
@@ -846,6 +901,10 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
         name="fa fa-file-excel-o"
       />,
       null,
+      <Icon
+        className="theme-tc-dropdown-caret"
+        name="talend-caret-down"
+      />,
     ]
   }
 >
@@ -886,6 +945,7 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
             i18n={Object {}}
             id="dropdown-id"
             key=".0"
+            noCaret={true}
             onClick={[Function]}
             onKeyDown={[Function]}
             open={false}
@@ -934,10 +994,22 @@ exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
                     title={null}
                   />
                 </Icon>
-                 
-                <span
-                  className="caret"
-                />
+                <Icon
+                  className="theme-tc-dropdown-caret"
+                  name="talend-caret-down"
+                >
+                  <svg
+                    aria-hidden="true"
+                    className="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+                    focusable="false"
+                    name="talend-caret-down"
+                    title={null}
+                  >
+                    <use
+                      xlinkHref="#talend-caret-down"
+                    />
+                  </svg>
+                </Icon>
               </button>
             </Button>
           </DropdownToggle>
@@ -1251,6 +1323,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
     className="theme-tc-dropdown-button tc-dropdown-button"
     i18n={Object {}}
     id="dropdown-id"
+    noCaret={true}
     onSelect={[Function]}
     onToggle={[Function]}
     role="button"
@@ -1262,6 +1335,10 @@ exports[`ActionDropdown should render immutable items 1`] = `
         >
           related items
         </span>,
+        <Icon
+          className="theme-tc-dropdown-caret"
+          name="talend-caret-down"
+        />,
       ]
     }
   >
@@ -1301,6 +1378,7 @@ exports[`ActionDropdown should render immutable items 1`] = `
               i18n={Object {}}
               id="dropdown-id"
               key=".0"
+              noCaret={true}
               onClick={[Function]}
               onKeyDown={[Function]}
               open={false}
@@ -1342,10 +1420,22 @@ exports[`ActionDropdown should render immutable items 1`] = `
                   >
                     related items
                   </span>
-                   
-                  <span
-                    className="caret"
-                  />
+                  <Icon
+                    className="theme-tc-dropdown-caret"
+                    name="talend-caret-down"
+                  >
+                    <svg
+                      aria-hidden="true"
+                      className="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+                      focusable="false"
+                      name="talend-caret-down"
+                      title={null}
+                    >
+                      <use
+                        xlinkHref="#talend-caret-down"
+                      />
+                    </svg>
+                  </Icon>
                 </button>
               </Button>
             </DropdownToggle>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-18149

Split dropdown action is not possible to change now (without modifying react-bootstrap ), as there is no such possibility to pass custom icon renderer

As discussed in Jira comments, it's ok to change only dropdown action, since we don't plan to use Split dropdown a lot 

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
