### PR TITLE
feat(forms/comparator): display icons

### DIFF
--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
@@ -83,10 +83,6 @@ class Comparator extends React.Component {
 		);
 	}
 
-	componentDidMount() {
-		// FIXME
-	}
-
 	onSelect(event, { value }) {
 		this.props.onChange(event, {
 			schema: this.props.schema,

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
@@ -26,6 +26,22 @@ export const ICONS_MAPPING = {
 };
 
 /**
+ * Format operator title
+ * @param operator Operator
+ * @param value Operator value as fallback
+ * @returns {string} Formatted title
+ */
+function getFormattedTitle(operator, value) {
+	if (operator) {
+		if (operator.symbol) {
+			return `${operator.symbol} (${operator.name})`;
+		}
+		return operator.name;
+	}
+	return value;
+}
+
+/**
  * Adapt part (operator or value) schema
  * @param schema The Comparator schema
  * @param part 'operator' or 'value'
@@ -122,17 +138,12 @@ class Comparator extends React.Component {
 		const map = schema.titleMap || [];
 		const symbols = (schema.options && schema.options.symbols) || {};
 		return this.getOperatorSchema().titleMap.map(({ value }) => {
-			const titles = map.find(m => m.value === value);
-			let title;
-			if (titles) {
-				title = titles.symbol ? `${titles.symbol} (${titles.name})` : titles.name;
-			} else {
-				title = value;
-			}
+			const operator = map.find(m => m.value === value);
+			const title = getFormattedTitle(operator, value);
 			return {
 				value,
 				title,
-				name: titles ? titles.name : '',
+				name: operator ? operator.name : '',
 				symbol: symbols[value] || value,
 				icon: ICONS_MAPPING[value],
 			};
@@ -163,7 +174,7 @@ class Comparator extends React.Component {
 				<ActionDropdown
 					icon={current && current.icon}
 					hideLabel={!!(current && current.icon)}
-					label={current && current.symbol}
+					label={current && (current.icon && current.name ? current.name : current.symbol)}
 					onSelect={this.onSelect}
 					disabled={this.getOperatorSchema().disabled}
 					items={this.getOperatorsMap().map(({ label, value, title, icon }, index) => ({

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
@@ -4,10 +4,26 @@ import last from 'lodash/last';
 import classNames from 'classnames';
 
 import ActionDropdown from '@talend/react-components/lib/Actions/ActionDropdown';
+
 import Text from '../Text';
 import Widget from '../../Widget';
 
 import theme from './Comparator.scss';
+
+export const ICONS_MAPPING = {
+	'=': 'talend-equal',
+	'!=': 'talend-not-equal',
+	'≅': 'talend-contains',
+	'≇': 'talend-not-contains',
+	'|>': 'talend-starts-with',
+	'>|': 'talend-ends-with',
+	':': 'talend-between',
+	'>': 'talend-greater-than',
+	'>=': 'talend-greater-than-equal',
+	'<': 'talend-less-than',
+	'<=': 'talend-less-than-equal',
+	'^\\': 'talend-regex',
+};
 
 /**
  * Adapt part (operator or value) schema
@@ -15,6 +31,12 @@ import theme from './Comparator.scss';
  * @param part 'operator' or 'value'
  */
 function getPartSchema(schema, part) {
+	const schemaRest = { ...schema };
+	delete schemaRest.key;
+	delete schemaRest.items;
+	delete schemaRest.schema;
+	delete schemaRest.type;
+	delete schemaRest.widget;
 	const childKey = schema.key.concat(part);
 	const childrenSchemas = schema.items || [];
 	let childSchema = childrenSchemas.find(item => last(item.key) === part);
@@ -23,18 +45,27 @@ function getPartSchema(schema, part) {
 	}
 	return {
 		...childSchema,
+		...schemaRest,
 		key: childKey,
-		autoFocus: schema.autoFocus || childSchema.autoFocus,
-		disabled: schema.disabled || childSchema.disabled,
-		readOnly: schema.readOnly || childSchema.readOnly,
 	};
 }
 
-function OperatorListElement({ symbol, name, selected }) {
+function OperatorListElement({ symbol, icon, name, selected }) {
+	if (icon && !name) {
+		return null;
+	}
 	return (
-		<span className={classNames(theme.operator, { [theme.selected]: selected })}>
-			{symbol && <span>{symbol}</span>}
-			{name && <span className={classNames(theme.name)}>{name}</span>}
+		<span
+			className={classNames(theme.operator, 'tf-comparator-operator', {
+				[theme.selected]: selected,
+			})}
+		>
+			{symbol && !icon && (
+				<span className={classNames(theme.symbol, 'tf-comparator-operator-symbol')}>{symbol}</span>
+			)}
+			{name && (
+				<span className={classNames(theme.name, 'tf-comparator-operator-name')}>{name}</span>
+			)}
 		</span>
 	);
 }
@@ -50,6 +81,10 @@ class Comparator extends React.Component {
 		console.warn(
 			"UNSTABLE WARNING: The 'Comparator' is not ready to be used in Apps. Code can (will) change outside the release process until it's ready.",
 		);
+	}
+
+	componentDidMount() {
+		// FIXME
 	}
 
 	onSelect(event, { value }) {
@@ -92,18 +127,24 @@ class Comparator extends React.Component {
 		const symbols = (schema.options && schema.options.symbols) || {};
 		return this.getOperatorSchema().titleMap.map(({ value }) => {
 			const titles = map.find(m => m.value === value);
-			const title = titles ? `${titles.symbol} (${titles.name})` : value;
+			let title;
+			if (titles) {
+				title = titles.symbol ? `${titles.symbol} (${titles.name})` : titles.name;
+			} else {
+				title = value;
+			}
 			return {
 				value,
 				title,
 				name: titles ? titles.name : '',
 				symbol: symbols[value] || value,
+				icon: ICONS_MAPPING[value],
 			};
 		});
 	}
 
 	getOperatorsMap() {
-		return this.getFormattedOperators().map(({ value, title, name, symbol }) => ({
+		return this.getFormattedOperators().map(({ value, title, name, symbol, icon }) => ({
 			value,
 			title,
 			label: (
@@ -111,8 +152,10 @@ class Comparator extends React.Component {
 					selected={this.props.value.operator === value}
 					name={name}
 					symbol={symbol}
+					icon={icon}
 				/>
 			),
+			icon,
 		}));
 	}
 
@@ -122,14 +165,17 @@ class Comparator extends React.Component {
 		return (
 			<div className={classNames(theme.comparator)}>
 				<ActionDropdown
+					icon={current && current.icon}
+					hideLabel={!!(current && current.icon)}
 					label={current && current.symbol}
 					onSelect={this.onSelect}
 					disabled={this.getOperatorSchema().disabled}
-					items={this.getOperatorsMap().map(({ label, value, title }, index) => ({
+					items={this.getOperatorsMap().map(({ label, value, title, icon }, index) => ({
 						id: `comparison-operator-${index}`,
 						label,
 						value,
 						title,
+						icon,
 					}))}
 					noCaret
 				/>
@@ -161,6 +207,7 @@ if (process.env.NODE_ENV !== 'production') {
 	OperatorListElement.propTypes = {
 		symbol: PropTypes.string,
 		name: PropTypes.string,
+		icon: PropTypes.string,
 		selected: PropTypes.bool,
 	};
 }

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
@@ -11,18 +11,18 @@ import Widget from '../../Widget';
 import theme from './Comparator.scss';
 
 export const ICONS_MAPPING = {
-	'=': 'talend-equal',
-	'!=': 'talend-not-equal',
-	'≅': 'talend-contains',
-	'≇': 'talend-not-contains',
-	'|>': 'talend-starts-with',
-	'>|': 'talend-ends-with',
-	':': 'talend-between',
-	'>': 'talend-greater-than',
-	'>=': 'talend-greater-than-equal',
-	'<': 'talend-less-than',
-	'<=': 'talend-less-than-equal',
-	'^\\': 'talend-regex',
+	equals: 'talend-equal',
+	not_equals: 'talend-not-equal',
+	contains: 'talend-contains',
+	not_contains: 'talend-not-contains',
+	starts_with: 'talend-starts-with',
+	ends_with: 'talend-ends-with',
+	between: 'talend-between',
+	greater_than: 'talend-greater-than',
+	greater_equals_to: 'talend-greater-than-equal',
+	less_than: 'talend-less-than',
+	less_equals_to: 'talend-less-than-equal',
+	regex: 'talend-regex',
 };
 
 /**

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.test.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.test.js
@@ -15,7 +15,7 @@ describe('Comparator field', () => {
 				type: 'object',
 				required: ['value'],
 				properties: {
-					operator: { type: 'string', enum: ['>', '<', '='] },
+					operator: { type: 'string', enum: ['greater_than', 'less_than', 'equals'] },
 					value: { type: 'string' },
 				},
 			},
@@ -27,9 +27,9 @@ describe('Comparator field', () => {
 					key: ['default', 'operator'],
 					type: 'select',
 					titleMap: [
-						{ name: 'Greater than', value: '>' },
-						{ name: 'Less than', value: '<' },
-						{ name: '=', value: '=' },
+						{ name: 'Greater than', value: 'greater_than' },
+						{ name: 'Less than', value: 'less_than' },
+						{ name: 'Equals', value: 'equals' },
 					],
 				},
 				{

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.test.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.test.js
@@ -28,7 +28,7 @@ describe('Comparator field', () => {
 					type: 'select',
 					titleMap: [
 						{ name: 'Greater than', value: '>' },
-						{ name: 'Lower than', value: '<' },
+						{ name: 'Less than', value: '<' },
 						{ name: '=', value: '=' },
 					],
 				},

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.scss
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.scss
@@ -16,6 +16,10 @@ $tf-comparator-operator-background: $gallery !default;
 
 			&-menu {
 				min-width: auto;
+				border-top: {
+					left-radius: 0;
+					right-radius: 0;
+				}
 			}
 
 			.tc-svg-icon {

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.scss
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.scss
@@ -1,3 +1,9 @@
+$tf-comparator-operator-height: 3.2rem !default;
+$tf-comparator-operator-width: 5rem !default;
+$tf-comparator-operator-top: 3.4rem !default;
+$tf-comparator-operator-color: $dove-gray !default;
+$tf-comparator-operator-background: $gallery !default;
+
 .comparator {
 	position: relative;
 	padding-top: $padding-normal;
@@ -6,46 +12,47 @@
 	:global {
 		.dropdown {
 			position: absolute;
-			top: 3.6rem;
+			top: $tf-comparator-operator-top;
+
+			&-menu {
+				min-width: auto;
+			}
+
+			.tc-svg-icon {
+				flex-shrink: 0;
+			}
 
 			.btn {
-				width: 2.5rem;
-				height: 2.5rem;
-				min-height: 2.5rem;
-				padding: 0;
-				color: $dove-gray;
-				z-index: 1;
-				border: {
-					bottom-left-radius: 0;
-					bottom-right-radius: 0;
-					top-left-radius: 0.4rem;
-					top-right-radius: 0.4rem;
+				padding: {
+					left: $padding-smaller;
+					right: $padding-smaller;
 				}
+				height: $tf-comparator-operator-height;
+				min-height: $tf-comparator-operator-height;
+				width: $tf-comparator-operator-width;
+				color: $tf-comparator-operator-color;
+				border: {
+					radius: 0;
+					top-left-radius: 0.4rem;
+				}
+				z-index: 1;
 
 				&-default {
 					box-shadow: none;
-					background-color: $gallery;
-
-					&:hover {
-						opacity: 1;
-					}
-				}
-
-				.tc-dropdown-button-title-label {
-					height: 2.5rem;
+					background-color: $tf-comparator-operator-background;
 				}
 			}
 		}
 
 		.form-group {
-			padding-top: $padding-normal;
-			margin-bottom: $padding-normal;
+			padding-top: $padding-large;
 
 			.control-label {
 				top: 0;
 			}
+
 			.form-control {
-				padding-left: 3.3rem;
+				padding-left: $tf-comparator-operator-width + 1rem;
 			}
 		}
 	}
@@ -56,7 +63,7 @@
 		font-weight: bold;
 	}
 
-	.name {
-		margin-left: 1rem;
+	.symbol + .name {
+		padding-left: 1rem;
 	}
 }

--- a/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
@@ -15,10 +15,10 @@ exports[`Comparator field should render default Comparator 1`] = `
             icon="talend-greater-than"
             name=""
             selected={false}
-            symbol=">"
+            symbol="greater_than"
           />,
-          "title": ">",
-          "value": ">",
+          "title": "greater_than",
+          "value": "greater_than",
         },
         Object {
           "icon": "talend-less-than",
@@ -27,10 +27,10 @@ exports[`Comparator field should render default Comparator 1`] = `
             icon="talend-less-than"
             name=""
             selected={false}
-            symbol="<"
+            symbol="less_than"
           />,
-          "title": "<",
-          "value": "<",
+          "title": "less_than",
+          "value": "less_than",
         },
         Object {
           "icon": "talend-equal",
@@ -39,10 +39,10 @@ exports[`Comparator field should render default Comparator 1`] = `
             icon="talend-equal"
             name=""
             selected={false}
-            symbol="="
+            symbol="equals"
           />,
-          "title": "=",
-          "value": "=",
+          "title": "equals",
+          "value": "equals",
         },
       ]
     }
@@ -91,10 +91,10 @@ exports[`Comparator field should render disabled Comparator 1`] = `
             icon="talend-greater-than"
             name=""
             selected={false}
-            symbol=">"
+            symbol="greater_than"
           />,
-          "title": ">",
-          "value": ">",
+          "title": "greater_than",
+          "value": "greater_than",
         },
         Object {
           "icon": "talend-less-than",
@@ -103,10 +103,10 @@ exports[`Comparator field should render disabled Comparator 1`] = `
             icon="talend-less-than"
             name=""
             selected={false}
-            symbol="<"
+            symbol="less_than"
           />,
-          "title": "<",
-          "value": "<",
+          "title": "less_than",
+          "value": "less_than",
         },
         Object {
           "icon": "talend-equal",
@@ -115,10 +115,10 @@ exports[`Comparator field should render disabled Comparator 1`] = `
             icon="talend-equal"
             name=""
             selected={false}
-            symbol="="
+            symbol="equals"
           />,
-          "title": "=",
-          "value": "=",
+          "title": "equals",
+          "value": "equals",
         },
       ]
     }

--- a/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
@@ -5,11 +5,14 @@ exports[`Comparator field should render default Comparator 1`] = `
   className="theme-comparator"
 >
   <withI18nextTranslation(ActionDropdown)
+    hideLabel={false}
     items={
       Array [
         Object {
+          "icon": "talend-greater-than",
           "id": "comparison-operator-0",
           "label": <OperatorListElement
+            icon="talend-greater-than"
             name=""
             selected={false}
             symbol=">"
@@ -18,8 +21,10 @@ exports[`Comparator field should render default Comparator 1`] = `
           "value": ">",
         },
         Object {
+          "icon": "talend-less-than",
           "id": "comparison-operator-1",
           "label": <OperatorListElement
+            icon="talend-less-than"
             name=""
             selected={false}
             symbol="<"
@@ -28,8 +33,10 @@ exports[`Comparator field should render default Comparator 1`] = `
           "value": "<",
         },
         Object {
+          "icon": "talend-equal",
           "id": "comparison-operator-2",
           "label": <OperatorListElement
+            icon="talend-equal"
             name=""
             selected={false}
             symbol="="
@@ -50,18 +57,15 @@ exports[`Comparator field should render default Comparator 1`] = `
     onFinish={[Function]}
     schema={
       Object {
-        "autoFocus": undefined,
-        "disabled": undefined,
         "key": Array [
           "default",
           "value",
         ],
-        "readOnly": undefined,
         "required": true,
         "schema": Object {
           "type": "string",
         },
-        "title": "value",
+        "title": "Default comparator",
         "type": "text",
       }
     }
@@ -77,11 +81,14 @@ exports[`Comparator field should render disabled Comparator 1`] = `
 >
   <withI18nextTranslation(ActionDropdown)
     disabled={true}
+    hideLabel={false}
     items={
       Array [
         Object {
+          "icon": "talend-greater-than",
           "id": "comparison-operator-0",
           "label": <OperatorListElement
+            icon="talend-greater-than"
             name=""
             selected={false}
             symbol=">"
@@ -90,8 +97,10 @@ exports[`Comparator field should render disabled Comparator 1`] = `
           "value": ">",
         },
         Object {
+          "icon": "talend-less-than",
           "id": "comparison-operator-1",
           "label": <OperatorListElement
+            icon="talend-less-than"
             name=""
             selected={false}
             symbol="<"
@@ -100,8 +109,10 @@ exports[`Comparator field should render disabled Comparator 1`] = `
           "value": "<",
         },
         Object {
+          "icon": "talend-equal",
           "id": "comparison-operator-2",
           "label": <OperatorListElement
+            icon="talend-equal"
             name=""
             selected={false}
             symbol="="
@@ -122,18 +133,16 @@ exports[`Comparator field should render disabled Comparator 1`] = `
     onFinish={[Function]}
     schema={
       Object {
-        "autoFocus": undefined,
         "disabled": true,
         "key": Array [
           "default",
           "value",
         ],
-        "readOnly": undefined,
         "required": true,
         "schema": Object {
           "type": "string",
         },
-        "title": "value",
+        "title": "Default comparator",
         "type": "text",
       }
     }

--- a/packages/forms/src/UIForm/fields/Comparator/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/displayMode/TextMode.component.js
@@ -1,13 +1,17 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import Icon from '@talend/react-components/lib/Icon';
+import { ICONS_MAPPING } from '../Comparator.component';
 import { TextMode as FieldTemplate } from '../../FieldTemplate';
 
 export default function TextMode(props) {
 	const { id, schema, value } = props;
-
+	const iconName = ICONS_MAPPING[value.operator];
 	return (
 		<FieldTemplate id={id} label={schema.title}>
-			{`${value.operator} ${value.value || ''}`}
+			{iconName && <Icon name={iconName} />}
+			{!iconName && value.operator}
+			{`${value.operator ? ' ' : ''}${value.value || ''}`}
 		</FieldTemplate>
 	);
 }

--- a/packages/forms/src/UIForm/fields/Comparator/displayMode/__snapshots__/TextMode.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/displayMode/__snapshots__/TextMode.test.js.snap
@@ -5,6 +5,9 @@ exports[`Text field text display mode should render a comparator field in text m
   id="myForm"
   label="My input title"
 >
-  &gt;= 666
+  <Icon
+    name="talend-greater-than-equal"
+  />
+   666
 </FieldTemplate>
 `;

--- a/packages/forms/src/UIForm/fields/Comparator/displayMode/__snapshots__/TextMode.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/displayMode/__snapshots__/TextMode.test.js.snap
@@ -5,9 +5,7 @@ exports[`Text field text display mode should render a comparator field in text m
   id="myForm"
   label="My input title"
 >
-  <Icon
-    name="talend-greater-than-equal"
-  />
+  &gt;=
    666
 </FieldTemplate>
 `;

--- a/packages/forms/stories-core/json/fields/core-comparator-input.json
+++ b/packages/forms/stories-core/json/fields/core-comparator-input.json
@@ -10,7 +10,21 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": ["=", "!=", "≅", "≇", "|>", ">|", ":", "<", "<=", ">", ">=", "^\\", "😊"]
+            "enum": [
+              "equals",
+              "not_equals",
+              "contains",
+              "not_contains",
+              "starts_with",
+              "ends_with",
+              "between",
+              "greater_than",
+              "greater_equals_to",
+              "less_than",
+              "less_equals_to",
+              "regex",
+              "😊"
+            ]
           },
           "value": {
             "type": "string"
@@ -23,7 +37,21 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": ["=", "!=", "≅", "≇", "|>", ">|", ":", "<", "<=", ">", ">=", "^\\", "😊"]
+            "enum": [
+              "equals",
+              "not_equals",
+              "contains",
+              "not_contains",
+              "starts_with",
+              "ends_with",
+              "between",
+              "greater_than",
+              "greater_equals_to",
+              "less_than",
+              "less_equals_to",
+              "regex",
+              "😊"
+            ]
           },
           "value": {
             "type": "string"
@@ -75,55 +103,55 @@
       "titleMap": [
         {
           "name": "Equals to",
-          "value": "="
+          "value": "equals"
         },
         {
           "name": "Not equals to",
-          "value": "!="
+          "value": "not_equals"
         },
         {
           "name": "Contains",
-          "value": "≅"
+          "value": "contains"
         },
         {
           "name": "Not contains",
-          "value": "≇"
+          "value": "not_contains"
         },
         {
           "name": "Starts with",
-          "value": "|>"
+          "value": "starts_with"
         },
         {
           "name": "Ends with",
-          "value": ">|"
+          "value": "ends_with"
         },
         {
           "name": "Between",
-          "value": ":"
+          "value": "between"
         },
         {
           "name": "Less or equal to",
-          "value": "<="
+          "value": "less_equals_to"
         },
         {
           "name": "Less than",
-          "value": "<"
+          "value": "less_than"
         },
         {
           "name": "Greater than",
-          "value": ">"
+          "value": "greater_than"
         },
         {
           "name": "Greater or equal to",
-          "value": ">="
+          "value": "greater_equals_to"
+        },
+        {
+          "name": "RegEx",
+          "value": "regex"
         },
         {
           "name": "Something",
           "value": "😊"
-        },
-        {
-          "name": "RegEx",
-          "value": "^\\"
         }
       ],
       "tooltip": "👋"
@@ -159,7 +187,7 @@
   ],
   "properties": {
     "default": {
-      "operator": ">"
+      "operator": "greater_than"
     },
     "numeric": {
       "operator": "orng"

--- a/packages/forms/stories-core/json/fields/core-comparator-input.json
+++ b/packages/forms/stories-core/json/fields/core-comparator-input.json
@@ -10,15 +10,28 @@
         "properties": {
           "operator": {
             "type": "string",
-            "enum": [">", "<", "="]
+            "enum": ["=", "!=", "≅", "≇", "|>", ">|", ":", "<", "<=", ">", ">=", "^\\", "😊"]
           },
           "value": {
             "type": "string"
           }
         }
       },
-
+      "withLabels": {
+        "type": "object",
+        "required": ["value"],
+        "properties": {
+          "operator": {
+            "type": "string",
+            "enum": ["=", "!=", "≅", "≇", "|>", ">|", ":", "<", "<=", ">", ">=", "^\\", "😊"]
+          },
+          "value": {
+            "type": "string"
+          }
+        }
+      },
       "numeric": {
+        "title": "Not value",
         "type": "object",
         "required": ["value"],
         "properties": {
@@ -33,7 +46,6 @@
           }
         }
       },
-
       "disabled": {
         "type": "object",
         "required": ["value"],
@@ -56,12 +68,70 @@
       "widget": "comparator",
       "title": "Default comparator"
     },
-
+    {
+      "key": "withLabels",
+      "widget": "comparator",
+      "title": "Comparator with labels",
+      "titleMap": [
+        {
+          "name": "Equals to",
+          "value": "="
+        },
+        {
+          "name": "Not equals to",
+          "value": "!="
+        },
+        {
+          "name": "Contains",
+          "value": "≅"
+        },
+        {
+          "name": "Not contains",
+          "value": "≇"
+        },
+        {
+          "name": "Starts with",
+          "value": "|>"
+        },
+        {
+          "name": "Ends with",
+          "value": ">|"
+        },
+        {
+          "name": "Between",
+          "value": ":"
+        },
+        {
+          "name": "Less or equal to",
+          "value": "<="
+        },
+        {
+          "name": "Less than",
+          "value": "<"
+        },
+        {
+          "name": "Greater than",
+          "value": ">"
+        },
+        {
+          "name": "Greater or equal to",
+          "value": ">="
+        },
+        {
+          "name": "Something",
+          "value": "😊"
+        },
+        {
+          "name": "RegEx",
+          "value": "^\\"
+        }
+      ],
+      "tooltip": "👋"
+    },
     {
       "key": "numeric",
       "widget": "comparator",
-      "title": "Numeric comparator",
-
+      "title": "Customs numeric comparator",
       "titleMap": [
         {
           "name": "Orange",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Comparator` still uses the operator as a string
 
**What is the chosen solution to this problem?**
`Comparator` can use Talend icons

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
