### PR TITLE
feat(components): richlayout with forwardref

### DIFF
--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
@@ -37,33 +37,21 @@ const Footer = ({ id, children, className }) => (
 );
 Footer.propTypes = TooltipPropTypes;
 
-export default class RichLayout extends React.Component {
-	constructor(props) {
-		super(props);
-		this.richLayout = React.createRef();
-	}
+const RichLayout = React.forwardRef((props, ref) => (
+	<span id={props.id} ref={ref} tabIndex="-1">
+		<Header id={`${props.id}-header`}>
+			{Inject.getReactElement(props.getComponent, props.Header)}
+		</Header>
+		<Body id={`${props.id}-body`} className={props.className}>
+			{props.text && <p>{props.text}</p>}
+			{!props.text && Inject.getReactElement(props.getComponent, props.Content)}
+		</Body>
+		<Footer id={`${props.id}-footer`}>
+			{Inject.getReactElement(props.getComponent, props.Footer)}
+		</Footer>
+	</span>
+));
 
-	focusRichLayout() {
-		this.richLayout.current.focus();
-	}
-
-	render() {
-		return (
-			<span id={this.props.id} ref={this.richLayout} tabIndex="-1">
-				<Header id={`${this.props.id}-header`}>
-					{Inject.getReactElement(this.props.getComponent, this.props.Header)}
-				</Header>
-				<Body id={`${this.props.id}-body`} className={this.props.className}>
-					{this.props.text && <p>{this.props.text}</p>}
-					{!this.props.text && Inject.getReactElement(this.props.getComponent, this.props.Content)}
-				</Body>
-				<Footer id={`${this.props.id}-footer`}>
-					{Inject.getReactElement(this.props.getComponent, this.props.Footer)}
-				</Footer>
-			</span>
-		);
-	}
-}
 RichLayout.Header = Header;
 RichLayout.Body = Body;
 RichLayout.Footer = Footer;
@@ -76,4 +64,7 @@ RichLayout.propTypes = {
 	Footer: Inject.getReactElement.propTypes,
 	text: PropTypes.string,
 	id: PropTypes.string.isRequired,
+	ref: PropTypes.func,
 };
+
+export default RichLayout;

--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
@@ -37,21 +37,32 @@ const Footer = ({ id, children, className }) => (
 );
 Footer.propTypes = TooltipPropTypes;
 
