### PR TITLE
feat(component/grid): allow to disable drag n drop

### DIFF
--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -6,7 +6,12 @@ import classNames from 'classnames';
 
 import Tile from './Tile';
 import { SKELETON_TILE_CONF } from './Tile/Skeleton/SkeletonTile.component';
+
 import css from './Grid.scss';
+import { getTheme } from '../theme';
+
+const theme = getTheme(css);
+
 
 // eslint-disable-next-line new-cap
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -43,8 +48,8 @@ function Grid({
 }) {
 	return (
 		<ResponsiveGridLayout
-			className={classNames(css.layout, 'layout', {
-				[css.draggable]: isDraggable,
+			className={theme('layout', {
+				draggable: isDraggable,
 			})}
 			onLayoutChange={onLayoutChange}
 			onDragStop={onDragStop}

--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -2,9 +2,11 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import 'react-grid-layout/css/styles.css';
 import { Responsive, WidthProvider } from 'react-grid-layout';
+import classNames from 'classnames';
+
 import Tile from './Tile';
 import { SKELETON_TILE_CONF } from './Tile/Skeleton/SkeletonTile.component';
-import './Grid.scss';
+import css from './Grid.scss';
 
 // eslint-disable-next-line new-cap
 const ResponsiveGridLayout = WidthProvider(Responsive);
@@ -29,6 +31,7 @@ const noOp = () => {};
 function Grid({
 	children,
 	isResizable = false,
+	isDraggable = true,
 	onLayoutChange = noOp,
 	onBreakpointChange = noOp,
 	onDragStop = noOp,
@@ -40,7 +43,9 @@ function Grid({
 }) {
 	return (
 		<ResponsiveGridLayout
-			className="layout"
+			className={classNames(css.layout, 'layout', {
+				[css.draggable]: isDraggable,
+			})}
 			onLayoutChange={onLayoutChange}
 			onDragStop={onDragStop}
 			onResizeStop={onResizeStop}
@@ -53,13 +58,14 @@ function Grid({
 			isResizable={isResizable}
 			useCSSTransforms={false}
 			verticalCompact={verticalCompact}
+			isDraggable={isDraggable}
 		>
 			{isLoading
 				? (skeletonConfiguration || SKELETON_TILE_CONF).map(tile => (
-						<div className={'skeleton-tile'} key={tile.key} data-grid={tile['data-grid']}>
-							<Tile.Skeleton />
-						</div>
-				  ))
+					<div className={'skeleton-tile'} key={tile.key} data-grid={tile['data-grid']}>
+						<Tile.Skeleton />
+					</div>
+				))
 				: children}
 		</ResponsiveGridLayout>
 	);
@@ -69,6 +75,7 @@ Grid.propTypes = {
 	children: PropTypes.node,
 	compactType: PropTypes.string,
 	isResizable: PropTypes.bool,
+	isDraggable: PropTypes.bool,
 	onLayoutChange: PropTypes.func,
 	onBreakpointChange: PropTypes.func,
 	onDragStop: PropTypes.func,

--- a/packages/components/src/GridLayout/Grid.scss
+++ b/packages/components/src/GridLayout/Grid.scss
@@ -1,17 +1,25 @@
-:global(.react-grid-item) {
-	display: flex;
-	flex-direction: column;
-	border: 1px solid $gallery;
-	border-radius: 4px;
-	&:hover {
-		box-shadow: 0 2px 2px rgba(0, 0, 0, 0.175);
-		cursor: move;
+.layout	{
+	:global(.react-grid-item) {
+		display: flex;
+		flex-direction: column;
+		border: 1px solid $gallery;
+		border-radius: 4px;
 	}
-	&:global(.react-grid-placeholder) {
-		background: $scooter;
-	}
-}
 
-:global(.skeleton-tile .tc-tile-container .tc-tile-body) {
-	padding: 0;
+	:global(.skeleton-tile .tc-tile-container .tc-tile-body) {
+		padding: 0;
+	}
+
+	&.draggable {
+		:global(.react-grid-item) {
+			&:global(.react-grid-placeholder) {
+				background: $scooter;
+			}
+
+			&:hover {
+				box-shadow: 0 2px 2px rgba(0, 0, 0, 0.175);
+				cursor: move;
+			}
+		}
+	}
 }

--- a/packages/components/stories/GridLayout.js
+++ b/packages/components/stories/GridLayout.js
@@ -118,7 +118,7 @@ function ChartTile({ tile }) {
 	);
 }
 
-function GridContainer({ isLoading = false, skeletonConfiguration }) {
+function GridContainer({ isLoading = false, skeletonConfiguration, isResizable = true, ...rest}) {
 	const [tiles, setTiles] = useState([
 		{
 			header: {
@@ -164,9 +164,11 @@ function GridContainer({ isLoading = false, skeletonConfiguration }) {
 	return (
 		<div className="App">
 			<GridLayout
-				isResizable
 				isLoading={isLoading}
-				skeletonConfiguration={skeletonConfiguration}>
+				isResizable={isResizable}
+				skeletonConfiguration={skeletonConfiguration}
+				{...rest}
+			>
 				{ tiles.map(tile => (
 					<div key={tile.key} data-grid={tile['data-grid']}>
 						<ChartTile tile={tile} />
@@ -186,6 +188,9 @@ storiesOf('GridLayout', module)
 		</div>
 	))
 	.add('default', () => <GridContainer />)
+	.add('not draggable', () => <GridContainer isDraggable={false} />)
+	.add('not resizable', () => <GridContainer isResizable={false} />)
+	.add('neither draggable nor resizable', () => <GridContainer isDraggable={false} isResizable={false} />)
 	.add('isLoading', () => <GridContainer isLoading />)
 	.add('isLoading with custom grid', () => <GridContainer isLoading skeletonConfiguration={customSkeletonConf} />);
 ;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It's not possible to disable drag n drop in the grid

**What is the chosen solution to this problem?**

Allow to disable drag n drop with a new `isDraggable` prop.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
