### PR TITLE
fix(form): select placeholder

### DIFF
--- a/packages/forms/src/UIForm/fields/Select/Select.component.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.js
@@ -59,7 +59,7 @@ export default function Select({
 				aria-required={schema.required}
 				aria-describedby={`${descriptionId} ${errorId}`}
 			>
-				<option disabled>{placeholder}</option>
+				<option disabled value={placeholder ? '' : undefined}>{placeholder}</option>
 				{schema.titleMap &&
 					schema.titleMap.map((option, index) => {
 						const optionProps = {

--- a/packages/forms/src/UIForm/fields/Select/Select.component.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.js
@@ -59,7 +59,9 @@ export default function Select({
 				aria-required={schema.required}
 				aria-describedby={`${descriptionId} ${errorId}`}
 			>
-				<option disabled value={placeholder ? '' : undefined}>{placeholder}</option>
+				<option disabled value={placeholder ? '' : undefined}>
+					{placeholder}
+				</option>
 				{schema.titleMap &&
 					schema.titleMap.map((option, index) => {
 						const optionProps = {

--- a/packages/forms/src/UIForm/fields/Select/Select.component.test.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
+import omit from 'lodash/omit';
 
 import Select from './Select.component';
 
@@ -32,6 +33,27 @@ describe('Select field', () => {
 				onChange={jest.fn()}
 				onFinish={jest.fn()}
 				schema={schema}
+				value={'lol'}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render simple select without placeholder', () => {
+		// given
+		const localSchema = omit(schema, 'placeholder');
+
+		// when
+		const wrapper = shallow(
+			<Select
+				id={'mySelect'}
+				isValid
+				errorMessage={'My Error Message'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={localSchema}
 				value={'lol'}
 			/>,
 		);

--- a/packages/forms/src/UIForm/fields/Select/__snapshots__/Select.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Select/__snapshots__/Select.component.test.js.snap
@@ -25,6 +25,7 @@ exports[`Select field should render disabled input 1`] = `
   >
     <option
       disabled={true}
+      value=""
     >
       Please select a value
     </option>
@@ -71,6 +72,7 @@ exports[`Select field should render readOnly input 1`] = `
   >
     <option
       disabled={true}
+      value=""
     >
       Please select a value
     </option>
@@ -122,6 +124,7 @@ exports[`Select field should render select multiple 1`] = `
   >
     <option
       disabled={true}
+      value=""
     >
       Please select a value
     </option>
@@ -168,9 +171,54 @@ exports[`Select field should render simple select 1`] = `
   >
     <option
       disabled={true}
+      value=""
     >
       Please select a value
     </option>
+    <option
+      value="foo"
+    >
+      My foo title
+    </option>
+    <option
+      value="bar"
+    >
+      My bar title
+    </option>
+    <option
+      value="lol"
+    >
+      My lol title
+    </option>
+  </select>
+</FieldTemplate>
+`;
+
+exports[`Select field should render simple select without placeholder 1`] = `
+<FieldTemplate
+  description="Select me"
+  errorMessage="My Error Message"
+  id="mySelect"
+  isValid={true}
+  label="My Select title"
+  labelAfter={true}
+  required={true}
+>
+  <select
+    aria-describedby="mySelect-description mySelect-error"
+    aria-invalid={false}
+    aria-required={true}
+    autoFocus={true}
+    className="form-control"
+    id="mySelect"
+    multiple={false}
+    onChange={[Function]}
+    readOnly={false}
+    value="lol"
+  >
+    <option
+      disabled={true}
+    />
     <option
       value="foo"
     >

--- a/packages/forms/stories-core/json/fields/core-select.json
+++ b/packages/forms/stories-core/json/fields/core-select.json
@@ -22,6 +22,15 @@
           "qux"
         ]
       },
+      "choiceListWithPlaceholder": {
+        "type": "string",
+        "enum": [
+          "foo",
+          "bar",
+          "fuzz",
+          "qux"
+        ]
+      },
       "multipleChoicesList": {
         "type": "array",
         "items": {
@@ -55,6 +64,11 @@
         "fuzz": "My custom fuzz title",
         "qux": "my custom qux title"
       }
+    },
+    {
+      "key": "choiceListWithPlaceholder",
+      "title": "Choice list with placeholder",
+      "placeholder": "Please select..."
     },
     {
       "key": "multipleChoicesList",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In an empty form, the placeholder of the select is not selected, nor visible, but the first element of the list is selected.

**What is the chosen solution to this problem?**
Add an empty value to the option with the placeholder in order to have this one selected.
Storybook example : http://2385.talend.surge.sh/forms/?path=/story/core-fields--core-select

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
