### PR TITLE
fix(guided-tour): no opacity on background

### DIFF
--- a/packages/components/src/GuidedTour/GuidedTour.component.js
+++ b/packages/components/src/GuidedTour/GuidedTour.component.js
@@ -54,7 +54,6 @@ function GuidedTour({ className, disableAllInteractions, steps, ...rest }) {
 					label={t('GUIDEDTOUR_LAST_STEP', { defaultValue: 'Let me try' })}
 				/>
 			}
-			maskClassName="tc-guided-tour__mask"
 			maskSpace={10}
 			rounded={4}
 			showNavigationNumber={false}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When resolving the dependencies, it take the latest version of reactour in your application.
In the latest minor version, there were a change on some behaviour 

https://github.com/elrumordelaluz/reactour/pull/243/files#diff-b694de960bb460757a01ebeb7eb1a339R7
So if there is a `maskClassName` props defined for the Tour component, the opacity is gone and the render looks like that :
![image](https://user-images.githubusercontent.com/2909671/80116760-a646ef80-8586-11ea-9716-2aba0d71ca17.png)

**What is the chosen solution to this problem?**
Remove the class as we don't use it anyway

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
