### PR TITLE
fix(TMC-18418): simplebar-does-not-work-in-firefox

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -35,7 +35,7 @@ $toggle-button-padding: $padding-small;
 
 	.action-list-container {
 		flex: 1;
-		height: calc(100% - 7rem); // specific to Safari
+		height: calc(100vh - 12rem); // specific to Safari
 
 		:global .tc-action-list-item {
 			.btn.btn-link {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-18418

Firefiox does not handle % in calc, because of this simplebar does not work, as it expects height to be set
Tested in all browsers except Safari, would be nice if someone could help and test in it


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