-export default function RichLayout(props) {
-	return (
-		<span id={props.id}>
-			<Header id={`${props.id}-header`}>
-				{Inject.getReactElement(props.getComponent, props.Header)}
-			</Header>
-			<Body id={`${props.id}-body`} className={props.className}>
-				{props.text && <p>{props.text}</p>}
-				{!props.text && Inject.getReactElement(props.getComponent, props.Content)}
-			</Body>
-			<Footer id={`${props.id}-footer`}>
-				{Inject.getReactElement(props.getComponent, props.Footer)}
-			</Footer>
-		</span>
-	);
+export default class RichLayout extends React.Component {
+	constructor(props) {
+		super(props);
+		this.richLayout = React.createRef();
+	}
+
+	focusRichLayout() {
+		this.richLayout.current.focus();
+	}
+
+	render() {
+		return (
+			<span id={this.props.id} ref={this.richLayout} tabIndex="-1">
+				<Header id={`${this.props.id}-header`}>
+					{Inject.getReactElement(this.props.getComponent, this.props.Header)}
+				</Header>
+				<Body id={`${this.props.id}-body`} className={this.props.className}>
+					{this.props.text && <p>{this.props.text}</p>}
+					{!this.props.text && Inject.getReactElement(this.props.getComponent, this.props.Content)}
+				</Body>
+				<Footer id={`${this.props.id}-footer`}>
+					{Inject.getReactElement(this.props.getComponent, this.props.Footer)}
+				</Footer>
+			</span>
+		);
+	}
 }
 RichLayout.Header = Header;
 RichLayout.Body = Body;

--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
@@ -6,11 +6,7 @@ import theme from './RichLayout.scss';
 
 const TooltipPropTypes = {
 	id: PropTypes.string.isRequired,
-	children: PropTypes.oneOfType([
-		PropTypes.element,
-		PropTypes.arrayOf(PropTypes.element),
-		PropTypes.string,
-	]),
+	children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
 	className: PropTypes.string,
 };
 
@@ -38,7 +34,7 @@ const Footer = ({ id, children, className }) => (
 Footer.propTypes = TooltipPropTypes;
 
 const RichLayout = React.forwardRef((props, ref) => (
-	<span id={props.id} ref={ref} tabIndex="-1">
+	<div id={props.id} ref={ref} tabIndex="-1">
 		<Header id={`${props.id}-header`}>
 			{Inject.getReactElement(props.getComponent, props.Header)}
 		</Header>
@@ -49,7 +45,7 @@ const RichLayout = React.forwardRef((props, ref) => (
 		<Footer id={`${props.id}-footer`}>
 			{Inject.getReactElement(props.getComponent, props.Footer)}
 		</Footer>
-	</span>
+	</div>
 ));
 
 RichLayout.Header = Header;

--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.component.js
@@ -64,7 +64,6 @@ RichLayout.propTypes = {
 	Footer: Inject.getReactElement.propTypes,
 	text: PropTypes.string,
 	id: PropTypes.string.isRequired,
-	ref: PropTypes.func,
 };
 
 export default RichLayout;

--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.test.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.test.js
@@ -20,4 +20,13 @@ describe('RichLayout', () => {
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+
+	it('should set the focus on the popover', () => {
+		const wrapper = shallow(<RichLayout id="richlayout" text="loreum" />);
+		const focus = jest.fn();
+		wrapper.instance().richLayout = { current: { focus } };
+
+		wrapper.instance().focusRichLayout();
+		expect(focus).toHaveBeenCalled();
+	});
 });

--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.test.js
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.test.js
@@ -20,13 +20,4 @@ describe('RichLayout', () => {
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
-
-	it('should set the focus on the popover', () => {
-		const wrapper = shallow(<RichLayout id="richlayout" text="loreum" />);
-		const focus = jest.fn();
-		wrapper.instance().richLayout = { current: { focus } };
-
-		wrapper.instance().focusRichLayout();
-		expect(focus).toHaveBeenCalled();
-	});
 });

--- a/packages/components/src/RichTooltip/RichLayout/__snapshots__/RichLayout.test.js.snap
+++ b/packages/components/src/RichTooltip/RichLayout/__snapshots__/RichLayout.test.js.snap
@@ -3,6 +3,7 @@
 exports[`RichLayout should render RichLayout with header, content and footer 1`] = `
 <span
   id="richlayout"
+  tabIndex="-1"
 >
   <Header
     id="richlayout-header"
@@ -31,6 +32,7 @@ exports[`RichLayout should render RichLayout with header, content and footer 1`]
 exports[`RichLayout should render with a text in the body 1`] = `
 <span
   id="richlayout"
+  tabIndex="-1"
 >
   <Header
     id="richlayout-header"

--- a/packages/components/src/RichTooltip/RichLayout/__snapshots__/RichLayout.test.js.snap
+++ b/packages/components/src/RichTooltip/RichLayout/__snapshots__/RichLayout.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`RichLayout should render RichLayout with header, content and footer 1`] = `
-<span
+<div
   id="richlayout"
   tabIndex="-1"
 >
@@ -26,11 +26,11 @@ exports[`RichLayout should render RichLayout with header, content and footer 1`]
       Footer
     </div>
   </Footer>
-</span>
+</div>
 `;
 
 exports[`RichLayout should render with a text in the body 1`] = `
-<span
+<div
   id="richlayout"
   tabIndex="-1"
 >
@@ -47,5 +47,5 @@ exports[`RichLayout should render with a text in the body 1`] = `
   <Footer
     id="richlayout-footer"
   />
-</span>
+</div>
 `;

--- a/packages/components/stories/RichTooltip.js
+++ b/packages/components/stories/RichTooltip.js
@@ -31,7 +31,12 @@ const addInfo = {
 	onClick: action('header.add.onClick'),
 };
 
-const header = [<HeaderTitle title="Pipelines" />, <Action {...addInfo} />];
+const header = (
+	<React.Fragment>
+		<HeaderTitle title="Pipelines" />
+		<Action {...addInfo} />
+	</React.Fragment>
+);
 const headerWithActions = [
 	<HeaderTitle title="Pipelines" />,
 	<Actions
@@ -94,7 +99,9 @@ storiesOf('RichTooltip', module)
 		<div>
 			<Action
 				id="default"
-				overlayComponent={<RichLayout Header={header} text={shortLoreum} Footer={footer} />}
+				overlayComponent={
+					<RichLayout id="richlayout" Header={header} text={shortLoreum} Footer={footer} />
+				}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -106,7 +113,12 @@ storiesOf('RichTooltip', module)
 			<Action
 				id="default"
 				overlayComponent={
-					<RichLayout Header={headerWithActions} text={shortLoreum} Footer={footer} />
+					<RichLayout
+						id="richlayout"
+						Header={headerWithActions}
+						text={shortLoreum}
+						Footer={footer}
+					/>
 				}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
@@ -118,7 +130,7 @@ storiesOf('RichTooltip', module)
 		<div>
 			<Action
 				id="default"
-				overlayComponent={<RichLayout Header={header} />}
+				overlayComponent={<RichLayout id="richlayout" Header={header} />}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -129,7 +141,7 @@ storiesOf('RichTooltip', module)
 		<div>
 			<Action
 				id="loading"
-				overlayComponent={<RichLayout Content={<CircularProgress />} />}
+				overlayComponent={<RichLayout id="richlayout" Content={<CircularProgress />} />}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -140,7 +152,9 @@ storiesOf('RichTooltip', module)
 		<div>
 			<Action
 				id="error"
-				overlayComponent={<RichLayout Content={<RichError title="Whoops!" error="One error." />} />}
+				overlayComponent={
+					<RichLayout id="richlayout" Content={<RichError title="Whoops!" error="One error." />} />
+				}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -152,7 +166,7 @@ storiesOf('RichTooltip', module)
 			<p>with a short text</p>
 			<Action
 				id="short-text"
-				overlayComponent={<RichLayout text={shortLoreum} />}
+				overlayComponent={<RichLayout id="richlayout" text={shortLoreum} />}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -160,7 +174,7 @@ storiesOf('RichTooltip', module)
 			<p>with a long text</p>
 			<Action
 				id="body-long-text"
-				overlayComponent={<RichLayout text={LongLoreum} />}
+				overlayComponent={<RichLayout id="richlayout" text={LongLoreum} />}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}
@@ -171,7 +185,9 @@ storiesOf('RichTooltip', module)
 		<div>
 			<Action
 				id="custom-body"
-				overlayComponent={<RichLayout Header={header} Content={customBody} Footer={footer} />}
+				overlayComponent={
+					<RichLayout id="richlayout" Header={header} Content={customBody} Footer={footer} />
+				}
 				overlayPlacement="bottom"
 				tooltipPlacement="right"
 				{...myAction}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The popover is visible in the list while the popover has the focus.
A button lost his focus if we set it to disabled. So the focus is lost on the popover.

![lost_focus](https://user-images.githubusercontent.com/20772261/69815856-7eca4180-11f7-11ea-874d-f1504a50059d.gif)


**What is the chosen solution to this problem?**

Add a function to add the focus on the popover

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
