### PR TITLE
chore(stepper): use @talend/scripts

### DIFF
--- a/packages/stepper/babel.config.js
+++ b/packages/stepper/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config');

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -5,17 +5,16 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepare": "rimraf ./lib && babel -d lib ./src/ --ignore 'src/**/*.test.js' && cpx -v \"./src/**/*.scss\" ./lib",
-    "start": "start-storybook -p 6009",
-    "test": "jest --silent",
-    "test:noisy": "jest",
-    "test:watch": "jest --watch",
-    "test:cov": "jest --coverage",
+    "prepare": "talend-scripts build:lib",
+    "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
+    "test:noisy": "cross-env TZ=Europe/Paris talend-scripts test",
+    "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",
+    "test:cov": "cross-env TZ=Europe/Paris talend-scripts test --coverage",
     "test:demo": "build-storybook",
-    "lint:es": "eslint --config ../../.eslintrc src",
-    "lint": "npm run lint:es",
-    "storybook": "start-storybook -p 6009",
-    "build-storybook": "build-storybook"
+    "lint:style": "sass-lint -v -q",
+    "lint:es": "talend-scripts lint:es",
+    "lint": "npm run lint:es && npm run lint:style",
+    "start": "start-storybook -p 6009"
   },
   "keywords": [
     "react",
@@ -38,13 +37,6 @@
     "lodash": "^4.17.4"
   },
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/plugin-proposal-class-properties": "^7.8.3",
-    "@babel/plugin-proposal-object-rest-spread": "^7.8.3",
-    "@babel/polyfill": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/addon-a11y": "^5.3.1",
     "@storybook/addon-actions": "^5.3.1",
     "@storybook/addons": "^5.3.1",
@@ -52,10 +44,8 @@
     "@talend/icons": "^5.2.0-y.1",
     "@talend/react-components": "^5.2.0-y.1",
     "babel-loader": "^8.0.6",
-    "cpx2": "^2.0.0",
     "css-loader": "^1.0.1",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "i18next": "^15.1.3",
     "immutable": "^3.8.1",
     "jsdom": "^16.2.2",
@@ -66,7 +56,6 @@
     "react-i18next": "^10.11.4",
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.3.1",
-    "rimraf": "^3.0.2",
     "sass-loader": "^7.3.1",
     "style-loader": "^0.23.0"
   },
@@ -79,26 +68,6 @@
     "react-i18next": "^10.11.4",
     "react-redux": "^5.0.7",
     "react-transition-group": "^2.3.1"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!**/__snapshots__/**"
-    ],
-    "roots": [
-      "src"
-    ],
-    "testRegex": "src/.*\\.test\\.js$",
-    "moduleNameMapper": {
-      "^.+\\.(css|scss)$": "<rootDir>/test/styleMock.js"
-    },
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../test-setup.js"
-    ],
-    "coveragePathIgnorePatterns": [
-      "index.js"
-    ]
   },
   "publishConfig": {
     "access": "public"

--- a/packages/stepper/talend-scripts.json
+++ b/packages/stepper/talend-scripts.json
@@ -1,0 +1,3 @@
+{
+  "preset": "@talend/scripts-preset-react-lib"
+}

--- a/packages/stepper/test/styleMock.js
+++ b/packages/stepper/test/styleMock.js
@@ -1,6 +1,0 @@
-module.exports = new Proxy(
-	{},
-	{
-		get: (target, key) => key !== '__esModule' && `theme-${key}`,
-	},
-);

--- a/yarn.lock
+++ b/yarn.lock
@@ -565,7 +565,7 @@
     "@babel/helper-plugin-utils" "^7.8.3"
     "@babel/plugin-syntax-numeric-separator" "^7.8.3"
 
-"@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.8.3", "@babel/plugin-proposal-object-rest-spread@^7.9.5":
+"@babel/plugin-proposal-object-rest-spread@^7.6.2", "@babel/plugin-proposal-object-rest-spread@^7.9.5":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.9.5.tgz#3fd65911306d8746014ec0d0cf78f0e39a149116"
   integrity sha512-VP2oXvAf7KCYTthbUHwBlewbl1Iq059f6seJGsxMizaCdgHIeczOr7FBqELhSqfkIl04Fi8okzWzl63UKbQmmg==


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Migration to talend/scripts: stepper

**What is the chosen solution to this problem?**
* remove all tool dependencies
* use @talend/scripts to build/test/lint

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
