### PR TITLE
feat(forms): use @talend/scripts for build

### DIFF
--- a/packages/forms/babel.config.js
+++ b/packages/forms/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config');

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,17 +5,14 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "rimraf ./lib && babel -d lib ./src/ --ignore 'src/**/*.stories.js','src/**/*.test.js' && cpx -v \"./src/**/*.scss\" lib",
-    "test": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "prepare": "talend-scripts build:lib",
+    "test": "talend-scripts test",
+    "test:watch": "talend-scripts test --watch",
+    "test:cov": "talend-scripts test --coverage",
     "test:demo": "build-storybook",
-    "lint:es": "eslint --config ../../.eslintrc src",
+    "lint:es": "talend-scripts lint:es",
     "lint:style": "sass-lint -v -q",
-    "lint": "npm run lint:es",
-    "storybook": "start-storybook -p 6008",
-    "start": "start-storybook -p 6008",
-    "build-storybook": "build-storybook"
+    "start": "start-storybook -p 6008"
   },
   "keywords": [
     "react",
@@ -48,15 +45,6 @@
     "uuid": "^3.0.1"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/plugin-syntax-dynamic-import": "^7.8.3",
-    "@babel/plugin-transform-object-assign": "^7.8.3",
-    "@babel/polyfill": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/addon-a11y": "^5.3.1",
     "@storybook/addon-actions": "^5.3.1",
     "@storybook/addon-knobs": "^5.3.1",
@@ -66,10 +54,10 @@
     "@talend/icons": "^5.2.0-y.1",
     "@talend/locales-tui": "^5.1.1",
     "@talend/react-components": "^5.2.0-y.1",
+    "@talend/scripts-core": "^5.2.1",
+    "@talend/scripts-preset-react-lib": "^5.2.1",
     "autoprefixer": "^7.1.4",
-    "cpx2": "^2.0.0",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "enzyme-to-json": "^3.3.5",
     "i18next": "^15.1.3",
     "jest-in-case": "^1.0.2",
@@ -81,7 +69,6 @@
     "react-dom": "^16.8.6",
     "react-i18next": "^10.11.4",
     "react-test-renderer": "^16.8.6",
-    "rimraf": "^3.0.2",
     "sass-lint": "^1.13.1",
     "sass-loader": "^7.3.1",
     "storybook-addon-i18next": "^1.2.1"
@@ -94,24 +81,6 @@
     "react-ace": "6.2.0",
     "react-dom": "^16.8.6",
     "react-i18next": "^10.10.0"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!**/__snapshots__/**"
-    ],
-    "roots": [
-      "src",
-      "__mocks__"
-    ],
-    "testRegex": "&*\\.test\\.js$",
-    "moduleNameMapper": {
-      "^.+\\.(css|scss)$": "<rootDir>/__mocks__/styleMock.js"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../test-setup.js"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/forms/talend-scripts.json
+++ b/packages/forms/talend-scripts.json
@@ -1,0 +1,3 @@
+{
+  "preset": "@talend/scripts-preset-react-lib"
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1186,13 +1186,6 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-dynamic-import@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz#62bf98b2da3cd21d626154fc96ee5b3cb68eacb3"
-  integrity sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
-  dependencies:
-    "@babel/helper-plugin-utils" "^7.8.0"
-
 "@babel/plugin-syntax-export-default-from@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-export-default-from/-/plugin-syntax-export-default-from-7.8.3.tgz#f1e55ce850091442af4ba9c2550106035b29d678"


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Migration to talend/scripts: forms

**What is the chosen solution to this problem?**
* remove all tool dependencies
* use @talend/scripts to build/test/lint

This PR does not fix everything. This will be for future PRs
* fix lint errors
* fix tests

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
