### PR TITLE
feat(components/piechart): new sizes

### DIFF
--- a/packages/components/src/PieChart/PieChartButton.test.js
+++ b/packages/components/src/PieChart/PieChartButton.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+import { PIECHART_SIZES } from './PieChartIcon.component';
 import PieChartButton, { decorateWithOverlay, wrapMouseEvent } from './PieChartButton.component';
 
 describe('PieChartButton', () => {
@@ -27,12 +28,19 @@ describe('PieChartButton', () => {
 			},
 		];
 		it('should render a PieChartButton', () => {
-			const wrapper = shallow(<PieChartButton display="small" model={pieChartData} />);
+			const wrapper = shallow(
+				<PieChartButton display={PIECHART_SIZES.SMALL} model={pieChartData} />,
+			);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 		it('should render nothing', () => {
 			const wrapper = shallow(
-				<PieChartButton available={false} display="medium" labelIndex={2} model={pieChartData} />,
+				<PieChartButton
+					available={false}
+					display={PIECHART_SIZES.MEDIUM}
+					labelIndex={2}
+					model={pieChartData}
+				/>,
 			);
 
 			expect(wrapper.getElement()).toBeNull();
@@ -41,7 +49,12 @@ describe('PieChartButton', () => {
 			const onClick = jest.fn();
 			const event = {};
 			const wrapper = shallow(
-				<PieChartButton label="my label" display="small" model={pieChartData} onClick={onClick} />,
+				<PieChartButton
+					label="my label"
+					display={PIECHART_SIZES.SMALL}
+					model={pieChartData}
+					onClick={onClick}
+				/>,
 			);
 
 			wrapper
@@ -61,7 +74,7 @@ describe('PieChartButton', () => {
 			const overlayComponent = <div>I am an overlay</div>;
 			const wrapper = shallow(
 				<PieChartButton
-					display="medium"
+					display={PIECHART_SIZES.MEDIUM}
 					labelIndex={2}
 					model={pieChartData}
 					overlayComponent={overlayComponent}
@@ -79,7 +92,7 @@ describe('PieChartButton', () => {
 			const myOverlayRef = jest.fn();
 			mount(
 				<PieChartButton
-					display="medium"
+					display={PIECHART_SIZES.MEDIUM}
 					labelIndex={2}
 					model={pieChartData}
 					overlayComponent={overlayComponent}

--- a/packages/components/src/PieChart/PieChartIcon.component.js
+++ b/packages/components/src/PieChart/PieChartIcon.component.js
@@ -12,20 +12,22 @@ import { getTheme } from '../theme';
 const theme = getTheme(pieChartCssModule);
 export const PIECHART_CONSTANTS = {
 	MIN_SIZE: 20,
-	MAX_SIZE: 50,
+	MAX_SIZE: 100,
 	MAX_PERCENT: 100,
 	BASE_INNER_RADIUS: 6,
 	BASE_OUTER_RADIUS: 9,
 	BASE_PAD_ANGLE: 0.2,
 	INNER_RADIUS_PER_PIXEL: 0.4,
 	OUTER_RADIUS_PER_PIXEL: 0.45,
-	PAD_ANGLE_PER_PIXEL: 0.0033,
+	PAD_ANGLE_PER_PIXEL: 0.0013,
 };
 
 const displaySizes = {
 	small: 20,
 	medium: 35,
 	large: 50,
+	xlarge: 80,
+	xxlarge: 100,
 };
 
 // we need just one instance of this, it's just a generator
@@ -333,7 +335,7 @@ export function PieChartIconComponent({
 }
 
 export const pieChartIconPropTypes = {
-	display: PropTypes.oneOf(['small', 'medium', 'large']),
+	display: PropTypes.oneOf(['small', 'medium', 'large', 'xlarge', 'xxlarge']),
 	hideLabel: PropTypes.bool,
 	labelIndex: PropTypes.number,
 	loading: PropTypes.bool,

--- a/packages/components/src/PieChart/PieChartIcon.component.js
+++ b/packages/components/src/PieChart/PieChartIcon.component.js
@@ -22,6 +22,15 @@ export const PIECHART_CONSTANTS = {
 	PAD_ANGLE_PER_PIXEL: 0.0013,
 };
 
+
+export const PIECHART_SIZES = {
+	SMALL: 'small',
+	MEDIUM: 'medium',
+	LARGE: 'large',
+	XLARGE: 'xlarge',
+	XXLARGE: 'xxlarge',
+};
+
 const displaySizes = {
 	small: 20,
 	medium: 35,

--- a/packages/components/src/PieChart/PieChartIcon.component.js
+++ b/packages/components/src/PieChart/PieChartIcon.component.js
@@ -22,7 +22,6 @@ export const PIECHART_CONSTANTS = {
 	PAD_ANGLE_PER_PIXEL: 0.0013,
 };
 
-
 export const PIECHART_SIZES = {
 	SMALL: 'small',
 	MEDIUM: 'medium',

--- a/packages/components/src/PieChart/PieChartIcon.test.js
+++ b/packages/components/src/PieChart/PieChartIcon.test.js
@@ -10,6 +10,7 @@ import {
 	getPercentageToIndex,
 	PieChartIconComponent,
 	setMinimumPercentage,
+	PIECHART_SIZES,
 } from './PieChartIcon.component';
 
 describe('PieChart', () => {
@@ -42,7 +43,9 @@ describe('PieChart', () => {
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 		it('should render a PieChart', () => {
-			const wrapper = shallow(<PieChartIconComponent display="small" model={pieChartData} />);
+			const wrapper = shallow(
+				<PieChartIconComponent display={PIECHART_SIZES.SMALL} model={pieChartData} />,
+			);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 		it('should spread extra props on svg', () => {

--- a/packages/components/src/PieChart/PieChartIcon.test.js
+++ b/packages/components/src/PieChart/PieChartIcon.test.js
@@ -258,7 +258,7 @@ describe('PieChart', () => {
 			expect(result).toEqual({
 				innerRadius: 18,
 				outerRadius: 22,
-				padAngle: 0.101,
+				padAngle: 0.161,
 				svgSize: 50,
 			});
 		});
@@ -272,7 +272,7 @@ describe('PieChart', () => {
 			expect(result).toEqual({
 				innerRadius: 9,
 				outerRadius: 12,
-				padAngle: 0.1736,
+				padAngle: 0.18960000000000002,
 				svgSize: 28,
 			});
 		});

--- a/packages/components/src/PieChart/index.js
+++ b/packages/components/src/PieChart/index.js
@@ -1,5 +1,5 @@
 import PieChartButton from './PieChartButton.component';
-import PieChartIcon from './PieChartIcon.component';
+import PieChartIcon, { PIECHART_SIZES } from './PieChartIcon.component';
 import PieChart from './PieChart.component';
 
-export { PieChart as default, PieChartButton, PieChartIcon };
+export { PieChart as default, PieChartButton, PieChartIcon, PIECHART_SIZES };

--- a/packages/components/stories/PieChart.js
+++ b/packages/components/stories/PieChart.js
@@ -73,6 +73,10 @@ stories
 			<PieChart display="medium" model={pieChartData1} />
 			<p>Large : </p>
 			<PieChart display="large" model={pieChartData1} />
+			<p>X-Large : </p>
+			<PieChart display="xlarge" model={pieChartData1} />
+			<p>XX-Large : </p>
+			<PieChart display="xxlarge" model={pieChartData1} />
 			<p>with other data :</p>
 			<PieChart display="medium" model={pieChartData2} />
 			<p>without label :</p>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Bigger pie charts are needed for the dataset overview

**What is the chosen solution to this problem?**

Add xlarge and xxlarge displays.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
