### PR TITLE
feat(TFD-10234): Add optionnal display of types

### DIFF
--- a/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
@@ -21,6 +21,7 @@ exports[`ModelViewerBranch render ModelViewerBranch 1`] = `
       value={Object {}}
     />
     <SimpleTextKeyValue
+      displayTypes={false}
       formattedKey="myValueValue"
       formattedValue="myKeyValue"
       separator=" "
@@ -50,6 +51,7 @@ exports[`ModelViewerBranch render ModelViewerBranch as a union 1`] = `
       value={Object {}}
     />
     <SimpleTextKeyValue
+      displayTypes={false}
       formattedKey="myValueValue"
       formattedValue="({...})"
       separator=" "

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
@@ -11,6 +11,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf 1`] = `
     title="toto"
   />
   <SimpleTextKeyValue
+    displayTypes={false}
     formattedKey="toto"
     separator=" "
     value=""
@@ -32,6 +33,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf highlighted 1`] = `
     title=" (typeSem)*"
   />
   <SimpleTextKeyValue
+    displayTypes={false}
     separator=" "
     value="(typeSem)*"
   />
@@ -52,6 +54,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf with additional data 1`] 
     title=" (typeSem)*"
   />
   <SimpleTextKeyValue
+    displayTypes={false}
     separator=" "
     value="(typeSem)*"
   />

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -10,6 +10,7 @@ export function RecordsViewerLeaf({
 	renderLeafAdditionalValue,
 	className,
 	nodeHighlighted,
+	displayTypes,
 }) {
 	return (
 		<div
@@ -20,10 +21,10 @@ export function RecordsViewerLeaf({
 		>
 			{renderLeafAdditionalValue && renderLeafAdditionalValue(value)}
 			<SimpleTextKeyValue
-				formattedKey={`${dataKey}:`}
+				formattedKey={`${dataKey}`}
 				value={value.data}
 				schema={value.schema}
-				separator={' '}
+				displayTypes={displayTypes}
 			/>
 		</div>
 	);
@@ -31,13 +32,14 @@ export function RecordsViewerLeaf({
 
 RecordsViewerLeaf.propTypes = {
 	className: PropTypes.string,
-	dataKey: PropTypes.string,
+	dataKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	nodeHighlighted: PropTypes.bool,
 	value: PropTypes.shape({
 		data: PropTypes.object,
 		schema: PropTypes.object,
 	}),
 	renderLeafAdditionalValue: PropTypes.func,
+	displayTypes: PropTypes.bool,
 };
 
 export default RecordsViewerLeaf;

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -21,7 +21,7 @@ export function RecordsViewerLeaf({
 		>
 			{renderLeafAdditionalValue && renderLeafAdditionalValue(value)}
 			<SimpleTextKeyValue
-				formattedKey={`${dataKey}`}
+				formattedKey={dataKey}
 				value={value.data}
 				schema={value.schema}
 				displayTypes={displayTypes}

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
@@ -5,13 +5,13 @@ exports[`Component should render the leaf 1`] = `
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
 >
   <SimpleTextKeyValue
-    formattedKey="myDataKey:"
+    displayTypes={false}
+    formattedKey="myDataKey"
     schema={
       Object {
         "type": "int",
       }
     }
