### PR TITLE
fix(cmf): onError when value is undefined

### DIFF
--- a/packages/cmf/__tests__/onError.test.js
+++ b/packages/cmf/__tests__/onError.test.js
@@ -9,7 +9,7 @@ describe('onError', () => {
 	let state;
 	let config;
 	beforeEach(() => {
-		state = { foo: { ok: 'should be kept', password: 'secret' } };
+		state = { foo: { ok: 'should be kept', password: 'secret', keyUndefined: undefined } };
 		store = mock.store(state);
 		store.dispatch = jest.fn();
 		config = {

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -101,6 +101,8 @@ function prepareObject(originalState) {
 			});
 		} else if (valueType === 'object') {
 			acc[key] = prepareObject(state[key]);
+		} else if (valueType === 'undefined') {
+			acc[key] = state[key];
 		} else {
 			// anonym it
 			acc[key] = anon(state[key], key);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
issue with onError when value is undefined

**What is the chosen solution to this problem?**
manage this specific case and update test

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
