### PR TITLE
fix(ActionIconToggle): transparent border on focus

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -33,7 +33,7 @@ $tc-icon-toggle-border: 1px solid $gray;
 	}
 
 	&, &:focus {
-		border: $tc-icon-toggle-gray-border;
+		border: $tc-icon-toggle-border;
 	}
 
 	&[disabled] {

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -32,7 +32,8 @@ $tc-icon-toggle-border: 1px solid $gray;
 		color: $gray;
 	}
 
-	&, &:focus {
+	&,
+	&:focus {
 		border: $tc-icon-toggle-border;
 	}
 

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -32,7 +32,7 @@ $tc-icon-toggle-border: 1px solid $gray;
 		color: $gray;
 	}
 
-	&:focus {
+	&, &:focus {
 		border: $tc-icon-toggle-gray-border;
 	}
 

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -1,6 +1,6 @@
 $tc-icon-toggle-size: 2.4rem !default;
 $tc-icon-toggle-icon-size: $svg-sm-size !default;
-$tc-icon-toggle-gray-border: 1px solid $gray;
+$tc-icon-toggle-border: 1px solid $gray;
 
 @mixin tc-icon-toggle($btn-size: $tc-icon-toggle-size, $icon-size: $tc-icon-toggle-icon-size) {
 	height: $btn-size;

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -20,7 +20,6 @@ $tc-icon-toggle-border: 1px solid $gray;
 	justify-content: center;
 	align-items: center;
 
-	border: $tc-icon-toggle-gray-border;
 	background-color: transparent;
 
 	box-shadow: none;

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -1,5 +1,6 @@
 $tc-icon-toggle-size: 2.4rem !default;
 $tc-icon-toggle-icon-size: $svg-sm-size !default;
+$tc-icon-toggle-gray-border: 1px solid $gray;
 
 @mixin tc-icon-toggle($btn-size: $tc-icon-toggle-size, $icon-size: $tc-icon-toggle-icon-size) {
 	height: $btn-size;
@@ -19,7 +20,7 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 	justify-content: center;
 	align-items: center;
 
-	border: 1px solid $gray;
+	border: $tc-icon-toggle-gray-border;
 	background-color: transparent;
 
 	box-shadow: none;
@@ -33,7 +34,7 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 	}
 
 	&:focus {
-		border: 1px solid $gray;
+		border: $tc-icon-toggle-gray-border;
 	}
 
 	&[disabled] {

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -32,6 +32,10 @@ $tc-icon-toggle-icon-size: $svg-sm-size !default;
 		color: $gray;
 	}
 
+	&:focus {
+		border: 1px solid $gray;
+	}
+
 	&[disabled] {
 		&:hover,
 		&:focus {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is no border when the ActionIconToggle has the focus
![image](https://user-images.githubusercontent.com/2909671/67020202-1cf9c080-f0fe-11e9-8446-468f3e4c2234.png)

**What is the chosen solution to this problem?**
Specify one

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
