### PR TITLE
chore(forms/ResourcePicker): updating the way selection works and sel…

### DIFF
--- a/packages/components/src/ResourcePicker/Resource/Resource.scss
+++ b/packages/components/src/ResourcePicker/Resource/Resource.scss
@@ -57,8 +57,7 @@
 		}
 	}
 
-	&:hover,
-	&:focus {
+	&:hover {
 		background-color: $wild-sand;
 
 		.data-container {
@@ -69,8 +68,7 @@
 		}
 	}
 
-	&:global(.selected),
-	&:active {
+	&:global(.selected) {
 		background: tint($scooter, 90);
 
 		.data-container {

--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
@@ -74,7 +74,7 @@ class ResourcePicker extends Component {
 		}
 
 		if (index > -1) {
-			if (multi) {
+			if (multi || !this.props.schema.required) {
 				selected.splice(index, 1);
 			} else {
 				// in single selection if the resource is already selected do nothing

--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.js
@@ -74,7 +74,12 @@ class ResourcePicker extends Component {
 		}
 
 		if (index > -1) {
-			selected.splice(index, 1);
+			if (multi) {
+				selected.splice(index, 1);
+			} else {
+				// in single selection if the resource is already selected do nothing
+				return;
+			}
 		} else {
 			selected.push(id);
 		}

--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
@@ -227,8 +227,17 @@ describe('ResourcePicker field', () => {
 		});
 	});
 
-	it('should unselect', async () => {
-		const wrapper = await mount(<ResourcePicker {...props} />);
+	it('should unselect in multi case', async () => {
+		const onChangeUnselect = jest.fn();
+		const multi = {
+			...props,
+			onChange: onChangeUnselect,
+			schema: {
+				...props.schema,
+				multi: true,
+			},
+		};
+		const wrapper = await mount(<ResourcePicker {...multi} />);
 		await wrapper.instance().busy;
 		wrapper.update();
 
@@ -240,10 +249,28 @@ describe('ResourcePicker field', () => {
 			.find(ResourceComponent)
 			.at(0)
 			.simulate('click');
-		expect(props.onChange).toBeCalledWith(expect.anything(), {
-			schema: expect.anything(),
-			value: undefined,
-		});
+		expect(onChangeUnselect.mock.calls.length).toBe(2);
+	});
+
+	it('should not unselect single selection', async () => {
+		const onChangeUnselect = jest.fn();
+		const unselectProps = {
+			...props,
+			onChange: onChangeUnselect,
+		};
+		const wrapper = await mount(<ResourcePicker {...unselectProps} />);
+		await wrapper.instance().busy;
+		wrapper.update();
+
+		wrapper
+			.find(ResourceComponent)
+			.at(0)
+			.simulate('click');
+		wrapper
+			.find(ResourceComponent)
+			.at(0)
+			.simulate('click');
+		expect(onChangeUnselect.mock.calls.length).toBe(1);
 	});
 
 	it('should not allow multi selection', async () => {

--- a/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
+++ b/packages/forms/src/UIForm/fields/ResourcePicker/ResourcePicker.component.test.js
@@ -252,11 +252,15 @@ describe('ResourcePicker field', () => {
 		expect(onChangeUnselect.mock.calls.length).toBe(2);
 	});
 
-	it('should not unselect single selection', async () => {
+	it('should not unselect single selection when value is required', async () => {
 		const onChangeUnselect = jest.fn();
 		const unselectProps = {
 			...props,
 			onChange: onChangeUnselect,
+			schema: {
+				...props.schema,
+				required: true,
+			},
 		};
 		const wrapper = await mount(<ResourcePicker {...unselectProps} />);
 		await wrapper.instance().busy;
@@ -271,6 +275,31 @@ describe('ResourcePicker field', () => {
 			.at(0)
 			.simulate('click');
 		expect(onChangeUnselect.mock.calls.length).toBe(1);
+	});
+
+	it('should unselect single selection when value is not required', async () => {
+		const onChangeUnselect = jest.fn();
+		const unselectProps = {
+			...props,
+			onChange: onChangeUnselect,
+			schema: {
+				...props.schema,
+				required: false,
+			},
+		};
+		const wrapper = await mount(<ResourcePicker {...unselectProps} />);
+		await wrapper.instance().busy;
+		wrapper.update();
+
+		wrapper
+			.find(ResourceComponent)
+			.at(0)
+			.simulate('click');
+		wrapper
+			.find(ResourceComponent)
+			.at(0)
+			.simulate('click');
+		expect(onChangeUnselect.mock.calls.length).toBe(2);
 	});
 
 	it('should not allow multi selection', async () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- removing the unselect when single selecting and value is required in the resourcepicker
- style issue when focusing, we could think that the resource was selected : 
![image](https://user-images.githubusercontent.com/14272767/64333926-d9c51180-cfd7-11e9-9879-e18840ecf86b.png)
same thing goes for active

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
