### PR TITLE
fix(date-picker): Issue with input field width

### DIFF
--- a/packages/components/src/DateTimePickers/shared/InputSizer/InputSizer.component.js
+++ b/packages/components/src/DateTimePickers/shared/InputSizer/InputSizer.component.js
@@ -21,7 +21,7 @@ function InputSizer({ placeholder, inputText, children }) {
 
 	useEffect(() => {
 		setWidth(sizerRef.current.getBoundingClientRect().width);
-	}, [inputText, placeholder]);
+	});
 
 	const style = inputText ? inputTextSizerStyle : placeholderSizerStyle;
 	const text = inputText || placeholder;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-19294
There's a problem with `InputSizer` component which is used to measure the width of input.(for date picker, the input field width base on content). for initial render it didn't run `useEffect` logic to update width.
**What is the chosen solution to this problem?**
remove conditions to run useEffect so it will run on initial render.
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
