### PR TITLE
fix(components): VirtualizedList - resizable.js workingIndex is equal to -1

### DIFF
--- a/packages/components/src/VirtualizedList/utils/resizable.js
+++ b/packages/components/src/VirtualizedList/utils/resizable.js
@@ -188,15 +188,18 @@ const changeWidthColumn = (setWidthFn, getIndexFn) => (index, listWidth) => ([
 	deltaX,
 ]) => {
 	let workingIndex = index;
+	let absDeltaX = deltaX;
 	if (getIndexFn) {
 		workingIndex = getIndexFn(index, columnsWidths);
 	}
-	const currentColumn = columnsWidths[workingIndex];
-	if (!currentColumn.width) {
-		throwNoWidthErrorMsg(currentColumn.dataKey);
-	}
-	const absDeltaX = transformDeltaValue(currentColumn, deltaX);
 	if (workingIndex >= 0) {
+		const currentColumn = columnsWidths[workingIndex];
+
+		if (!currentColumn.width) {
+			throwNoWidthErrorMsg(currentColumn.dataKey);
+		}
+		absDeltaX = transformDeltaValue(currentColumn, deltaX);
+
 		const widthBeforeChange = currentColumn.width;
 		flow([
 			setWidthFn(absDeltaX, listWidth, currentTotalWidth),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
An error is visible when the last column is reduced at the minimum possible

![ListResizableError](https://user-images.githubusercontent.com/32456736/67682600-0bcb7200-f990-11e9-8485-ee7f7706d297.gif)

In fact the variable workingIndex is set to -1 and in this case there is no related value in columnsWidths

![ListResizableError2](https://user-images.githubusercontent.com/32456736/67682822-82686f80-f990-11e9-8de0-ea2e1fbea5d8.gif)


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
