### PR TITLE
fix(components/ListComposition): Expose useCollectionSelection hook

### DIFF
--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -8,7 +8,7 @@ import Toolbar from './Toolbar';
 import VList from './VList';
 import { sortCollection, useCollectionSort } from './Manager/hooks/useCollectionSort.hook';
 import { filterCollection, useCollectionFilter } from './Manager/hooks/useCollectionFilter.hook';
-import { useCollectionSelection } from './Manager/hooks/useCollectionSelection.hook';
+import useCollectionSelection from './Manager/hooks/useCollectionSelection.hook';
 import useCollectionActions from './Manager/hooks/useCollectionActions.hook';
 
 export default {

--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -8,6 +8,7 @@ import Toolbar from './Toolbar';
 import VList from './VList';
 import { sortCollection, useCollectionSort } from './Manager/hooks/useCollectionSort.hook';
 import { filterCollection, useCollectionFilter } from './Manager/hooks/useCollectionFilter.hook';
+import { useCollectionSelection } from './Manager/hooks/useCollectionSelection.hook';
 import useCollectionActions from './Manager/hooks/useCollectionActions.hook';
 
 export default {
@@ -26,6 +27,7 @@ export const hooks = {
 	useCollectionSort,
 	sortCollection,
 	useCollectionFilter,
+	useCollectionSelection,
 	filterCollection,
 	useDisplayMode: useLocalStorage,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`useCollectionSelection` is not exposed in ListComposition index, therefore it can't be used by _list composers_

**What is the chosen solution to this problem?**
Expose the hook like the other ones.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
