### PR TITLE
Revert(components): ListComposition SortBy render condition

### DIFF
--- a/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
@@ -3,12 +3,11 @@ import PropTypes from 'prop-types';
 import { Navbar, NavDropdown, Nav, NavItem, MenuItem } from 'react-bootstrap';
 import uuid from 'uuid';
 
-import { DISPLAY_MODE } from '../constants';
 import { useListContext } from '../context';
 
 function SortBy(props) {
 	const { id, initialValue, options, onChange, value } = props;
-	const { displayMode, sortParams, setSortParams, t } = useListContext();
+	const { sortParams, setSortParams, t } = useListContext();
 	const isControlled = onChange;
 
 	useEffect(() => {
@@ -16,10 +15,6 @@ function SortBy(props) {
 			setSortParams(initialValue);
 		}
 	}, []);
-
-	if (displayMode === DISPLAY_MODE.TABLE) {
-		return null;
-	}
 
 	const currentValue = isControlled ? value : sortParams;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
After discussion with @nicomaligne and @jsomsanith-tlnd, the display of the condition to display the sortBy component need to be managed by the app and not by the component himself
**What is the chosen solution to this problem?**
Revert the change made in https://github.com/Talend/ui/pull/2365 for the sortby component
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
