### PR TITLE
feat(component/dialog): allow to set raw html as children

### DIFF
--- a/packages/components/src/AboutDialog/__snapshots__/AboutDialog.snapshot.test.js.snap
+++ b/packages/components/src/AboutDialog/__snapshots__/AboutDialog.snapshot.test.js.snap
@@ -15,6 +15,7 @@ exports[`AboutDialog should render 1`] = `
       },
     }
   }
+  allowHTML={false}
   autoFocus={true}
   backdrop={true}
   className="theme-about-dialog about-dialog"
@@ -64,6 +65,7 @@ exports[`AboutDialog should render in loading mode 1`] = `
       },
     }
   }
+  allowHTML={false}
   autoFocus={true}
   backdrop={true}
   className="theme-about-dialog about-dialog"
@@ -113,6 +115,7 @@ exports[`AboutDialog should render services 1`] = `
       },
     }
   }
+  allowHTML={false}
   autoFocus={true}
   backdrop={true}
   className="theme-about-dialog about-dialog"
@@ -190,6 +193,7 @@ exports[`AboutDialog should render with custom copyright 1`] = `
       },
     }
   }
+  allowHTML={false}
   autoFocus={true}
   backdrop={true}
   className="theme-about-dialog about-dialog"

--- a/packages/components/src/Dialog/Dialog.component.js
+++ b/packages/components/src/Dialog/Dialog.component.js
@@ -34,6 +34,7 @@ function Dialog({
 	subtitle,
 	error,
 	progress,
+	allowHTML,
 	size,
 	type,
 	...props
@@ -83,7 +84,11 @@ function Dialog({
 			{injected('before-modal-body')}
 			<Modal.Body>
 				{injected('before-children')}
-				{children}
+				{ allowHTML ? (<p
+					dangerouslySetInnerHTML={{
+						__html: children,
+					}}
+				/>) : children }
 				{injected('after-children')}
 			</Modal.Body>
 			{injected('before-modal-body')}
@@ -117,6 +122,7 @@ Dialog.defaultProps = {
 	keyboard: true,
 	restoreFocus: true,
 	type: Dialog.TYPES.DEFAULT,
+	allowHTML: false,
 };
 
 Dialog.propTypes = {
@@ -127,6 +133,7 @@ Dialog.propTypes = {
 	size: PropTypes.oneOf(['sm', 'small', 'lg', 'large']),
 	children: PropTypes.element,
 	show: PropTypes.bool,
+	allowHTML: PropTypes.bool,
 	action: PropTypes.shape(Action.propTypes),
 	footer: PropTypes.object,
 	actionbar: PropTypes.object,

--- a/packages/components/src/Dialog/Dialog.test.js
+++ b/packages/components/src/Dialog/Dialog.test.js
@@ -110,4 +110,9 @@ describe('Dialog', () => {
 		const wrapper = shallow(<Dialog {...flexProps}>{children}</Dialog>);
 		expect(wrapper.hasClass('modal-flex')).toBe(true);
 	});
+	it('render HTML tags if allowHTML is true', () => {
+		const html = 'hey <h1>lol</h1>';
+		const wrapper = shallow(<Dialog {...defaultProps} allowHTML>{html}</Dialog>);
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
 });

--- a/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
+++ b/packages/components/src/Dialog/__snapshots__/Dialog.test.js.snap
@@ -1,5 +1,50 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Dialog render HTML tags if allowHTML is true 1`] = `
+<Modal
+  animation={true}
+  aria-labelledby={null}
+  aria-modal="true"
+  autoFocus={true}
+  backdrop={true}
+  bsClass="modal"
+  className=""
+  dialogComponentClass={[Function]}
+  enforceFocus={true}
+  keyboard={true}
+  manager={
+    ModalManager {
+      "add": [Function],
+      "containers": Array [],
+      "data": Array [],
+      "handleContainerOverflow": true,
+      "hideSiblingNodes": true,
+      "isTopModal": [Function],
+      "modals": Array [],
+      "remove": [Function],
+    }
+  }
+  onHide={[Function]}
+  renderBackdrop={[Function]}
+  restoreFocus={true}
+  role="dialog"
+  show={true}
+>
+  <ModalBody
+    bsClass="modal-body"
+    componentClass="div"
+  >
+    <p
+      dangerouslySetInnerHTML={
+        Object {
+          "__html": "hey <h1>lol</h1>",
+        }
+      }
+    />
+  </ModalBody>
+</Modal>
+`;
+
 exports[`Dialog should render 1`] = `
 <Modal
   animation={true}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It is not possible to set raw HTML as Dialog children.

**What is the chosen solution to this problem?**

Allow to set raw HTML (new `allowHTML` prop).

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
