### PR TITLE
feat(theme): update regal-blue value

### DIFF
--- a/packages/theme/src/theme/_colors.scss
+++ b/packages/theme/src/theme/_colors.scss
@@ -12,7 +12,7 @@ $green-talend: #b6be00;
 /// and to draw attention to the important elements of interaction.
 ///
 /// @type Color
-$regal-blue: #17486e;
+$regal-blue: #19426c;
 
 /// Primary color, mostly used for the selected elements
 /// and to draw attention to the important elements of interaction.


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Regal-blue color has changed in guideline
![image](https://user-images.githubusercontent.com/10761073/79752013-dfc3f480-8313-11ea-89f6-a96fb66d5563.png)


**What is the chosen solution to this problem?**
Update the color value in the bootstrap theme

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
