### PR TITLE
fix(TFD-8758):  Edit icon disappears when the artifact title is too long

### DIFF
--- a/packages/components/src/EditableText/EditableText.scss
+++ b/packages/components/src/EditableText/EditableText.scss
@@ -14,6 +14,7 @@ $tc-circle-editable-text-size: 16px !default;
 }
 
 .tc-editable-text {
+	width: 100%;
 	:global(.tc-editable-text-wording-wrapper) {
 		@include ellipsis;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In SubHeader when the title is too long the edit icon (the pen) disappears
https://jira.talendforge.org/browse/TFD-8758
**What is the chosen solution to this problem?**
the icon is always shown even if the title is long
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
