### PR TITLE
fix(datalist): dropdown click and item data-feature

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -126,7 +126,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...inputProps,
 		items: rest.items || [],
 		itemProps: ({ itemIndex }) => ({
-			onMouseDown: rest.onSelect,
+			onClick: rest.onSelect,
 			'aria-disabled': rest.items[itemIndex] && rest.items[itemIndex].disabled,
 		}),
 	};

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -258,7 +258,7 @@ export function renderItem(item, { value, ...rest }) {
 				[theme.selected]: value === title,
 			})}
 			title={title}
-			data-feature={rest['data-feature']}
+			data-feature={item['data-feature'] || rest['data-feature']}
 		>
 			{get(item, 'icon') && <Icon className={theme['item-icon']} {...item.icon} />}
 			<div className={theme['item-text']}>

--- a/packages/components/src/Typeahead/Typeahead.test.js
+++ b/packages/components/src/Typeahead/Typeahead.test.js
@@ -173,7 +173,7 @@ describe('Typeahead', () => {
 			typeaheadInstance
 				.find('Item')
 				.at(0)
-				.simulate('mouseDown');
+				.simulate('click');
 
 			// then
 			expect(onSelect).toBeCalled();

--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -82,7 +82,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
         aria-selected={true}
         className="theme-item-highlighted tc-typeahead-item-highlighted"
         id="react-autowhatever-42--item-0"
-        onMouseDown={[Function]}
+        onClick={[Function]}
         role="option"
       >
         <div
@@ -158,7 +158,7 @@ exports[`MultiSelectTagWidget should render section title when items has categor
           aria-selected={true}
           className="theme-item-highlighted tc-typeahead-item-highlighted"
           id="react-autowhatever-42-section-0-item-0"
-          onMouseDown={[Function]}
+          onClick={[Function]}
           role="option"
         >
           <div


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- triggering the logic on onMouseDown prevents onClick event to happen and so pendo can't catch the click
- use data-feature property of the event

**What is the chosen solution to this problem?**
- replace event
- use item data-feature property

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
