### PR TITLE
fix(TSD-408): double scroll bar on deprecated multi tag select

### DIFF
--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/MultiSelectTagWidget.scss
@@ -50,7 +50,7 @@ $tf-typeahead-section-border-color: #e0e0e0 !default;
 		background-color: $white;
 		border-radius: $border-radius-base;
 		box-shadow: 0 1px 3px 0 $shadow;
-		overflow-y: auto;
+		overflow-y: hidden;
 		z-index: 999;
 
 		.section-title {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
quick fixing this for project using semantic type, as migration to new form is in process.
![image-2019-09-19-15-13-17-230](https://user-images.githubusercontent.com/14272767/65343788-2dd61580-dbd6-11e9-94c6-be9dbbff9a4f.png)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
