### PR TITLE
chore(datagrid): use @talend/scripts for build

### DIFF
--- a/packages/datagrid/.eslintrc
+++ b/packages/datagrid/.eslintrc
@@ -1,0 +1,7 @@
+{
+	"extends": "./../../node_modules/@talend/scripts-config-eslint/.eslintrc",
+	"rules": {
+		"@typescript-eslint/indent": 0,
+		"react/no-unescaped-entities": 0
+	}
+}

--- a/packages/datagrid/babel.config.js
+++ b/packages/datagrid/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config');

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -5,17 +5,14 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "rimraf ./lib && babel -d lib ./src/ --ignore 'src/**/*.test.js','src/**/*.stories.js' && cpx -v \"./src/**/*.scss\" ./lib",
+    "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6010",
-    "test": "jest --silent",
-    "test:noisy": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "test": "talend-scripts test --silent",
+    "test:noisy": "talend-scripts test",
+    "test:watch": "talend-scripts test --watch",
+    "test:cov": "talend-scripts test --coverage",
     "test:demo": "build-storybook",
-    "lint:es": "eslint --config ../../.eslintrc --ignore-path ../../.eslintignore src",
-    "lint": "npm run lint:es",
-    "storybook": "start-storybook -p 6010",
-    "build-storybook": "build-storybook"
+    "lint:es": "talend-scripts lint:es"
   },
   "keywords": [
     "react",
@@ -39,13 +36,6 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/polyfill": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/addon-a11y": "^5.3.1",
     "@storybook/addon-actions": "^5.3.1",
     "@storybook/addons": "^5.3.1",
@@ -54,11 +44,11 @@
     "@talend/locales-tui": "^5.1.1",
     "@talend/react-components": "^5.2.0-y.1",
     "@talend/react-storybook-cmf": "^5.2.0-y.1",
+    "@talend/scripts-core": "^5.2.1",
+    "@talend/scripts-preset-react-lib": "^5.2.1",
     "babel-loader": "^8.0.6",
-    "cpx2": "^2.0.0",
     "css-loader": "^1.0.1",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "i18next": "^15.1.3",
     "immutable": "^3.8.1",
     "jsdom": "^16.2.2",
@@ -67,7 +57,6 @@
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-i18next": "^10.11.4",
-    "rimraf": "^3.0.2",
     "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1",
     "style-loader": "^0.23.0"
@@ -80,26 +69,6 @@
     "prop-types": "^15.5.10",
     "react": "^16.8.6",
     "react-i18next": "^10.10.0"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!**/__snapshots__/**"
-    ],
-    "roots": [
-      "src"
-    ],
-    "testRegex": "src/.*\\.test\\.js$",
-    "moduleNameMapper": {
-      "^.+\\.(css|scss)$": "<rootDir>/test/styleMock.js"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../test-setup.js"
-    ],
-    "coveragePathIgnorePatterns": [
-      "index.js"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
+++ b/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
@@ -11,7 +11,7 @@ import {
 	QUALITY_INVALID_KEY,
 	QUALITY_EMPTY_KEY,
 	QUALITY_VALID_KEY,
-} from '../../constants/';
+} from '../../constants';
 
 /**
  * check if the type is null

--- a/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.test.js
+++ b/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.test.js
@@ -1,7 +1,7 @@
 import Immutable, { fromJS } from 'immutable';
 import omit from 'lodash/omit';
 
-import { QUALITY_KEY } from '../../constants/';
+import { QUALITY_KEY } from '../../constants';
 import {
 	convertSample,
 	getCellValue,

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -3,7 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { IconsProvider } from '@talend/react-components';
 
-import DataGrid from './';
+import DataGrid from '.';
 import DynamicDataGrid from '../../stories/DynamicDataGrid.component';
 import FasterDatagrid from '../../stories/FasterDatagrid.component';
 import ImmutableDataGrid from '../../stories/ImmutableDatagrid.component';

--- a/packages/datagrid/src/containers/DataGrid/DataGrid.container.js
+++ b/packages/datagrid/src/containers/DataGrid/DataGrid.container.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 
-import Component from '../../components/';
+import Component from '../../components';
 import DATAGRID_PROPTYPES from '../../components/DataGrid/DataGrid.proptypes';
 
 export const DISPLAY_NAME = 'Container(DataGrid)';

--- a/packages/datagrid/src/containers/datagrid.container.stories.js
+++ b/packages/datagrid/src/containers/datagrid.container.stories.js
@@ -6,7 +6,7 @@ import mock from '@talend/react-cmf/lib/mock';
 import { IconsProvider } from '@talend/react-components';
 import api from '@talend/react-cmf';
 
-import DataGrid from './';
+import DataGrid from '.';
 import register from '../register';
 import theme from '../components/DataGrid/DataGrid.scss';
 import sample from '../../stories/sample.json';

--- a/packages/datagrid/talend-scripts.json
+++ b/packages/datagrid/talend-scripts.json
@@ -1,0 +1,3 @@
+{
+  "preset": "@talend/scripts-preset-react-lib"
+}

--- a/packages/datagrid/test/styleMock.js
+++ b/packages/datagrid/test/styleMock.js
@@ -1,6 +1,0 @@
-module.exports = new Proxy(
-	{},
-	{
-		get: (target, key) => key !== '__esModule' && `theme-${key}`,
-	},
-);


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Migration to talend/scripts: datagrid

**What is the chosen solution to this problem?**
* remove all tool dependencies
* use @talend/scripts to build/test/lint
* customise some eslint rules

This PR does not fix everything. This will be for future PRs
* fix lint errors
* fix tests

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
