### PR TITLE
fix(components/grid): lint error

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -49,8 +49,8 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   43:11  error  Caution: `i18next` also has a named export `t`. Check if you meant to write `import {t} from 'i18next'` instead  import/no-named-as-default-member
 
 /home/travis/build/Talend/ui/packages/components/src/GridLayout/Grid.component.js
-  59:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
-  62:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
+  68:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
+  71:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   129:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role

--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import 'react-grid-layout/css/styles.css';
 import { Responsive, WidthProvider } from 'react-grid-layout';
-import classNames from 'classnames';
 
 import Tile from './Tile';
 import { SKELETON_TILE_CONF } from './Tile/Skeleton/SkeletonTile.component';

--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -11,7 +11,6 @@ import { getTheme } from '../theme';
 
 const theme = getTheme(css);
 
-
 // eslint-disable-next-line new-cap
 const ResponsiveGridLayout = WidthProvider(Responsive);
 const MARGIN = 20;
@@ -66,10 +65,10 @@ function Grid({
 		>
 			{isLoading
 				? (skeletonConfiguration || SKELETON_TILE_CONF).map(tile => (
-					<div className={'skeleton-tile'} key={tile.key} data-grid={tile['data-grid']}>
-						<Tile.Skeleton />
-					</div>
-				))
+						<div className={'skeleton-tile'} key={tile.key} data-grid={tile['data-grid']}>
+							<Tile.Skeleton />
+						</div>
+				  ))
 				: children}
 		</ResponsiveGridLayout>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

I introduced `  5:8  error  'classNames' is defined but never used  no-unused-vars` with my last PR #2613 .

**What is the chosen solution to this problem?**
Remove the useless `classnames` import.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
