### PR TITLE
feat(TDC-3798): Implement containsIgnoreCase operator

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,11 @@ Types of changes
 
 ## [unreleased]
 
+### Added
+
+- [feat](https://github.com/Talend/ui/pull/2732):  Implement containsIgnoreCase operator
+
+
 ## [0.5.2]
 
 ### Fixed

--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -1,5 +1,6 @@
 const operatorNames = {
 	contains: 'contains',
+	containsIgnoreCase: 'containsIgnoreCase',
 	equals: 'equals',
 	notEquals: 'notEquals',
 	in: 'in',
@@ -29,6 +30,13 @@ const standardOperators = t => ({
 			defaultValue: 'Contains',
 		}),
 		name: 'contains',
+		iconName: 'contains',
+	},
+	[operatorNames.containsIgnoreCase]: {
+		label: t('OPERATOR_CONTAINS_LABEL', {
+			defaultValue: 'Contains',
+		}),
+		name: 'containsIgnoreCase',
 		iconName: 'contains',
 	},
 	[operatorNames.in]: {

--- a/packages/faceted-search/src/queryClient/tql.js
+++ b/packages/faceted-search/src/queryClient/tql.js
@@ -35,6 +35,7 @@ const prepareBadges = flow([removeBadgesWithEmptyValue, getBadgesQueryValues]);
  */
 const getTqlClassOperatorsDictionary = query => ({
 	contains: query.contains,
+	containsIgnoreCase: query.containsIgnoreCase,
 	equals: query.equal,
 	in: query.in,
 	notEquals: query.unequal,

--- a/packages/faceted-search/src/queryClient/tql.test.js
+++ b/packages/faceted-search/src/queryClient/tql.test.js
@@ -396,4 +396,24 @@ describe('createTqlQuery', () => {
 		// Then
 		expect(result).toEqual('(price = 293820983098.23)');
 	});
+	it('should return an containsIgnoreCase tql query when value is using the containsIgnoreCase operator', () => {
+		// Given
+		const badgeContainsIgnoreCase = [
+			{
+				properties: {
+					attribute: 'Title',
+					operator: {
+						label: 'Contains',
+						name: 'containsIgnoreCase',
+						iconName: 'contains',
+					},
+					value: 'Dataset Title',
+				},
+			},
+		];
+		// When
+		const result = createTqlQuery(badgeContainsIgnoreCase);
+		// Then
+		expect(result).toEqual("(Title containsIgnoreCase 'Dataset Title')");
+	});
 });

--- a/packages/faceted-search/stories/badgesDefinitions.story.js
+++ b/packages/faceted-search/stories/badgesDefinitions.story.js
@@ -11,7 +11,7 @@ export const badgeName = {
 	metadata: {
 		badgePerFacet: 'N',
 		entitiesPerBadge: '1',
-		operators: ['contains', 'equals', 'notEquals', 'match a regexp'],
+		operators: ['containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
 	},
 };
 
@@ -162,7 +162,7 @@ export const badgeTextAsCustomAttribute = {
 		category: 'Custom attributes',
 		badgePerFacet: 'N',
 		entitiesPerBadge: '1',
-		operators: ['contains', 'equals', 'notEquals', 'match a regexp'],
+		operators: ['containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
 	},
 };
 
@@ -202,7 +202,7 @@ export const badgeTextAsCategory = {
 		category: 'Very long long long long long long category',
 		badgePerFacet: 'N',
 		entitiesPerBadge: '1',
-		operators: ['contains', 'equals'],
+		operators: ['containsIgnoreCase', 'equals'],
 	},
 };
 
@@ -219,6 +219,6 @@ export const badgeEmptyLabel = {
 	metadata: {
 		badgePerFacet: 'N',
 		entitiesPerBadge: '1',
-		operators: ['contains', 'equals'],
+		operators: ['containsIgnoreCase', 'equals'],
 	},
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In faceted-search package, contains operator is used to check contains in string comparaison. This is great but this TQL operator is case sensitive, that may be annoying for end-user.

To avoid this, this PR implement the `containsIgnoreCase` in operator faceted search dictionary. It have the same label / icon that `contains` operator because at the end, we want to only serve one of these in app.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
