### PR TITLE
fix(cmf): trigger error on console when the value on the setting is null

### DIFF
--- a/packages/cmf/__tests__/onError.test.js
+++ b/packages/cmf/__tests__/onError.test.js
@@ -42,14 +42,16 @@ describe('onError', () => {
 	});
 	describe('addAction', () => {
 		it('should add action in singleton', () => {
-			onError.addAction({ type: 'FOO', password: 'secret' });
+			onError.addAction({ type: 'FOO', password: 'secret', value: null, other: false, number: 0 });
 			const info = onError.getReportInfo(new Error('my'));
 			expect(info.actions.length).toBe(1);
-			expect(info.actions[0]).toMatchObject({
+			expect(info.actions[0]).toEqual({
 				type: 'FOO',
 				password: expect.anything(),
+				value: null,
+				other: false,
+				number: 0,
 			});
-			expect(info.actions[0].password).not.toBe('secret');
 		});
 		it('should keep last 20 actions', () => {
 			// eslint-disable-next-line no-plusplus

--- a/packages/cmf/__tests__/onError.test.js
+++ b/packages/cmf/__tests__/onError.test.js
@@ -42,7 +42,14 @@ describe('onError', () => {
 	});
 	describe('addAction', () => {
 		it('should add action in singleton', () => {
-			onError.addAction({ type: 'FOO', password: 'secret', value: null, other: false, number: 0 });
+			onError.addAction({
+				type: 'FOO',
+				password: 'secret',
+				value: null,
+				other: false,
+				number: 0,
+				NaN,
+			});
 			const info = onError.getReportInfo(new Error('my'));
 			expect(info.actions.length).toBe(1);
 			expect(info.actions[0]).toEqual({
@@ -51,7 +58,9 @@ describe('onError', () => {
 				value: null,
 				other: false,
 				number: 0,
+				NaN,
 			});
+			expect(info.actions[0].password).not.toBe('secret');
 		});
 		it('should keep last 20 actions', () => {
 			// eslint-disable-next-line no-plusplus

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -82,7 +82,12 @@ function anon(value, key) {
  * @return {Object} friendly with JSON.stringify
  */
 function prepareObject(originalState) {
-	const state = originalState.toJS ? originalState.toJS() : originalState;
+	const state = originalState && originalState.toJS ? originalState.toJS() : originalState;
+
+	if (state === undefined || state === null) {
+		return '';
+	}
+
 	return Object.keys(state).reduce((acc, key) => {
 		const valueType = Array.isArray(acc[key]) ? 'array' : typeof state[key];
 		if (valueType === 'function') {

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -82,12 +82,11 @@ function anon(value, key) {
  * @return {Object} friendly with JSON.stringify
  */
 function prepareObject(originalState) {
-	if (state === null) {
+	if (originalState === null) {
 		return null;
 	}
 
 	const state = originalState.toJS ? originalState.toJS() : originalState;
-
 
 	return Object.keys(state).reduce((acc, key) => {
 		const valueType = Array.isArray(acc[key]) ? 'array' : typeof state[key];

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -82,11 +82,12 @@ function anon(value, key) {
  * @return {Object} friendly with JSON.stringify
  */
 function prepareObject(originalState) {
-	const state = originalState && originalState.toJS ? originalState.toJS() : originalState;
-
 	if (state === null) {
 		return null;
 	}
+
+	const state = originalState.toJS ? originalState.toJS() : originalState;
+
 
 	return Object.keys(state).reduce((acc, key) => {
 		const valueType = Array.isArray(acc[key]) ? 'array' : typeof state[key];

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -84,8 +84,8 @@ function anon(value, key) {
 function prepareObject(originalState) {
 	const state = originalState && originalState.toJS ? originalState.toJS() : originalState;
 
-	if (state === undefined || state === null) {
-		return '';
+	if (state === null) {
+		return null;
 	}
 
 	return Object.keys(state).reduce((acc, key) => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We have some errors on the console when the value on the settings is null

**What is the chosen solution to this problem?**
return empty string if the value is null

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
