### PR TITLE
feat(cmf): allOf expression

### DIFF
--- a/packages/cmf/__tests__/expressions/index.test.js
+++ b/packages/cmf/__tests__/expressions/index.test.js
@@ -84,9 +84,9 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test2', 'test4'])).toBe(
-				true,
-			);
+			expect(
+				expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test2', 'test4']),
+			).toBe(true);
 		});
 		it('should return false if all values are not present in the list', () => {
 			const context = mock.context();
@@ -98,18 +98,18 @@ describe('expressions', () => {
 				}),
 			});
 			context.store.getState = () => state;
-			expect(expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test4', 'test5'])).toBe(
-				false,
-			);
+			expect(
+				expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test4', 'test5']),
+			).toBe(false);
 		});
-		it('should return false if collection doesn\'t exist', () => {
+		it("should return false if collection doesn't exist", () => {
 			const context = mock.context();
 			const state = mock.state();
 			context.store.getState = () => state;
 			state.cmf.collections = new Immutable.Map({});
-			expect(expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test0', 'test1'])).toBe(
-				false,
-			);
+			expect(
+				expressions['cmf.collections.oneOf']({ context }, 'article.tags', ['test0', 'test1']),
+			).toBe(false);
 		});
 		it('should throw an error if values are not an array', () => {
 			const context = mock.context();
@@ -121,8 +121,66 @@ describe('expressions', () => {
 					tags: new Immutable.List(['test', 'test2', 'test3']),
 				}),
 			});
-			expect(() => expressions['cmf.collections.oneOf']({ context }, 'article.tags', 'test'))
-				.toThrow(/^You should pass an array of values to check if one of them is present$/);
+			expect(() =>
+				expressions['cmf.collections.oneOf']({ context }, 'article.tags', 'test'),
+			).toThrow(/^You should pass an array of values to check if one of them is present$/);
+		});
+	});
+	describe('cmf.collections.allOf', () => {
+		it('should return true if all of the values are present in the list', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.collections = new Immutable.Map({
+				article: new Immutable.Map({
+					title: 'title',
+					tags: new Immutable.List(['test', 'test2', 'test3']),
+				}),
+			});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.collections.allOf']({ context }, 'article.tags', [
+					'test',
+					'test2',
+					'test3',
+				]),
+			).toBe(true);
+		});
+		it('should return false if not all values are not present in the list', () => {
+			const context = mock.context();
+			const state = mock.state();
+			state.cmf.collections = new Immutable.Map({
+				article: new Immutable.Map({
+					title: 'title',
+					tags: new Immutable.List(['test', 'test2', 'test3']),
+				}),
+			});
+			context.store.getState = () => state;
+			expect(
+				expressions['cmf.collections.allOf']({ context }, 'article.tags', ['test2', 'test3']),
+			).toBe(false);
+		});
+		it("should return false if collection doesn't exist", () => {
+			const context = mock.context();
+			const state = mock.state();
+			context.store.getState = () => state;
+			state.cmf.collections = new Immutable.Map({});
+			expect(
+				expressions['cmf.collections.allOf']({ context }, 'article.tags', ['test0', 'test1']),
+			).toBe(false);
+		});
+		it('should throw an error if values are not an array', () => {
+			const context = mock.context();
+			const state = mock.state();
+			context.store.getState = () => state;
+			state.cmf.collections = new Immutable.Map({
+				article: new Immutable.Map({
+					title: 'title',
+					tags: new Immutable.List(['test', 'test2', 'test3']),
+				}),
+			});
+			expect(() =>
+				expressions['cmf.collections.allOf']({ context }, 'article.tags', 'test'),
+			).toThrow(/^You should pass an array of values to check if all of them are present$/);
 		});
 	});
 

--- a/packages/cmf/src/expressions/allOf.js
+++ b/packages/cmf/src/expressions/allOf.js
@@ -1,0 +1,15 @@
+import get from 'lodash/get';
+import Immutable from 'immutable';
+
+export default function getAllOfFunction(statePath) {
+	return function includes({ context }, immutablePath, values) {
+		if (!Array.isArray(values)) {
+			throw new Error('You should pass an array of values to check if all of them are present');
+		}
+		const arr = get(context.store.getState(), statePath, new Immutable.Map()).getIn(
+			immutablePath.split('.'),
+			new Immutable.List(),
+		);
+		return arr.size > 0 && arr.every(value => values.includes(value));
+	};
+}

--- a/packages/cmf/src/expressions/index.js
+++ b/packages/cmf/src/expressions/index.js
@@ -1,3 +1,4 @@
+import allOf from './allOf';
 import getInState from './getInState';
 import includes from './includes';
 import oneOf from './oneOf';
@@ -8,4 +9,5 @@ export default {
 	'cmf.collections.includes': includes('cmf.collections'),
 	'cmf.components.includes': includes('cmf.components'),
 	'cmf.collections.oneOf': oneOf('cmf.collections'),
+	'cmf.collections.allOf': allOf('cmf.collections'),
 };

--- a/packages/cmf/src/expressions/index.md
+++ b/packages/cmf/src/expressions/index.md
@@ -101,6 +101,18 @@ export cmfConnect({mapStateToProps})(MyComponent)
 		}
 	}
 ```
+### allOf
+
+```json
+	"props": {
+		"MyArticle#default": {
+			"renderIfExpression": {
+				"id": "cmf.collections.allOf",
+				"args": ["identity.entitlements", [ "ARTICLE_READ", "ARTICLE_CREATE" ]]
+			},
+		}
+	}
+```
 
 ## cmf.components
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When you try to check at least two permissions using _cmf expression_, you are stuck.

**What is the chosen solution to this problem?**
Let's introduce `allOf` two check several values from _cmf collections_

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
