### PR TITLE
fix(sidepanel): double tooltip

### DIFF
--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -14,12 +14,7 @@ import theme from './ActionList.scss';
  */
 function getActionId(id, action) {
 	if (action.id || action.label) {
-		const actionId =
-			action.id ||
-			action.label
-				.toLowerCase()
-				.split(' ')
-				.join('-');
+		const actionId = action.id || action.label.toLowerCase().split(' ').join('-');
 		return id && `${id}-nav-${actionId}`;
 	}
 	return undefined;
@@ -58,7 +53,6 @@ function ActionListItem({ getComponent, id, onSelect, action, isSelected, isNav,
 
 	return (
 		<li
-			title={action.label}
 			key={action.key || action.label}
 			className={classNames(theme['tc-action-list-item'], 'tc-action-list-item', itemClassName, {
 				active: isSelected,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Do we like tooltips ? Yes ✅ 
Do we like double tooltips ? Nooo :x:

![image](https://user-images.githubusercontent.com/2909671/80117934-10ac5f80-8588-11ea-8270-da92e2a392f7.png)

**What is the chosen solution to this problem?**
As we already use the tooltip trigger on the actions in the sidepanel, the label on the li has no utility. This component (the ActionList) seems to be used only in the sidepanel.
This label was there for an elipsis we don't have anymore.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
