### PR TITLE
feat(components/datalist): allow empty values

### DIFF
--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -316,7 +316,7 @@ class Datalist extends Component {
 			}
 			const selectedEnumValue = get(enumValue, 'value');
 
-			if (selectedEnumValue || !this.props.restricted) {
+			if ((selectedEnumValue || this.props.allowEmpty) || !this.props.restricted) {
 				this.props.onChange(event, { value: selectedEnumValue || value });
 				this.setState({
 					previousValue: previousValue.name,
@@ -440,6 +440,7 @@ if (process.env.NODE_ENV !== 'production') {
 		multiSection: PropTypes.bool.isRequired,
 		readOnly: PropTypes.bool,
 		restricted: PropTypes.bool,
+		allowEmpty: PropTypes.bool,
 		titleMap: PropTypes.arrayOf(
 			PropTypes.oneOfType([
 				PropTypes.shape({

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -316,8 +316,10 @@ class Datalist extends Component {
 			}
 			const selectedEnumValue = get(enumValue, 'value');
 
-			if ((selectedEnumValue || this.props.allowEmpty) || !this.props.restricted) {
-				this.props.onChange(event, { value: selectedEnumValue || value });
+			if (selectedEnumValue || this.props.allowEmpty || !this.props.restricted) {
+				this.props.onChange(event, {
+					value: !selectedEnumValue && selectedEnumValue !== '' ? value : selectedEnumValue,
+				});
 				this.setState({
 					previousValue: previousValue.name,
 				});

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -194,6 +194,30 @@ describe('Datalist component', () => {
 		expect(onChange).toBeCalledWith(expect.anything(), payload);
 	});
 
+	it('should allow to change with empty value in restricted mode when allowEmpty is set', () => {
+		const onChange = jest.fn();
+		const wrapper = mount(
+			<Datalist
+				id="my-datalist"
+				isValid
+				multiSection={false}
+				errorMessage={'This should be correct'}
+				onChange={onChange}
+				restricted
+				allowEmpty
+				{...props}
+				value={'foo'}
+			/>,
+		);
+		const input = wrapper.find('input').at(0);
+		input.simulate('change', { target: { value: '' } });
+
+		input.simulate('blur');
+
+		const payload = { value: '' };
+		expect(onChange).toBeCalledWith(expect.anything(), payload);
+	});
+
 	it('should not reset to old value when clearing input, in restricted mode, and then onBlur', () => {
 		// given
 		const onChange = jest.fn();

--- a/packages/components/stories/Datalist.js
+++ b/packages/components/stories/Datalist.js
@@ -58,12 +58,10 @@ storiesOf('Datalist', module)
 			...propsMultiSection,
 			titleMap: propsMultiSection.titleMap.map(titleMap => ({
 				...titleMap,
-				suggestions: titleMap.suggestions.map(
-					suggestion => ({
-						...suggestion,
-						icon: { name: 'talend-clock' },
-					}),
-				),
+				suggestions: titleMap.suggestions.map(suggestion => ({
+					...suggestion,
+					icon: { name: 'talend-clock' },
+				})),
 			})),
 		};
 		return (
@@ -169,4 +167,17 @@ storiesOf('Datalist', module)
 				<Datalist {...combinationSectionProps} />
 			</form>
 		);
-	});
+	})
+
+	.add('restricted but with empty values allowed', () => (
+		<form className="form">
+			<IconsProvider />
+			<h3>With empty value</h3>
+			<Datalist
+				{...singleSectionProps}
+				restricted
+				allowEmpty
+				titleMap={[{ name: '', value: '' }, ...defaultProps.titleMap]}
+			/>
+		</form>
+	));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In restricted mode, empty values are ignored (onChanged is not called).

**What is the chosen solution to this problem?**

Add an `allowEmpty` property to manage empty values in restricted mode.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
