### PR TITLE
fix(components/datalist): onBlur is called before onClick

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -126,6 +126,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...inputProps,
 		items: rest.items || [],
 		itemProps: ({ itemIndex }) => ({
+			onMouseDown: event => event.preventDefault(),
 			onClick: rest.onSelect,
 			'aria-disabled': rest.items[itemIndex] && rest.items[itemIndex].disabled,
 		}),

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -76,6 +76,7 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-0"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -99,6 +100,7 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-1"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -213,6 +215,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -260,6 +263,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -347,6 +351,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -540,6 +545,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -570,6 +576,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -628,6 +635,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -723,6 +731,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-0"
+          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >
@@ -747,6 +756,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-1"
+          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >

--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -83,6 +83,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
         className="theme-item-highlighted tc-typeahead-item-highlighted"
         id="react-autowhatever-42--item-0"
         onClick={[Function]}
+        onMouseDown={[Function]}
         role="option"
       >
         <div
@@ -159,6 +160,7 @@ exports[`MultiSelectTagWidget should render section title when items has categor
           className="theme-item-highlighted tc-typeahead-item-highlighted"
           id="react-autowhatever-42-section-0-item-0"
           onClick={[Function]}
+          onMouseDown={[Function]}
           role="option"
         >
           <div


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When you start typing and select a suggestion, `onBlur` event is triggered and the selection looks to be random.
![ui](https://user-images.githubusercontent.com/18534166/79476550-6a9daa00-8009-11ea-8ab4-453e952e7407.gif)

**What is the chosen solution to this problem?**
Since `onClick` is [needed for usage tracking](https://github.com/Talend/ui/pull/2741), prevent `onMouseDown` event default behavior in order to let calling `onClick` before `onBlur`!

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
