### PR TITLE
fix(RichTooltip): the resourceList should take all the width

### DIFF
--- a/packages/components/src/RichTooltip/RichLayout/RichLayout.scss
+++ b/packages/components/src/RichTooltip/RichLayout/RichLayout.scss
@@ -93,5 +93,6 @@ $tc-popover-header-footer-height: 7rem !default;
 .rich-layout {
 	:global(.tc-resource-list) {
 		margin: 0 (-1 * $padding-large);
+		flex-grow: 1;
 	}
 }

--- a/packages/components/stories/RichTooltip.js
+++ b/packages/components/stories/RichTooltip.js
@@ -203,11 +203,7 @@ storiesOf('RichTooltip', module)
 					<RichLayout
 						id="richlayout"
 						Header={header}
-						Content={
-							<div style={{ width: '100%', height: '30rem' }}>
-								<FilteredResourceList isLoading />
-							</div>
-						}
+						Content={<FilteredResourceList isLoading />}
 					/>
 				}
 				overlayPlacement="bottom"
@@ -224,11 +220,7 @@ storiesOf('RichTooltip', module)
 					<RichLayout
 						id="richlayout"
 						Header={header}
-						Content={
-							<div style={{ width: '100%', height: '30rem' }}>
-								<FilteredResourceList collection={pipelines} renderAs={Pipeline} />
-							</div>
-						}
+						Content={<FilteredResourceList collection={pipelines} renderAs={Pipeline} />}
 					/>
 				}
 				overlayPlacement="bottom"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the resource list should take all the width without a container to define it when we wrap it with the RichTooltip

**What is the chosen solution to this problem?**
apply flex-grow: 1 when the resource list is wrapped by the component

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
