### PR TITLE
feat(TMC-17837): add tooltip trigger in tree view item icon

### DIFF
--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 
+import TooltipTrigger from '../../TooltipTrigger';
 import { Action } from '../../Actions';
 import Icon from '../../Icon';
 import Badge from '../../Badge';
@@ -32,7 +33,18 @@ export function getItemIcon(iconName = 'talend-folder', isOpened) {
  */
 function TreeViewIcon({ icon, isOpened }) {
 	if (typeof icon === 'object') {
-		return <Icon {...icon} className={classNames(css['tc-treeview-img'], icon.className)} />;
+		return icon.tooltipLabel ? (
+			<TooltipTrigger
+				label={icon.tooltipLabel}
+				tooltipPlacement={icon.tooltipPlacement || 'top'}
+			>
+				<span>
+					<Icon name={icon.name} className={classNames(css['tc-treeview-img'], icon.className)} />
+				</span>
+			</TooltipTrigger>
+		) : (
+			<Icon {...icon} className={classNames(css['tc-treeview-img'], icon.className)} />
+		);
 	}
 
 	return (

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -34,10 +34,7 @@ export function getItemIcon(iconName = 'talend-folder', isOpened) {
 function TreeViewIcon({ icon, isOpened }) {
 	if (typeof icon === 'object') {
 		return icon.tooltipLabel ? (
-			<TooltipTrigger
-				label={icon.tooltipLabel}
-				tooltipPlacement={icon.tooltipPlacement || 'top'}
-			>
+			<TooltipTrigger label={icon.tooltipLabel} tooltipPlacement={icon.tooltipPlacement || 'top'}>
 				<span>
 					<Icon name={icon.name} className={classNames(css['tc-treeview-img'], icon.className)} />
 				</span>

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
@@ -58,6 +58,7 @@ $item-height: 4rem;
 		.tc-treeview-img {
 			max-height: 2rem;
 			margin-right: 1rem;
+			vertical-align: middle;
 		}
 
 		.tc-treeview-item-name {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow, mount } from 'enzyme';
+import { shallow } from 'enzyme';
 
 import TreeViewItem, { getItemIcon } from './TreeViewItem.component';
 

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -18,7 +18,10 @@ const item = {
 			id: 11,
 			name: 'mami',
 			toggled: true,
-			children: [{ id: 111, name: 'me' }, { id: 112, name: 'bro' }],
+			children: [
+				{ id: 111, name: 'me' },
+				{ id: 112, name: 'bro' },
+			],
 		},
 		{
 			id: 12,
@@ -126,7 +129,12 @@ describe('TreeView item', () => {
 
 		const wrapper = shallow(<TreeViewItem {...propsWithIconAndTooltip} />);
 
-		expect(wrapper.find('TreeViewIcon').dive().getElement()).toMatchSnapshot();
+		expect(
+			wrapper
+				.find('TreeViewIcon')
+				.dive()
+				.getElement(),
+		).toMatchSnapshot();
 	});
 
 	it('should toggle item on toggle button click', () => {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import TreeViewItem, { getItemIcon } from './TreeViewItem.component';
 
@@ -48,6 +48,15 @@ const itemWithIcon = {
 	counter: 101,
 	showCounter: true,
 };
+
+const itemWithIconAndTooltip = {
+	...itemWithIcon,
+	icon: {
+		name: 'talend-versioning',
+		tooltipLabel: 'New version of the Pokemon is available',
+	},
+};
+
 const items = [item, { id: 2, name: 'grandma' }, { id: 3, name: 'granduncle' }, itemWithIcon];
 
 const defaultProps = {
@@ -106,6 +115,18 @@ describe('TreeView item', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render items with icon and tooltip', () => {
+		// when
+		const propsWithIconAndTooltip = {
+			...propsWithIcons,
+			item: itemWithIconAndTooltip,
+		};
+
+		const wrapper = shallow(<TreeViewItem {...propsWithIconAndTooltip} />);
+
+		expect(wrapper.find('TreeViewIcon').dive().getElement()).toMatchSnapshot();
 	});
 
 	it('should toggle item on toggle button click', () => {

--- a/packages/components/src/TreeView/TreeViewItem/__snapshots__/TreeViewItem.test.js.snap
+++ b/packages/components/src/TreeView/TreeViewItem/__snapshots__/TreeViewItem.test.js.snap
@@ -119,3 +119,17 @@ exports[`TreeView item should render items with icon 1`] = `
   </div>
 </li>
 `;
+
+exports[`TreeView item should render items with icon and tooltip 1`] = `
+<TooltipTrigger
+  label="New version of the Pokemon is available"
+  tooltipPlacement="top"
+>
+  <span>
+    <Icon
+      className="theme-tc-treeview-img"
+      name="talend-versioning"
+    />
+  </span>
+</TooltipTrigger>
+`;

--- a/packages/components/stories/TreeView.js
+++ b/packages/components/stories/TreeView.js
@@ -32,7 +32,8 @@ const structureWithIcons = [
 		children: [{ name: 'Hitmonchan' }],
 		isOpened: false,
 		icon: {
-			name: 'src-http://static.pokemonpets.com/images/monsters-images-300-300/106-Hitmonlee.png',
+			name: 'talend-versioning',
+			tooltipLabel: 'New version of the Pokemon is available',
 		},
 	},
 	{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-17837

In TMC plan steps are represented by tree view, now need to show corresponding icons if task does not use latest artifact version, or auto upgrade failed

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
