### PR TITLE
fix(forms): step attribute for input with type number

### DIFF
--- a/packages/forms/src/UIForm/fields/Comparator/README.md
+++ b/packages/forms/src/UIForm/fields/Comparator/README.md
@@ -42,7 +42,8 @@ Advanced configuration
             "value": {
                 "type": "number",
                 "minimum": -100,
-                "maximum": 100
+                "maximum": 100,
+                "step": 0.01
             }
         }
     }

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -52,6 +52,7 @@ export default function Text(props) {
 				value={value}
 				min={get(schema, 'schema.minimum')}
 				max={get(schema, 'schema.maximum')}
+				step={get(schema, 'schema.step')}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes
 				aria-invalid={!isValid}
 				aria-required={get(schema, 'required')}

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -156,6 +156,31 @@ describe('Text field', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render input with step attribute', () => {
+		// given
+		const stepSchema = {
+			...schema,
+			type: 'number',
+			schema: {
+				type: 'number',
+				step: 0.01,
+			},
+		};
+
+		// when
+		const wrapper = shallow(
+			<Text id={'myForm'} isValid onChange={jest.fn()} onFinish={jest.fn()} schema={stepSchema} />,
+		);
+
+		// then
+		expect(
+			wrapper
+				.find('[type="number"]')
+				.at(0)
+				.props().step,
+		).toEqual(0.01);
+	});
+
 	it('should trigger onChange', () => {
 		// given
 		const onChange = jest.fn();

--- a/packages/forms/stories-core/json/fields/core-text.json
+++ b/packages/forms/stories-core/json/fields/core-text.json
@@ -15,6 +15,12 @@
         "minimum": 0,
         "maximum": 7
       },
+      "numberMinMaxStep": {
+        "type": "number",
+        "minimum": 1.5,
+        "maximum": 3,
+        "step": 0.1
+      },
       "password": {
         "type": "string"
       }
@@ -32,6 +38,10 @@
     {
       "key": "numberMinMax",
       "title": "Number (with min and max)"
+    },
+    {
+      "key": "numberMinMaxStep",
+      "title": "Number (with min, max and step)"
     },
     {
       "key": "password",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Cannot add step attribute to `input[type="number"]` at the moment.

**What is the chosen solution to this problem?**
Let's be able to add it like `min` and `max`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
