### PR TITLE
feat(date picker)add a transition to selected color

### DIFF
--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -10,6 +10,7 @@
 	&.selected {
 		background-color: $lochmara;
 		color: $white;
+		transition: color 0.2s ease-in;
 		font-weight: $font-weight-semi-bold;
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the date picker, click to another day, the background have a little delay. We have the white text color and grey background at the beginning, it’s pretty annoying.
**What is the chosen solution to this problem?**
the reason is in the tertiary button, there is a transition to the background.
`transition: background 0.2s ease-in;`
I will try to add a transition to the color  of `selected` button.
`transition: color 0.2s ease-in;`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
