### PR TITLE
fix(FacetedSearch): tql error on empty value array

### DIFF
--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -13,7 +13,7 @@ const isNotEmptyOrNull = value => value && value.length;
 const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
 
 const filterBadgeWithNoValue = ({ properties }) => {
-	if (Array.isArray(properties.value)) {
+	if (Array.isArray(properties.value) && properties.value.length) {
 		return properties.value.every(isObjectIdNotEmptyOrNull);
 	}
 	return isNotEmptyOrNull(properties.value);

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -170,4 +170,50 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('');
 	});
+	it('should return an empty tql query', () => {
+		// Given
+		const badgesWithMultipleValues = [
+			{
+				properties: {
+					attribute: 'connection.type',
+					operator: {
+						label: 'In',
+						name: 'in',
+					},
+					type: 'select',
+					value: [
+						{
+							id: '',
+							label: 'HDFS',
+							checked: true,
+						},
+					],
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badgesWithMultipleValues);
+		// Then
+		expect(result).toEqual('');
+	});
+	it('should return an empty tql query when value is totally empty', () => {
+		// Given
+		const badgesWithMultipleValues = [
+			{
+				properties: {
+					attribute: 'connection.type',
+					operator: {
+						label: 'In',
+						name: 'in',
+					},
+					type: 'select',
+					value: [],
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badgesWithMultipleValues);
+		// Then
+		expect(result).toEqual('');
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Operator in and empty array throw a js exception.
**What is the chosen solution to this problem?**
Add a condition to remove any badge with [], to avoid problems.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
