### PR TITLE
chore(storybook-cmf): use @talend/scripts

### DIFF
--- a/packages/storybook-cmf/babel.config.js
+++ b/packages/storybook-cmf/babel.config.js
@@ -1,1 +1,0 @@
-module.exports = require('../../babel.config');

--- a/packages/storybook-cmf/package.json
+++ b/packages/storybook-cmf/package.json
@@ -17,28 +17,21 @@
     "addon"
   ],
   "scripts": {
-    "prepare": "rimraf ./lib && babel -d lib ./src/ --ignore 'src/**/*.test.js'",
-    "lint": "eslint --config ../../.eslintrc src",
-    "test": "jest",
-    "test:demo": "echo nothing to demo"
+    "prepare": "talend-scripts build:lib",
+    "test": "talend-scripts test",
+    "test:demo": "echo nothing to demo",
+    "lint:es": "talend-scripts lint:es"
   },
   "main": "lib/index.js",
   "mainSrc": "src/index.js",
   "devDependencies": {
-    "@babel/cli": "^7.8.3",
-    "@babel/core": "^7.8.3",
-    "@babel/preset-env": "^7.8.3",
-    "@babel/preset-react": "^7.8.3",
     "@storybook/react": "^5.3.1",
     "@talend/react-cmf": "^5.2.0-y.1",
-    "babel-loader": "^8.0.6",
     "enzyme": "^3.9.0",
-    "enzyme-adapter-react-16": "^1.11.2",
     "react": "^16.8.6",
     "react-dom": "^16.8.6",
     "react-redux": "^5.0.7",
-    "redux-saga": "^0.15.4",
-    "rimraf": "^3.0.2"
+    "redux-saga": "^0.15.4"
   },
   "dependencies": {
     "@storybook/addon-actions": "^5.3.1",
@@ -47,17 +40,8 @@
     "prop-types": "^15.5.10"
   },
   "peerDependencies": {
-    "@kadira/storybook": "^2",
+    "@storybook/react": "^5.3.1",
     "@talend/react-cmf": "^5.0.0",
     "react": "^16.8.6"
-  },
-  "jest": {
-    "roots": [
-      "src"
-    ],
-    "testRegex": "&*\\.test\\.js$",
-    "setupFilesAfterEnv": [
-      "<rootDir>/../../test-setup.js"
-    ]
   }
 }

--- a/packages/storybook-cmf/talend-scripts.json
+++ b/packages/storybook-cmf/talend-scripts.json
@@ -1,0 +1,3 @@
+{
+  "preset": "@talend/scripts-preset-react-lib"
+}


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Migration to talend/scripts: storybook-cmf

**What is the chosen solution to this problem?**
* remove all tool dependencies
* use @talend/scripts to build/test/lint

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