-    separator=" "
     value={
       Object {
         "value": "myValue",
@@ -26,13 +26,13 @@ exports[`Component should render the leaf highlighted 1`] = `
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf theme-tc-records-viewer-leaf-highlighted tc-records-viewer-leaf-highlighted"
 >
   <SimpleTextKeyValue
-    formattedKey="myDataKey:"
+    displayTypes={false}
+    formattedKey="myDataKey"
     schema={
       Object {
         "type": "int",
       }
     }
-    separator=" "
     value={
       Object {
         "value": "myValue",
@@ -51,13 +51,13 @@ exports[`Component should render the leaf with additional value 1`] = `
     myValue
   </div>
   <SimpleTextKeyValue
-    formattedKey="myDataKey:"
+    displayTypes={false}
+    formattedKey="myDataKey"
     schema={
       Object {
         "type": "int",
       }
     }
-    separator=" "
     value={
       Object {
         "value": "myValue",
@@ -72,13 +72,13 @@ exports[`Component should render the leaf with padding offset 1`] = `
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
 >
   <SimpleTextKeyValue
-    formattedKey="myDataKey:"
+    displayTypes={false}
+    formattedKey="myDataKey"
     schema={
       Object {
         "type": "int",
       }
     }
-    separator=" "
     value={
       Object {
         "value": "myValue",

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -110,7 +110,7 @@ export default function SimpleTextKeyValue({
 					{separator}
 					{displayTypes && schema && value && (
 						<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>
-							({schema.type.type || value.unionKey})
+							- {schema.type.type || value.unionKey}
 						</span>
 					)}
 				</span>

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -40,6 +40,7 @@ function getTypeRenderer(schemaType) {
 
 export function AvroRenderer({ colDef, data }) {
 	const typeRenderer = getTypeRenderer(colDef.avro.type);
+
 	const dateToString = value => {
 		if (value === null) {
 			return value;
@@ -54,6 +55,7 @@ export function AvroRenderer({ colDef, data }) {
 
 	switch (typeRenderer) {
 		case 'DefaultInt':
+		case 'number':
 			return (
 				<DefaultValueRenderer
 					value={data.value}
@@ -62,6 +64,8 @@ export function AvroRenderer({ colDef, data }) {
 			);
 
 		case 'DefaultDate':
+		case 'date':
+		case 'datetime':
 			return (
 				<DefaultValueRenderer
 					value={dateToString(data.value)}
@@ -93,6 +97,7 @@ export default function SimpleTextKeyValue({
 	separator,
 	style,
 	value,
+	displayTypes,
 }) {
 	return (
 		<span
@@ -103,6 +108,11 @@ export default function SimpleTextKeyValue({
 				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
 					{formattedKey}
 					{separator}
+					{displayTypes && schema && value && (
+						<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>
+							({schema.type.type || value.unionKey})
+						</span>
+					)}
 				</span>
 			)}
 			{!schema && value && (
@@ -122,4 +132,9 @@ SimpleTextKeyValue.propTypes = {
 	value: PropTypes.object,
 	separator: PropTypes.string,
 	style: PropTypes.object,
+	displayTypes: PropTypes.bool,
+};
+
+SimpleTextKeyValue.defaultProps = {
+	displayTypes: false,
 };

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -132,7 +132,7 @@ SimpleTextKeyValue.propTypes = {
 	value: PropTypes.object,
 	separator: PropTypes.string,
 	style: PropTypes.object,
-	displayTypes: PropTypes.bool.isRequired,
+	displayTypes: PropTypes.bool,
 };
 
 SimpleTextKeyValue.defaultProps = {

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -132,7 +132,7 @@ SimpleTextKeyValue.propTypes = {
 	value: PropTypes.object,
 	separator: PropTypes.string,
 	style: PropTypes.object,
-	displayTypes: PropTypes.bool,
+	displayTypes: PropTypes.bool.isRequired,
 };
 
 SimpleTextKeyValue.defaultProps = {

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
@@ -9,7 +9,7 @@
 		font-weight: 400;
 	}
 	&-key {
-		margin-right: 5px;
+		margin-right: $padding-smaller;
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
@@ -9,12 +9,17 @@
 		font-weight: 400;
 	}
 	&-key {
+		margin-right: 5px;
 		overflow: hidden;
 		white-space: nowrap;
 		text-overflow: ellipsis;
 		flex-shrink: 1;
 		color: $dove-gray;
 		vertical-align: top;
+	}
+
+	&-key::after {
+		content: ':';
 	}
 
 	&-value {
@@ -30,6 +35,12 @@
 		display: inline-block;
 		color: $brand-primary;
 		font-family: 'Inconsolata';
+	}
+
+	&-type {
+		color: $dark-silver;
+		opacity: 0.75;
+		margin-left: $padding-smaller;
 	}
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TFD-10234
With TPD using those components to display the preview, we need to add an option to display types of data to have the same functionality as before.

**What is the chosen solution to this problem?**
Add an option that add types display on each leaf. By default no enabled.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
