### PR TITLE
fix(components/virtualizedlist): increase row height in large mode

### DIFF
--- a/packages/components/src/VirtualizedList/ListGrid/ListGrid.component.js
+++ b/packages/components/src/VirtualizedList/ListGrid/ListGrid.component.js
@@ -71,7 +71,7 @@ ListGrid.propTypes = {
 };
 
 ListGrid.defaultProps = {
-	rowHeight: 135,
+	rowHeight: 170,
 };
 
 export default ListGrid;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

[According to the guidelines](http://guidelines.talend.com/document/92132#/navigation-layout/list), the large mode should allow to display three row plus the title, but :

<img width="1015" alt="image" src="https://user-images.githubusercontent.com/26482371/70234857-dc174300-1761-11ea-99eb-6847acc56349.png">


**What is the chosen solution to this problem?**

Increase to row height from 135px to 170px :  

<img width="1017" alt="image" src="https://user-images.githubusercontent.com/26482371/70234789-b722d000-1761-11ea-985d-8ef1d07cea6c.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
