### PR TITLE
fix(ListComposition): fix alignment of sort by elements

### DIFF
--- a/packages/components/src/List/ListComposition/SortBy/SortBy.scss
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.scss
@@ -46,6 +46,7 @@ $tc-order-chooser-icon-size: 0.6rem !default;
 	&-items > a[role='button'] {
 		display: inline-block;
 		text-transform: lowercase;
+		white-space: nowrap;
 		&::first-letter {
 			text-transform: uppercase;
 		}

--- a/packages/components/src/List/ListComposition/SortBy/SortBy.scss
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.scss
@@ -24,8 +24,7 @@ $tc-order-chooser-icon-size: 0.6rem !default;
 
 	&-order-chooser[type='button'] {
 		display: flex;
-		margin-bottom: $padding-smaller;
-		align-items: flex-end;
+		align-items: center;
 		padding: 0;
 		&:hover,
 		&:focus,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
on Firefox, there's problem of alignment with sort by elements:
![image](https://user-images.githubusercontent.com/3214228/68359134-d8d66a80-0155-11ea-9884-ef5f4c370483.png)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
