### PR TITLE
feat(components/listcomposition): add boolean cell type

### DIFF
--- a/packages/components/src/VirtualizedList/CellBoolean/BooleanColumn.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/BooleanColumn.component.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { defaultColumnConfiguration } from '../Content.component';
+import CellBoolean from './CellBoolean.component';
+
+export const cellType = 'texticon';
+export const booleanColumnConfiguration = {
+	cellRenderer: props => <CellBoolean {...props} />,
+};
+
+// this is a fake component to be usable in JSX,
+// but the element is used as props object internally (VirtualizedList / RV)
+export default function BooleanColumn() {
+	return null;
+}
+
+BooleanColumn.defaultProps = {
+	...defaultColumnConfiguration,
+	...booleanColumnConfiguration,
+};

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
@@ -1,0 +1,43 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import classnames from 'classnames';
+import { withTranslation } from 'react-i18next';
+
+import I18N_DOMAIN_COMPONENTS from '../../constants';
+import getDefaultT from '../../translate';
+
+import Action from '../../Actions/Action';
+import styles from './CellBoolean.scss';
+
+/**
+ * Cell renderer that displays a boolean
+ */
+class CellBoolean extends React.Component {
+	shouldComponentUpdate(nextProps) {
+		return this.props.cellData !== nextProps.cellData;
+	}
+
+	render() {
+		const { cellData, t } = this.props;
+
+		return (
+			<div className={classnames('cell-boolean-container', styles['cell-boolean-container'])}>
+				{ cellData === true && t('BOOLEAN_VALUE_TRUE', { defaultValue: 'Yes' }) }
+				{ cellData === false && t('BOOLEAN_VALUE_FALSE', { defaultValue: 'No' }) }
+			</div>
+		);
+	}
+}
+
+CellBoolean.displayName = 'VirtualizedList(CellBoolean)';
+CellBoolean.propTypes = {
+	// The cell value : props.rowData[props.dataKey]
+	cellData: PropTypes.string,
+	t: PropTypes.func,
+};
+
+CellBoolean.defaultProps = {
+	t: getDefaultT(),
+};
+
+export default withTranslation(I18N_DOMAIN_COMPONENTS)(CellBoolean);

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.scss
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.scss
@@ -1,0 +1,3 @@
+.cell-icon-container {
+	display: flex;
+}

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.test.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.test.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CellBoolean from './CellBoolean.component';
+
+describe('CellBoolean', () => {
+	it('should render an empty cell', () => {
+		const wrapper = shallow(<CellBoolean />);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render a truthy value', () => {
+		const wrapper = shallow(<CellBoolean cellData />);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render a falsy value', () => {
+		const wrapper = shallow(<CellBoolean cellData={false} />);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/VirtualizedList/CellBoolean/__snapshots__/CellBoolean.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellBoolean/__snapshots__/CellBoolean.test.js.snap
@@ -1,0 +1,129 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellBoolean should render a falsy value 1`] = `
+<VirtualizedList(CellBoolean)
+  cellData={false}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
+    }
+  }
+  t={[Function]}
+  tReady={true}
+/>
+`;
+
+exports[`CellBoolean should render a truthy value 1`] = `
+<VirtualizedList(CellBoolean)
+  cellData={true}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
+    }
+  }
+  t={[Function]}
+  tReady={true}
+/>
+`;
+
+exports[`CellBoolean should render an empty cell 1`] = `
+<VirtualizedList(CellBoolean)
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
+    }
+  }
+  t={[Function]}
+  tReady={true}
+/>
+`;

--- a/packages/components/src/VirtualizedList/CellBoolean/index.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/index.js
@@ -1,0 +1,4 @@
+import BooleanColumn, { cellType, booleanColumnConfiguration } from './BooleanColumn.component';
+
+export { cellType, BooleanColumn };
+export default booleanColumnConfiguration;

--- a/packages/components/src/VirtualizedList/index.js
+++ b/packages/components/src/VirtualizedList/index.js
@@ -7,6 +7,7 @@ import { CheckboxColumn } from './CellCheckbox';
 import { DatetimeColumn } from './CellDatetime';
 import { TextIconColumn } from './CellTextIcon';
 import { TitleColumn } from './CellTitle';
+import { BooleanColumn } from './CellBoolean';
 
 export { cellDictionary, headerDictionary } from './utils/dictionary';
 export * from './utils/constants';
@@ -21,5 +22,6 @@ VirtualizedList.Datetime = DatetimeColumn;
 VirtualizedList.Text = Content;
 VirtualizedList.TextIcon = TextIconColumn;
 VirtualizedList.Title = TitleColumn;
+VirtualizedList.Boolean = BooleanColumn;
 
 export default VirtualizedList;

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -24,6 +24,7 @@ function CustomList(props) {
 		<List.VList id="my-vlist" {...props}>
 			<List.VList.Text label="Id" dataKey="id" />
 			<List.VList.Title label="Name" dataKey="name" columnData={titleProps} />
+			<List.VList.Boolean label="Valid" dataKey="isValid" />
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />
 			<List.VList.Text label="Author" dataKey="author" />

--- a/packages/components/stories/ListComposition/collection.js
+++ b/packages/components/stories/ListComposition/collection.js
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions';
+import random from 'lodash/random';
 
 const fewTitleActions = [
 	{
@@ -252,6 +253,7 @@ for (let i = 0; i < 100; i += 1) {
 	simpleCollection.push({
 		id: i,
 		name: `Title with icon and actions ${i}`,
+		isValid: [true, false, undefined][random(2)],
 		tag: 'test',
 		created: 1474495200,
 		modified: 1474495200,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

There is no boolean column type in List Composition

**What is the chosen solution to this problem?**

Add it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
