### PR TITLE
fix(About): year in copyright

### DIFF
--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -100,7 +100,10 @@ function AboutDialog({
 					<Text
 						text={
 							copyrights ||
-							t('ABOUT_COPYRIGHTS', { defaultValue: '© 2018 Talend. All Rights Reserved' })
+							t('ABOUT_COPYRIGHTS', {
+								defaultValue: '© {{year}} Talend. All Rights Reserved',
+								year: new Date().getFullYear(),
+							})
 						}
 						size={Skeleton.SIZES.large}
 						loading={loading}

--- a/packages/components/src/AboutDialog/AboutDialog.snapshot.test.js
+++ b/packages/components/src/AboutDialog/AboutDialog.snapshot.test.js
@@ -17,6 +17,11 @@ const props = {
 };
 
 describe('AboutDialog', () => {
+	beforeAll(() => {
+		const RealDate = Date;
+		global.Date = jest.fn(() => new RealDate(2018, 1, 1));
+	});
+
 	it('should render', () => {
 		const wrapper = shallow(<AboutDialog.WrappedComponent {...props} />);
 		expect(wrapper.getElement()).toMatchSnapshot();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
About modal has a `2018` hard coded year in i18n default value.

**What is the chosen solution to this problem?**
Use current date

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
