### PR TITLE
feat(components/gridlayout): authorize to override columns and breakpoints props

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -37,8 +37,8 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   279:53  error  'footerActions' is defined but never used               no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/GridLayout/Grid.component.js
-  68:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
-  71:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
+  70:7  error  Expected indentation of 5 tab characters but found 6  react/jsx-indent
+  73:2  error  Mixed spaces and tabs                                 no-mixed-spaces-and-tabs
 
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.component.js
   116:37  error  Elements with ARIA roles must use a valid, non-abstract ARIA role  jsx-a11y/aria-role

--- a/packages/components/src/GridLayout/Grid.component.js
+++ b/packages/components/src/GridLayout/Grid.component.js
@@ -15,14 +15,14 @@ const theme = getTheme(css);
 const ResponsiveGridLayout = WidthProvider(Responsive);
 const MARGIN = 20;
 
-const columns = {
+const DEFAULT_COLUMNS = {
 	s: 2,
 	m: 4,
 	l: 6,
 	xl: 12,
 };
 
-const breakpoints = {
+const DEFAULT_BREAKPOINTS = {
 	s: 479,
 	m: 768,
 	l: 1024,
@@ -43,6 +43,8 @@ function Grid({
 	skeletonConfiguration,
 	compactType = 'vertical',
 	verticalCompact = true,
+	columns = DEFAULT_COLUMNS,
+	breakpoints = DEFAULT_BREAKPOINTS,
 }) {
 	return (
 		<ResponsiveGridLayout
@@ -84,6 +86,18 @@ Grid.propTypes = {
 	onDragStop: PropTypes.func,
 	onResizeStop: PropTypes.func,
 	isLoading: PropTypes.bool,
+	columns: PropTypes.shape({
+		s: PropTypes.number,
+		m: PropTypes.number,
+		l: PropTypes.number,
+		xl: PropTypes.number,
+	}),
+	breakpoints: PropTypes.shape({
+		s: PropTypes.number,
+		m: PropTypes.number,
+		l: PropTypes.number,
+		xl: PropTypes.number,
+	}),
 	skeletonConfiguration: PropTypes.arrayOf(
 		PropTypes.shape({
 			key: PropTypes.string.isRequired,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

columns and breakpoints props cannot be overridden

**What is the chosen solution to this problem?**

allow new columns and breakpoints props

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
