### PR TITLE
fix: remove sidepanel uppercase

### DIFF
--- a/packages/components/src/ActionList/ActionList.scss
+++ b/packages/components/src/ActionList/ActionList.scss
@@ -19,6 +19,7 @@ $tc-action-list-item-border-size: 2px !default;
 			.btn.btn-link {
 				padding: $padding-normal;
 				text-overflow: inherit;
+				text-transform: unset;
 
 				> span {
 					margin-left: $padding-normal;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
PR #2585 removed the uppercase in components' css. But for SidePanel (that uses ActionsList), the items are buttons, and they inherit the buttons css, that transform the text into uppercase.

**What is the chosen solution to this problem?**
Set the text transform to `unset` for the side panel items.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
