### PR TITLE
Fix(date picker): fix focus issue of date picker

### DIFF
--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.component.js
@@ -158,6 +158,9 @@ class CalendarPicker extends React.Component {
 			);
 		}
 
+		const isTodayFocusable =
+			this.pickerRef && this.pickerRef.contains(document.activeElement) ? 0 : -1;
+
 		return (
 			<div
 				className={theme.container}
@@ -182,6 +185,7 @@ class CalendarPicker extends React.Component {
 						})}
 						onClick={this.onClickToday}
 						className="btn-tertiary btn-info"
+						tabIndex={isTodayFocusable}
 					/>
 				</div>
 			</div>

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
@@ -26,6 +26,7 @@ exports[`CalendarPicker should render 1`] = `
       className="btn-tertiary btn-info"
       label="Today"
       onClick={[Function]}
+      tabIndex={-1}
     />
   </div>
 </div>

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.component.js
@@ -89,7 +89,6 @@ class YearPicker extends React.Component {
 						iconTransform="rotate-90"
 						label={t('DATEPICKER_YEAR_PREVIOUS', { defaultValue: 'Go to previous year' })}
 						onClick={this.scrollUp}
-						tabIndex="-1"
 						link
 						hideLabel
 					/>,
@@ -139,7 +138,6 @@ class YearPicker extends React.Component {
 						iconTransform="rotate-270"
 						label={t('DATEPICKER_YEAR_NEXT', { defaultValue: 'Go to next year' })}
 						onClick={this.scrollDown}
-						tabIndex="-1"
 						link
 						hideLabel
 					/>,

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/__snapshots__/YearPicker.test.js.snap
@@ -12,7 +12,6 @@ exports[`YearPicker should default render with current year in middle when "sele
     label="Go to previous year"
     link={true}
     onClick={[Function]}
-    tabIndex="-1"
   />
   <ol
     onWheel={[Function]}
@@ -103,7 +102,6 @@ exports[`YearPicker should default render with current year in middle when "sele
     label="Go to next year"
     link={true}
     onClick={[Function]}
-    tabIndex="-1"
   />
 </div>
 `;
@@ -120,7 +118,6 @@ exports[`YearPicker should render 1`] = `
     label="Go to previous year"
     link={true}
     onClick={[Function]}
-    tabIndex="-1"
   />
   <ol
     onWheel={[Function]}
@@ -214,7 +211,6 @@ exports[`YearPicker should render 1`] = `
     label="Go to next year"
     link={true}
     onClick={[Function]}
-    tabIndex="-1"
   />
 </div>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This is to fix 2 issues of date picker gesture:
* `YearPicker`: The arrows (up/down) should not be focusable. 
* `Today` button should be focusable when focus in picker popper, and not focusable when focus is outside of picker popper.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
