### PR TITLE
chore(containers): use @talend/scripts for build

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -72,7 +72,7 @@
     "@storybook/react": "^5.3.1",
     "@talend/bootstrap-theme": "^5.2.0-y.1",
     "@talend/icons": "^5.2.0-y.1",
-    "@talend/locales-tui": "^4.30.1",
+    "@talend/locales-tui": "^5.1.1",
     "@talend/scripts-core": "^5.2.1",
     "@talend/scripts-preset-react-lib": "^5.2.1",
     "autoprefixer": "^7.1.4",

--- a/packages/components/test/styleMock.js
+++ b/packages/components/test/styleMock.js
@@ -1,3 +1,0 @@
-module.exports = new Proxy({}, {
-	get: (target, key) => key !== '__esModule' && `theme-${key}`,
-});

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -5,16 +5,13 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "rimraf ./lib && babel -d lib ./src/ --ignore 'src/**/*.stories.js','src/**/*.test.js' && cpx -v \"./src/**/*.scss\" ./lib",
+    "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6007",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test": "talend-scripts test",
+    "test:watch": "talend-scripts test --watch",
+    "test:cov": "talend-scripts test --coverage",
     "test:demo": "build-storybook",
-    "lint:es": "eslint --config ../../.eslintrc src",
-    "lint": "npm run lint:es",
-    "storybook": "start-storybook -p 6007",
-    "build-storybook": "build-storybook"
+    "lint:es": "talend-scripts lint:es"
   },
   "keywords": [
     "react",
@@ -44,30 +41,23 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/polyfill": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/addon-a11y": "^5.3.1",
     "@storybook/addon-actions": "^5.3.1",
     "@storybook/addons": "^5.3.1",
     "@storybook/react": "^5.3.1",
     "@talend/bootstrap-theme": "^5.2.0-y.1",
     "@talend/icons": "^5.2.0-y.1",
-    "@talend/locales-tui": "^4.30.1",
+    "@talend/locales-tui": "^5.1.1",
     "@talend/react-cmf": "^5.2.0-y.1",
     "@talend/react-cmf-router": "^3.2.1",
     "@talend/react-components": "^5.2.0-y.1",
     "@talend/react-forms": "^5.2.0-y.1",
     "@talend/react-storybook-cmf": "^5.2.0-y.1",
+    "@talend/scripts-core": "^5.2.1",
+    "@talend/scripts-preset-react-lib": "^5.2.1",
     "babel-loader": "^8.0.6",
-    "cpx2": "^2.0.0",
     "css-loader": "^1.0.1",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "i18next": "^15.1.3",
     "jest-in-case": "^1.0.2",
     "node-sass": "^4.13.1",
@@ -78,7 +68,6 @@
     "react-router": "^3.2.0",
     "react-test-renderer": "^16.8.6",
     "redux-saga-tester": "^1.0.373",
-    "rimraf": "^3.0.2",
     "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1",
     "style-loader": "^0.23.0"
@@ -94,23 +83,6 @@
     "react": "^16.8.6",
     "react-i18next": "^10.11.4",
     "react-router": "^3.2.0"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!**/__snapshots__/**"
-    ],
-    "roots": [
-      "src"
-    ],
-    "testRegex": "src/.*\\.test\\.js$",
-    "moduleNameMapper": {
-      "^.+\\.(css|scss)$": "<rootDir>/test/styleMock.js"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../test-setup.js"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/containers/talend-scripts.json
+++ b/packages/containers/talend-scripts.json
@@ -1,0 +1,3 @@
+{
+  "preset": "@talend/scripts-preset-react-lib"
+}

--- a/packages/containers/test/styleMock.js
+++ b/packages/containers/test/styleMock.js
@@ -1,3 +1,0 @@
-module.exports = new Proxy({}, {
-	get: (target, key) => key !== '__esModule' && `theme-${key}`,
-});

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -51,7 +51,7 @@
     "@storybook/addons": "^5.3.1",
     "@storybook/react": "^5.3.1",
     "@talend/icons": "^5.2.0-y.1",
-    "@talend/locales-tui": "^4.30.1",
+    "@talend/locales-tui": "^5.1.1",
     "@talend/react-components": "^5.2.0-y.1",
     "@talend/react-storybook-cmf": "^5.2.0-y.1",
     "babel-loader": "^8.0.6",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -64,7 +64,7 @@
     "@storybook/react": "^5.3.1",
     "@talend/bootstrap-theme": "^5.2.0-y.1",
     "@talend/icons": "^5.2.0-y.1",
-    "@talend/locales-tui": "^4.30.1",
+    "@talend/locales-tui": "^5.1.1",
     "@talend/react-components": "^5.2.0-y.1",
     "autoprefixer": "^7.1.4",
     "cpx2": "^2.0.0",

--- a/test-setup.js
+++ b/test-setup.js
@@ -52,8 +52,8 @@ jest.mock('i18next', () => {
 	};
 	i18n.init = () => {};
 	return {
-		createInstance: () => i18n,
 		...i18n,
+		createInstance: () => i18n,
 	};
 });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -4741,6 +4741,11 @@
   resolved "https://registry.yarnpkg.com/@talend/locales-tui/-/locales-tui-4.30.1.tgz#67425be0f38a52fc8cd01d15f3a12c0bca183121"
   integrity sha512-3Oa6gnlUX1WaMW3/tgz5oeP8bqwW4OaWd2ON3URlRCl9Ck0+vUvtWu7j28qTNGrOQBOdASYcW3Yu1mb1q0yylQ==
 
+"@talend/locales-tui@^5.1.1":
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/@talend/locales-tui/-/locales-tui-5.1.1.tgz#32ff344967994ee443c5df88bc023f916f093187"
+  integrity sha512-ayGeokKrf8GjXiXUGmDqOBqBA2WankswQK2ttJJ87o0rlMqssrCP0Ed0vrEo3JPkiXKCM248mVD18deip4mQRQ==
+
 "@talend/react-cmf-router@^3.2.1":
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/@talend/react-cmf-router/-/react-cmf-router-3.2.1.tgz#3d67811a08f66f9989f0fb12bd3d20d09edd00e8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4736,11 +4736,6 @@
     objectpath "^1.2.1"
     tv4 "^1.3.0"
 
-"@talend/locales-tui@^4.30.1":
-  version "4.30.1"
-  resolved "https://registry.yarnpkg.com/@talend/locales-tui/-/locales-tui-4.30.1.tgz#67425be0f38a52fc8cd01d15f3a12c0bca183121"
-  integrity sha512-3Oa6gnlUX1WaMW3/tgz5oeP8bqwW4OaWd2ON3URlRCl9Ck0+vUvtWu7j28qTNGrOQBOdASYcW3Yu1mb1q0yylQ==
-
 "@talend/locales-tui@^5.1.1":
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/@talend/locales-tui/-/locales-tui-5.1.1.tgz#32ff344967994ee443c5df88bc023f916f093187"


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Migration to talend/scripts: components

**What is the chosen solution to this problem?**
* remove all tool dependencies
* use @talend/scripts to build/test/lint
* customise some eslint rules

This PR does not fix everything. This will be for future PRs
* fix lint errors
* fix tests

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
