### PR TITLE
fix(component): imports

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -71,6 +71,9 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
+/home/travis/build/Talend/ui/packages/components/src/Toggle/Checkbox.js
+  3:1  error  Prefer default export  import/prefer-default-export
+
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
   9:8  error  'Action' is defined but never used  no-unused-vars
 
@@ -81,6 +84,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   71:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 47 problems (44 errors, 3 warnings)
+✖ 48 problems (45 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -3,7 +3,9 @@ import React from 'react';
 import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
 
-import { Dialog, Skeleton, Icon } from '../';
+import Dialog from '../Dialog';
+import Skeleton from '../Skeleton';
+import Icon from '../Icon';
 import getDefaultT from '../translate';
 import theme from './AboutDialog.scss';
 

--- a/packages/components/src/ResourcePicker/ResourcePicker.component.js
+++ b/packages/components/src/ResourcePicker/ResourcePicker.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { VirtualizedList } from '../';
+import VirtualizedList from '../VirtualizedList';
 import getRowSelectionRenderer from '../VirtualizedList/RowSelection';
 
 import Resource from './Resource';

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -1,6 +1,9 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { Skeleton, Icon, Action, EditableText } from '../../';
+import Skeleton from '../../Skeleton';
+import Icon from '../../Icon';
+import Action from '../../Actions/Action';
+import EditableText from '../../EditableText';
 import TitleSubHeader, { SubTitle } from './TitleSubHeader.component';
 
 describe('TitleSubHeader', () => {

--- a/packages/components/src/Table/Header/TableSortHeader.js
+++ b/packages/components/src/Table/Header/TableSortHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
-import { ActionButton } from '../../index';
+import ActionButton from '../../Actions/ActionButton';
 
 function getIcon(sorter) {
 	return sorter.icons && sorter.icons[sorter.direction];

--- a/packages/components/src/Toggle/Checkbox.component.js
+++ b/packages/components/src/Toggle/Checkbox.component.js
@@ -1,6 +1,0 @@
-import React from 'react';
-import Toggle from './Toggle.component';
-
-export default function Checkbox(props) {
-	return <Toggle className="checkbox" {...props} />;
-}

--- a/packages/components/src/Toggle/Checkbox.component.js
+++ b/packages/components/src/Toggle/Checkbox.component.js
@@ -1,0 +1,6 @@
+import React from 'react';
+import Toggle from './Toggle.component';
+
+export default function Checkbox(props) {
+	return <Toggle className="checkbox" {...props} />;
+}

--- a/packages/components/src/Toggle/Checkbox.js
+++ b/packages/components/src/Toggle/Checkbox.js
@@ -1,0 +1,3 @@
+import Toggle from './Toggle.component';
+
+export function Checkbox(params) { return new Toggle({ className: 'checkbox', ...params }); }

--- a/packages/components/src/Toggle/Checkbox.js
+++ b/packages/components/src/Toggle/Checkbox.js
@@ -1,3 +1,5 @@
 import Toggle from './Toggle.component';
 
-export function Checkbox(params) { return new Toggle({ className: 'checkbox', ...params }); }
+export function Checkbox(params) {
+	return new Toggle({ className: 'checkbox', ...params });
+}

--- a/packages/components/src/Toggle/index.js
+++ b/packages/components/src/Toggle/index.js
@@ -2,4 +2,4 @@ import Toggle from './Toggle.component';
 
 export default Toggle;
 
-export { Checkbox } from './Checkbox.component';
+export { Checkbox } from './Checkbox';

--- a/packages/components/src/Toggle/index.js
+++ b/packages/components/src/Toggle/index.js
@@ -2,4 +2,4 @@ import Toggle from './Toggle.component';
 
 export default Toggle;
 
-export function Checkbox(params) { return new Toggle({ className: 'checkbox', ...params }); }
+export { Checkbox } from './Checkbox.component';

--- a/packages/components/src/TreeView/TreeView.component.js
+++ b/packages/components/src/TreeView/TreeView.component.js
@@ -2,7 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import Action from '../Actions/Action';
-import TreeViewItem from './TreeViewItem/';
+import TreeViewItem from './TreeViewItem';
 
 import theme from './TreeView.scss';
 import withTreeGesture from '../Gesture/withTreeGesture';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Some component rely on other getting them from the index.
This is not friendly with code-splitting

**What is the chosen solution to this problem?**

Replace theses import with direct import to it.
This PR is a subpart of #2607 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
