### PR TITLE
fix(GuidedTour): add loading message

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,6 +2,11 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
+/home/travis/build/Talend/ui/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+  16:5   error  Strings must use singlequote  quotes
+  23:8   error  Strings must use singlequote  quotes
+  24:40  error  Strings must use singlequote  quotes
+
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Badges/index.js
   3:10  error  Prefer default export  import/prefer-default-export
 
@@ -75,6 +80,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 29 problems (27 errors, 2 warnings)
-  1 error, 0 warnings potentially fixable with the `--fix` option.
+✖ 32 problems (30 errors, 2 warnings)
+  4 errors, 0 warnings potentially fixable with the `--fix` option.
 

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,11 +2,6 @@
 
 The react/require-extension rule is deprecated. Please use the import/extensions rule from eslint-plugin-import instead.
 
-/home/travis/build/Talend/ui/packages/components/src/AppGuidedTour/DemoContentStep.component.js
-  16:5   error  Strings must use singlequote  quotes
-  23:8   error  Strings must use singlequote  quotes
-  24:40  error  Strings must use singlequote  quotes
-
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Badges/index.js
   3:10  error  Prefer default export  import/prefer-default-export
 
@@ -80,6 +75,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 32 problems (30 errors, 2 warnings)
-  4 errors, 0 warnings potentially fixable with the `--fix` option.
+✖ 29 problems (27 errors, 2 warnings)
+  1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -11,6 +11,7 @@ import {
 	SHOW_COMPLETED_TRANSITION_TIMER,
 } from '../Stepper/Stepper.component';
 import I18N_DOMAIN_COMPONENTS from '../constants';
+import DemoContentStep from './DemoContentStep.component';
 
 const DEMO_CONTENT_STEP_ID = 1;
 export const DEFAULT_LOCAL_STORAGE_KEY = 'app-guided-tour-viewed';
@@ -109,7 +110,7 @@ function AppGuidedTour({
 						header: t('GUIDED_TOUR_WELCOME_STEP_HEADER', {
 							defaultValue: 'Importing demo content',
 						}),
-						body: () => (demoContentSteps.length ? <Stepper steps={demoContentSteps} /> : null),
+						body: () => <DemoContentStep demoContentSteps={demoContentSteps} />,
 					},
 				},
 				...steps,

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
@@ -71,6 +71,7 @@ describe('AppGuidedTour', () => {
 		});
 
 		expect(wrapper.find('Tour').prop('goToStep')).toBe(1);
