### PR TITLE
feat(TCCUI-65/date picker): move black border for date button focus

### DIFF
--- a/packages/components/src/DateTimePickers/pickers/DateTimePicker/DateTimePicker.scss
+++ b/packages/components/src/DateTimePickers/pickers/DateTimePicker/DateTimePicker.scss
@@ -2,10 +2,6 @@
 	color: $dove-gray;
 	min-height: 25rem;
 	padding: $padding-normal;
-
-	button:focus {
-		outline: 1px solid black;
-	}
 }
 
 .footer {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
http://guidelines.talend.com/document/92132#/ui-controls/date-time-picker-1561102408
**What is the chosen solution to this problem?**
move black border for focus, it will use the default accessbility style.
![compare](https://user-images.githubusercontent.com/2328653/65604345-dff84d80-dfd9-11e9-96c9-73ba198b5494.png)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
