### PR TITLE
feat(components/ListComposition): Expose setSelectedIds from hooks

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
@@ -36,6 +36,7 @@ export default function useCollectionSelection(
 		isSelected,
 		allIsSelected: selectedIds.length > 0 && selectedIds.length === collection.length,
 		selectedIds,
+		setSelectedIds,
 		onToggleAll,
 		onToggleItem,
 	};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
External events can change the items of the list. This can cause an issue for example when deleting elements from the list :

![deleteallgroup](https://user-images.githubusercontent.com/38908846/67404348-8ae93080-f5b3-11e9-872b-1757f5181412.gif)

As we can see, multiSelectActions remain in place while their state should be resumed.

Therefore we need to also be able to update the item selection accordingly.

**What is the chosen solution to this problem?**
Expose state setter

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
