### PR TITLE
fix: Storybook on IE11

### DIFF
--- a/.storybook/i18n.js
+++ b/.storybook/i18n.js
@@ -7,7 +7,7 @@ import { locales as tuiLocales } from '@talend/locales-tui/locales';
 i18n.use(initReactI18next).init({
 	debug: false,
 	interpolation: {
-		format: (value, format) => {
+		format: function(value, format) {
 			if (value && format === 'lowercase') return value.toLocaleLowerCase();
 			if (value && format === 'uppercase') return value.toLocaleUpperCase();
 			return value;

--- a/.storybook/sortStories.js
+++ b/.storybook/sortStories.js
@@ -14,7 +14,7 @@ const categories = [
 
 addParameters({
 	options: {
-		storySort: (a, b) => {
+		storySort: function(a, b) {
 			const aCat = a[1].kind ? a[1].kind.split('/')[0] : '';
 			const bCat = b[1].kind ? b[1].kind.split('/')[0] : '';
 			const aLevel = categories.indexOf(aCat);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook does not work on IE11 anymore

**What is the chosen solution to this problem?**
Storybook does not transpile all imports and IE11 does not support arrow functions
https://github.com/storybookjs/storybook/issues/9242

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
