### PR TITLE
fix(sidepanel): incorrect docked width

### DIFF
--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -147,7 +147,7 @@ $large-docked-width: 7rem;
 		&.docked {
 			:global {
 				.tc-action-list {
-					width: $docked-width;
+					width: $large-docked-width;
 					min-width: auto;
 				}
 			}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The docked large sidepanel has a wrong width

**What is the chosen solution to this problem?**
The docked large panel is 7rem

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
