### PR TITLE
fix(CollapsiblePanel): Fix border with nested components

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -2,7 +2,7 @@
 
 
 src/CollapsiblePanel/CollapsiblePanel.scss
-  143:5  error  Mixins should come before declarations  mixins-before-declarations
+  142:5  error  Mixins should come before declarations  mixins-before-declarations
 
 src/DateTimePickers/pickers/TimePicker/TimePicker.scss
   26:9  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -56,7 +56,6 @@ $tc-skeleton-background-color: #dfdfdf !default;
 // due to react-bootstrap
 :global(.panel .panel) {
 	margin: 0;
-	border: none;
 }
 
 .tc-collapsible-panel {

--- a/packages/components/stories/CollapsiblePanel.js
+++ b/packages/components/stories/CollapsiblePanel.js
@@ -297,4 +297,35 @@ storiesOf('CollapsiblePanel', module)
 				expanded
 			/>
 		</div>
+	))
+	.add('Nested', () => (
+		<div className="col-lg-offset-1 col-lg-10">
+			<IconsProvider defaultIcons={icons} />
+			<h1>Nested</h1>
+			<CollapsiblePanel
+				id="panel-nested-1"
+				header={[{ label: 'First level CollapsiblePanel' }]}
+				onToggle={action('onToggle')}
+				onSelect={action('onSelect')}
+				expanded
+			>
+				<CollapsiblePanel
+					id="panel-nested-2"
+					header={[{ label: 'Second level CollapsiblePanel' }]}
+					onToggle={action('onToggle')}
+					onSelect={action('onSelect')}
+					expanded
+				>
+					<CollapsiblePanel
+						id="panel-nested-3"
+						header={[{ label: 'Third level CollapsiblePanel' }]}
+						onToggle={action('onToggle')}
+						onSelect={action('onSelect')}
+						expanded
+					>
+						Lorem ipsum dolor sit amet.
+					</CollapsiblePanel>
+				</CollapsiblePanel>
+			</CollapsiblePanel>
+		</div>
 	));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we nest CollapsiblePanel, we loose the border on nested component. This is make the usage unreadable, mostly on form.

The problem was introduced in this PR: [https://github.com/Talend/ui/pull/229](https://github.com/Talend/ui/pull/229) for this JIRA ticket: [https://jira.talendforge.org/browse/TUX-207](https://jira.talendforge.org/browse/TUX-207)
This was made for a TDP component.

**What is the chosen solution to this problem?**
Remove a global scss override, and create a story to show this specific usage.

Story: [http://2478.talend.surge.sh/components/?path=/story/collapsiblepanel--nested](http://2478.talend.surge.sh/components/?path=/story/collapsiblepanel--nested)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
