### PR TITLE
fix(component): ListComposition -error with filter hook when a value is null

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -1,7 +1,9 @@
 import { useMemo, useState } from 'react';
+import isNil from 'lodash/isNil';
 
-function defaultFilterFunction(value = '', textFilter) {
-	return value
+function defaultFilterFunction(value, textFilter) {
+	const filteredValue = isNil(value) ? '' : value;
+	return filteredValue
 		.toString()
 		.toLowerCase()
 		.includes(textFilter);

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
@@ -41,6 +41,11 @@ const collection = [
 		lastName: 'Dorsey',
 		number: 4,
 	},
+	{
+		firstName: undefined,
+		lastName: null,
+		number: 5,
+	},
 ];
 
 describe('useCollectionFilter', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an error when a value in the list is null (not undefined)
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters
**What is the chosen solution to this problem?**
Manage the both case null and undefined with isNil

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
