### PR TITLE
chore(audit): temporary disable the CI job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,10 +39,10 @@ matrix:
       after_success:
         - if [ -z "$GH_TOKEN" ]; then echo "No credentials, this PR must be from a fork. Analysis skipped."; travis_terminate 0; fi
         - .travis/after_success_prettier.sh
-        - (yarn audit --json | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/audit.json
-        - (yarn run audit-router | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/router.json
-        - (yarn run audit-scripts | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/scripts.json
-        - (yarn run audit-html | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/html-webpack-plugin.json
+        # - (yarn audit --json | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/audit.json
+        # - (yarn run audit-router | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/router.json
+        # - (yarn run audit-scripts | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/scripts.json
+        # - (yarn run audit-html | awk '{if(NR>1)print}') | grep "{" 1> npm-audit/html-webpack-plugin.json
         - .travis/after_success_lint.sh
         - .travis/after_success_git.sh
 

--- a/.travis/after_success_git.sh
+++ b/.travis/after_success_git.sh
@@ -20,9 +20,9 @@ if [ -n "$GH_TOKEN" ]; then
 			echo "✓ Commit optimized icons to $TRAVIS_PULL_REQUEST_BRANCH"
 		fi
 
-		git add npm-audit/
-		git -c user.name="travis" -c user.email="travis" commit -m "chore(ci): update libs security audit"
-		echo "✓ Commit updated audit output to $TRAVIS_PULL_REQUEST_BRANCH"
+		# git add npm-audit/
+		# git -c user.name="travis" -c user.email="travis" commit -m "chore(ci): update libs security audit"
+		# echo "✓ Commit updated audit output to $TRAVIS_PULL_REQUEST_BRANCH"
 
 		git add output/
 		git -c user.name="travis" -c user.email="travis" commit -m "chore(ci): update code style outputs"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We got some issues with our current audit scan like it's updating the pull request in kind of infinite loop.

**What is the chosen solution to this problem?**
Disable it while it's not working as it should be

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
