### PR TITLE
fix(faceted-search): Set initialOperatorOpened to false on hiding the value overlay

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Fixed
+
+- [fixed](https://github.com/Talend/ui/pull/2709): Set initialOperatorOpened to false on hiding the value overlay
+
 ## [0.5.0]
 
 ### Added

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -20,6 +20,7 @@ const theme = getTheme(cssModule);
 const findOperatorByName = name => operator => name === operator.name;
 
 const getOverlays = (initialOperatorOpened, initialValueOpened, operators) => {
+
 	if (operators.length < 2 && initialOperatorOpened) {
 		// To open the value just after the selection of the type
 		return useBadgeOverlayFlow(false, true);
@@ -88,6 +89,12 @@ const BadgeFaceted = ({
 		overlayDispatch(OVERLAY_FLOW_ACTIONS.openValue);
 		dispatch(BADGES_ACTIONS.closeInitialOpened(badgeId));
 	};
+
+	const onHideSubmitBadge = (...args) => {
+		dispatch(BADGES_ACTIONS.closeInitialOpened(badgeId));
+		onSubmitBadge(...args);
+	};
+
 	return (
 		<Badge id={id} className={theme('tc-badge-faceted')} display={size}>
 			<BadgeComposition.Category category={labelCategory} label={labelCategory} />
@@ -108,7 +115,7 @@ const BadgeFaceted = ({
 				className={theme('tc-badge-faceted-overlay')}
 				hideLabel={false}
 				label={labelValue}
-				onHide={onSubmitBadge}
+				onHide={onHideSubmitBadge}
 				opened={overlayState.valueOpened}
 				onChange={onChangeValueOverlay}
 				t={t}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a filter have only one operator, the badge is always opened on FacetedSearch mount.
This bug comes from #2640 , when we pass over the operator overlay. The `initialOperatorOpened` is never set to false, because this is done on hiding the operator overlay. Because we don't display it, we never fired the hiding method

**What is the chosen solution to this problem?**
Like we dispatch an action `closeInitialOpened` to set `initialOperatorOpened` and `initialValueOpened` to false on hiding the operator overlay, we do the same on hiding the value overlay.


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
