### PR TITLE
feat(TDC-3798): Expose helpers to filter badgeDefinitions operator

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Added
+
+- [feat](https://github.com/Talend/ui/pull/2734):  Expose an helper to remove `contains` operator if `containsIgnoreCase` is here
+
 ## [0.6.0]
 
 ### Added

--- a/packages/faceted-search/src/dictionary/helpers.dictionary.js
+++ b/packages/faceted-search/src/dictionary/helpers.dictionary.js
@@ -1,0 +1,36 @@
+import { operatorNames } from './operator.dictionary';
+
+export const removeOneOperator = (badgeDefinition, operatorToRemove) => {
+	const {
+		metadata: { operators },
+	} = badgeDefinition;
+
+	return {
+		...badgeDefinition,
+		metadata: {
+			...badgeDefinition.metadata,
+			operators: operators.filter(operator => operator !== operatorToRemove),
+		},
+	};
+};
+
+export const filterBadgesDefinitionsWithOneContains = badgesDefinitions =>
+	badgesDefinitions.map(badgeDefinition => {
+		const {
+			properties: { type },
+			metadata: { operators },
+		} = badgeDefinition;
+
+		const hasTwoContainsOperator =
+			type === 'text' &&
+			operators.includes(operatorNames.contains) &&
+			operators.includes(operatorNames.containsIgnoreCase);
+
+		if (hasTwoContainsOperator) {
+			return removeOneOperator(badgeDefinition, operatorNames.contains);
+		}
+
+		return badgeDefinition;
+	});
+
+export default { filterBadgesDefinitionsWithOneContains, removeOneOperator };

--- a/packages/faceted-search/src/dictionary/helpers.dictionary.test.js
+++ b/packages/faceted-search/src/dictionary/helpers.dictionary.test.js
@@ -1,0 +1,175 @@
+import { removeOneOperator, filterBadgesDefinitionsWithOneContains } from './helpers.dictionary';
+
+describe('removeOneOperator', () => {
+	it('should remove a specific operator from a badge definition', () => {
+		// given
+		const badgesDefinition = {
+			properties: {
+				attribute: 'name',
+				initialOperatorOpened: true,
+				initialValueOpened: false,
+				label: 'Name',
+				operator: {},
+				operators: [],
+				type: 'text',
+			},
+			metadata: {
+				badgePerFacet: 'N',
+				entitiesPerBadge: '1',
+				operators: ['contains', 'containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
+			},
+		};
+
+		// when
+		const result = removeOneOperator(badgesDefinition, 'contains');
+		// then
+		expect(result).toEqual({
+			properties: {
+				attribute: 'name',
+				initialOperatorOpened: true,
+				initialValueOpened: false,
+				label: 'Name',
+				operator: {},
+				operators: [],
+				type: 'text',
+			},
+			metadata: {
+				badgePerFacet: 'N',
+				entitiesPerBadge: '1',
+				operators: ['containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
+			},
+		});
+	});
+
+	it('should return the whole badgeDefinition if operator to delete is not present', () => {
+		// given
+		const badgesDefinition = {
+			properties: {
+				attribute: 'name',
+				initialOperatorOpened: true,
+				initialValueOpened: false,
+				label: 'Name',
+				operator: {},
+				operators: [],
+				type: 'text',
+			},
+			metadata: {
+				badgePerFacet: 'N',
+				entitiesPerBadge: '1',
+				operators: ['contains', 'containsIgnoreCase', 'notEquals', 'match a regexp'],
+			},
+		};
+
+		// when
+		const result = removeOneOperator(badgesDefinition, 'equals');
+		// then
+		expect(result).toEqual({
+			properties: {
+				attribute: 'name',
+				initialOperatorOpened: true,
+				initialValueOpened: false,
+				label: 'Name',
+				operator: {},
+				operators: [],
+				type: 'text',
+			},
+			metadata: {
+				badgePerFacet: 'N',
+				entitiesPerBadge: '1',
+				operators: ['contains', 'containsIgnoreCase', 'notEquals', 'match a regexp'],
+			},
+		});
+	});
+});
+
+describe('filterBadgesDefinitionsWithOneContains', () => {
+	it('should remove a contains operator in badge text if there is a containsIgnoreCase', () => {
+		// given
+		const badgesDefinitions = [
+			{
+				properties: {
+					attribute: 'name',
+					operator: {},
+					operators: [],
+					type: 'text',
+				},
+				metadata: {
+					operators: ['contains', 'containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
+				},
+			},
+			{
+				properties: {
+					attribute: 'price',
+					operator: {},
+					operators: [],
+					type: 'number',
+				},
+				metadata: {
+					operators: ['equals'],
+				},
+			},
+		];
+
+		// when
+		const result = filterBadgesDefinitionsWithOneContains(badgesDefinitions);
+		// then
+		expect(result).toEqual([
+			{
+				properties: {
+					attribute: 'name',
+					operator: {},
+					operators: [],
+					type: 'text',
+				},
+				metadata: {
+					operators: ['containsIgnoreCase', 'equals', 'notEquals', 'match a regexp'],
+				},
+			},
+			{
+				properties: {
+					attribute: 'price',
+					operator: {},
+					operators: [],
+					type: 'number',
+				},
+				metadata: {
+					operators: ['equals'],
+				},
+			},
+		]);
+	});
+
+	it('should do anything if there is not containsIgnoreCase operator', () => {
+		// given
+		const badgesDefinitions = [
+			{
+				properties: {
+					attribute: 'name',
+					operator: {},
+					operators: [],
+					type: 'text',
+				},
+				metadata: {
+					operators: ['contains', 'equals', 'notEquals', 'match a regexp'],
+				},
+			},
+		];
+
+		// when
+		const result = filterBadgesDefinitionsWithOneContains(badgesDefinitions);
+		// then
+		expect(result).toEqual([
+			{
+				properties: {
+					attribute: 'name',
+					operator: {},
+					operators: [],
+					type: 'text',
+				},
+				metadata: {
+					operators: ['contains', 'equals', 'notEquals', 'match a regexp'],
+				},
+			},
+		]);
+	});
+});

--- a/packages/faceted-search/src/dictionary/operator.dictionary.js
+++ b/packages/faceted-search/src/dictionary/operator.dictionary.js
@@ -90,4 +90,4 @@ const getOperatorsFromDict = (operatorsDictionary, operatorsKeys) =>
 		.filter(element => element !== undefined);
 
 // eslint-disable-next-line import/prefer-default-export
-export { createOperatorsDict, getOperatorsFromDict };
+export { operatorNames, createOperatorsDict, getOperatorsFromDict };

--- a/packages/faceted-search/src/index.js
+++ b/packages/faceted-search/src/index.js
@@ -5,6 +5,7 @@ import {
 	BasicSearch,
 } from './components';
 import * as constants from './constants';
+import dictionaryHelpers from './dictionary/helpers.dictionary';
 
 const components = {
 	Icon,
@@ -13,4 +14,8 @@ const components = {
 	BasicSearch,
 };
 
-export default { ...components, constants };
+const helpers = {
+	dictionary: dictionaryHelpers,
+};
+
+export default { ...components, constants, helpers };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In badge text, we have the `contains` operator and recently the new `containsIgnoreCase`. But in a end-user perspective, it's the same. Due to that, we want to have an helper to remove the `contains` badge in a badge definition only if there is a `containsIgnoreCase` operator.

Even if it's an Inventory needs, it can be useful to have this helpers directly exposed by faceted-search package

**What is the chosen solution to this problem?**
- Create a function`filterBadgesDefinitionsWithOneContains` to filter badge text and remove `contains` operator if `containsIgnoreCase` is present.
- Expose this helpers directly in the `index.js` package.
- Add tests case

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
