### PR TITLE
chore(List): add separator actions

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -57,7 +57,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   9:8  error  'Action' is defined but never used  no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
-  166:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
+  200:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/utils/tablerow.js
   42:3  warning  Unexpected console statement  no-console

--- a/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
+++ b/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
@@ -39,6 +39,9 @@ export function ListToVirtualizedList(props) {
 		if (!titleProps.persistentActionsKey) {
 			titleProps.persistentActionsKey = 'persistentActions';
 		}
+		if (!titleProps.arraysActionsKey) {
+			titleProps.arraysActionsKey = 'arraysActions';
+		}
 	}
 
 	// Backward compatibility: find array in object attr:

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -40,6 +40,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
         ],
         "titleProps": Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         },
@@ -89,6 +90,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
       titleProps={
         Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         }
@@ -476,6 +478,7 @@ exports[`List should render 1`] = `
         ],
         "titleProps": Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         },
@@ -1111,6 +1114,7 @@ exports[`List should render 1`] = `
       titleProps={
         Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         }
@@ -1499,6 +1503,7 @@ exports[`List should render id if provided 1`] = `
         ],
         "titleProps": Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         },
@@ -2153,6 +2158,7 @@ exports[`List should render id if provided 1`] = `
       titleProps={
         Object {
           "actionsKey": "actions",
+          "arraysActionsKey": "arraysActions",
           "onClick": [MockFunction],
           "persistentActionsKey": "persistentActions",
         }

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.component.js
@@ -43,6 +43,7 @@ class CellTitle extends React.Component {
 			onClick,
 			actionsKey,
 			persistentActionsKey,
+			arraysActionsKey,
 			displayModeKey,
 
 			getRowState,
@@ -92,6 +93,7 @@ class CellTitle extends React.Component {
 					rowData={rowData}
 					actionsKey={actionsKey}
 					persistentActionsKey={persistentActionsKey}
+					arraysActionsKey={arraysActionsKey}
 					displayMode={displayMode}
 					type={type}
 				/>

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -87,7 +87,8 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 	&:hover,
 	&:focus,
 	&:global(.ally-focus-within) {
-		:global(.tc-list-title .cell-title-actions) {
+		:global(.tc-list-title .cell-title-actions),
+		:global(.tc-list-title .cell-title-actions-separator) {
 			opacity: 1;
 			transition: opacity 0.15s ease-in;
 			visibility: visible;

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -34,7 +34,12 @@ function getSeparatorActions(separatorActions, getComponent) {
 				hideLabel
 				link
 			/>
-			<span className={classNames('cell-title-actions-separator', theme['cell-title-actions-separator'])} />
+			<span
+				className={classNames(
+					'cell-title-actions-separator',
+					theme['cell-title-actions-separator'],
+				)}
+			/>
 		</React.Fragment>
 	);
 }
@@ -46,7 +51,7 @@ function getLargeDisplayActions(separatorActions, actions, getComponent) {
 
 	return (
 		<React.Fragment>
-			{ getSeparatorActions(separatorActions, getComponent) }
+			{getSeparatorActions(separatorActions, getComponent)}
 			<Actions
 				getComponent={getComponent}
 				className={classNames('cell-title-actions', theme['cell-title-actions'])}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -177,7 +177,7 @@ export function CellTitleActionsComponent({
 }) {
 	let dataActions = get(rowData, actionsKey, []).filter(isAvailable);
 	let persistentActions = get(rowData, persistentActionsKey, []);
-	const arraysActions = get(rowData, arraysActionsKey);
+	const arraysActions = get(rowData, arraysActionsKey, []);
 	const hasActions = dataActions.length || persistentActions.length || arraysActions.length;
 	if (displayMode !== TITLE_MODE_TEXT || !hasActions) {
 		return null;
@@ -185,7 +185,7 @@ export function CellTitleActionsComponent({
 
 	const actions = [];
 	let separatorActions = [];
-	if (Array.isArray(arraysActions)) {
+	if (Array.isArray(arraysActions) && arraysActions.length > 0) {
 		[separatorActions, dataActions = [], persistentActions = []] = arraysActions;
 	}
 	if (type === LARGE) {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -34,9 +34,7 @@ function getSeparatorActions(separatorActions, getComponent) {
 				hideLabel
 				link
 			/>
-			<span className={
-				classNames('cell-title-actions-separator', theme['cell-title-actions-separator'])
-			} />
+			<span className={classNames('cell-title-actions-separator', theme['cell-title-actions-separator'])} />
 		</React.Fragment>
 	);
 }
@@ -183,7 +181,7 @@ export function CellTitleActionsComponent({
 	const actions = [];
 	let separatorActions = [];
 	if (Array.isArray(arraysActions)) {
-		[ separatorActions, dataActions = [], persistentActions = [] ] = arraysActions;
+		[separatorActions, dataActions = [], persistentActions = []] = arraysActions;
 	}
 	if (type === LARGE) {
 		actions.push(getLargeDisplayActions(separatorActions, dataActions, getComponent));
@@ -213,6 +211,8 @@ CellTitleActionsComponent.propTypes = {
 	actionsKey: PropTypes.string,
 	// The persistent actions property key. Actions = props.rowData[props.persistentActionsKey]
 	persistentActionsKey: PropTypes.string,
+	// The arrays actions property key. Actions = props.rowData[props.arraysActionsKey]
+	arraysActionsKey: PropTypes.string,
 	/** The display mode. */
 	displayMode: PropTypes.oneOf([TITLE_MODE_TEXT, TITLE_MODE_INPUT]),
 	getComponent: PropTypes.func,

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -175,7 +175,7 @@ export function CellTitleActionsComponent({
 	let dataActions = get(rowData, actionsKey, []).filter(isAvailable);
 	let persistentActions = get(rowData, persistentActionsKey, []);
 	const arraysActions = get(rowData, arraysActionsKey);
-	const hasActions = dataActions.length || persistentActions.length;
+	const hasActions = dataActions.length || persistentActions.length || arraysActions.length;
 	if (displayMode !== TITLE_MODE_TEXT || !hasActions) {
 		return null;
 	}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -5,22 +5,33 @@ $tc-list-title-dropdown-menu-triangle: '\25b2';
 $tc-list-title-dropup-menu-triangle: '\25bc';
 
 .main-title-actions-group {
+	display: flex;
+	align-items: center;
 	flex-grow: 0;
 	position: relative;
 	right: 0;
 	top: 0;
 	height: $btn-line-height;
 
+	.cell-title-actions-separator {
+		visibility: hidden;
+		opacity: 0;
+		&:after {
+			content: '|';
+			color: $dark-silver;
+		}
+	}
+
 	.cell-title-actions {
 		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
 		opacity: 0;
 		visibility: hidden;
 
-		position: absolute;
-		right: 100%;
+		// position: absolute;
+		// right: 100%;
 
-		padding-left: $padding-larger;
-		margin-right: $padding-smaller;
+		// padding-left: $padding-larger;
+		// margin-right: $padding-smaller;
 
 		.cell-title-actions-menu {
 			&:after {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { CellTitleActionsComponent } from './CellTitleActions.component';
 import { cellTitleDisplayModes, listTypes } from '../utils/constants';
+import { actions } from '../../List/ListComposition/Manager/hooks/useCollectionActions.hook.test';
 
 const { LARGE } = listTypes;
 
@@ -145,10 +146,24 @@ const persistentActions = [
 	},
 ];
 
+const arraysActions = [
+	[{
+		id: 'monitoring',
+		label: 'monitor something',
+		'data-feature': 'list.item.monitor',
+		icon: 'talend-line-charts',
+		onClick: jest.fn(),
+		hideLabel: true,
+	}],
+	fewSimpleActions,
+	persistentActions,
+];
+
 const props = {
 	id: 'my-actions',
 	actionsKey: 'actions',
 	persistentActionsKey: 'persistentActions',
+	arraysActionsKey: 'arraysActions',
 	getComponent: jest.fn(),
 };
 
@@ -294,6 +309,35 @@ describe('CellTitleActions', () => {
 
 		// then
 		expect(wrapper.find('.main-title-actions-group').getElement()).toMatchSnapshot();
+	});
+
+	it('should render all type of actions', () => {
+		// when
+		const wrapper = shallow(
+			<CellTitleActionsComponent
+				{...props}
+				displayMode={cellTitleDisplayModes.TITLE_MODE_TEXT}
+				rowData={{ arraysActions }}
+			/>,
+		);
+
+		// then
+		expect(wrapper.find('.main-title-actions-group').getElement()).toMatchSnapshot();
+	});
+
+	it('should render all type of actions with separator in large type', () => {
+		// when
+		const wrapper = shallow(
+			<CellTitleActionsComponent
+				{...props}
+				displayMode={cellTitleDisplayModes.TITLE_MODE_TEXT}
+				rowData={{ arraysActions }}
+				type={LARGE}
+			/>,
+		);
+
+		// then
+		expect(wrapper.find('.cell-title-actions-separator').length).toBe(1);
 	});
 
 	it('should stop keydown propagation', () => {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
@@ -146,14 +146,16 @@ const persistentActions = [
 ];
 
 const arraysActions = [
-	[{
-		id: 'monitoring',
-		label: 'monitor something',
-		'data-feature': 'list.item.monitor',
-		icon: 'talend-line-charts',
-		onClick: jest.fn(),
-		hideLabel: true,
-	}],
+	[
+		{
+			id: 'monitoring',
+			label: 'monitor something',
+			'data-feature': 'list.item.monitor',
+			icon: 'talend-line-charts',
+			onClick: jest.fn(),
+			hideLabel: true,
+		},
+	],
 	fewSimpleActions,
 	persistentActions,
 ];

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.test.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import { CellTitleActionsComponent } from './CellTitleActions.component';
 import { cellTitleDisplayModes, listTypes } from '../utils/constants';
-import { actions } from '../../List/ListComposition/Manager/hooks/useCollectionActions.hook.test';
 
 const { LARGE } = listTypes;
 

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
@@ -72,56 +72,58 @@ exports[`CellTitleActions should display all actions on LARGE display mode 1`] =
   id="my-actions"
   onKeyDown={[Function]}
 >
-  <Actions
-    actions={
-      Array [
-        Object {
-          "data-feature": "list.item.edit",
-          "icon": "talend-pencil",
-          "id": "edit",
-          "label": "edit",
-          "onClick": [MockFunction],
-        },
-        Object {
-          "data-feature": "list.item.delete",
-          "icon": "talend-trash",
-          "id": "delete",
-          "label": "delete",
-          "onClick": [MockFunction],
-        },
-        Object {
-          "data-feature": "list.item.copy",
-          "icon": "talend-files-o",
-          "id": "copy",
-          "label": "copy",
-          "onClick": [MockFunction],
-        },
-        Object {
-          "data-feature": "list.item.params",
-          "icon": "talend-cog",
-          "id": "params",
-          "label": "edit params",
-          "onClick": [MockFunction],
-        },
-        Object {
-          "data-feature": "list.item.download",
-          "icon": "talend-download",
-          "id": "download",
-          "label": "download",
-          "onClick": [MockFunction],
-        },
-      ]
-    }
-    className="cell-title-actions theme-cell-title-actions"
-    getComponent={[MockFunction]}
-    hideLabel={true}
-    link={true}
-    renderers={
-      Object {
-        "Action": [Function],
+  <React.Fragment>
+    <Actions
+      actions={
+        Array [
+          Object {
+            "data-feature": "list.item.edit",
+            "icon": "talend-pencil",
+            "id": "edit",
+            "label": "edit",
+            "onClick": [MockFunction],
+          },
+          Object {
+            "data-feature": "list.item.delete",
+            "icon": "talend-trash",
+            "id": "delete",
+            "label": "delete",
+            "onClick": [MockFunction],
+          },
+          Object {
+            "data-feature": "list.item.copy",
+            "icon": "talend-files-o",
+            "id": "copy",
+            "label": "copy",
+            "onClick": [MockFunction],
+          },
+          Object {
+            "data-feature": "list.item.params",
+            "icon": "talend-cog",
+            "id": "params",
+            "label": "edit params",
+            "onClick": [MockFunction],
+          },
+          Object {
+            "data-feature": "list.item.download",
+            "icon": "talend-download",
+            "id": "download",
+            "label": "download",
+            "onClick": [MockFunction],
+          },
+        ]
       }
-    }
-  />
+      className="cell-title-actions theme-cell-title-actions"
+      getComponent={[MockFunction]}
+      hideLabel={true}
+      link={true}
+      renderers={
+        Object {
+          "Action": [Function],
+        }
+      }
+    />
+  </React.Fragment>
 </div>
 `;
 
@@ -379,6 +381,94 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
       noCaret={true}
     />
   </div>
+</div>
+`;
+
+exports[`CellTitleActions should render all type of actions 1`] = `
+<div
+  className="main-title-actions-group theme-main-title-actions-group"
+  id="my-actions"
+  onKeyDown={[Function]}
+>
+  <div
+    className="cell-title-actions theme-cell-title-actions"
+  >
+    <Action
+      data-feature="list.item.monitor"
+      getComponent={[MockFunction]}
+      hideLabel={true}
+      icon="talend-line-charts"
+      id="monitoring"
+      label="monitor something"
+      link={true}
+      onClick={[MockFunction]}
+    />
+    <Action
+      data-feature="list.item.edit"
+      getComponent={[MockFunction]}
+      hideLabel={true}
+      icon="talend-pencil"
+      id="edit"
+      label="edit"
+      link={true}
+      onClick={[MockFunction]}
+    />
+    <withI18nextTranslation(ActionDropdown)
+      className="cell-title-actions-menu theme-cell-title-actions-menu"
+      hideLabel={true}
+      id="my-actions-ellispsis-actions"
+      items={
+        Array [
+          Object {
+            "data-feature": "list.item.delete",
+            "icon": "talend-trash",
+            "id": "delete",
+            "label": "delete",
+            "onClick": [MockFunction],
+          },
+          Object {
+            "data-feature": "list.item.copy",
+            "icon": "talend-files-o",
+            "id": "copy",
+            "label": "copy",
+            "onClick": [MockFunction],
+          },
+        ]
+      }
+      label="Open menu"
+      link={true}
+      noCaret={true}
+    />
+  </div>
+  <Actions
+    actions={
+      Array [
+        Object {
+          "className": "favorite",
+          "data-feature": "list.item.favorite",
+          "icon": "talend-star",
+          "label": "favorite",
+          "onClick": [MockFunction],
+        },
+        Object {
+          "className": "certify",
+          "data-feature": "list.item.certify",
+          "icon": "talend-badge",
+          "label": "certify",
+          "onClick": [MockFunction],
+        },
+      ]
+    }
+    className="persistent-actions theme-persistent-actions"
+    getComponent={[MockFunction]}
+    hideLabel={true}
+    link={true}
+    renderers={
+      Object {
+        "Action": [Function],
+      }
+    }
+  />
 </div>
 `;
 

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -73,6 +73,7 @@ const icons = {
 	'talend-column-chooser': talendIcons['talend-column-chooser'],
 	'talend-sort-desc': talendIcons['talend-sort-desc'],
 	'talend-sort-asc': talendIcons['talend-sort-asc'],
+	'talend-line-charts': talendIcons['talend-line-charts'],
 };
 
 const selected = [
@@ -179,6 +180,19 @@ const persistentActions = [
 		icon: 'talend-apache',
 		onClick: action('onEdit'),
 	},
+];
+
+const arraysActions = [
+	[{
+		id: 'monitoring',
+		label: 'monitor something',
+		'data-feature': 'list.item.monitor',
+		icon: 'talend-line-charts',
+		onClick: action('onMonitor'),
+		hideLabel: true,
+	}],
+	[...actions],
+	[...persistentActions],
 ];
 
 const props = {
@@ -593,6 +607,23 @@ storiesOf('List', module)
 			<List {...props} />
 		</div>
 	))
+	.add('Table arrays of actions display', () => {
+		const customProps = cloneDeep(props);
+		customProps.list.items = customProps.list.items.map(item => (
+			{ ...item, arraysActions })
+		);
+ 		return (
+			<div style={{ height: '70vh' }} className="virtualized-list">
+				<h1>List</h1>
+				<p>
+					Display the list in table mode using arrays of actions.
+					<br/>
+					This is the default mode.
+				</p>
+				<List {...customProps} />
+			</div>
+		);
+	})
 	.add('Table icons', () => {
 		const customProps = cloneDeep(props);
 
@@ -629,6 +660,23 @@ storiesOf('List', module)
 			<List {...props} rowHeight={140} displayMode="large" />
 		</div>
 	))
+	.add('large arrays of actions display', () => {
+		const customProps = cloneDeep(props);
+		customProps.list.items = customProps.list.items.map(item => (
+			{ ...item, arraysActions })
+		);
+		return (
+			<div style={{ height: '70vh' }} className="virtualized-list">
+				<h1>List</h1>
+				<p>
+					Display the list in table mode using arrays of actions.
+					<br/>
+					This is the default mode.
+				</p>
+				<List {...customProps} displayMode="large" />
+			</div>
+		);
+	})
 	.add('Large display overrides by rowRenderers', () => (
 		<div style={{ height: '70vh' }} className="virtualized-list">
 			<h1>List</h1>

--- a/packages/components/stories/ListComposition/ListComposition.js
+++ b/packages/components/stories/ListComposition/ListComposition.js
@@ -14,6 +14,7 @@ const titleProps = rowData => ({
 	'data-feature': `list.item.title.${rowData.id}`,
 	actionsKey: 'titleActions',
 	persistentActionsKey: 'persistentActions',
+	arraysActionsKey: 'arraysActions',
 	displayModeKey: 'display',
 	iconKey: 'icon',
 	onEditCancel: action('cancel-edit'),

--- a/packages/components/stories/ListComposition/collection.js
+++ b/packages/components/stories/ListComposition/collection.js
@@ -91,51 +91,6 @@ const titleActions = [
 				'data-feature': 'list.item.related',
 				onClick: action('document 1 click'),
 			},
-			{
-				label: 'document 2',
-				'data-feature': 'list.item.related',
-				onClick: action('document 2 click'),
-			},
-			{
-				label: 'document 3',
-				'data-feature': 'list.item.related',
-				onClick: action('document 3 click'),
-			},
-			{
-				label: 'document 4',
-				'data-feature': 'list.item.related',
-				onClick: action('document 4 click'),
-			},
-			{
-				label: 'document 5',
-				'data-feature': 'list.item.related',
-				onClick: action('document 5 click'),
-			},
-			{
-				label: 'document 6',
-				'data-feature': 'list.item.related',
-				onClick: action('document 6 click'),
-			},
-			{
-				label: 'document 7',
-				'data-feature': 'list.item.related',
-				onClick: action('document 7 click'),
-			},
-			{
-				label: 'document 8',
-				'data-feature': 'list.item.related',
-				onClick: action('document 8 click'),
-			},
-			{
-				label: 'document 9',
-				'data-feature': 'list.item.related',
-				onClick: action('document 9 click'),
-			},
-			{
-				label: 'document 10',
-				'data-feature': 'list.item.related',
-				onClick: action('document 10 click'),
-			},
 		],
 		pullRight: true,
 	},
@@ -156,6 +111,19 @@ const persistentActions = [
 		'data-feature': 'list.item.certify',
 		onClick: action('onCertify'),
 	},
+];
+
+const arraysActions = [
+	[{
+		id: 'monitoring',
+		label: 'monitor something',
+		'data-feature': 'list.item.monitor',
+		icon: 'talend-line-charts',
+		onClick: action('onMonitor'),
+		hideLabel: true,
+	}],
+	[...titleActions],
+	[...persistentActions],
 ];
 
 const complexCollection = [
@@ -264,6 +232,7 @@ for (let i = 0; i < 100; i += 1) {
 		className: 'item-0-class',
 		persistentActions,
 		titleActions,
+		arraysActions,
 	});
 }
 

--- a/packages/containers/examples/ExampleList.js
+++ b/packages/containers/examples/ExampleList.js
@@ -80,9 +80,10 @@ const actions = {
 	items: ['object:delete'],
 };
 
-const actionsWithPersistent = {
+const actionsWithPersistentAndSeparator = {
 	...actions,
 	persistentItemsActions: ['object:add'],
+	separatorActions: ['object:add']
 };
 
 const toolbar = {
@@ -219,7 +220,7 @@ const ExampleList = {
 		<div>
 			<IconsProvider />
 			<div className="list-container">
-				<List {...props} actions={actionsWithPersistent} items={items} />
+				<List {...props} actions={actionsWithPersistentAndSeparator} items={items} />
 			</div>
 		</div>
 	),

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -67,16 +67,30 @@ export const DEFAULT_STATE = new Map({
  * @return {Array}          [description]
  */
 export function getItems(context, props) {
-	return props.items.toJS().map(item =>
-		Object.assign({}, item, {
-			actions: getActionsProps(context, get(props, 'actions.items', []), item),
-			persistentActions: getActionsProps(
-				context,
-				get(props, 'actions.persistentItemsActions', []),
-				item,
-			),
-		}),
-	);
+	return props.items.toJS().map(item => {
+		const actions = getActionsProps(context, get(props, 'actions.items', []), item);
+		const persistentActions = getActionsProps(
+			context,
+			get(props, 'actions.persistentItemsActions', []),
+			item,
+		);
+		const separatorActions = getActionsProps(
+			context,
+			get(props, 'actions.separatorActions', []),
+			item,
+		);
+		const itemWithAction = {
+			...item,
+			actions,
+			persistentActions,
+		};
+		if (separatorActions && separatorActions.length > 0) {
+			itemWithAction.arraysActions = [
+				separatorActions, actions, separatorActions
+			]
+		}
+		return itemWithAction;
+	});
 }
 
 class List extends React.Component {

--- a/packages/containers/src/List/List.container.js
+++ b/packages/containers/src/List/List.container.js
@@ -85,9 +85,7 @@ export function getItems(context, props) {
 			persistentActions,
 		};
 		if (separatorActions && separatorActions.length > 0) {
-			itemWithAction.arraysActions = [
-				separatorActions, actions, separatorActions
-			]
+			itemWithAction.arraysActions = [separatorActions, actions, separatorActions];
 		}
 		return itemWithAction;
 	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
adding a new section in items actions : 
![image](https://user-images.githubusercontent.com/14272767/68750374-0d3ba200-0600-11ea-88e0-413212525229.png)

see : https://jira.talendforge.org/browse/TDS-4706
**What is the chosen solution to this problem?**
adding a new api for item buttons which is an array of array from left to right  separatorActions, actions, persistentActions
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
