### PR TITLE
fix(components/FocusManager): support ref as object in PropTypes

### DIFF
--- a/packages/components/src/FocusManager/FocusManager.component.js
+++ b/packages/components/src/FocusManager/FocusManager.component.js
@@ -15,7 +15,10 @@ export default class FocusManager extends Component {
 	static propTypes = {
 		onFocusOut: PropTypes.func,
 		onFocusIn: PropTypes.func,
-		divRef: PropTypes.func,
+		divRef: PropTypes.oneOfType([
+			PropTypes.object,
+			PropTypes.func,
+		]),
 	};
 
 	onFocus = event => {

--- a/packages/components/src/FocusManager/FocusManager.component.js
+++ b/packages/components/src/FocusManager/FocusManager.component.js
@@ -15,10 +15,7 @@ export default class FocusManager extends Component {
 	static propTypes = {
 		onFocusOut: PropTypes.func,
 		onFocusIn: PropTypes.func,
-		divRef: PropTypes.oneOfType([
-			PropTypes.object,
-			PropTypes.func,
-		]),
+		divRef: PropTypes.oneOfType([PropTypes.object, PropTypes.func]),
 	};
 
 	onFocus = event => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In `<FocusManager />` component, the prop definition is wrong for `divRef`. 
ref can be an object (when using `useRef` or `React.createRef()`) or a function (when using it as a callback).

**What is the chosen solution to this problem?**
Just fix prop declaration with a union.
This prevent some warning in console, specially in form which use this as an object (ex: https://github.com/Talend/ui/blob/master/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.js#L73)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
