### PR TITLE
fix(TCCUI-112): removing empty options when there's no placeholder

### DIFF
--- a/packages/forms/src/UIForm/fields/Select/Select.component.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.js
@@ -61,13 +61,11 @@ export default function Select({
 				aria-required={schema.required}
 				aria-describedby={`${descriptionId} ${errorId}`}
 			>
-				{
-					placeholder ? (
-						<option disabled value=''>
-							{placeholder}
-						</option>
-					) : null
-				}
+				{placeholder ? (
+					<option disabled value="">
+						{placeholder}
+					</option>
+				) : null}
 				{schema.titleMap &&
 					schema.titleMap.map((option, index) => {
 						const optionProps = {

--- a/packages/forms/src/UIForm/fields/Select/Select.component.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.js
@@ -61,9 +61,13 @@ export default function Select({
 				aria-required={schema.required}
 				aria-describedby={`${descriptionId} ${errorId}`}
 			>
-				<option disabled value={placeholder ? '' : undefined}>
-					{placeholder}
-				</option>
+				{
+					placeholder ? (
+						<option disabled value=''>
+							{placeholder}
+						</option>
+					) : null
+				}
 				{schema.titleMap &&
 					schema.titleMap.map((option, index) => {
 						const optionProps = {

--- a/packages/forms/src/UIForm/fields/Select/__snapshots__/Select.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Select/__snapshots__/Select.component.test.js.snap
@@ -227,9 +227,6 @@ exports[`Select field should render simple select without placeholder 1`] = `
     value="lol"
   >
     <option
-      disabled={true}
-    />
-    <option
       value="foo"
     >
       My foo title


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TCCUI-112

**What is the chosen solution to this problem?**
removing the option if there's no placeholder

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
