### PR TITLE
fix(TMC-18455): data list positioning

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -24,7 +24,7 @@ src/List/Toolbar/Toolbar.scss
   93:12  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
 
 src/Typeahead/Typeahead.scss
-  31:5  error  Mixins should come before declarations  mixins-before-declarations
+  32:5  error  Mixins should come before declarations  mixins-before-declarations
 
 ✖ 11 problems (9 errors, 2 warnings)
 

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -145,16 +145,17 @@ export function renderItemsContainerFactory(
 					computePosition: {
 						enabled: true,
 						fn: data => {
-							const OFFSET_FROM_SCREEN_BOUNDARIES = 15;
+							const GAP = 15; // the offset between the end of items container and screen boundaries
 							const inputDimensions = data.offsets.reference;
-							const offsetFromTop = inputDimensions.top - OFFSET_FROM_SCREEN_BOUNDARIES;
-							const offsetFromBottom = window.innerHeight - inputDimensions.top - inputDimensions.height - OFFSET_FROM_SCREEN_BOUNDARIES;
+							const { top, height } = inputDimensions;
+							const offsetTop = top - GAP;
+							const offsetBottom = window.innerHeight - top - height - GAP;
 							const placements = data.placement.split('-');
 							let newPlacement = data.placement;
-							if (placements[0] === 'top' && offsetFromBottom > offsetFromTop) {
+							if (placements[0] === 'top' && offsetBottom > offsetTop) {
 								newPlacement = `bottom-${placements[1]}`;
 							}
-							const maxHeight = newPlacement.includes('top') ? offsetFromTop : offsetFromBottom;
+							const maxHeight = newPlacement.includes('top') ? offsetTop : offsetBottom;
 
 							return {
 								...data,
@@ -166,7 +167,7 @@ export function renderItemsContainerFactory(
 								},
 							};
 						},
-					}
+					},
 				}}
 				positionFixed
 				boundariesElement="viewport"

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -130,6 +130,30 @@ export function renderItemsContainerFactory(
 			content = children;
 		}
 
