### PR TITLE
feat(faceted-search/AddFacetPopover): Filter badge by label, not attribute

### DIFF
--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.component.js
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.component.js
@@ -90,4 +90,4 @@ AddFacetPopover.propTypes = {
 };
 
 // eslint-disable-next-line import/prefer-default-export
-export { AddFacetPopover, filterByLabel };
+export { AddFacetPopover };

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.component.js
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.component.js
@@ -33,8 +33,8 @@ AddFacetRow.propTypes = {
 	onClick: PropTypes.func.isRequired,
 };
 
-const filterByAttribute = attribute => badgeDefinition =>
-	badgeDefinition.properties.attribute.includes(attribute);
+const filterByLabel = label => badgeDefinition =>
+	badgeDefinition.properties.label.toLowerCase().includes(label);
 
 const AddFacetPopover = ({ badgesDefinitions = [], id, initialFilterValue, onClick, t }) => {
 	const [filterValue, setFilterValue] = useState(initialFilterValue || '');
@@ -43,7 +43,7 @@ const AddFacetPopover = ({ badgesDefinitions = [], id, initialFilterValue, onCli
 	};
 	const resetFilter = () => setFilterValue('');
 	const badgesDefinitionsFaceted = useMemo(
-		() => badgesDefinitions.filter(filterByAttribute(filterValue.toLowerCase().trim())),
+		() => badgesDefinitions.filter(filterByLabel(filterValue.toLowerCase().trim())),
 		[badgesDefinitions, filterValue],
 	);
 	const addFacetId = `${id}-add-facet-popover`;
@@ -90,4 +90,4 @@ AddFacetPopover.propTypes = {
 };
 
 // eslint-disable-next-line import/prefer-default-export
-export { AddFacetPopover };
+export { AddFacetPopover, filterByLabel };

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopver.component.test.js
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopver.component.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { AddFacetPopover, filterByLabel } from './AddFacetPopover.component';
+import { AddFacetPopover } from './AddFacetPopover.component';
 import getDefaultT from '../../translate';
 
 const t = getDefaultT();
@@ -106,19 +106,5 @@ describe('AddFacetPopover', () => {
 		wrapper.find('button[aria-label="Name"]').simulate('click');
 		// Then
 		expect(onClick).toHaveBeenNthCalledWith(1, onClick.mock.calls[0][0], badgesDefinitions[0]);
-	});
-	it('should filter a badge definition by label', () => {
-		const badgeDefinition = {
-			properties: {
-				attribute: 'product.key',
-				label: 'Id',
-			},
-			metadata: {
-				badgeId: 'a006a689-82cd-4a58-8071-5f4285019cce',
-			},
-		};
-		expect(filterByLabel('id')(badgeDefinition)).toEqual(true);
-		expect(filterByLabel('i')(badgeDefinition)).toEqual(true);
-		expect(filterByLabel('product.key')(badgeDefinition)).toEqual(false);
 	});
 });

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopver.component.test.js
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopver.component.test.js
@@ -2,7 +2,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';
-import { AddFacetPopover } from './AddFacetPopover.component';
+import { AddFacetPopover, filterByLabel } from './AddFacetPopover.component';
 import getDefaultT from '../../translate';
 
 const t = getDefaultT();
@@ -106,5 +106,19 @@ describe('AddFacetPopover', () => {
 		wrapper.find('button[aria-label="Name"]').simulate('click');
 		// Then
 		expect(onClick).toHaveBeenNthCalledWith(1, onClick.mock.calls[0][0], badgesDefinitions[0]);
+	});
+	it('should filter a badge definition by label', () => {
+		const badgeDefinition = {
+			properties: {
+				attribute: 'product.key',
+				label: 'Id',
+			},
+			metadata: {
+				badgeId: 'a006a689-82cd-4a58-8071-5f4285019cce',
+			},
+		};
+		expect(filterByLabel('id')(badgeDefinition)).toEqual(true);
+		expect(filterByLabel('i')(badgeDefinition)).toEqual(true);
+		expect(filterByLabel('product.key')(badgeDefinition)).toEqual(false);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In faceted popover, when we need to choose a field, we have a search bar to help us.
Today, filtering is based on `attribute` string of badge definition, not on `label`.
Problem is, `attribute` can be really a technical key (like `product/name`). We need to filter by label, which is the value displayed to user in list below.

We also need to made label case insensitive because the `includes()` method is case sensitive.

**What is the chosen solution to this problem?**
- Filter by `label`, not `attribute`. 
- Make it case insensitive.
- Add some tests.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
