### PR TITLE
fix(faceted-search/tql): Full support of operator notEqual

### DIFF
--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -1,6 +1,6 @@
 const operatorNames = {
 	contains: 'contains',
-	equal: '=',
+	equal: 'equal',
 	notEqual: 'notEqual',
 	in: 'in',
 };
@@ -17,7 +17,7 @@ const standardOperators = t => ({
 		label: t('OPERATOR_EQUALS_LABEL', {
 			defaultValue: 'Equals',
 		}),
-		name: '=',
+		name: 'equal',
 		iconName: 'equal',
 	},
 	[operatorNames.contains]: {

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -32,6 +32,7 @@ const getTqlClassOperatorsDictionary = query => ({
 	contains: query.contains,
 	'=': query.equal,
 	in: query.in,
+	notEqual: query.unequal,
 });
 
 const formatValue = value => {

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -30,7 +30,7 @@ const prepareBadges = flow([removeBadgesWithEmptyValue, getBadgesQueryValues]);
  */
 const getTqlClassOperatorsDictionary = query => ({
 	contains: query.contains,
-	'=': query.equal,
+	equal: query.equal,
 	in: query.in,
 	notEqual: query.unequal,
 });

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -216,4 +216,24 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('');
 	});
+	it('should return an unequal tql query when value is using the notEqual operator', () => {
+		// Given
+		const badgeNotEqual = [
+			{
+				properties: {
+					attribute: 'name',
+					operator: {
+						label: 'Not equals',
+						name: 'notEqual',
+						iconName: 'not-equal',
+					},
+					value: 'product name',
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badgeNotEqual);
+		// Then
+		expect(result).toEqual("(name != 'product name')");
+	});
 });

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -18,7 +18,7 @@ describe('createTqlQuery', () => {
 				attribute: 'name',
 				operator: {
 					label: 'Equal',
-					name: '=',
+					name: 'equal',
 					iconName: 'equal',
 				},
 				value: 'another-badge\n\n',
@@ -95,7 +95,7 @@ describe('createTqlQuery', () => {
 					attribute: 'name',
 					operator: {
 						label: 'Equal',
-						name: '=',
+						name: 'equal',
 						iconName: 'equal',
 					},
 					value: 'another-badge\n\n',

--- a/packages/faceted-search/stories/facetedSearch.story.js
+++ b/packages/faceted-search/stories/facetedSearch.story.js
@@ -17,7 +17,7 @@ const badgeName = {
 	metadata: {
 		badges_per_facet: 'N',
 		entities_per_badge: '1',
-		operators: ['contains', '=', 'notEqual'],
+		operators: ['contains', 'equal', 'notEqual'],
 	},
 };
 

--- a/packages/faceted-search/stories/facetedSearch.story.js
+++ b/packages/faceted-search/stories/facetedSearch.story.js
@@ -17,7 +17,7 @@ const badgeName = {
 	metadata: {
 		badges_per_facet: 'N',
 		entities_per_badge: '1',
-		operators: ['contains', '='],
+		operators: ['contains', '=', 'notEqual'],
 	},
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`notEqual` operator is available in operators dictionary as a standard one. 
Problem, when we try to use it in a text badge with the `createTqlQuery` adapter, it pop an error: ` TypeError: queryFunction is not a function`
This is because a mapping is missing in the tql converter function `getTqlClassOperatorsDictionary`

**What is the chosen solution to this problem?**
Just add the key / value in the mapping function, add some tests / improve story

Also take the opportunity of this PR to rename the `=` operator in `equal`. **Be aware that it's a breaking change and that's need some changes on app usage.**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
