### PR TITLE
fix(components/ResourcePicker): display the button to remove the filter

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -23,8 +23,12 @@ src/List/Toolbar/Toolbar.scss
   80:6   error  Nesting depth 4 greater than max of 3                    nesting-depth
   93:12  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
 
+src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
+   5:16  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
+  11:30  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
+
 src/Typeahead/Typeahead.scss
   32:5  error  Mixins should come before declarations  mixins-before-declarations
 
-✖ 11 problems (9 errors, 2 warnings)
+✖ 13 problems (11 errors, 2 warnings)
 

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -23,12 +23,8 @@ src/List/Toolbar/Toolbar.scss
   80:6   error  Nesting depth 4 greater than max of 3                    nesting-depth
   93:12  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
 
-src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
-   5:16  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
-  11:30  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
-
 src/Typeahead/Typeahead.scss
   32:5  error  Mixins should come before declarations  mixins-before-declarations
 
-✖ 13 problems (11 errors, 2 warnings)
+✖ 11 problems (9 errors, 2 warnings)
 

--- a/packages/components/src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
+++ b/packages/components/src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
@@ -2,13 +2,13 @@
 	flex: 1;
 	position: relative;
 
-	input + div {
+	input + button.remove {
 		position: absolute;
 		top: 0;
 		right: 0;
 	}
 
-	input:not(:invalid) + div .remove {
+	input:not(:invalid) + button.remove {
 		display: inline-block;
 	}
 }

--- a/packages/components/src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
+++ b/packages/components/src/ResourcePicker/Toolbar/NameFilter/NameFilter.scss
@@ -2,13 +2,13 @@
 	flex: 1;
 	position: relative;
 
-	input + button.remove {
+	input + .remove {
 		position: absolute;
 		top: 0;
 		right: 0;
 	}
 
-	input:not(:invalid) + button.remove {
+	input:not(:invalid) + .remove {
 		display: inline-block;
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With this pr #2413, the selector is incorrect on the ressource picker. The button to remove the current filter doesn't display

**What is the chosen solution to this problem?**
fix the selector

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