+		expect(wrapper.find('DemoContentStep').length).toBe(1);
 	});
 	it('should reset state on close', () => {
 		const onRequestCloseMock = jest.fn();

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -18,7 +18,7 @@ export default function DemoContentStep({ demoContentSteps }) {
 				<Icon name="talend-info-circle" />
 				{i18n.t('tui-components:DEMO_CONTENT_LOADING_MESSAGE', {
 					defaultValue:
-						'Loading may take a few minutes to complete. Bear with us. Content is loading. Isn\'t it time for tea or coffee?',
+						"Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?",
 				})}
 			</p>
 			<Stepper steps={demoContentSteps} />

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -13,7 +13,7 @@ export default function DemoContentStep({ demoContentSteps }) {
 	}
 
 	return (
-		<>
+		<React.Fragment>
 			<p className={theme.info}>
 				<Icon name="talend-info-circle" />
 				{i18n.t('tui-components:DEMO_CONTENT_LOADING_MESSAGE', {
@@ -22,7 +22,7 @@ export default function DemoContentStep({ demoContentSteps }) {
 				})}
 			</p>
 			<Stepper steps={demoContentSteps} />
-		</>
+		</React.Fragment>
 	);
 }
 

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import Icon from '../Icon';
+import Stepper from '../Stepper';
+import { getI18nInstance } from '../translate';
+
+import theme from './DemoContentStep.scss';
+
+const i18n = getI18nInstance();
+
+export default function DemoContentStep({ demoContentSteps }) {
+	if (!demoContentSteps.length) {
+		return null;
+	}
+
+
+	return (
+		<>
+			<p className={theme.info}>
+				<Icon name="talend-info-circle" />
+				{i18n.t('tui-components:DEMO_CONTENT_INFO_TIME', { defaultValue: "Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?" })}
+			</p>
+			<Stepper steps={demoContentSteps} />
+		</>
+	);
+}
+
+DemoContentStep.propTypes = {
+	demoContentSteps: Stepper.propTypes.steps.isRequired,
+};

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -15,10 +15,9 @@ export default function DemoContentStep({ demoContentSteps }) {
 	return (
 		<React.Fragment>
 			<p className={theme.info}>
-				<Icon name="talend-info-circle" />
 				{i18n.t('tui-components:DEMO_CONTENT_LOADING_MESSAGE', {
 					defaultValue:
-						"Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?",
+						"Loading may take a few minutes to complete.\nIsn't it time for tea or coffee?",
 				})}
 			</p>
 			<Stepper steps={demoContentSteps} />

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -12,12 +12,14 @@ export default function DemoContentStep({ demoContentSteps }) {
 		return null;
 	}
 
-
 	return (
 		<>
 			<p className={theme.info}>
 				<Icon name="talend-info-circle" />
-				{i18n.t('tui-components:DEMO_CONTENT_INFO_TIME', { defaultValue: "Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?" })}
+				{i18n.t('tui-components:DEMO_CONTENT_INFO_TIME', {
+					defaultValue:
+						"Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?",
+				})}
 			</p>
 			<Stepper steps={demoContentSteps} />
 		</>

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -1,13 +1,12 @@
 import React from 'react';
-import Icon from '../Icon';
+import { useTranslation } from 'react-i18next';
 import Stepper from '../Stepper';
-import { getI18nInstance } from '../translate';
+import I18N_DOMAIN_COMPONENTS from '../constants';
 
 import theme from './DemoContentStep.scss';
 
-const i18n = getI18nInstance();
-
 export default function DemoContentStep({ demoContentSteps }) {
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	if (!demoContentSteps.length) {
 		return null;
 	}
@@ -15,7 +14,7 @@ export default function DemoContentStep({ demoContentSteps }) {
 	return (
 		<React.Fragment>
 			<p className={theme.info}>
-				{i18n.t('tui-components:DEMO_CONTENT_LOADING_MESSAGE', {
+				{t('DEMO_CONTENT_LOADING_MESSAGE', {
 					defaultValue:
 						"Loading may take a few minutes to complete.\nIsn't it time for tea or coffee?",
 				})}

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.js
@@ -16,9 +16,9 @@ export default function DemoContentStep({ demoContentSteps }) {
 		<>
 			<p className={theme.info}>
 				<Icon name="talend-info-circle" />
-				{i18n.t('tui-components:DEMO_CONTENT_INFO_TIME', {
+				{i18n.t('tui-components:DEMO_CONTENT_LOADING_MESSAGE', {
 					defaultValue:
-						"Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?",
+						'Loading may take a few minutes to complete. Bear with us. Content is loading. Isn\'t it time for tea or coffee?',
 				})}
 			</p>
 			<Stepper steps={demoContentSteps} />

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.test.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.test.js
@@ -6,7 +6,11 @@ import DemoContentStep from './DemoContentStep.component';
 
 describe('DemOContentStep', () => {
 	it('should show the demo content step', () => {
-		const wrapper = shallow(<DemoContentStep demoContentSteps={[{ label: 'Importing dataset', status: LOADING_STEP_STATUSES.FAILURE }]} />);
+		const wrapper = shallow(
+			<DemoContentStep
+				demoContentSteps={[{ label: 'Importing dataset', status: LOADING_STEP_STATUSES.FAILURE }]}
+			/>,
+		);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 		expect(wrapper.find('Stepper').length).toBe(1);

--- a/packages/components/src/AppGuidedTour/DemoContentStep.component.test.js
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.component.test.js
@@ -1,0 +1,20 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import { LOADING_STEP_STATUSES } from '../Stepper';
+import DemoContentStep from './DemoContentStep.component';
+
+describe('DemOContentStep', () => {
+	it('should show the demo content step', () => {
+		const wrapper = shallow(<DemoContentStep demoContentSteps={[{ label: 'Importing dataset', status: LOADING_STEP_STATUSES.FAILURE }]} />);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.find('Stepper').length).toBe(1);
+	});
+
+	it('should show nothing when no step', () => {
+		const wrapper = shallow(<DemoContentStep demoContentSteps={[]} />);
+
+		expect(wrapper.find('Stepper').length).toBe(0);
+	});
+});

--- a/packages/components/src/AppGuidedTour/DemoContentStep.scss
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.scss
@@ -6,5 +6,6 @@
 	svg {
 		color: $lochmara;
 		margin-right: $padding-small;
+		flex-shrink: 0;
 	}
 }

--- a/packages/components/src/AppGuidedTour/DemoContentStep.scss
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.scss
@@ -1,11 +1,3 @@
 .info {
-	display: flex;
-	justify-content: center;
-	align-items: center;
-
-	svg {
-		color: $lochmara;
-		margin-right: $padding-small;
-		flex-shrink: 0;
-	}
+	white-space: pre;
 }

--- a/packages/components/src/AppGuidedTour/DemoContentStep.scss
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.scss
@@ -1,0 +1,10 @@
+.info {
+	display: flex;
+	justify-content: center;
+	align-items: center;
+
+	svg {
+		color: $lochmara;
+		margin-right: $padding-small;
+	}
+}

--- a/packages/components/src/AppGuidedTour/__snapshots__/DemoContentStep.component.test.js.snap
+++ b/packages/components/src/AppGuidedTour/__snapshots__/DemoContentStep.component.test.js.snap
@@ -5,10 +5,8 @@ exports[`DemOContentStep should show the demo content step 1`] = `
   <p
     className="theme-info"
   >
-    <Icon
-      name="talend-info-circle"
-    />
-    Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?
+    Loading may take a few minutes to complete.
+Isn't it time for tea or coffee?
   </p>
   <Stepper
     steps={

--- a/packages/components/src/AppGuidedTour/__snapshots__/DemoContentStep.component.test.js.snap
+++ b/packages/components/src/AppGuidedTour/__snapshots__/DemoContentStep.component.test.js.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DemOContentStep should show the demo content step 1`] = `
+<React.Fragment>
+  <p
+    className="theme-info"
+  >
+    <Icon
+      name="talend-info-circle"
+    />
+    Loading may take a few minutes to complete. Bear with us. Content is loading. Isn't it time for tea or coffee?
+  </p>
+  <Stepper
+    steps={
+      Array [
+        Object {
+          "label": "Importing dataset",
+          "status": "failure",
+        },
+      ]
+    }
+  />
+</React.Fragment>
+`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The demo content can take a lot a time to importent the content.

**What is the chosen solution to this problem?**
Add a message to inform them that this step can take a lot a time

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