+		const computePopperPosition = data => {
+			const GAP = 15; // the offset between the end of items container and screen boundaries
+			const inputDimensions = data.offsets.reference;
+			const { top, height } = inputDimensions;
+			const offsetTop = top - GAP;
+			const offsetBottom = window.innerHeight - top - height - GAP;
+			const placements = data.placement.split('-');
+			let newPlacement = data.placement;
+			if (placements[0] === 'top' && offsetBottom > offsetTop) {
+				newPlacement = `bottom-${placements[1]}`;
+			}
+			const maxHeight = newPlacement.includes('top') ? offsetTop : offsetBottom;
+
+			return {
+				...data,
+				placement: newPlacement,
+				styles: {
+					...data.styles,
+					width: inputDimensions.width,
+					maxHeight,
+				},
+			};
+		};
+
 		return (
 			<Popper
 				modifiers={{
@@ -144,29 +168,7 @@ export function renderItemsContainerFactory(
 					},
 					computePosition: {
 						enabled: true,
-						fn: data => {
-							const GAP = 15; // the offset between the end of items container and screen boundaries
-							const inputDimensions = data.offsets.reference;
-							const { top, height } = inputDimensions;
-							const offsetTop = top - GAP;
-							const offsetBottom = window.innerHeight - top - height - GAP;
-							const placements = data.placement.split('-');
-							let newPlacement = data.placement;
-							if (placements[0] === 'top' && offsetBottom > offsetTop) {
-								newPlacement = `bottom-${placements[1]}`;
-							}
-							const maxHeight = newPlacement.includes('top') ? offsetTop : offsetBottom;
-
-							return {
-								...data,
-								placement: newPlacement,
-								styles: {
-									...data.styles,
-									width: inputDimensions.width,
-									maxHeight,
-								},
-							};
-						},
+						fn: data => computePopperPosition(data),
 					},
 				}}
 				positionFixed

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -84,6 +84,30 @@ renderInputComponent.propTypes = {
 	readOnly: PropTypes.bool,
 };
 
+function computePopperPosition(data) {
+	const GAP = 15; // the offset between the end of items container and screen boundaries
+	const inputDimensions = data.offsets.reference;
+	const { top, height } = inputDimensions;
+	const offsetTop = top - GAP;
+	const offsetBottom = window.innerHeight - top - height - GAP;
+	const placements = data.placement.split('-');
+	let newPlacement = data.placement;
+	if (placements[0] === 'top' && offsetBottom > offsetTop) {
+		newPlacement = `bottom-${placements[1]}`;
+	}
+	const maxHeight = newPlacement.includes('top') ? offsetTop : offsetBottom;
+
+	return {
+		...data,
+		placement: newPlacement,
+		styles: {
+			...data.styles,
+			width: inputDimensions.width,
+			maxHeight,
+		},
+	};
+}
+
 export function renderItemsContainerFactory(
 	items,
 	noResultText,
@@ -130,30 +154,6 @@ export function renderItemsContainerFactory(
 			content = children;
 		}
 
-		const computePopperPosition = data => {
-			const GAP = 15; // the offset between the end of items container and screen boundaries
-			const inputDimensions = data.offsets.reference;
-			const { top, height } = inputDimensions;
-			const offsetTop = top - GAP;
-			const offsetBottom = window.innerHeight - top - height - GAP;
-			const placements = data.placement.split('-');
-			let newPlacement = data.placement;
-			if (placements[0] === 'top' && offsetBottom > offsetTop) {
-				newPlacement = `bottom-${placements[1]}`;
-			}
-			const maxHeight = newPlacement.includes('top') ? offsetTop : offsetBottom;
-
-			return {
-				...data,
-				placement: newPlacement,
-				styles: {
-					...data.styles,
-					width: inputDimensions.width,
-					maxHeight,
-				},
-			};
-		};
-
 		return (
 			<Popper
 				modifiers={{
@@ -168,7 +168,7 @@ export function renderItemsContainerFactory(
 					},
 					computePosition: {
 						enabled: true,
-						fn: data => computePopperPosition(data),
+						fn: computePopperPosition,
 					},
 				}}
 				positionFixed

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -17,7 +17,7 @@ $tc-typeahead-section-header-color: #63aebd !default;
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
-$tc-typeahead-items-zindex: $zindex-typeahead;
+$tc-typeahead-items-zindex: $zindex-typeahead-items;
 
 .tc-typeahead-container {
 	position: relative;

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -17,6 +17,7 @@ $tc-typeahead-section-header-color: #63aebd !default;
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
+$tc-typeahead-items-zindex: 1035 !default;
 
 .tc-typeahead-container {
 	position: relative;
@@ -46,7 +47,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 		background-color: $tc-typeahead-opened-items-container-background-color;
 		border-radius: $tc-typeahead-items-border-radius;
 		box-shadow: $tc-typeahead-items-box-shadow;
-		z-index: $zindex-typeahead-items;
+		z-index: $tc-typeahead-items-zindex;
 	}
 
 	.items-body {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -17,6 +17,7 @@ $tc-typeahead-section-header-color: #63aebd !default;
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
+$tc-typeahead-items-zindex: $zindex-typeahead;
 
 .tc-typeahead-container {
 	position: relative;
@@ -36,6 +37,7 @@ $tc-typeahead-items-font-size: 1.5rem !default;
 	.items-container,
 	.items-body {
 		max-height: 70vh;
+		z-index: $tc-typeahead-items-zindex;
 	}
 
 	.items-container {

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -17,7 +17,6 @@ $tc-typeahead-section-header-color: #63aebd !default;
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
-$tc-typeahead-items-zindex: $zindex-typeahead-items;
 
 .tc-typeahead-container {
 	position: relative;
@@ -37,7 +36,6 @@ $tc-typeahead-items-zindex: $zindex-typeahead-items;
 	.items-container,
 	.items-body {
 		max-height: 70vh;
-		z-index: $tc-typeahead-items-zindex;
 	}
 
 	.items-container {
@@ -48,7 +46,7 @@ $tc-typeahead-items-zindex: $zindex-typeahead-items;
 		background-color: $tc-typeahead-opened-items-container-background-color;
 		border-radius: $tc-typeahead-items-border-radius;
 		box-shadow: $tc-typeahead-items-box-shadow;
-		z-index: $zindex-dropdown;
+		z-index: $zindex-typeahead-items;
 	}
 
 	.items-body {

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -43,12 +43,16 @@ exports[`Typeahead injection should use render props to inject extra components 
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <div>
         <div>
@@ -169,12 +173,16 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <div
         className="theme-section-container tc-typeahead-section-container"
@@ -428,12 +436,16 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <div
         className="theme-is-loading is-loading"
@@ -488,12 +500,16 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <div
         className="theme-section-container tc-typeahead-section-container"
@@ -689,12 +705,16 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <ul
         className="theme-items"
@@ -797,12 +817,16 @@ exports[`Typeahead items should render typeahead without items 1`] = `
         "pointerEvents": "none",
         "position": "absolute",
         "top": 0,
-        "width": 0,
       }
     }
   >
     <div
       className="theme-items-body"
+      style={
+        Object {
+          "maxHeight": undefined,
+        }
+      }
     >
       <div
         className="theme-no-result no-result"

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -53,7 +53,6 @@ $tc-badge-margin: $padding-smaller !default;
 			background-color: $tf-datalist-items-background-color;
 			border-radius: $border-radius-base;
 			box-shadow: 0 1px 3px 0 $tf-datalist-items-shadow-color;
-			z-index: 1035;
 		}
 
 		.items {

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.scss
@@ -53,7 +53,7 @@ $tc-badge-margin: $padding-smaller !default;
 			background-color: $tf-datalist-items-background-color;
 			border-radius: $border-radius-base;
 			box-shadow: 0 1px 3px 0 $tf-datalist-items-shadow-color;
-			z-index: 999;
+			z-index: 1035;
 		}
 
 		.items {

--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -62,12 +62,16 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
       "pointerEvents": "none",
       "position": "absolute",
       "top": 0,
-      "width": 0,
     }
   }
 >
   <div
     className="theme-items-body"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
   >
     <ul
       className="theme-items"
@@ -116,12 +120,16 @@ exports[`MultiSelectTagWidget should render section title when items has categor
       "pointerEvents": "none",
       "position": "absolute",
       "top": 0,
-      "width": 0,
     }
   }
 >
   <div
     className="theme-items-body"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
   >
     <div
       className="theme-section-container tc-typeahead-section-container"
@@ -189,12 +197,16 @@ exports[`MultiSelectTagWidget should take default message when there isnt items 
       "pointerEvents": "none",
       "position": "absolute",
       "top": 0,
-      "width": 0,
     }
   }
 >
   <div
     className="theme-items-body"
+    style={
+      Object {
+        "maxHeight": undefined,
+      }
+    }
   >
     <div
       className="theme-no-result no-result"

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -292,7 +292,6 @@ $dropdown-header-color: $gray-light !default;
 $zindex-navbar: 1000 !default;
 $zindex-dropdown: 1000 !default;
 $zindex-navbar-fixed: 1030 !default;
-$zindex-typeahead-items: 1035 !default;
 $zindex-modal-background: 1040 !default;
 $zindex-modal: 1050 !default;
 $zindex-popover: 1060 !default;

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -292,7 +292,7 @@ $dropdown-header-color: $gray-light !default;
 $zindex-navbar: 1000 !default;
 $zindex-dropdown: 1000 !default;
 $zindex-navbar-fixed: 1030 !default;
-$zindex-typeahead: 1035 !default;
+$zindex-typeahead-items: 1035 !default;
 $zindex-modal-background: 1040 !default;
 $zindex-modal: 1050 !default;
 $zindex-popover: 1060 !default;

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -292,6 +292,7 @@ $dropdown-header-color: $gray-light !default;
 $zindex-navbar: 1000 !default;
 $zindex-dropdown: 1000 !default;
 $zindex-navbar-fixed: 1030 !default;
+$zindex-typeahead: 1035 !default;
 $zindex-modal-background: 1040 !default;
 $zindex-modal: 1050 !default;
 $zindex-popover: 1060 !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-18455

After using popper, we have an issue with datalist positioning, if there are too many items that do not fit to screen, popper sets top position, although there are much more available space at the bottom (see on video attached to the jira)

The idea is to compute where is more available space and position items container accordingly, setting also max height so it won't go out from screen boundaries

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
