### PR TITLE
chore(forms/Toggle): calling onFinish on change event

### DIFF
--- a/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
+++ b/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
@@ -26,7 +26,6 @@ function ToggleWidget(props) {
 				disabled={disabled || valueIsUpdating}
 				id={id}
 				label={title}
-				onBlur={event => onFinish(event, { schema })}
 				onChange={event => {
 					onChange(event, { schema, value: !value });
 					onFinish(event, { schema, value: !value });

--- a/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
+++ b/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
@@ -27,7 +27,12 @@ function ToggleWidget(props) {
 				id={id}
 				label={title}
 				onBlur={event => onFinish(event, { schema })}
-				onChange={event => onChange(event, { schema, value: !value })}
+				onChange={
+					event => {
+						onChange(event, { schema, value: !value });
+						onFinish(event, { schema, value: !value });
+					}
+				}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes
 				aria-invalid={!isValid}
 				aria-required={schema.required}

--- a/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
+++ b/packages/forms/src/UIForm/fields/Toggle/Toggle.component.js
@@ -27,12 +27,10 @@ function ToggleWidget(props) {
 				id={id}
 				label={title}
 				onBlur={event => onFinish(event, { schema })}
-				onChange={
-					event => {
-						onChange(event, { schema, value: !value });
-						onFinish(event, { schema, value: !value });
-					}
-				}
+				onChange={event => {
+					onChange(event, { schema, value: !value });
+					onFinish(event, { schema, value: !value });
+				}}
 				// eslint-disable-next-line jsx-a11y/aria-proptypes
 				aria-invalid={!isValid}
 				aria-required={schema.required}

--- a/packages/forms/src/UIForm/fields/Toggle/Toggle.component.test.js
+++ b/packages/forms/src/UIForm/fields/Toggle/Toggle.component.test.js
@@ -100,26 +100,4 @@ describe('Toggle field', () => {
 		expect(onChange).toBeCalledWith(expect.anything(), { schema, value: false });
 		expect(onFinish).toBeCalledWith(expect.anything(), { schema, value: false });
 	});
-
-	it('should trigger onFinish on input blur', () => {
-		// given
-		const onFinish = jest.fn();
-		const wrapper = mount(
-			<Toggle
-				id={'myForm'}
-				isValid
-				errorMessage={'My error message'}
-				onChange={jest.fn()}
-				onFinish={onFinish}
-				schema={schema}
-				value
-			/>,
-		);
-
-		// when
-		wrapper.find('input').simulate('blur');
-
-		// then
-		expect(onFinish).toBeCalledWith(expect.anything(), { schema });
-	});
 });

--- a/packages/forms/src/UIForm/fields/Toggle/Toggle.component.test.js
+++ b/packages/forms/src/UIForm/fields/Toggle/Toggle.component.test.js
@@ -77,16 +77,17 @@ describe('Toggle field', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should trigger onChange', () => {
+	it('should trigger onChange and onFinish', () => {
 		// given
 		const onChange = jest.fn();
+		const onFinish = jest.fn();
 		const wrapper = mount(
 			<Toggle
 				id={'myForm'}
 				isValid
 				errorMessage={'My error message'}
 				onChange={onChange}
-				onFinish={jest.fn()}
+				onFinish={onFinish}
 				schema={schema}
 				value
 			/>,
@@ -97,6 +98,7 @@ describe('Toggle field', () => {
 
 		// then
 		expect(onChange).toBeCalledWith(expect.anything(), { schema, value: false });
+		expect(onFinish).toBeCalledWith(expect.anything(), { schema, value: false });
 	});
 
 	it('should trigger onFinish on input blur', () => {

--- a/packages/forms/src/UIForm/fields/Toggle/__snapshots__/Toggle.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Toggle/__snapshots__/Toggle.component.test.js.snap
@@ -20,7 +20,6 @@ exports[`Toggle field should render autoFocused input 1`] = `
     id="myForm"
     intermediate={false}
     label="My input title"
-    onBlur={[Function]}
     onChange={[Function]}
   />
 </FieldTemplate>
@@ -45,7 +44,6 @@ exports[`Toggle field should render disabled input 1`] = `
     id="myForm"
     intermediate={false}
     label="My input title"
-    onBlur={[Function]}
     onChange={[Function]}
   />
 </FieldTemplate>
@@ -70,7 +68,6 @@ exports[`Toggle field should render input 1`] = `
     id="myForm"
     intermediate={false}
     label="My input title"
-    onBlur={[Function]}
     onChange={[Function]}
   />
 </FieldTemplate>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in order to call trigger when toggle value change we need it to be like checkbox and call onFinish after.

**What is the chosen solution to this problem?**
calling onFinish in the onChange event
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
