### PR TITLE
feat(cmf): handle blob type

### DIFF
--- a/packages/cmf/__tests__/sagas/http.test.js
+++ b/packages/cmf/__tests__/sagas/http.test.js
@@ -173,6 +173,15 @@ describe('handleBody', () => {
 		});
 	});
 
+	it('should manage the body of the response like a blob', done => {
+		const headers = new Headers();
+		headers.append('Content-Type', 'application/zip');
+
+		handleBody({ blob: () => Promise.resolve(), headers }).then(() => {
+			done();
+		});
+	});
+
 	it('should manage the body of the response like a text', done => {
 		const headers = new Headers();
 		headers.append('Content-Type', 'text/plain');

--- a/packages/cmf/__tests__/sagas/http.test.js
+++ b/packages/cmf/__tests__/sagas/http.test.js
@@ -177,7 +177,10 @@ describe('handleBody', () => {
 		const headers = new Headers();
 		headers.append('Content-Type', 'application/zip');
 
-		handleBody({ blob: () => Promise.resolve(), headers }).then(() => {
+		const blob = jest.fn(() => Promise.resolve());
+
+		handleBody({ blob, headers }).then(() => {
+			expect(blob).toHaveBeenCalled();
 			done();
 		});
 	});

--- a/packages/cmf/src/sagas/http.js
+++ b/packages/cmf/src/sagas/http.js
@@ -56,6 +56,10 @@ export function handleBody(response) {
 		methodBody = 'json';
 	}
 
+	if (contentType && contentType.includes('application/zip')) {
+		methodBody = 'blob';
+	}
+
 	return response[methodBody]().then(data => ({ data, response }));
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

saga http don't handle the blob type

**What is the chosen solution to this problem?**



**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
