### PR TITLE
feat(GuidedTour): send event when the guided tour is closed

### DIFF
--- a/packages/containers/src/GuidedTour/GuidedTour.container.js
+++ b/packages/containers/src/GuidedTour/GuidedTour.container.js
@@ -35,6 +35,9 @@ class GuidedTourContainer extends React.Component {
 
 	closeTour = () => {
 		this.showControls();
+		if (this.props.onClose) {
+			this.props.onClose();
+		}
 
 		this.props.setState({ show: false });
 	};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The app don't know when the guided tour is closed

**What is the chosen solution to this problem?**

send event when onRequestClose is called

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
