### PR TITLE
feat(components/list): allow single selection

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -46,8 +46,8 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
-  41:3  warning  Unexpected console statement  no-console
-  69:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
+  42:3  warning  Unexpected console statement  no-console
+  70:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
 ✖ 25 problems (22 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
@@ -18,6 +18,7 @@ exports[`LazyLoadingList should render lazy loading list component 1`] = `
       id="myLazyLoadingList"
       onRowsRendered={[Function]}
       registerChild={[Function]}
+      selectionMode="MULTI"
     >
       <div
         className="theme-vlist"
@@ -28,6 +29,7 @@ exports[`LazyLoadingList should render lazy loading list component 1`] = `
           id="myLazyLoadingList"
           onRowsRendered={[Function]}
           registerChild={[Function]}
+          selectionMode="MULTI"
           sort={[Function]}
           sortDirection="ASC"
           type="TABLE"

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -115,6 +115,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
         isSelected={[Function]}
         onRowDoubleClick={[MockFunction]}
         onToggleAll={[MockFunction]}
+        selectionMode="MULTI"
         selectionToggle={[MockFunction]}
         sort={null}
         sortDirection="ASC"
@@ -270,6 +271,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                               "label": "Select this element",
                               "onChange": [MockFunction],
                               "onToggleAll": [MockFunction],
+                              "selectionMode": "MULTI",
                             }
                           }
                           dataKey=""
@@ -1134,6 +1136,7 @@ exports[`List should render 1`] = `
         isSelected={[Function]}
         onRowDoubleClick={[MockFunction]}
         onToggleAll={[MockFunction]}
+        selectionMode="MULTI"
         selectionToggle={[MockFunction]}
         sort={null}
         sortDirection="ASC"
@@ -1289,6 +1292,7 @@ exports[`List should render 1`] = `
                               "label": "Select this element",
                               "onChange": [MockFunction],
                               "onToggleAll": [MockFunction],
+                              "selectionMode": "MULTI",
                             }
                           }
                           dataKey=""
@@ -2174,6 +2178,7 @@ exports[`List should render id if provided 1`] = `
         isSelected={[Function]}
         onRowDoubleClick={[MockFunction]}
         onToggleAll={[MockFunction]}
+        selectionMode="MULTI"
         selectionToggle={[MockFunction]}
         sort={null}
         sortDirection="ASC"
@@ -2333,6 +2338,7 @@ exports[`List should render id if provided 1`] = `
                               "label": "Select this element",
                               "onChange": [MockFunction],
                               "onToggleAll": [MockFunction],
+                              "selectionMode": "MULTI",
                             }
                           }
                           dataKey=""

--- a/packages/components/src/ResourcePicker/__snapshots__/ResourcePicker.snap.test.js.snap
+++ b/packages/components/src/ResourcePicker/__snapshots__/ResourcePicker.snap.test.js.snap
@@ -54,6 +54,7 @@ exports[`ResourcePicker component snaps should render ResourcePicker in filtered
           "resource": [Function],
         }
       }
+      selectionMode="MULTI"
       type="resource"
     />
   </div>
@@ -108,6 +109,7 @@ exports[`ResourcePicker component snaps should render ResourcePicker with some R
           "resource": [Function],
         }
       }
+      selectionMode="MULTI"
       type="resource"
     />
   </div>
@@ -131,6 +133,7 @@ exports[`ResourcePicker component snaps should render ResourcePicker without any
           "resource": [Function],
         }
       }
+      selectionMode="MULTI"
       type="resource"
     />
   </div>
@@ -183,6 +186,7 @@ exports[`ResourcePicker component snaps should render ResourcePicker without too
           "resource": [Function],
         }
       }
+      selectionMode="MULTI"
       type="resource"
     />
   </div>

--- a/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.component.js
+++ b/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.component.js
@@ -3,6 +3,8 @@ import React from 'react';
 import classnames from 'classnames';
 import theme from './CellCheckbox.scss';
 
