### PR TITLE
fix(faceted-search/BasicSearch): Do not contrain onSubmit trigger

### DIFF
--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -36,7 +36,7 @@ const BasicSearch = ({
 	const [state, dispatch] = useFacetedBadges(badgesFaceted, setBadgesFaceted);
 
 	useEffect(() => {
-		if (state.badges.length && !state.badges.some(isInCreation)) {
+		if (!state.badges.some(isInCreation)) {
 			onSubmit({}, state.badges);
 		}
 	}, [state.badges, onSubmit]);

--- a/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -67,7 +67,7 @@ exports[`BasicSearch should render the default html output with some badges 1`] 
         </button>
       </div>
       <button role="button"
-              aria-label="Delete badge"
+              aria-label="Remove filter"
               id="tc-badge-delete-name-7bc9bd07-3b46-4b8c-a406-a08b6263de5b-badge-text"
               aria-describedby="42"
               type="button"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
onSubmit execution in `BasicSearch` is conditioned based on badges length. We don't want that anymore, it need to be done on the app side.

**What is the chosen solution to this problem?**
Remove the condition.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
