### PR TITLE
feat(components/CollapsiblePanel): add skeleton instead of status text

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -39,6 +39,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/ResourcePicker/ResourcePicker.component.js
   17:2  warning  Unexpected console statement  no-console
 
+/home/travis/build/Talend/ui/packages/components/src/Status/Status.component.js
+  63:2  error  Expected a default case  default-case
+
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
@@ -49,6 +52,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   41:3  warning  Unexpected console statement  no-console
   69:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 25 problems (22 errors, 3 warnings)
+✖ 26 problems (23 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -39,9 +39,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/ResourcePicker/ResourcePicker.component.js
   17:2  warning  Unexpected console statement  no-console
 
-/home/travis/build/Talend/ui/packages/components/src/Status/Status.component.js
-  63:2  error  Expected a default case  default-case
-
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
@@ -52,6 +49,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   41:3  warning  Unexpected console statement  no-console
   69:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 26 problems (23 errors, 3 warnings)
+✖ 25 problems (22 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -2,7 +2,7 @@
 
 
 src/CollapsiblePanel/CollapsiblePanel.scss
-  137:5  error  Mixins should come before declarations  mixins-before-declarations
+  143:5  error  Mixins should come before declarations  mixins-before-declarations
 
 src/DateTimePickers/pickers/TimePicker/TimePicker.scss
   26:9  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -4,7 +4,7 @@ $tc-collapsible-panel-padding-larger: $padding-larger !default;
 $tc-collapsible-panel-btn-color: #555964;
 $tc-collapsible-descriptive-panel-content-description-color: #808080 !default;
 $tc-toggle-color: #555964 !default;
-$tc-skeleton-background-color: #cbcbcb !default;
+$tc-skeleton-background-color: #dfdfdf !default;
 
 @mixin type-col($width: 100%) {
 	flex-basis: $width;

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -4,6 +4,7 @@ $tc-collapsible-panel-padding-larger: $padding-larger !default;
 $tc-collapsible-panel-btn-color: #555964;
 $tc-collapsible-descriptive-panel-content-description-color: #808080 !default;
 $tc-toggle-color: #555964 !default;
+$tc-skeleton-background-color: #cbcbcb !default;
 
 @mixin type-col($width: 100%) {
 	flex-basis: $width;
@@ -70,7 +71,8 @@ $tc-toggle-color: #555964 !default;
 	&.success,
 	&.danger,
 	&.muted,
-	&.warning {
+	&.warning,
+	&.skeleton {
 		padding-left: 1px;
 		border-left: 5px solid;
 	}
@@ -108,6 +110,10 @@ $tc-toggle-color: #555964 !default;
 		:global(.tc-status-label) {
 			color: $brand-warning;
 		}
+	}
+
+	&.skeleton {
+		border-left-color: $tc-skeleton-background-color;
 	}
 
 	.panel-header-content {

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -75,9 +75,9 @@ function renderIcon(status, icon, progress) {
 					size={Skeleton.SIZES.small}
 				/>
 			);
+		default:
+			return icon && <Icon name={icon} />;
 	}
-
-	return icon && <Icon name={icon} />;
 }
 
 function renderLabel(status, label) {

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -5,6 +5,7 @@ import classNames from 'classnames';
 import Actions from './../Actions/Actions.component';
 import CircularProgress from './../CircularProgress/CircularProgress.component';
 import Icon from './../Icon/Icon.component';
+import Skeleton from '../Skeleton'
 
 import css from './Status.scss';
 
@@ -36,6 +37,7 @@ export const STATUS = {
 	FAILED: 'failed',
 	CANCELED: 'canceled',
 	WARNING: 'warning',
+	SKELETON: 'skeleton',
 };
 
 export function getbsStyleFromStatus(status) {
@@ -50,19 +52,46 @@ export function getbsStyleFromStatus(status) {
 			return 'muted';
 		case STATUS.WARNING:
 			return 'warning';
+		case STATUS.SKELETON:
+			return 'skeleton';
 		default:
 			return '';
 	}
 }
 
 function renderIcon(status, icon, progress) {
-	if (status === STATUS.IN_PROGRESS) {
-		if (icon) {
-			return <Icon name={icon} />;
-		}
-		return <CircularProgress size={'small'} percent={progress} />;
+	switch (status) {
+		case STATUS.IN_PROGRESS:
+			if (icon) {
+				return <Icon name={icon} />;
+			}
+			return <CircularProgress size={'small'} percent={progress} />;
+
+		case STATUS.SKELETON:
+			return 	(
+				<Skeleton
+					className={classNames(css['tc-status-skeleton-item'], 'tc-status-skeleton-item')}
+					type={Skeleton.TYPES.circle}
+					size={Skeleton.SIZES.small}
+				/>
+			);
 	}
+
 	return icon && <Icon name={icon} />;
+}
+
+function renderLabel(status, label) {
+	if (status === STATUS.SKELETON) {
+		return 	(
+			<Skeleton
+				className={classNames(css['tc-status-skeleton-item'], 'tc-status-skeleton-item')}
+				type={Skeleton.TYPES.text}
+				size={Skeleton.SIZES.large}
+			/>
+		);
+	}
+
+	return label;
 }
 
 export function Status({ status, label, icon, actions, progress }) {
@@ -79,7 +108,9 @@ export function Status({ status, label, icon, actions, progress }) {
 	return (
 		<div role="status" className={rootClassnames}>
 			<span className={iconClassnames}>{renderIcon(status, icon, progress)}</span>
-			<span className={classNames(css['tc-status-label'], 'tc-status-label')}>{label}</span>
+			<span className={classNames(css['tc-status-label'], 'tc-status-label')}>
+				{renderLabel(status, label)}
+			</span>
 			<Actions
 				actions={actions}
 				className={classNames(css['tc-status-actions'], 'tc-status-actions')}

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -5,7 +5,7 @@ import classNames from 'classnames';
 import Actions from './../Actions/Actions.component';
 import CircularProgress from './../CircularProgress/CircularProgress.component';
 import Icon from './../Icon/Icon.component';
-import Skeleton from '../Skeleton'
+import Skeleton from '../Skeleton';
 
 import css from './Status.scss';
 
@@ -68,7 +68,7 @@ function renderIcon(status, icon, progress) {
 			return <CircularProgress size={'small'} percent={progress} />;
 
 		case STATUS.SKELETON:
-			return 	(
+			return (
 				<Skeleton
 					className={classNames(css['tc-status-skeleton-item'], 'tc-status-skeleton-item')}
 					type={Skeleton.TYPES.circle}
@@ -82,7 +82,7 @@ function renderIcon(status, icon, progress) {
 
 function renderLabel(status, label) {
 	if (status === STATUS.SKELETON) {
-		return 	(
+		return (
 			<Skeleton
 				className={classNames(css['tc-status-skeleton-item'], 'tc-status-skeleton-item')}
 				type={Skeleton.TYPES.text}

--- a/packages/components/src/Status/Status.scss
+++ b/packages/components/src/Status/Status.scss
@@ -64,6 +64,6 @@ $tc-status-space-btn-icon-label: 5px !default;
 }
 
 .tc-status-skeleton-item {
-	margin-right: 10px;
+	margin-right: $padding-small;
 	display: flex;
 }

--- a/packages/components/src/Status/Status.scss
+++ b/packages/components/src/Status/Status.scss
@@ -38,6 +38,10 @@ $tc-status-space-btn-icon-label: 5px !default;
 		&.warning {
 			color: $brand-warning;
 		}
+
+		&.skeleton {
+			color: $gray;
+		}
 	}
 
 	&-actions {
@@ -57,4 +61,9 @@ $tc-status-space-btn-icon-label: 5px !default;
 			opacity: 1;
 		}
 	}
+}
+
+.tc-status-skeleton-item {
+	margin-right: 10px;
+	display: flex;
 }

--- a/packages/components/src/Status/Status.snapshot.test.js
+++ b/packages/components/src/Status/Status.snapshot.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 
-import { Status } from './Status.component';
+import { Status, STATUS } from './Status.component';
 
 jest.mock('react-dom');
 
@@ -65,7 +65,7 @@ const inProgressStatusWithPercent = {
 };
 
 const skeletonStatusProps = {
-	status: 'skeleton',
+	status: STATUS.SKELETON,
 };
 
 describe('Status', () => {

--- a/packages/components/src/Status/Status.snapshot.test.js
+++ b/packages/components/src/Status/Status.snapshot.test.js
@@ -68,7 +68,6 @@ const skeletonStatusProps = {
 	status: 'skeleton',
 };
 
-
 describe('Status', () => {
 	it('should render a label with Icon', () => {
 		// when

--- a/packages/components/src/Status/Status.snapshot.test.js
+++ b/packages/components/src/Status/Status.snapshot.test.js
@@ -64,6 +64,11 @@ const inProgressStatusWithPercent = {
 	],
 };
 
+const skeletonStatusProps = {
+	status: 'skeleton',
+};
+
+
 describe('Status', () => {
 	it('should render a label with Icon', () => {
 		// when
@@ -104,6 +109,14 @@ describe('Status', () => {
 	it('should render a label with a fixed circular progress', () => {
 		// when
 		const wrapper = renderer.create(<Status {...inProgressStatusWithPercent} />).toJSON();
+
+		// then
+		expect(wrapper).toMatchSnapshot();
+	});
+
+	it('should render a label with a skeleton', () => {
+		// when
+		const wrapper = renderer.create(<Status {...skeletonStatusProps} />).toJSON();
 
 		// then
 		expect(wrapper).toMatchSnapshot();

--- a/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
+++ b/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
@@ -310,3 +310,42 @@ exports[`Status should render a label with a fixed circular progress 1`] = `
   </div>
 </div>
 `;
+
+exports[`Status should render a label with a skeleton 1`] = `
+<div
+  className="theme-tc-status tc-status"
+  role="status"
+>
+  <span
+    className="theme-tc-status-icon tc-status-icon theme-skeleton"
+  >
+    <span
+      aria-label="circle (loading)"
+      className="tc-skeleton theme-tc-skeleton tc-skeleton-circle theme-tc-skeleton-circle tc-skeleton-circle-small theme-tc-skeleton-circle-small theme-tc-status-skeleton-item tc-status-skeleton-item theme-theme-tc-status-skeleton-item tc-status-skeleton-item tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+      style={
+        Object {
+          "height": undefined,
+          "width": undefined,
+        }
+      }
+    />
+  </span>
+  <span
+    className="theme-tc-status-label tc-status-label"
+  >
+    <span
+      aria-label="text (loading)"
+      className="tc-skeleton theme-tc-skeleton tc-skeleton-text theme-tc-skeleton-text tc-skeleton-text-large theme-tc-skeleton-text-large theme-tc-status-skeleton-item tc-status-skeleton-item theme-theme-tc-status-skeleton-item tc-status-skeleton-item tc-skeleton-heartbeat theme-tc-skeleton-heartbeat"
+      style={
+        Object {
+          "height": undefined,
+          "width": undefined,
+        }
+      }
+    />
+  </span>
+  <div
+    className="tc-actions theme-tc-status-actions tc-status-actions btn-group"
+  />
+</div>
+`;

--- a/packages/components/stories/CollapsiblePanel.js
+++ b/packages/components/stories/CollapsiblePanel.js
@@ -57,6 +57,21 @@ const statusCanceledHeader = [
 		icon: 'talend-cross',
 	},
 ];
+
+const statusSkeletonHeader = [
+	{
+		displayMode: 'status',
+		status: 'skeleton',
+	},
+	{
+		displayMode: 'badge',
+		label: 'Execution',
+		bsStyle: 'info',
+		tooltipPlacement: 'top',
+		tooltipLabel: 'Updating execution status...',
+	},
+];
+
 const statusInProgressHeader = [
 	{
 		displayMode: 'status',
@@ -171,6 +186,7 @@ storiesOf('CollapsiblePanel', module)
 				header={statusInProgressHeader}
 				status={'inProgress'}
 			/>
+			<CollapsiblePanel id="panel-header-12" header={statusSkeletonHeader} status={'skeleton'} />
 		</div>
 	))
 	.add('Body', () => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In order to finish Task Execution live updates feature in TMC (updates come from server side),
we need a way to set execution status with a skeleton, as we don't know actual status at the moment.

Please take a look to mock-up:
https://jira.talendforge.org/secure/attachment/203492/image.png

**What is the chosen solution to this problem?**

I added 'skeleton' status to header props.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
