### PR TITLE
fix(ActionButton): Remove styles and span

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -213,19 +213,7 @@ export function ActionButton(props) {
 				tooltipPlacement={tooltipPlacement}
 				className={tooltipClassName}
 			>
-				{btnIsDisabled ? (
-					<span
-						className={classNames(
-							theme['tc-action-disabled-btn-container'],
-							'tc-action-disabled-btn-container',
-							buttonProps.className,
-						)}
-					>
-						{btn}
-					</span>
-				) : (
-					btn
-				)}
+				{btn}
 			</TooltipTrigger>
 		);
 	}

--- a/packages/components/src/Actions/ActionButton/ActionButton.scss
+++ b/packages/components/src/Actions/ActionButton/ActionButton.scss
@@ -2,7 +2,3 @@
 	margin-left: $padding-smaller;
 	margin-right: $padding-small;
 }
-
-.tc-action-disabled-btn-container {
-	padding: 0;
-}

--- a/packages/components/src/EditableText/EditableText.scss
+++ b/packages/components/src/EditableText/EditableText.scss
@@ -27,10 +27,6 @@ $tc-circle-editable-text-size: 16px !default;
 		display: flex;
 		align-items: center;
 		max-width: 90rem;
-
-		:global(.tc-action-disabled-btn-container) {
-			height: 19px;
-		}
 	}
 
 	&-wording {

--- a/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
@@ -6579,74 +6579,75 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                             label="Loading"
                                             tooltipPlacement="bottom"
                                           >
-                                            <span
+                                            <Button
+                                              active={false}
                                               aria-describedby={42}
-                                              className="theme-tc-action-disabled-btn-container tc-action-disabled-btn-container btn-icon-only theme-btn-disabled"
+                                              aria-label="Loading (in progress)"
+                                              block={false}
+                                              bsClass="btn"
+                                              bsStyle="link"
+                                              className="btn-icon-only theme-btn-disabled"
+                                              disabled={true}
                                               key=".0"
                                               onBlur={[Function]}
                                               onClick={[Function]}
                                               onFocus={[Function]}
                                               onKeyPress={[Function]}
+                                              onMouseDown={[Function]}
                                               onMouseOut={[Function]}
                                               onMouseOver={[Function]}
+                                              role="link"
                                             >
-                                              <Button
-                                                active={false}
+                                              <button
+                                                aria-describedby={42}
                                                 aria-label="Loading (in progress)"
-                                                block={false}
-                                                bsClass="btn"
-                                                bsStyle="link"
-                                                className="btn-icon-only theme-btn-disabled"
+                                                className="btn-icon-only theme-btn-disabled btn btn-link"
                                                 disabled={true}
+                                                onBlur={[Function]}
                                                 onClick={[Function]}
+                                                onFocus={[Function]}
+                                                onKeyPress={[Function]}
                                                 onMouseDown={[Function]}
+                                                onMouseOut={[Function]}
+                                                onMouseOver={[Function]}
                                                 role="link"
+                                                type="button"
                                               >
-                                                <button
-                                                  aria-label="Loading (in progress)"
-                                                  className="btn-icon-only theme-btn-disabled btn btn-link"
-                                                  disabled={true}
-                                                  onClick={[Function]}
-                                                  onMouseDown={[Function]}
-                                                  role="link"
-                                                  type="button"
+                                                <withI18nextTranslation(CircularProgress)
+                                                  key="icon"
+                                                  size="small"
                                                 >
-                                                  <withI18nextTranslation(CircularProgress)
-                                                    key="icon"
+                                                  <CircularProgress
+                                                    i18n={Object {}}
                                                     size="small"
+                                                    t={[Function]}
+                                                    tReady={true}
                                                   >
-                                                    <CircularProgress
-                                                      i18n={Object {}}
-                                                      size="small"
-                                                      t={[Function]}
-                                                      tReady={true}
+                                                    <svg
+                                                      aria-busy="true"
+                                                      aria-label="Loading "
+                                                      className="tc-circular-progress theme-loader theme-animate theme-small"
+                                                      focusable="false"
+                                                      viewBox="0 0 50 50"
                                                     >
-                                                      <svg
-                                                        aria-busy="true"
-                                                        aria-label="Loading "
-                                                        className="tc-circular-progress theme-loader theme-animate theme-small"
-                                                        focusable="false"
-                                                        viewBox="0 0 50 50"
-                                                      >
-                                                        <circle
-                                                          className="theme-path"
-                                                          cx={25}
-                                                          cy={25}
-                                                          fill="none"
-                                                          r={20}
-                                                          style={
-                                                            Object {
-                                                              "strokeDasharray": 12.566370614359172,
-                                                              "strokeDashoffset": 0,
-                                                            }
+                                                      <circle
+                                                        className="theme-path"
+                                                        cx={25}
+                                                        cy={25}
+                                                        fill="none"
+                                                        r={20}
+                                                        style={
+                                                          Object {
+                                                            "strokeDasharray": 12.566370614359172,
+                                                            "strokeDashoffset": 0,
                                                           }
-                                                        />
-                                                      </svg>
-                                                    </CircularProgress>
-                                                  </withI18nextTranslation(CircularProgress)>
-                                                </button>
-                                              </Button>
-                                            </span>
+                                                        }
+                                                      />
+                                                    </svg>
+                                                  </CircularProgress>
+                                                </withI18nextTranslation(CircularProgress)>
+                                              </button>
+                                            </Button>
                                           </TooltipTrigger>
                                         </ActionButton>
                                       </withI18nextTranslation(ActionButton)>
@@ -12111,76 +12112,77 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                           label="Loading"
                           tooltipPlacement="top"
                         >
-                          <span
+                          <Button
+                            active={false}
                             aria-describedby={42}
-                            className="theme-tc-action-disabled-btn-container tc-action-disabled-btn-container btn-icon-only theme-btn-disabled"
+                            aria-label="Loading (in progress)"
+                            block={false}
+                            bsClass="btn"
+                            bsStyle="link"
+                            className="btn-icon-only theme-btn-disabled"
+                            disabled={true}
+                            id="loading"
                             key=".0"
                             onBlur={[Function]}
                             onClick={[Function]}
                             onFocus={[Function]}
                             onKeyPress={[Function]}
+                            onMouseDown={[Function]}
                             onMouseOut={[Function]}
                             onMouseOver={[Function]}
+                            role="link"
                           >
-                            <Button
-                              active={false}
+                            <button
+                              aria-describedby={42}
                               aria-label="Loading (in progress)"
-                              block={false}
-                              bsClass="btn"
-                              bsStyle="link"
-                              className="btn-icon-only theme-btn-disabled"
+                              className="btn-icon-only theme-btn-disabled btn btn-link"
                               disabled={true}
                               id="loading"
+                              onBlur={[Function]}
                               onClick={[Function]}
+                              onFocus={[Function]}
+                              onKeyPress={[Function]}
                               onMouseDown={[Function]}
+                              onMouseOut={[Function]}
+                              onMouseOver={[Function]}
                               role="link"
+                              type="button"
                             >
-                              <button
-                                aria-label="Loading (in progress)"
-                                className="btn-icon-only theme-btn-disabled btn btn-link"
-                                disabled={true}
-                                id="loading"
-                                onClick={[Function]}
-                                onMouseDown={[Function]}
-                                role="link"
-                                type="button"
+                              <withI18nextTranslation(CircularProgress)
+                                key="icon"
+                                size="small"
                               >
-                                <withI18nextTranslation(CircularProgress)
-                                  key="icon"
+                                <CircularProgress
+                                  i18n={Object {}}
                                   size="small"
+                                  t={[Function]}
+                                  tReady={true}
                                 >
-                                  <CircularProgress
-                                    i18n={Object {}}
-                                    size="small"
-                                    t={[Function]}
-                                    tReady={true}
+                                  <svg
+                                    aria-busy="true"
+                                    aria-label="Loading "
+                                    className="tc-circular-progress theme-loader theme-animate theme-small"
+                                    focusable="false"
+                                    viewBox="0 0 50 50"
                                   >
-                                    <svg
-                                      aria-busy="true"
-                                      aria-label="Loading "
-                                      className="tc-circular-progress theme-loader theme-animate theme-small"
-                                      focusable="false"
-                                      viewBox="0 0 50 50"
-                                    >
-                                      <circle
-                                        className="theme-path"
-                                        cx={25}
-                                        cy={25}
-                                        fill="none"
-                                        r={20}
-                                        style={
-                                          Object {
-                                            "strokeDasharray": 12.566370614359172,
-                                            "strokeDashoffset": 0,
-                                          }
+                                    <circle
+                                      className="theme-path"
+                                      cx={25}
+                                      cy={25}
+                                      fill="none"
+                                      r={20}
+                                      style={
+                                        Object {
+                                          "strokeDasharray": 12.566370614359172,
+                                          "strokeDashoffset": 0,
                                         }
-                                      />
-                                    </svg>
-                                  </CircularProgress>
-                                </withI18nextTranslation(CircularProgress)>
-                              </button>
-                            </Button>
-                          </span>
+                                      }
+                                    />
+                                  </svg>
+                                </CircularProgress>
+                              </withI18nextTranslation(CircularProgress)>
+                            </button>
+                          </Button>
                         </TooltipTrigger>
                       </ActionButton>
                     </withI18nextTranslation(ActionButton)>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When an EditableText is empty, the submit button is disabled and the display is suddenly broken like this : 
![image](https://user-images.githubusercontent.com/59565911/74446762-aa64db80-4e78-11ea-9995-c6c5063ad949.png)

**What is the chosen solution to this problem?**
Remove the duplicated button styles (applied on span and button) by removing the span, who seems to be unnecessary.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
