### PR TITLE
fix(components): the list doesn't take the all available height 

### DIFF
--- a/packages/components/src/List/ListComposition/List.scss
+++ b/packages/components/src/List/ListComposition/List.scss
@@ -10,6 +10,7 @@
 }
 
 .vlist {
+	height: 100%;
 	flex-grow: 1;
 	flex-shrink: 1;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The old list take the all available height , not the composition list

**What is the chosen solution to this problem?**
fix that
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
