### PR TITLE
fix(faceted-search/queryClient): Fix TQL creation function with numbers

### DIFF
--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/generator.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/generator.test.js
@@ -175,16 +175,8 @@ describe('Date generator', () => {
 					{ index: 1, name: 'February' },
 					{ index: 2, name: 'March' },
 				],
-				[
-					{ index: 3, name: 'April' },
-					{ index: 4, name: 'May' },
-					{ index: 5, name: 'June' },
-				],
-				[
-					{ index: 6, name: 'July' },
-					{ index: 7, name: 'August' },
-					{ index: 8, name: 'September' },
-				],
+				[{ index: 3, name: 'April' }, { index: 4, name: 'May' }, { index: 5, name: 'June' }],
+				[{ index: 6, name: 'July' }, { index: 7, name: 'August' }, { index: 8, name: 'September' }],
 				[
 					{ index: 9, name: 'October' },
 					{ index: 10, name: 'November' },

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/generator.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/generator.test.js
@@ -175,8 +175,16 @@ describe('Date generator', () => {
 					{ index: 1, name: 'February' },
 					{ index: 2, name: 'March' },
 				],
-				[{ index: 3, name: 'April' }, { index: 4, name: 'May' }, { index: 5, name: 'June' }],
-				[{ index: 6, name: 'July' }, { index: 7, name: 'August' }, { index: 8, name: 'September' }],
+				[
+					{ index: 3, name: 'April' },
+					{ index: 4, name: 'May' },
+					{ index: 5, name: 'June' },
+				],
+				[
+					{ index: 6, name: 'July' },
+					{ index: 7, name: 'August' },
+					{ index: 8, name: 'September' },
+				],
 				[
 					{ index: 9, name: 'October' },
 					{ index: 10, name: 'November' },

--- a/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.component.test.js
@@ -16,9 +16,15 @@ describe('TimePicker component', () => {
 			const event = expect.anything();
 			const wrapper = mount(<TimePicker onChange={onChange} />);
 			// when
-			wrapper.find('button').at(3).simulate('click');
+			wrapper
+				.find('button')
+				.at(3)
+				.simulate('click');
 			// then
-			expect(onChange).toBeCalledWith(event, { textInput: '03:00', time: { hours: '03', minutes: '00', seconds: '00' } });
+			expect(onChange).toBeCalledWith(event, {
+				textInput: '03:00',
+				time: { hours: '03', minutes: '00', seconds: '00' },
+			});
 		});
 		it('should hightlight item matches user input', () => {
 			// when
@@ -28,7 +34,12 @@ describe('TimePicker component', () => {
 			wrapper.update();
 			// then
 			expect(scrollIntoViewMock).toBeCalledWith({ block: 'center' });
-			expect(wrapper.find('button').at(12).hasClass('highlight')).toBe(true);
+			expect(
+				wrapper
+					.find('button')
+					.at(12)
+					.hasClass('highlight'),
+			).toBe(true);
 		});
 		it('should scroll the first match into view when user inputs', () => {
 			// given
@@ -43,7 +54,12 @@ describe('TimePicker component', () => {
 
 			// then
 			expect(scrollIntoViewMock).toBeCalledWith({ block: 'center' });
-			expect(wrapper.find('button').at(20).hasClass('highlight')).toBe(true);
+			expect(
+				wrapper
+					.find('button')
+					.at(20)
+					.hasClass('highlight'),
+			).toBe(true);
 		});
 	});
 });

--- a/packages/components/stories/List.js
+++ b/packages/components/stories/List.js
@@ -29,7 +29,6 @@ function ListColumnChooser({ list, ...rest }) {
 	return <List {...rest} list={enrichedList} columnChooser={columnChooser} />;
 }
 
-
 /**
  * Cell renderer that displays hello + text
  */
@@ -632,23 +631,26 @@ storiesOf('List', module)
 	))
 	.add('Large arrays of actions display', () => {
 		const customProps = cloneDeep(props);
-		const separatorActions = [{
-			id: 'monitoring',
-			label: 'monitor something',
-			'data-feature': 'list.item.monitor',
-			icon: 'talend-line-charts',
-			onClick: action('onMonitor'),
-			hideLabel: true,
-		}];
-		customProps.list.items = customProps.list.items.map(item => (
-			{ ...item, actions: [separatorActions, actions] })
-		);
+		const separatorActions = [
+			{
+				id: 'monitoring',
+				label: 'monitor something',
+				'data-feature': 'list.item.monitor',
+				icon: 'talend-line-charts',
+				onClick: action('onMonitor'),
+				hideLabel: true,
+			},
+		];
+		customProps.list.items = customProps.list.items.map(item => ({
+			...item,
+			actions: [separatorActions, actions],
+		}));
 		return (
 			<div style={{ height: '70vh' }} className="virtualized-list">
 				<h1>List</h1>
 				<p>
 					Display the list in table mode using arrays of actions.
-					<br/>
+					<br />
 					This is the default mode.
 				</p>
 				<List {...customProps} displayMode="large" />

--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -25,6 +25,7 @@ Types of changes
 - `Security` in case of vulnerabilities.
 
 ## [Unreleased]
+- [Fixed](https://github.com/Talend/ui/pull/2554): Fix TQL creation with badges number
 
 ## [0.2.3]
 ### Breaking changes

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -9,7 +9,7 @@ const getBadgeQueryValues = ({ properties }) => [
 
 const getBadgesQueryValues = badges => badges.map(getBadgeQueryValues);
 
-const isNotEmptyOrNull = value => value && value.length;
+const isNotEmptyOrNull = value => !!(typeof value === 'number' || (value && value.length));
 const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
 
 const filterBadgeWithNoValue = ({ properties }) => {

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -12,19 +12,19 @@ const getBadgesQueryValues = badges => badges.map(getBadgeQueryValues);
 
 const isValidValue = value => {
 	if (typeof value === 'string') {
-		return isEmpty(value);
+		return !isEmpty(value);
 	}
-	return Number.isNaN(value);
+	return !Number.isNaN(value);
 };
 
-const filterBadgeWithNoValue = ({ properties }) => {
+const keepValidValues = ({ properties }) => {
 	if (Array.isArray(properties.value)) {
-		return !properties.value.every(({ id }) => isValidValue(id));
+		return properties.value.length && properties.value.every(({ id }) => isValidValue(id));
 	}
-	return !isValidValue(properties.value);
+	return isValidValue(properties.value);
 };
 
-const removeBadgesWithEmptyValue = badges => badges.filter(filterBadgeWithNoValue);
+const removeBadgesWithEmptyValue = badges => badges.filter(keepValidValues);
 
 const prepareBadges = flow([removeBadgesWithEmptyValue, getBadgesQueryValues]);
 

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -1,4 +1,5 @@
 import { Query } from '@talend/daikon-tql-client';
+import isEmpty from 'lodash/isEmpty';
 import flow from 'lodash/flow';
 
 const getBadgeQueryValues = ({ properties }) => [
@@ -9,17 +10,18 @@ const getBadgeQueryValues = ({ properties }) => [
 
 const getBadgesQueryValues = badges => badges.map(getBadgeQueryValues);
 
-const isNotEmptyOrNull = value => value && value.length;
-const isValidNumber = value => typeof value === 'number' && !isNaN(value);
-
-const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
-const isValidBadge = value => isValidNumber(value) || isNotEmptyOrNull(value);
+const isValidValue = value => {
+	if (typeof value === 'string') {
+		return isEmpty(value);
+	}
+	return Number.isNaN(value);
+};
 
 const filterBadgeWithNoValue = ({ properties }) => {
-	if (Array.isArray(properties.value) && properties.value.length) {
-		return properties.value.every(isObjectIdNotEmptyOrNull);
+	if (Array.isArray(properties.value)) {
+		return !properties.value.every(({ id }) => isValidValue(id));
 	}
-	return isValidBadge(properties.value);
+	return !isValidValue(properties.value);
 };
 
 const removeBadgesWithEmptyValue = badges => badges.filter(filterBadgeWithNoValue);

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -9,14 +9,16 @@ const getBadgeQueryValues = ({ properties }) => [
 
 const getBadgesQueryValues = badges => badges.map(getBadgeQueryValues);
 
-const isNotEmptyOrNull = value => typeof value === 'number' || (value && value.length);
+const isNotEmptyOrNull = value => value && value.length;
+const isValidNumber = value => typeof value === 'number' && !isNaN(value);
+
 const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
 
 const filterBadgeWithNoValue = ({ properties }) => {
 	if (Array.isArray(properties.value) && properties.value.length) {
 		return properties.value.every(isObjectIdNotEmptyOrNull);
 	}
-	return isNotEmptyOrNull(properties.value);
+	return isNotEmptyOrNull(properties.value) || isValidNumber(properties.value);
 };
 
 const removeBadgesWithEmptyValue = badges => badges.filter(filterBadgeWithNoValue);

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -13,12 +13,13 @@ const isNotEmptyOrNull = value => value && value.length;
 const isValidNumber = value => typeof value === 'number' && !isNaN(value);
 
 const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
+const isValidBadge = value => isValidNumber(value) || isNotEmptyOrNull(value);
 
 const filterBadgeWithNoValue = ({ properties }) => {
 	if (Array.isArray(properties.value) && properties.value.length) {
 		return properties.value.every(isObjectIdNotEmptyOrNull);
 	}
-	return isNotEmptyOrNull(properties.value) || isValidNumber(properties.value);
+	return isValidBadge(properties.value);
 };
 
 const removeBadgesWithEmptyValue = badges => badges.filter(filterBadgeWithNoValue);

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -9,7 +9,7 @@ const getBadgeQueryValues = ({ properties }) => [
 
 const getBadgesQueryValues = badges => badges.map(getBadgeQueryValues);
 
-const isNotEmptyOrNull = value => !!(typeof value === 'number' || (value && value.length));
+const isNotEmptyOrNull = value => typeof value === 'number' || (value && value.length);
 const isObjectIdNotEmptyOrNull = value => isNotEmptyOrNull(value.id);
 
 const filterBadgeWithNoValue = ({ properties }) => {

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -247,14 +247,14 @@ describe('createTqlQuery', () => {
 						name: 'greaterThan',
 						iconName: 'greater-than',
 					},
-					value: '2298.23',
+					value: 2298.23,
 				},
 			},
 		];
 		// When
 		const result = createTqlQuery(badgeNotEqual);
 		// Then
-		expect(result).toEqual("(price > '2298.23')");
+		expect(result).toEqual('(price > 2298.23)');
 	});
 	it('should return an unequal tql query when value is using the greaterThanOrEqual operator', () => {
 		// Given
@@ -267,14 +267,14 @@ describe('createTqlQuery', () => {
 						name: 'greaterThanOrEqual',
 						iconName: 'greater-than-equal',
 					},
-					value: '12.9823',
+					value: 12.9823,
 				},
 			},
 		];
 		// When
 		const result = createTqlQuery(badgeNotEqual);
 		// Then
-		expect(result).toEqual("(price >= '12.9823')");
+		expect(result).toEqual('(price >= 12.9823)');
 	});
 	it('should return an unequal tql query when value is using the lessThan operator', () => {
 		// Given
@@ -287,14 +287,14 @@ describe('createTqlQuery', () => {
 						name: 'lessThan',
 						iconName: 'less-than',
 					},
-					value: '20938.20938',
+					value: 20938.20938,
 				},
 			},
 		];
 		// When
 		const result = createTqlQuery(badgeNotEqual);
 		// Then
-		expect(result).toEqual("(price < '20938.20938')");
+		expect(result).toEqual('(price < 20938.20938)');
 	});
 	it('should return an unequal tql query when value is using the lessThanOrEqual operator', () => {
 		// Given
@@ -307,13 +307,13 @@ describe('createTqlQuery', () => {
 						name: 'lessThanOrEqual',
 						iconName: 'less-than-equal',
 					},
-					value: '20982309892.23',
+					value: 20982309892.23,
 				},
 			},
 		];
 		// When
 		const result = createTqlQuery(badgeNotEqual);
 		// Then
-		expect(result).toEqual("(price <= '20982309892.23')");
+		expect(result).toEqual('(price <= 20982309892.23)');
 	});
 });

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -316,4 +316,84 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('(price <= 20982309892.23)');
 	});
+	it('should handle a NaN number value as an invalid value', () => {
+		// Given
+		const badge = [
+			{
+				properties: {
+					attribute: 'price',
+					operator: {
+						label: 'Equal',
+						name: 'equal',
+						iconName: 'equal',
+					},
+					value: NaN,
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badge);
+		// Then
+		expect(result).toEqual('');
+	});
+	it('should handle a zero number value', () => {
+		// Given
+		const badge = [
+			{
+				properties: {
+					attribute: 'price',
+					operator: {
+						label: 'Equal',
+						name: 'equal',
+						iconName: 'equal',
+					},
+					value: 0,
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badge);
+		// Then
+		expect(result).toEqual('(price = 0)');
+	});
+	it('should handle a negative number value', () => {
+		// Given
+		const badge = [
+			{
+				properties: {
+					attribute: 'price',
+					operator: {
+						label: 'Equal',
+						name: 'equal',
+						iconName: 'equal',
+					},
+					value: -12098029830,
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badge);
+		// Then
+		expect(result).toEqual('(price = -12098029830)');
+	});
+	it('should handle a float number value', () => {
+		// Given
+		const badge = [
+			{
+				properties: {
+					attribute: 'price',
+					operator: {
+						label: 'Equal',
+						name: 'equal',
+						iconName: 'equal',
+					},
+					value: 293820983098.23,
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badge);
+		// Then
+		expect(result).toEqual('(price = 293820983098.23)');
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TQL creation do not works for badge numbers.
I write a wrong unit test which have value as a string instead of a number. With that, all is good.
But the badge number return a number, not a string.
The problem come from `isNotEmptyOrNull` function which do not return a boolean and not handle numbers for now.

**What is the chosen solution to this problem?**
Fix the `isNotEmptyOrNull` function and tests.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
