### PR TITLE
feat(components/tooltiptrigger): expose css classes

### DIFF
--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -221,10 +221,18 @@ function TooltipTrigger({
 
 			{visible &&
 				ReactDOM.createPortal(
-					<div className={theme['tc-tooltip-container']} style={style}>
+					<div
+						className={classNames(theme['tc-tooltip-container'], 'tc-tooltip-container')}
+						style={style}
+					>
 						<div
 							id={id}
-							className={classNames(theme['tc-tooltip-body'], theme[`tc-tooltip-${placement}`])}
+							className={classNames(
+								theme['tc-tooltip-body'],
+								theme[`tc-tooltip-${placement}`],
+								'tc-tooltip-body',
+								`tc-tooltip-${placement}`,
+							)}
 						>
 							{label}
 						</div>

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -102,6 +102,7 @@ const props = {
 function TooltipTrigger({
 	children,
 	label,
+	className,
 	tooltipDelay,
 	tooltipPlacement = 'right',
 	tooltipHeight = DEFAULT_OFFSET_Y,
@@ -222,7 +223,7 @@ function TooltipTrigger({
 			{visible &&
 				ReactDOM.createPortal(
 					<div
-						className={classNames(theme['tc-tooltip-container'], 'tc-tooltip-container')}
+						className={classNames(theme['tc-tooltip-container'], 'tc-tooltip-container', className)}
 						style={style}
 					>
 						<div
@@ -252,6 +253,7 @@ TooltipTrigger.propTypes = {
 	tooltipWidth: PropTypes.number,
 	tooltipDelay: PropTypes.number,
 	children: PropTypes.element,
+	className: PropTypes.string,
 };
 
 export default TooltipTrigger;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

TPD needs to apply a custom style to tooltips, but raw css classes are not exposed.

**What is the chosen solution to this problem?**

Add row css classes.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
