### PR TITLE
fix(UIForm): pass array item key to resolve index in condition

### DIFF
--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -13,7 +13,7 @@ export function adaptAdditionalRules(mergedSchema) {
 	// skip enum validation if explicitly not restricted
 	const { schema } = mergedSchema;
 	if (mergedSchema.restricted === false) {
-		if (schema.type === 'array' && (schema.items && schema.items.enum)) {
+		if (schema.type === 'array' && schema.items && schema.items.enum) {
 			return {
 				...mergedSchema,
 				schema: {
@@ -161,7 +161,7 @@ export function validateAll(mergedSchema, properties, customValidationFn) {
 	const results = {};
 	mergedSchema.forEach(schema => {
 		const value = getValue(properties, schema);
-		const subResults = !shouldValidate(schema.condition, properties)
+		const subResults = !shouldValidate(schema.condition, properties, schema.key)
 			? true
 			: validateSingle(schema, value, properties, customValidationFn, true); // deep validation
 		Object.assign(results, subResults);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Defining an array, with complex items with conditions introduce a failure.
When the condition is within an array item, the system tries to resolve the key, injecting the index.

Example:
```javascript
const condition = {
    '==': {
        key: configuration.filters[].isDynamic,
        value: true,
    },
};
```

When the condition is evaluation on `configuration.filters[2]` object, it first resolves the condition key to have `configuration.filters[2].isDynamic`, then get the value from form data, and compare it to the condition value.

The issue is due to the call of shouldValidate (same function as shouldRender), where the item key is not passed. So resolving the condition key result in a failure, when we try to get the index from item key, which is undefined.

**What is the chosen solution to this problem?**

Pass the item key.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
