### PR TITLE
feat(components/FilterBar): data-test

### DIFF
--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -41,9 +41,11 @@ function FilterInput(props) {
 		placeholder,
 		value,
 		t,
+		...rest
 	} = props;
 
 	const inputProps = {
+		'data-test': rest['data-test'],
 		id,
 		name: 'search',
 		type: 'search',
@@ -167,6 +169,7 @@ export class FilterBarComponent extends React.Component {
 				>
 					<Icon name="talend-search" className={theme['search-icon']} />
 					<FilterInput
+						data-test={this.props['data-test']}
 						autoFocus={this.props.autoFocus}
 						id={this.props.id && `${this.props.id}-input`}
 						debounceMinLength={this.props.debounceMinLength}
@@ -201,6 +204,7 @@ FilterBarComponent.propTypes = {
 	autoFocus: PropTypes.bool,
 	id: PropTypes.string,
 	className: PropTypes.string,
+	'data-test': PropTypes.string,
 	'data-feature': PropTypes.string,
 	debounceMinLength: PropTypes.number,
 	debounceTimeout: PropTypes.number,

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -86,6 +86,7 @@ FilterInput.propTypes = {
 	onToggle: PropTypes.func,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,
+	'data-test': PropTypes.string,
 	t: PropTypes.func.isRequired,
 };
 

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -41,6 +41,15 @@ describe('FilterBar', () => {
 		expect(filterInstance.props().className).toContain('custom-test');
 	});
 
+	it('should accept data-test attribute', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} data-test={'my.test'} />,
+		);
+		// then
+		expect(filterInstance.find('input').prop('data-test')).toEqual('my.test');
+	});
+
 	it('should be able to switch autofocus to false', () => {
 		// given
 		const filterInstance = shallow(<FilterBarComponent {...defaultProps} autoFocus={false} />);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Input form `FilterBar` is not reachable from E2E tests (Cypress)

**What is the chosen solution to this problem?**
Be able to pass `data-test` to the generated input

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
