### PR TITLE
feat(components/slider): accept getTooltipContainer props

### DIFF
--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -209,6 +209,7 @@ class Slider extends React.Component {
 		id: PropTypes.string,
 		value: PropTypes.oneOfType([PropTypes.number, PropTypes.arrayOf(PropTypes.number)]),
 		onChange: PropTypes.func.isRequired,
+		getTooltipContainer: PropTypes.func,
 		onAfterChange: PropTypes.func,
 		captionActions: PropTypes.array,
 		captionIcons: PropTypes.array,
@@ -217,7 +218,6 @@ class Slider extends React.Component {
 		max: PropTypes.number.isRequired,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
-		getTooltipContainer: PropTypes.func,
 	};
 
 	constructor(props) {

--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -177,12 +177,13 @@ function getCaption(
  * Function to set the tooltip
  * @param {function} captionsFormat the function to format the caption
  */
-function getHandle(captionsFormat) {
+function getHandle(captionsFormat, getTooltipContainer) {
 	function Handle(props) {
 		return (
 			<Tooltip
 				prefixCls="rc-slider-tooltip"
 				overlay={captionsFormat(props.value)}
+				getTooltipContainer={getTooltipContainer}
 				visible
 				placement="top"
 				key={props.index}
@@ -216,12 +217,13 @@ class Slider extends React.Component {
 		max: PropTypes.number.isRequired,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
+		getTooltipContainer: PropTypes.func,
 	};
 
 	constructor(props) {
 		super(props);
 		this.state = {
-			handle: getHandle(props.captionsFormat),
+			handle: getHandle(props.captionsFormat, props.getTooltipContainer),
 		};
 	}
 

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -23,6 +23,7 @@ const delimiterStyle = {
 	borderBottom: '1px dashed grey',
 };
 
+
 const actions = [
 	{
 		id: 'icon1',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

getTooltipContainer cannot be passed to the handle tooltip

**What is the chosen solution to this problem?**

Add getTooltipContainer prop to the Slider component

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
