### PR TITLE
chore(forms/MultiSelectTag): calling onFinish when focusing out

### DIFF
--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -171,11 +171,13 @@ export default class MultiSelectTag extends React.Component {
 	/**
 	 * Remove all suggestions
 	 */
-	resetSuggestions() {
+	resetSuggestions(event) {
+		const { onFinish, schema } = this.props;
 		this.setState({
 			suggestions: undefined,
 			focusedItemIndex: undefined,
 		});
+		onFinish(event, { schema });
 	}
 
 	/**


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Trying to add a customValidation on the multitag select widget, but the onFinish is not called when blurring.

**What is the chosen solution to this problem?**
Calling onFinish when focusing out from the typeahead

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
