### PR TITLE
fix(components/subheaderbar): icon not centered on ie

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -28,8 +28,10 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 	padding: 0;
 
 	svg {
+		display: block;
 		color: $gray;
 	}
+
 	&[disabled] {
 		&:hover,
 		&:focus {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

![image](https://user-images.githubusercontent.com/26482371/65428050-ec32ae00-de13-11e9-888f-a28c097752fd.png)


**What is the chosen solution to this problem?**

Force `display: block;` on svg.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
