### PR TITLE
feat(theme): avoid using css-modules

### DIFF
--- a/packages/theme/src/theme/_visual-helpers.scss
+++ b/packages/theme/src/theme/_visual-helpers.scss
@@ -118,16 +118,16 @@
 
 		[role='presentation'] {
 			// Sorry, Bootstrap customization sucks
-			:global(.btn),
-			:global(.btn.open),
-			:global(.dropdown.open .btn) {
+			.btn,
+			.btn.open,
+			.dropdown.open .btn {
 				&,
 				&:hover {
 					background: none;
 				}
 			}
 
-			:global(.btn) {
+			.btn {
 				&:hover,
 				&:focus {
 					box-shadow: 0 200px 100px -100px rgba(255, 255, 255, 0.12) inset;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Theme uses `:global` which it works when you import it using css-modules loader but not with CSS.

**What is the chosen solution to this problem?**
Remove css-modules scope usage

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
