### PR TITLE
feat(cmf): add root option to target render element

### DIFF
--- a/packages/cmf/__tests__/bootstrap.test.js
+++ b/packages/cmf/__tests__/bootstrap.test.js
@@ -1,3 +1,5 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
 import createSagaMiddleware from 'redux-saga';
 
 import bootstrap, * as internals from '../src/bootstrap';
@@ -52,6 +54,7 @@ jest.mock('../src/store', () => ({
 describe('bootstrap', () => {
 	beforeEach(() => {
 		onError.bootstrap.mockClear();
+		ReactDOM.render.mockClear();
 	});
 	describe('error management', () => {
 
@@ -187,6 +190,17 @@ describe('bootstrap', () => {
 				},
 			};
 			bootstrap(options);
+		});
+		it('should bootstrap in element', () => {
+			const div = document.createElement('div');
+			const options = {
+				root: div,
+			};
+			expect(ReactDOM.render).not.toHaveBeenCalled();
+			bootstrap(options);
+			expect(ReactDOM.render).toHaveBeenCalled();
+			const args = ReactDOM.render.mock.calls[0];
+			expect(args[1]).toBe(div);
 		});
 	});
 });

--- a/packages/cmf/src/bootstrap.js
+++ b/packages/cmf/src/bootstrap.js
@@ -124,6 +124,7 @@ function DefaultRootComponent() {
 export default function bootstrap(appOptions = {}) {
 	// setup asap
 	const options = cmfModule(appOptions);
+	assertTypeOf(options, 'root', 'object');
 	assertTypeOf(options, 'appId', 'string');
 	assertTypeOf(options, 'RootComponent', 'function');
 
@@ -136,10 +137,11 @@ export default function bootstrap(appOptions = {}) {
 	onError.bootstrap(options, store);
 	saga.run();
 	const RootComponent = options.RootComponent || DefaultRootComponent;
+	const element = options.root || document.getElementById(appId);
 	render(
 		<App store={store} loading={options.AppLoader} withSettings={!!options.settingsURL}>
 			<RootComponent />
 		</App>,
-		document.getElementById(appId),
+		element,
 	);
 }

--- a/packages/cmf/src/bootstrap.js
+++ b/packages/cmf/src/bootstrap.js
@@ -83,10 +83,7 @@ export function bootstrapRedux(options, sagaMiddleware) {
 	}
 	let enhancer = bactchedSubscribe;
 	if (typeof options.enhancer === 'function') {
-		enhancer = compose(
-			options.enhancer,
-			bactchedSubscribe,
-		);
+		enhancer = compose(options.enhancer, bactchedSubscribe);
 	}
 	const middlewares = options.middlewares || [];
 	const store = storeAPI.initialize(options.reducer, options.preloadedState, enhancer, [

--- a/packages/cmf/src/bootstrap.md
+++ b/packages/cmf/src/bootstrap.md
@@ -22,6 +22,7 @@ cmf.bootstrap({
 | name | type | default | description |
 | -- | -- | -- | -- |
 | settingsURL | string | '/settings.json' | REQUIRED This URL to fetch the cmf settings.json file |
+| root | HTMLElement | document.getElementById(appId) | DOM element where to render the React application |
 | appId | string | 'app' | DOM element id, where to render the React application |
 | components | Object | undefined | A components dictionary where each key/value are registered in cmf registry so you can refer them in settings |
 | actionCreators | Object | undefined | Same as `components` |

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -82,6 +82,7 @@ const MERGE_FNS = {
 	id: () => undefined,
 	modules: () => undefined,
 	onError: getUnique,
+	root: getUnique,
 	appId: getUnique,
 	RootComponent: getUnique,
 	AppLoader: getUnique,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It is impossible to take an element not in the document to render a CMF app

**What is the chosen solution to this problem?**

Add `root` option to bootstrap so you can render a CMF app where you want.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
