### PR TITLE
fix(List): cell title actions makes the title unreadable

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -91,7 +91,6 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 			opacity: 1;
 			width: 100%;
 			transition: opacity 0.15s ease-in;
-			visibility: visible;
 		}
 	}
 }

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -89,6 +89,7 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 	&:global(.ally-focus-within) {
 		:global(.tc-list-title .cell-title-actions) {
 			opacity: 1;
+			width: 100%;
 			transition: opacity 0.15s ease-in;
 			visibility: visible;
 		}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -16,7 +16,6 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	.cell-title-actions {
 		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
 		opacity: 0;
-		visibility: hidden;
 		width: 0;
 
 		&:not(:last-child):after {

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -17,6 +17,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
 		opacity: 0;
 		visibility: hidden;
+		width: 0;
 
 		&:not(:last-child):after {
 			content: '|';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
since using flex box in the separator actions PR, a regression has been introduced : 
![image](https://user-images.githubusercontent.com/14272767/69550190-e172d180-0f9a-11ea-8e2b-44e90c34d137.png)

**What is the chosen solution to this problem?**
switching width only on hover and focus
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
