### PR TITLE
fix: sass-loader transitive vulnerability

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -117,7 +117,7 @@
     "react-test-renderer": "^16.8.6",
     "rimraf": "^3.0.2",
     "sass-lint": "^1.13.1",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1",
     "style-loader": "^0.23.0"
   },

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -87,7 +87,7 @@
     "react-test-renderer": "^16.8.6",
     "redux-saga-tester": "^1.0.373",
     "rimraf": "^3.0.2",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1",
     "style-loader": "^0.23.0"
   },

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -76,7 +76,7 @@
     "react-dom": "^16.8.6",
     "react-i18next": "^10.11.4",
     "rimraf": "^3.0.2",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1",
     "style-loader": "^0.23.0"
   },

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -77,7 +77,7 @@
     "react-dom": "^16.8.6",
     "react-i18next": "^10.11.4",
     "rimraf": "^3.0.2",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "style-loader": "^0.23.0"
   },
   "peerDependencies": {

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -91,7 +91,7 @@
     "react-test-renderer": "^16.8.6",
     "rimraf": "^3.0.2",
     "sass-lint": "^1.13.1",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1"
   },
   "peerDependencies": {

--- a/packages/scripts/package.json
+++ b/packages/scripts/package.json
@@ -84,7 +84,7 @@
     "react-test-renderer": "^16.8.6",
     "resolve-url-loader": "2.3.0",
     "rimraf": "^2.6.2",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "style-loader": "^0.23.0",
     "terser-webpack-plugin": "^1.2.3",
     "uglifyjs-webpack-plugin": "1.2.7",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -75,7 +75,7 @@
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.3.1",
     "rimraf": "^3.0.2",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "style-loader": "^0.23.0"
   },
   "peerDependencies": {

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -42,7 +42,7 @@
     "postcss-loader": "^3.0.0",
     "rimraf": "^3.0.2",
     "sass-lint": "^1.13.1",
-    "sass-loader": "^7.1.0",
+    "sass-loader": "^7.3.1",
     "style-loader": "^0.23.0",
     "url-loader": "^1.1.2",
     "webpack": "^4.42.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6561,15 +6561,6 @@ clone-deep@^0.2.4:
     lazy-cache "^1.0.3"
     shallow-clone "^0.1.2"
 
-clone-deep@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-2.0.2.tgz#00db3a1e173656730d1188c3d6aced6d7ea97713"
-  dependencies:
-    for-own "^1.0.0"
-    is-plain-object "^2.0.4"
-    kind-of "^6.0.0"
-    shallow-clone "^1.0.0"
-
 clone-deep@^4.0.0, clone-deep@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/clone-deep/-/clone-deep-4.0.1.tgz#c19fd9bdbbf85942b4fd979c84dcf7d5f07c2387"
@@ -9194,12 +9185,6 @@ for-in@^1.0.1, for-in@^1.0.2:
 for-own@^0.1.3:
   version "0.1.5"
   resolved "https://registry.yarnpkg.com/for-own/-/for-own-0.1.5.tgz#5265c681a4f294dabbf17c9509b6763aa84510ce"
-  dependencies:
-    for-in "^1.0.1"
-
-for-own@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/for-own/-/for-own-1.0.0.tgz#c63332f415cedc4b04dbfe70cf836494c53cb44b"
   dependencies:
     for-in "^1.0.1"
 
@@ -12187,10 +12172,6 @@ lodash.some@^4.6.0:
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
-
-lodash.tail@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.tail/-/lodash.tail-4.1.1.tgz#d2333a36d9e7717c8ad2f7cacafec7c32b444664"
 
 lodash.template@^4.0.2:
   version "4.4.0"
@@ -16135,16 +16116,16 @@ sass-lint@^1.13.1:
     path-is-absolute "^1.0.0"
     util "^0.10.3"
 
-sass-loader@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.1.0.tgz#16fd5138cb8b424bf8a759528a1972d72aad069d"
+sass-loader@^7.3.1:
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/sass-loader/-/sass-loader-7.3.1.tgz#a5bf68a04bcea1c13ff842d747150f7ab7d0d23f"
+  integrity sha512-tuU7+zm0pTCynKYHpdqaPpe+MMTQ76I9TPZ7i4/5dZsigE350shQWe5EZNl5dBidM49TPET75tNqRbcsUZWeNA==
   dependencies:
-    clone-deep "^2.0.1"
+    clone-deep "^4.0.1"
     loader-utils "^1.0.1"
-    lodash.tail "^4.1.1"
     neo-async "^2.5.0"
-    pify "^3.0.0"
-    semver "^5.5.0"
+    pify "^4.0.1"
+    semver "^6.3.0"
 
 sax@^1.1.5, sax@^1.2.4, sax@~1.2.4:
   version "1.2.4"
@@ -16395,14 +16376,6 @@ shallow-clone@^0.1.2:
     is-extendable "^0.1.1"
     kind-of "^2.0.1"
     lazy-cache "^0.2.3"
-    mixin-object "^2.0.1"
-
-shallow-clone@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-1.0.0.tgz#4480cd06e882ef68b2ad88a3ea54832e2c48b571"
-  dependencies:
-    is-extendable "^0.1.1"
-    kind-of "^5.0.0"
     mixin-object "^2.0.1"
 
 shallow-clone@^3.0.0:


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`Sass-loader v7.2.0` depends on `clone-deep v4.0.1` that depends on `kind-of v6.0.2`.

**What is the chosen solution to this problem?**
Upgrade sass-loader to v7.3.1

(This has no incidence on bundles, it is used to lad our style in storybook)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
