### PR TITLE
feat(TCCUI-130): folder tree view without icons

### DIFF
--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -85,33 +85,33 @@ const structureWithoutIcons = [
 		name: 'hitmonlee',
 		children: [{ name: 'Hitmonchan' }],
 		isOpened: false,
-		icon: 'false',
+		icon: false,
 	},
 	{
 		name: 'pikachu',
 		children: [
 			{
 				name: 'raichu',
-				icon: 'false',
+				icon: false,
 			},
 		],
 		isOpened: true,
-		icon: 'false',
+		icon: false,
 	},
 	{
 		id: 'selected',
 		name: 'Abra',
-		icon: 'false',
+		icon: false,
 		isOpened: true,
 		children: [
 			{
 				name: 'Kadabra',
-				icon: 'false',
+				icon: false,
 				isOpened: true,
 				children: [
 					{
 						name: 'Alakazam',
-						icon: 'false',
+						icon: false,
 					},
 				],
 			},

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -85,33 +85,33 @@ const structureWithoutIcons = [
 		name: 'hitmonlee',
 		children: [{ name: 'Hitmonchan' }],
 		isOpened: false,
-		icon: 'none',
+		icon: 'false',
 	},
 	{
 		name: 'pikachu',
 		children: [
 			{
 				name: 'raichu',
-				icon: 'none',
+				icon: 'false',
 			},
 		],
 		isOpened: true,
-		icon: 'none',
+		icon: 'false',
 	},
 	{
 		id: 'selected',
 		name: 'Abra',
-		icon: 'none',
+		icon: 'false',
 		isOpened: true,
 		children: [
 			{
 				name: 'Kadabra',
-				icon: 'none',
+				icon: 'false',
 				isOpened: true,
 				children: [
 					{
 						name: 'Alakazam',
-						icon: 'none',
+						icon: 'false',
 					},
 				],
 			},

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -80,6 +80,45 @@ const structureWithIcons = [
 	},
 ];
 
+const structureWithoutIcons = [
+	{
+		name: 'hitmonlee',
+		children: [{ name: 'Hitmonchan' }],
+		isOpened: false,
+		icon: 'none',
+	},
+	{
+		name: 'pikachu',
+		children: [
+			{
+				name: 'raichu',
+				icon: 'none',
+			},
+		],
+		isOpened: true,
+		icon: 'none',
+	},
+	{
+		id: 'selected',
+		name: 'Abra',
+		icon: 'none',
+		isOpened: true,
+		children: [
+			{
+				name: 'Kadabra',
+				icon: 'none',
+				isOpened: true,
+				children: [
+					{
+						name: 'Alakazam',
+						icon: 'none',
+					},
+				],
+			},
+		],
+	},
+];
+
 const removeAction = [
 	{
 		action: action('itemRemoveCallback'),
@@ -387,6 +426,18 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<div style={style}>
 				<IconsProvider />
 				<TreeView {...cornerCaseLongName} />
+			</div>
+		</div>
+	))
+	.add('without icons', () => (
+		<div>
+			<h1>TreeView</h1>
+			<h3>Definition</h3>
+			<p>A view component to display any tree structure, like folders or categories.</p>
+			<h3>Default property-set without icons: </h3>
+			<div style={style}>
+				<IconsProvider />
+				<TreeView {...withAddAction} structure={structureWithoutIcons} />
 			</div>
 		</div>
 	));

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -32,6 +32,9 @@ export function getItemIcon(iconName = 'talend-folder', isOpened) {
  * @param isOpened if the treeview is opened
  */
 function TreeViewIcon({ icon, isOpened }) {
+	if (icon === 'none') {
+		return null;
+	}
 	if (typeof icon === 'object') {
 		return icon.tooltipLabel ? (
 			<TooltipTrigger label={icon.tooltipLabel} tooltipPlacement={icon.tooltipPlacement || 'top'}>

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -32,9 +32,6 @@ export function getItemIcon(iconName = 'talend-folder', isOpened) {
  * @param isOpened if the treeview is opened
  */
 function TreeViewIcon({ icon, isOpened }) {
-	if (icon === 'none') {
-		return null;
-	}
 	if (typeof icon === 'object') {
 		return icon.tooltipLabel ? (
 			<TooltipTrigger label={icon.tooltipLabel} tooltipPlacement={icon.tooltipPlacement || 'top'}>
@@ -271,7 +268,7 @@ class TreeViewItem extends React.Component {
 							link
 						/>
 					) : null}
-					<TreeViewIcon key="icon" icon={icon} isOpened={showOpenedFolder} />
+					{icon !== 'false' && <TreeViewIcon key="icon" icon={icon} isOpened={showOpenedFolder} />}
 					<span
 						key="label"
 						className={classNames('tc-treeview-item-name', css['tc-treeview-item-name'])}

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -49,7 +49,7 @@ function TreeViewIcon({ icon, isOpened }) {
 	);
 }
 TreeViewIcon.propTypes = {
-	icon: PropTypes.oneOfType([PropTypes.string, PropTypes.shape(Icon.propTypes)]),
+	icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.shape(Icon.propTypes)]),
 	isOpened: PropTypes.bool,
 };
 
@@ -75,7 +75,7 @@ class TreeViewItem extends React.Component {
 			name: PropTypes.string.isRequired,
 			isOpened: PropTypes.bool,
 			children: PropTypes.arrayOf(PropTypes.object),
-			icon: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+			icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.object]),
 			actions: PropTypes.arrayOf(
 				PropTypes.shape({
 					action: PropTypes.func,
@@ -268,7 +268,7 @@ class TreeViewItem extends React.Component {
 							link
 						/>
 					) : null}
-					{icon !== 'false' && <TreeViewIcon key="icon" icon={icon} isOpened={showOpenedFolder} />}
+					{icon !== false && <TreeViewIcon key="icon" icon={icon} isOpened={showOpenedFolder} />}
 					<span
 						key="label"
 						className={classNames('tc-treeview-item-name', css['tc-treeview-item-name'])}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently the folder tree view component show the talend-folder as the default icon if the icon is not specified.
In some cases, we need to display folder and sub-folders without any icons.
https://jira.talendforge.org/browse/TCCUI-130
Ref:
https://jira.talendforge.org/browse/TMC-16719

**What is the chosen solution to this problem?**
Do not render Icon if specified with "icon: none".
http://2691.talend.surge.sh/components/?path=/story/data-tree-foldertreeview--without-icons
Any item in the tree structure can be displayed without icon by specifying the value 'none' for 'icon' property. 
{ 
...,
icon: 'none' 
}

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
