### PR TITLE
fix(FacetedSearch): Change equal key operator to equals

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Fixed
+
+- [fixed]: Change equal key operator to equals
+
 ## [0.2.4]
 
 ### Fixed

--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -14,14 +14,14 @@ const standardOperators = t => ({
 		label: t('OPERATOR_NOT_EQUALS_LABEL', {
 			defaultValue: 'Not equals',
 		}),
-		name: 'notEqual',
+		name: 'notEquals',
 		iconName: 'not-equal',
 	},
 	[operatorNames.equal]: {
 		label: t('OPERATOR_EQUALS_LABEL', {
 			defaultValue: 'Equals',
 		}),
-		name: 'equal',
+		name: 'equals',
 		iconName: 'equal',
 	},
 	[operatorNames.contains]: {

--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -48,7 +48,7 @@ const standardOperators = t => ({
 		label: t('OPERATOR_GREATER_THAN_OR_EQUAL_LABEL', {
 			defaultValue: 'Greater than or equal',
 		}),
-		name: 'greaterThanOrEqual',
+		name: 'greaterThanOrEquals',
 		iconName: 'greater-than-equal',
 	},
 	[operatorNames.lessThan]: {
@@ -62,7 +62,7 @@ const standardOperators = t => ({
 		label: t('OPERATOR_LESS_THAN_OR_EQUAL_LABEL', {
 			defaultValue: 'Less than or equal',
 		}),
-		name: 'lessThanOrEqual',
+		name: 'lessThanOrEquals',
 		iconName: 'less-than-equal',
 	},
 });

--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -1,12 +1,12 @@
 const operatorNames = {
 	contains: 'contains',
-	equal: 'equal',
-	notEqual: 'notEqual',
+	equals: 'equal',
+	notEquals: 'notEqual',
 	in: 'in',
 	greaterThan: 'greaterThan',
-	greaterThanOrEqual: 'greaterThanOrEqual',
+	greaterThanOrEquals: 'greaterThanOrEqual',
 	lessThan: 'lessThan',
-	lessThanOrEqual: 'lessThanOrEqual',
+	lessThanOrEquals: 'lessThanOrEqual',
 };
 
 const standardOperators = t => ({

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -35,13 +35,13 @@ const prepareBadges = flow([removeBadgesWithEmptyValue, getBadgesQueryValues]);
  */
 const getTqlClassOperatorsDictionary = query => ({
 	contains: query.contains,
-	equal: query.equal,
+	equals: query.equal,
 	in: query.in,
-	notEqual: query.unequal,
+	notEquals: query.unequal,
 	greaterThan: query.greaterThan,
-	greaterThanOrEqual: query.greaterThanOrEqual,
+	greaterThanOrEquals: query.greaterThanOrEqual,
 	lessThan: query.lessThan,
-	lessThanOrEqual: query.lessThanOrEqual,
+	lessThanOrEquals: query.lessThanOrEqual,
 });
 
 const formatValue = value => {

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -256,7 +256,7 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('(price > 2298.23)');
 	});
-	it('should return an unequal tql query when value is using the greaterThanOrEqual operator', () => {
+	it('should return an unequal tql query when value is using the greaterThanOrEquals operator', () => {
 		// Given
 		const badgeNotEqual = [
 			{
@@ -296,7 +296,7 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('(price < 20938.20938)');
 	});
-	it('should return an unequal tql query when value is using the lessThanOrEqual operator', () => {
+	it('should return an unequal tql query when value is using the lessThanOrEquals operator', () => {
 		// Given
 		const badgeNotEqual = [
 			{

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -18,7 +18,7 @@ describe('createTqlQuery', () => {
 				attribute: 'name',
 				operator: {
 					label: 'Equal',
-					name: 'equal',
+					name: 'equals',
 					iconName: 'equal',
 				},
 				value: 'another-badge\n\n',
@@ -95,7 +95,7 @@ describe('createTqlQuery', () => {
 					attribute: 'name',
 					operator: {
 						label: 'Equal',
-						name: 'equal',
+						name: 'equals',
 						iconName: 'equal',
 					},
 					value: 'another-badge\n\n',
@@ -224,7 +224,7 @@ describe('createTqlQuery', () => {
 					attribute: 'name',
 					operator: {
 						label: 'Not equals',
-						name: 'notEqual',
+						name: 'notEquals',
 						iconName: 'not-equal',
 					},
 					value: 'product name',
@@ -264,7 +264,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Greater than or equal',
-						name: 'greaterThanOrEqual',
+						name: 'greaterThanOrEquals',
 						iconName: 'greater-than-equal',
 					},
 					value: 12.9823,
@@ -304,7 +304,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Less than or equal',
-						name: 'lessThanOrEqual',
+						name: 'lessThanOrEquals',
 						iconName: 'less-than-equal',
 					},
 					value: 20982309892.23,
@@ -324,7 +324,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Equal',
-						name: 'equal',
+						name: 'equals',
 						iconName: 'equal',
 					},
 					value: NaN,
@@ -344,7 +344,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Equal',
-						name: 'equal',
+						name: 'equals',
 						iconName: 'equal',
 					},
 					value: 0,
@@ -364,7 +364,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Equal',
-						name: 'equal',
+						name: 'equals',
 						iconName: 'equal',
 					},
 					value: -12098029830,
@@ -384,7 +384,7 @@ describe('createTqlQuery', () => {
 					attribute: 'price',
 					operator: {
 						label: 'Equal',
-						name: 'equal',
+						name: 'equals',
 						iconName: 'equal',
 					},
 					value: 293820983098.23,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
It's more idiomatic english to use equals (or is equal). Fixing the operator key.
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
