### PR TITLE
fix(components/list): default value for collection using useCollectionActions hook

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
@@ -1,6 +1,10 @@
 import { useMemo } from 'react';
 
-export default function useCollectionActions(collection = [], actions = [], persistentActions = []) {
+export default function useCollectionActions(
+	collection = [],
+	actions = [],
+	persistentActions = [],
+) {
 	return useMemo(
 		() =>
 			collection.map(item => ({

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionActions.hook.js
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-export default function useCollectionActions(collection, actions = [], persistentActions = []) {
+export default function useCollectionActions(collection = [], actions = [], persistentActions = []) {
 	return useMemo(
 		() =>
 			collection.map(item => ({


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we use a hook named `useCollectionActions` from the List component, 
it fails if the collection is not yet available.

**What is the chosen solution to this problem?**
Use default value to avoid error

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
