### PR TITLE
TDC-3820: Pass props data-feature in BadgeDelete

### DIFF
--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
@@ -6,7 +6,7 @@ import { getTheme } from '../../../theme';
 
 const theme = getTheme(badgeCssModule);
 
-const BadgeDelete = ({ disabled, id, label, onClick, t }) => (
+const BadgeDelete = ({ disabled, id, label, onClick, t, dataFeature }) => (
 	<Action
 		className={theme('tc-badge-delete-icon')}
 		disabled={disabled}
@@ -18,6 +18,7 @@ const BadgeDelete = ({ disabled, id, label, onClick, t }) => (
 		link
 		onClick={onClick}
 		role="button"
+		data-feature={dataFeature}
 	/>
 );
 
@@ -26,6 +27,7 @@ BadgeDelete.propTypes = {
 	id: PropTypes.string,
 	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
+	dataFeature: PropTypes.string,
 	t: PropTypes.func,
 };
 

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.test.js
@@ -45,4 +45,18 @@ describe('BadgeDelete', () => {
 		// then
 		expect(wrapper.find('button').prop('aria-label')).toBe('My custom label');
 	});
+	it('should pass the props dataFeature to the button', () => {
+		// given
+		const onClick = jest.fn();
+		const props = {
+			id: 'my-id',
+			dataFeature: 'feature-delete',
+			onClick,
+			t: getDefaultT(),
+		};
+		// when
+		const wrapper = mount(<BadgeDelete {...props} />);
+		// then
+		expect(wrapper.find('button').prop('data-feature')).toBe('feature-delete');
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can't have a data-feature attribute on button with BadgeDelete action.

We need this to have a better data-feature tagging plan in `faceted-search` package.

**What is the chosen solution to this problem?**
Passed the props from BadgeDelete to Action component

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
