### PR TITLE
fix(components): align timezone-support version

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,7 +66,7 @@
     "simplebar-react": "^1.2.2",
     "simulant": "^0.2.2",
     "styled-components": "^4.1.3",
-    "timezone-support": "^2.0.2",
+    "timezone-support": "^1.5.5",
     "uuid": "^3.0.1"
   },
   "devDependencies": {

--- a/versions/dependencies.js
+++ b/versions/dependencies.js
@@ -55,6 +55,7 @@ module.exports = {
 	slugify: '^1.1.0',
 	uuid: '^3.0.1', // prefer bson-objectid
 	tv4: '^1.3.0',
+	'timezone-support': '^1.5.5',
 
 	// deps: libs that interact with the DOM
 	'd3-shape': '1.2.0',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4667,7 +4667,7 @@ commander@2.19.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
 
-commander@2.20.0, commander@2.x.x, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
+commander@2.x.x, commander@^2.15.1, commander@^2.19.0, commander@^2.20.0, commander@^2.7.1, commander@^2.8.1, commander@^2.9.0, commander@~2.20.0:
   version "2.20.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.0.tgz#d58bb2b5c1ee8f87b0d340027e9e94e222c5a422"
 
@@ -14408,12 +14408,6 @@ timezone-support@^1.5.5:
   resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-1.8.1.tgz#0a8c04d0614be6fccdd2280aaad5072fa5d31e5f"
   dependencies:
     commander "2.19.0"
-
-timezone-support@^2.0.2:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-2.0.2.tgz#801d6924478b1b60f09b90699ce1127a6044cbe7"
-  dependencies:
-    commander "2.20.0"
 
 tiny-emitter@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The following PR:
https://github.com/Talend/ui/pull/2479/files#diff-8ee2343978836a779dc9f8d6b794c3b2R13727

has added the package `timezone-support` in two different versions.

Effect:
<img width="883" alt="Screenshot 2019-12-31 at 16 21 17" src="https://user-images.githubusercontent.com/19857479/71625839-506ec600-2bea-11ea-9838-18da3ef54736.png">


**What is the chosen solution to this problem?**

* downgrade our version to align with `date-fns-timezone` one.
* update version script so every project who would like to directly integrate will be aligned.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
