### PR TITLE
fix(faceted-search/BadgeTextArea): Disable resize on textarea

### DIFF
--- a/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.scss
@@ -16,4 +16,8 @@
 	:global(.tc-tooltip-footer) {
 		justify-content: flex-end;
 	}
+
+	:global(textarea.form-control) {
+		resize: none;
+	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In text badge, the resize of textarea do not work properly: 
- Textarea can be more larger than the popover
- Visual glitch appear
- Browser can shutdown on Windows > Chrome

**What is the chosen solution to this problem?**
As resize textarea do not take part of the guideline, we simply remove this feature.
Guideline: [https://company-57688.frontify.com/document/215501#/navigation-layout/filtering-search](https://company-57688.frontify.com/document/215501#/navigation-layout/filtering-search)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
