### PR TITLE
fix(Forms/SimpleCheckbox): using value props for checked attribute

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,6 +5,12 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/deprecated/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+  3:17  error  'useState' is defined but never used  no-unused-vars
+
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+  128:10  error  'wrapper' is assigned a value but never used  no-unused-vars
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
    4:10  error  'Actions' is defined but never used                                                                                        no-unused-vars
   34:9   error  'iconTransform' is assigned a value but never used                                                                         no-unused-vars
@@ -22,6 +28,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
   109:55  error  Closing curly brace should be on the same line as opening curly brace or on the line after the previous block  brace-style
 
-✖ 14 problems (14 errors, 0 warnings)
+✖ 16 problems (16 errors, 0 warnings)
   6 errors, 0 warnings potentially fixable with the `--fix` option.
 

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,12 +5,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/deprecated/fields/CollapsibleFieldset.js
   82:8  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
-  3:17  error  'useState' is defined but never used  no-unused-vars
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
-  128:10  error  'wrapper' is assigned a value but never used  no-unused-vars
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
    4:10  error  'Actions' is defined but never used                                                                                        no-unused-vars
   34:9   error  'iconTransform' is assigned a value but never used                                                                         no-unused-vars
@@ -28,6 +22,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
   109:55  error  Closing curly brace should be on the same line as opening curly brace or on the line after the previous block  brace-style
 
-✖ 16 problems (16 errors, 0 warnings)
+✖ 14 problems (14 errors, 0 warnings)
   6 errors, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
@@ -14,17 +14,15 @@ export default function SimpleCheckBox({
 	schema,
 	value,
 }) {
-	const [checked, setChecked] = useState(value);
-
 	const { autoFocus } = schema;
 
 	function getDataFeature() {
 		const dataFeature = schema['data-feature'];
-		return dataFeature ? `${dataFeature}.${checked ? 'uncheck' : 'check'}` : undefined;
+		return dataFeature ? `${dataFeature}.${value ? 'uncheck' : 'check'}` : undefined;
 	}
 
 	function getDataChecked() {
-		if (checked) {
+		if (value) {
 			return 2;
 		}
 		return 0;
@@ -39,12 +37,11 @@ export default function SimpleCheckBox({
 					disabled={disabled}
 					onChange={event => {
 						const isChecked = event.target.checked;
-						setChecked(isChecked);
 						onChange(event, { schema, value: isChecked });
 						onFinish(event, { schema, value: isChecked });
 					}}
 					type="checkbox"
-					checked={checked}
+					checked={value}
 					data-checked={getDataChecked()}
 					// eslint-disable-next-line jsx-a11y/aria-proptypes
 					aria-invalid={!isValid}

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.component.js
@@ -1,6 +1,6 @@
 /* eslint-disable jsx-a11y/label-has-for */
 import PropTypes from 'prop-types';
-import React, { useState } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 
 export default function SimpleCheckBox({

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
@@ -107,7 +107,7 @@ describe('SimpleCheckBox field', () => {
 	describe('data-feature', () => {
 		const dataFeature = 'my.custom.feature';
 
-		it('should render checkbox with specific data-feature while starting to be unchecked', () => {
+		it('should render checkbox with check data-feature when checkbox is unchecked', () => {
 			const wrapper = shallow(
 				<SimpleCheckBox
 					describedby={'myForm-description myForm-error'}
@@ -124,7 +124,7 @@ describe('SimpleCheckBox field', () => {
 			expect(wrapper.find(`label[data-feature="${dataFeature}.check"]`).exists()).toBeTruthy();
 		});
 
-		it('should render checkbox with specific data-feature while starting to be checked', () => {
+		it('should render checkbox with uncheck data-feature when checkbox is checked', () => {
 			const wrapper = shallow(
 				<SimpleCheckBox
 					describedby={'myForm-description myForm-error'}
@@ -139,6 +139,7 @@ describe('SimpleCheckBox field', () => {
 					value
 				/>,
 			);
+			expect(wrapper.find(`label[data-feature="${dataFeature}.uncheck"]`).exists()).toBeTruthy();
 		});
 	});
 });

--- a/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/SimpleCheckBox.test.js
@@ -122,15 +122,6 @@ describe('SimpleCheckBox field', () => {
 				/>,
 			);
 			expect(wrapper.find(`label[data-feature="${dataFeature}.check"]`).exists()).toBeTruthy();
-
-			// when
-			wrapper
-				.find('input')
-				.at(0)
-				.simulate('change', { target: { checked: true } });
-
-			// then
-			expect(wrapper.find(`label[data-feature="${dataFeature}.uncheck"]`).exists()).toBeTruthy();
 		});
 
 		it('should render checkbox with specific data-feature while starting to be checked', () => {
@@ -148,16 +139,6 @@ describe('SimpleCheckBox field', () => {
 					value
 				/>,
 			);
-			expect(wrapper.find(`label[data-feature="${dataFeature}.uncheck"]`).exists()).toBeTruthy();
-
-			// when
-			wrapper
-				.find('input')
-				.at(0)
-				.simulate('change', { target: { checked: false } });
-
-			// then
-			expect(wrapper.find(`label[data-feature="${dataFeature}.check"]`).exists()).toBeTruthy();
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Since the introduction of an internal state which is used in the input checked attribute, the checkbox doesn't update anymore when changing properties in form.

**What is the chosen solution to this problem?**
Removing the state and use the "value" props for the input checked attribute
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
