### PR TITLE
feat(forms/lang): Update some array messages to be more readable

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
@@ -44,7 +44,7 @@ function DefaultArrayTemplate(props) {
 					bsStyle={'info'}
 					onClick={onAdd}
 					disabled={valueIsUpdating || schema.disabled}
-					label={options.btnLabel || t('ARRAY_ADD_ELEMENT', { defaultValue: 'New Element' })}
+					label={options.btnLabel || t('ARRAY_ADD_ELEMENT', { defaultValue: 'Add' })}
 				/>
 			)}
 			<Message

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
@@ -14,7 +14,7 @@ exports[`Default Array Template component should render default array template 1
     bsStyle="info"
     className="theme-tf-array-add tf-array-add"
     id="my-template-btn"
-    label="New Element"
+    label="Add"
     onClick={[MockFunction]}
   />
   <Message

--- a/packages/forms/src/UIForm/lang.js
+++ b/packages/forms/src/UIForm/lang.js
@@ -64,10 +64,10 @@ export default function getLanguage(t = defaultTranslate) {
 		}),
 		// Array errors
 		ARRAY_LENGTH_SHORT: t('ERROR_ARRAY_LENGTH_SHORT', {
-			defaultValue: 'Array is too short ({length}), minimum {minimum}',
+			defaultValue: 'Minimum number of items: {minimum}',
 		}),
 		ARRAY_LENGTH_LONG: t('ERROR_ARRAY_LENGTH_LONG', {
-			defaultValue: 'Array is too long ({length}), maximum {maximum}',
+			defaultValue: 'Maximum number of items: {maximum}',
 		}),
 		ARRAY_UNIQUE: t('ERROR_ARRAY_UNIQUE', {
 			defaultValue: 'Array items are not unique (indices {match1} and {match2})',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Errors message for minimum and maximum items of arrays is too technical for user. We don't want to talk about `array` in message as it's an abstract notion.

**What is the chosen solution to this problem?**
We checked with the technical documentation team to use this new words: 
- `New element` > `Add`
- `Array is too short ({length}), minimum {minimum}` > `Minimum number of items: {minimum}`
- `Array is too long ({length}), maximum {maximum}` > `Maximum number of items: {maximum}`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