+import { SELECTION_MODE } from '../utils/constants';
+
 /**
  * Cell renderer that displays a checkbox
  */
@@ -18,14 +20,16 @@ class CellCheckbox extends React.Component {
 
 	render() {
 		const { cellData, columnData, rowData, rowIndex } = this.props;
-		const { id, label, onChange } = columnData;
+		const { id, label, selectionMode, onChange } = columnData;
+		const type = selectionMode === SELECTION_MODE.SINGLE ? 'radio' : 'checkbox';
+
 		return (
 			<form className={classnames('tc-list-checkbox', theme['tc-list-checkbox'])}>
 				<div className="checkbox">
 					<label htmlFor={id && `${id}-${rowIndex}-check`}>
 						<input
 							id={id && `${id}-${rowIndex}-check`}
-							type="checkbox"
+							type={type}
 							onChange={e => {
 								onChange(e, rowData);
 							}}

--- a/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.test.js
+++ b/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.test.js
@@ -28,6 +28,20 @@ describe('CellActions', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render radio button', () => {
+		// when
+		const wrapper = shallow(
+			<CellCheckbox
+				cellData={false}
+				columnData={{ ...columnData, selectionMode: 'SINGLE' }}
+				rowIndex={25}
+			/>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	it('should trigger callback on checkbox toggle', () => {
 		// given
 		const event = { target: 'lol' };

--- a/packages/components/src/VirtualizedList/CellCheckbox/__snapshots__/CellCheckbox.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellCheckbox/__snapshots__/CellCheckbox.test.js.snap
@@ -30,6 +30,36 @@ exports[`CellActions should render checked checkbox 1`] = `
 </form>
 `;
 
+exports[`CellActions should render radio button 1`] = `
+<form
+  className="tc-list-checkbox theme-tc-list-checkbox"
+>
+  <div
+    className="checkbox"
+  >
+    <label
+      htmlFor="my-checkbox-25-check"
+    >
+      <input
+        checked={false}
+        id="my-checkbox-25-check"
+        onChange={[Function]}
+        type="radio"
+      />
+      <span
+        className="tc-cell-checkbox"
+      >
+        <span
+          className="sr-only"
+        >
+          My Test Check
+        </span>
+      </span>
+    </label>
+  </div>
+</form>
+`;
+
 exports[`CellActions should render unchecked checkbox 1`] = `
 <form
   className="tc-list-checkbox theme-tc-list-checkbox"

--- a/packages/components/src/VirtualizedList/PropTypes.js
+++ b/packages/components/src/VirtualizedList/PropTypes.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import { SORT_BY } from './utils/constants';
+import { SORT_BY, SELECTION_MODE } from './utils/constants';
 
 export default {
 	// <VirtualizedList.Content> elements to configure the content fields
@@ -43,6 +43,8 @@ export default {
 	/** Function to call on element selection
 	 *  This determines the display of the selection checkboxes. */
 	selectionToggle: PropTypes.func,
+	// Current selection mode ('MULTI' | 'SINGLE')
+	selectionMode: PropTypes.oneOf([SELECTION_MODE.MULTI, SELECTION_MODE.SINGLE]),
 	// Function to call on sort change in ListTable rendering (header click)
 	sort: PropTypes.func,
 	// Content field of the current sort

--- a/packages/components/src/VirtualizedList/VirtualizedList.component.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.component.js
@@ -1,7 +1,7 @@
 import React, { useEffect, useRef, useState } from 'react';
 import { AutoSizer } from 'react-virtualized';
 import get from 'lodash/get';
-import { listTypes } from './utils/constants';
+import { listTypes, SELECTION_MODE } from './utils/constants';
 import Loader from '../Loader';
 import RendererSelector from './RendererSelector.component';
 import propTypes from './PropTypes';
@@ -38,6 +38,7 @@ function VirtualizedList(props) {
 		rowRenderers,
 		scrollToIndex,
 		selectionToggle,
+		selectionMode,
 		sort,
 		sortBy,
 		sortDirection,
@@ -52,6 +53,7 @@ function VirtualizedList(props) {
 		isSelected,
 		onToggleAll,
 		selectionToggle,
+		selectionMode,
 	});
 	const [widthsOfColumnsState, setWidthsOfColumnsState] = useState();
 	const rendererSelectorRef = useRef();
@@ -121,6 +123,7 @@ VirtualizedList.displayName = 'VirtualizedList';
 VirtualizedList.propTypes = propTypes;
 VirtualizedList.defaultProps = {
 	defaultHeight: 250,
+	selectionMode: SELECTION_MODE.MULTI,
 };
 
 export default VirtualizedList;

--- a/packages/components/src/VirtualizedList/utils/__snapshots__/tablerow.test.js.snap
+++ b/packages/components/src/VirtualizedList/utils/__snapshots__/tablerow.test.js.snap
@@ -41,6 +41,7 @@ Array [
         "label": "Select this element",
         "onChange": [MockFunction],
         "onToggleAll": undefined,
+        "selectionMode": undefined,
       }
     }
     dataKey=""

--- a/packages/components/src/VirtualizedList/utils/constants.js
+++ b/packages/components/src/VirtualizedList/utils/constants.js
@@ -14,6 +14,11 @@ export const SORT_BY = {
 	DESC: 'DESC',
 };
 
+export const SELECTION_MODE = {
+	MULTI: 'MULTI',
+	SINGLE: 'SINGLE',
+};
+
 export const internalIds = {
 	rowSelector: 'tc-list-internal-row-selector',
 };

--- a/packages/components/src/VirtualizedList/utils/tablerow.js
+++ b/packages/components/src/VirtualizedList/utils/tablerow.js
@@ -12,7 +12,7 @@ import { internalIds } from './constants';
  * Insert a checkbox column configuration to select a row.
  */
 export function insertSelectionConfiguration(props) {
-	const { collection, children, isSelected, onToggleAll, selectionToggle } = props;
+	const { collection, children, isSelected, onToggleAll, selectionToggle, selectionMode } = props;
 	let contentsConfiguration = React.Children.toArray(children);
 	if (selectionToggle && isSelected) {
 		const toggleColumn = (
@@ -28,6 +28,7 @@ export function insertSelectionConfiguration(props) {
 				columnData={{
 					label: 'Select this element',
 					onChange: selectionToggle,
+					selectionMode,
 					onToggleAll,
 					collection,
 					isSelected,

--- a/packages/components/stories/VirtualizedList.js
+++ b/packages/components/stories/VirtualizedList.js
@@ -472,7 +472,7 @@ storiesOf('VirtualizedList', module)
 					id={'my-list'}
 					isSelected={item => item.id === 2}
 					selectionToggle={action('selectionToggle')}
-					selectionMode={'SINGLE'}
+					selectionMode="SINGLE"
 
 				>
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />

--- a/packages/components/stories/VirtualizedList.js
+++ b/packages/components/stories/VirtualizedList.js
@@ -459,6 +459,31 @@ storiesOf('VirtualizedList', module)
 			</section>
 		</div>
 	))
+
+
+
+	.add('List > Table with radio button title', () => (
+		<div className="virtualized-list">
+			<h1>Virtualized List with radio button title</h1>
+			<IconsProvider defaultIcons={icons} />
+			<section style={{ height: '50vh' }}>
+				<VirtualizedList
+					collection={collection}
+					id={'my-list'}
+					isSelected={item => item.id === 2}
+					selectionToggle={action('selectionToggle')}
+					selectionMode={'SINGLE'}
+
+				>
+					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
+					<VirtualizedList.Text label="Author" dataKey="author" />
+					<VirtualizedList.Datetime label="Modified" dataKey="modified" />
+				</VirtualizedList>
+			</section>
+		</div>
+	))
+
+
 	.add('List > Table : sort', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We are not able to display radio buttons in front of a row to indicate that only a single element is selectable.

**What is the chosen solution to this problem?**

Introduce a `selectionMode` which can take `SINGLE` or `MULTI` to the list.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
