### PR TITLE
fix(TMC-18688): datalist lost suggestions after selecting item twice

### DIFF
--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -368,9 +368,10 @@ class Datalist extends Component {
 				groups = groups
 					.map(group => ({
 						...group,
-						suggestions: value && value !== this.state.previousValue
-							? group.suggestions.filter(item => regex.test(item.name))
-							: group.suggestions,
+						suggestions:
+							value && value !== this.state.previousValue
+								? group.suggestions.filter(item => regex.test(item.name))
+								: group.suggestions,
 					}))
 					.filter(group => group.suggestions.length > 0);
 			} else {

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -368,7 +368,7 @@ class Datalist extends Component {
 				groups = groups
 					.map(group => ({
 						...group,
-						suggestions: value
+						suggestions: value && value !== this.state.previousValue
 							? group.suggestions.filter(item => regex.test(item.name))
 							: group.suggestions,
 					}))


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-18688

In TMC when creating plan and selecting the same item twice, only items with the same name as selected are available for selection (in datalist suggestions)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
