### PR TITLE
fix(Dropdown): down to up is disabled when there is not enough space

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -153,7 +153,11 @@ class ActionDropdown extends React.Component {
 			if (dropdownContainer) {
 				const dropdownRect = dropdownMenu.getBoundingClientRect();
 				const containerRect = dropdownContainer.getBoundingClientRect();
-				if (!dropdown.classList.contains('dropup') && dropdownRect.bottom > containerRect.bottom) {
+				if (
+					!dropdown.classList.contains('dropup') &&
+					dropdownRect.bottom > containerRect.bottom &&
+					dropdownRect.height < containerRect.top
+				) {
 					dropdown.classList.add('dropup');
 				} else if (dropdown.classList.contains('dropup') && dropdownRect.top < containerRect.top) {
 					dropdown.classList.remove('dropup');

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -25,24 +25,23 @@ function InjectDropdownMenuItem({
 	withMenuItem,
 	liProps,
 	menuItemProps,
-	key,
 	onSelect,
 	onKeyDown,
 	...rest
 }) {
 	const Renderers = Inject.getAll(getComponent, { MenuItem });
 	if (divider) {
-		return <Renderers.MenuItem key={key} {...menuItemProps} divider />;
+		return <Renderers.MenuItem {...menuItemProps} divider />;
 	}
 	if (withMenuItem) {
 		return (
-			<Renderers.MenuItem key={key} {...menuItemProps} onSelect={onSelect} onKeyDown={onKeyDown}>
+			<Renderers.MenuItem {...menuItemProps} onSelect={onSelect} onKeyDown={onKeyDown}>
 				<Inject component={component} getComponent={getComponent} {...rest} />
 			</Renderers.MenuItem>
 		);
 	}
 	return (
-		<li role="presentation" key={key} {...liProps}>
+		<li role="presentation" {...liProps}>
 			<Inject component={component} getComponent={getComponent} onSelect={onSelect} {...rest} />
 		</li>
 	);
@@ -55,7 +54,6 @@ InjectDropdownMenuItem.propTypes = {
 	withMenuItem: PropTypes.bool,
 	liProps: PropTypes.object,
 	menuItemProps: PropTypes.object,
-	key: PropTypes.number,
 	onSelect: PropTypes.func,
 	onKeyDown: PropTypes.func,
 };

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.test.js
@@ -169,8 +169,8 @@ describe('Dropup', () => {
 	cases('dropdown/dropup switch', testSwitch, [
 		{
 			name: 'should dropup on dropdown bottom overflow',
-			containerPosition: { top: 0, bottom: 35 },
-			menuPosition: { top: 20, bottom: 40 },
+			containerPosition: { top: 60, bottom: 95 },
+			menuPosition: { top: 80, bottom: 100, height: 20 },
 			isInitialDropup: false,
 			isDropupExpected: true,
 		},
@@ -183,17 +183,24 @@ describe('Dropup', () => {
 		},
 		{
 			name: 'should do nothing on dropdown without overflow',
-			containerPosition: { top: 0, bottom: 35 },
-			menuPosition: { top: 20, bottom: 30 },
+			containerPosition: { top: 60, bottom: 95 },
+			menuPosition: { top: 80, bottom: 90, height: 10 },
 			isInitialDropup: false,
 			isDropupExpected: false,
 		},
 		{
 			name: 'should do nothing on dropup without overflow',
-			containerPosition: { top: 0, bottom: 35 },
+			containerPosition: { top: 0, bottom: 60 },
 			menuPosition: { top: 20, bottom: 30 },
 			isInitialDropup: true,
 			isDropupExpected: true,
+		},
+		{
+			name: 'should do nothing on dropdown without enough space (top and bottom)',
+			containerPosition: { top: 10, bottom: 30 },
+			menuPosition: { top: 20, bottom: 90, height: 60 },
+			isInitialDropup: false,
+			isDropupExpected: false,
 		},
 	]);
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a dropdown has not enough place on the bottom, it switches automatically to dropup.
But when there is no space on top, the menu is just not displayed

![dropdown](https://user-images.githubusercontent.com/10761073/64328987-bea1d400-cfce-11e9-9c12-0f9f5c1cdc1b.gif)


**What is the chosen solution to this problem?**
Do not switch to dropup when there is not enough space

Bonus: as I go through the file, I removed an access to key props that is not a prop, but an internal react prop. It is always undefined when we try to access to it.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
