### PR TITLE
chore(datagrid): fix tests with @talend/scripts

### DIFF
--- a/packages/cmf/scripts/cmf-settings.i18n.test.js
+++ b/packages/cmf/scripts/cmf-settings.i18n.test.js
@@ -70,21 +70,12 @@ const {
 
 describe('i18n scripts', () => {
 	describe('#getNameSpacesByLocale', () => {
-		it('should get initiailized i18next with the locales', () => {
+		it('should get initialized i18next with the locales', () => {
 			expect(
 				getNameSpacesByLocale([{ name: 'ns1', path: 'src/{{namespace}}/{{locale}}' }], 'fr'),
 			).toEqual({
 				ns1: { key1: 'bar', oldKey: 'bar' },
 			});
-		});
-	});
-
-	describe('#getI18Next', () => {
-		// we have mock i18next
-		it('should get i18next mock', () => {
-			expect(
-				getI18Next(['fr'], [{ name: 'ns1', path: 'src/{{namespace}}/{{locale}}' }]).isMock,
-			).toBe(true);
 		});
 	});
 
@@ -107,7 +98,12 @@ describe('i18n scripts', () => {
 			const localizedJSON = getLocalesFromNamespaceInFolder('root', namespace);
 
 			expect(localizedJSON).toEqual(
-				new Map([['KEY2', 'key2'], ['KEY1', 'key1'], ['KEY3', 'key3'], ['KEY4', 'key4']]),
+				new Map([
+					['KEY2', 'key2'],
+					['KEY1', 'key1'],
+					['KEY3', 'key3'],
+					['KEY4', 'key4'],
+				]),
 			);
 		});
 	});
@@ -128,7 +124,15 @@ describe('i18n scripts', () => {
 			const filePath = './src/{{namespace}}/{{locale}}';
 			const namespace = 'ns1';
 
-			updateLocale(new Map([['key2', 'test'], ['key1', 'foo']]), locale, namespace, filePath);
+			updateLocale(
+				new Map([
+					['key2', 'test'],
+					['key1', 'foo'],
+				]),
+				locale,
+				namespace,
+				filePath,
+			);
 			expect(writeFileSync).toHaveBeenCalledWith(
 				getPathFromPattern(filePath, namespace, locale),
 				JSON.stringify(
@@ -149,7 +153,16 @@ describe('i18n scripts', () => {
 			const filePath = './src/{{namespace}}/{{locale}}';
 			const namespace = 'ns1';
 
-			updateLocale(new Map([['key2', 'test'], ['key1', 'foo']]), locale, namespace, filePath, true);
+			updateLocale(
+				new Map([
+					['key2', 'test'],
+					['key1', 'foo'],
+				]),
+				locale,
+				namespace,
+				filePath,
+				true,
+			);
 			expect(writeFileSync).toHaveBeenCalledWith(
 				getPathFromPattern(filePath, namespace, locale),
 				JSON.stringify(
@@ -191,7 +204,15 @@ describe('i18n scripts', () => {
 			const filePath = './src/{{namespace}}/{{locale}}';
 			const namespace = 'ns1';
 
-			updateLocale(new Map([['key1', 'foo'], ['newKey', 'new']]), namespace, locale, filePath);
+			updateLocale(
+				new Map([
+					['key1', 'foo'],
+					['newKey', 'new'],
+				]),
+				namespace,
+				locale,
+				filePath,
+			);
 
 			expect(writeFileSync).toHaveBeenCalledWith(
 				getPathFromPattern(filePath, locale, namespace),
@@ -300,7 +321,12 @@ describe('i18n scripts', () => {
 			};
 			const locale = getLocalesFromNamespace(json, namespace);
 
-			expect(locale).toEqual(new Map([['KEY1', 'foo'], ['KEY2', 'bar']]));
+			expect(locale).toEqual(
+				new Map([
+					['KEY1', 'foo'],
+					['KEY2', 'bar'],
+				]),
+			);
 		});
 
 		it('should parse a JSON with a key without namespace', () => {

--- a/packages/components/src/Skeleton/Skeleton.component.js
+++ b/packages/components/src/Skeleton/Skeleton.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import Icon from '../Icon';
 import skeletonCssModule from './Skeleton.scss';
 import { getTheme } from '../theme';
@@ -46,7 +46,16 @@ function getTranslatedType(t, type) {
  * @param {number} props.height height to override size's height
  * @param {string} props.className classes to apply on skeleton
  */
-function Skeleton({ heartbeat, type, size, width, height, name, className, t }) {
+function Skeleton({
+	heartbeat = true,
+	type = TYPES.text,
+	size = SIZES.medium,
+	width,
+	height,
+	name,
+	className,
+}) {
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const classes = theme(
 		'tc-skeleton',
 		`tc-skeleton-${type}`,
@@ -68,24 +77,16 @@ function Skeleton({ heartbeat, type, size, width, height, name, className, t }) 
 
 Skeleton.propTypes = {
 	heartbeat: PropTypes.bool,
-	type: PropTypes.oneOf([TYPES.button, TYPES.circle, TYPES.icon, TYPES.text]).isRequired,
+	type: PropTypes.oneOf([TYPES.button, TYPES.circle, TYPES.icon, TYPES.text]),
 	size: PropTypes.oneOf([SIZES.small, SIZES.medium, SIZES.large, SIZES.xlarge]),
 	width: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	height: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
 	name: PropTypes.string,
 	className: PropTypes.string,
-	t: PropTypes.func,
-};
-
-Skeleton.defaultProps = {
-	type: TYPES.text,
-	size: SIZES.medium,
-	heartbeat: true,
 };
 
 Skeleton.displayName = 'Skeleton';
-const TranslatedSkeleton = withTranslation(I18N_DOMAIN_COMPONENTS)(Skeleton);
-TranslatedSkeleton.TYPES = TYPES;
-TranslatedSkeleton.SIZES = SIZES;
+Skeleton.TYPES = TYPES;
+Skeleton.SIZES = SIZES;
 
-export default TranslatedSkeleton;
+export default Skeleton;

--- a/packages/datagrid/jest.config.js
+++ b/packages/datagrid/jest.config.js
@@ -1,0 +1,8 @@
+const path = require('path');
+const defaults = require('../../node_modules/@talend/scripts-config-jest/jest.config.js');
+
+module.exports = {
+	...defaults,
+	testRegex: '.*\\.test.js$',
+	setupFilesAfterEnv: [...defaults.setupFilesAfterEnv, path.join(__dirname, '../../test-setup.js')],
+};

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -176,10 +176,6 @@ export default class DataGrid extends React.Component {
 	}
 
 	getAgGridConfig() {
-		if (this.props.getRowDataFn && this.props.rowData) {
-			console.warn('Should use either rowData nor getRowDataFn. Not the both at the same time');
-		}
-
 		let rowData = this.props.rowData;
 		if (typeof this.props.getRowDataFn === 'function') {
 			rowData = this.props.getRowDataFn(this.props.data, this.props.startIndex);

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -254,7 +254,7 @@ describe('#DataGrid', () => {
 	});
 
 	it('should render one Skeleton is InProgress', () => {
-		const wrapper = shallow(<DataGrid loading getComponent={getComponent} />);
+		const wrapper = shallow(<DataGrid loading />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -265,10 +265,7 @@ describe('#AgGrid API', () => {
 		const api = {};
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		expect(wrapper.instance().gridAPI).toBe(api);
 	});
@@ -384,10 +381,7 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -414,10 +408,7 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -440,10 +431,7 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -472,10 +460,7 @@ describe('#Datagrid method', () => {
 		instance.removeFocusColumn = jest.fn();
 		instance.updateStyleFocusColumn = jest.fn();
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		instance.onFocusedColumn(currentColId);
 
@@ -620,10 +605,7 @@ describe('#Datagrid method', () => {
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 		const instance = wrapper.instance();
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({ api });
+		wrapper.find('AgGridReact').props().onGridReady({ api });
 
 		instance.onKeyDownHeaderColumn(
 			{
@@ -645,13 +627,10 @@ describe('#Datagrid method', () => {
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 		const instance = wrapper.instance();
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({
-				setFocusedCell,
-				ensureIndexVisible,
-			});
+		wrapper.find('AgGridReact').props().onGridReady({
+			setFocusedCell,
+			ensureIndexVisible,
+		});
 
 		instance.onKeyDownHeaderColumn(
 			{
@@ -681,12 +660,9 @@ describe('#Datagrid method', () => {
 		);
 		const instance = wrapper.instance();
 
-		wrapper
-			.find('AgGridReact')
-			.props()
-			.onGridReady({
-				api,
-			});
+		wrapper.find('AgGridReact').props().onGridReady({
+			api,
+		});
 
 		instance.onBodyScroll(event);
 

--- a/packages/datagrid/src/components/DataGrid/__snapshots__/DataGrid.test.js.snap
+++ b/packages/datagrid/src/components/DataGrid/__snapshots__/DataGrid.test.js.snap
@@ -291,7 +291,7 @@ exports[`#DataGrid should render one Skeleton is InProgress 1`] = `
 <div
   className="theme-td-grid-loading theme-td-grid td-grid"
 >
-  <withI18nextTranslation(Skeleton)
+  <Skeleton
     name="talend-table"
     type="icon"
   />

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Icon } from '@talend/react-components';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import getDefaultT from '../../translate';
 import I18N_DOMAIN_DATAGRID from '../../constant';
@@ -130,6 +130,7 @@ function replaceWhiteCharacters(content, regexp, t) {
 }
 
 export function FormatValueComponent(props) {
+	const { t } = useTranslation(I18N_DOMAIN_DATAGRID);
 	let content = [];
 
 	const hiddenCharsRegExpMatch = props.value.match(REG_EXP_LEADING_TRAILING_WHITE_SPACE_CHARACTERS);
@@ -138,7 +139,7 @@ export function FormatValueComponent(props) {
 		content = replaceWhiteCharacters(
 			hiddenCharsRegExpMatch[1],
 			REG_EXP_REPLACED_WHITE_SPACE_CHARACTERS,
-			props.t,
+			t,
 		);
 	}
 
@@ -146,7 +147,7 @@ export function FormatValueComponent(props) {
 		const formattedContent = replaceWhiteCharacters(
 			hiddenCharsRegExpMatch[2],
 			REG_EXP_CAPTUR_LINE_FEEDING,
-			props.t,
+			t,
 		);
 		content = [...content, ...formattedContent];
 	}
@@ -155,7 +156,7 @@ export function FormatValueComponent(props) {
 		const formattedContent = replaceWhiteCharacters(
 			hiddenCharsRegExpMatch[3],
 			REG_EXP_REPLACED_WHITE_SPACE_CHARACTERS,
-			props.t,
+			t,
 		);
 		content = [...content, ...formattedContent];
 	}
@@ -165,11 +166,6 @@ export function FormatValueComponent(props) {
 
 FormatValueComponent.propTypes = {
 	value: PropTypes.string,
-	t: PropTypes.func,
 };
 
-FormatValueComponent.defaultProps = {
-	t: getDefaultT(),
-};
-
-export default withTranslation(I18N_DOMAIN_DATAGRID)(FormatValueComponent);
+export default FormatValueComponent;

--- a/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.component.js
@@ -1,45 +1,34 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import I18N_DOMAIN_DATAGRID from '../../constant';
-import getDefaultT from '../../translate';
 
 import { QUALITY_INVALID_KEY, QUALITY_EMPTY_KEY, QUALITY_VALID_KEY } from '../../constants';
 
 import theme from './QualityIndicator.scss';
 
-function getTooltip(t, qualityIndex) {
-	if (qualityIndex === QUALITY_INVALID_KEY) {
-		return t('QUALITY_INDICATOR_INVALID_VALUE', { defaultValue: 'Invalid value' });
-	}
+function QualityIndicator(props) {
+	const { t } = useTranslation(I18N_DOMAIN_DATAGRID);
 
-	return '';
-}
-
-export function QualityIndicatorComponent(props) {
 	if (props.qualityIndex !== QUALITY_INVALID_KEY) {
-		return false;
+		return null;
 	}
 
 	return (
 		<div
-			className={classNames(theme['td-cell-quality-indicator'], 'td-cell-quality-indicator', {
-				[theme['td-cell-quality-indicator-invalid']]: props.qualityIndex === QUALITY_INVALID_KEY,
-			})}
-			title={getTooltip(props.t, props.qualityIndex)}
+			className={classNames(
+				theme['td-cell-quality-indicator'],
+				'td-cell-quality-indicator',
+				theme['td-cell-quality-indicator-invalid'],
+			)}
+			title={t('QUALITY_INDICATOR_INVALID_VALUE', { defaultValue: 'Invalid value' })}
 		/>
 	);
 }
-
-QualityIndicatorComponent.propTypes = {
+QualityIndicator.propTypes = {
 	qualityIndex: PropTypes.oneOf([QUALITY_INVALID_KEY, QUALITY_EMPTY_KEY, QUALITY_VALID_KEY]),
-	t: PropTypes.func,
 };
 
-QualityIndicatorComponent.defaultProps = {
-	t: getDefaultT(),
-};
-
-export default withTranslation(I18N_DOMAIN_DATAGRID)(QualityIndicatorComponent);
+export default QualityIndicator;

--- a/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.test.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.test.js
@@ -1,18 +1,18 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { QualityIndicatorComponent } from './QualityIndicator.component';
+import QualityIndicator from './QualityIndicator.component';
 import { QUALITY_INVALID_KEY, QUALITY_VALID_KEY } from '../../constants';
 
 describe('#QualityIndicator', () => {
 	it('should render when quality index is QUALITY_INVALID_KEY', () => {
-		const wrapper = shallow(<QualityIndicatorComponent qualityIndex={QUALITY_INVALID_KEY} />);
+		const wrapper = shallow(<QualityIndicator qualityIndex={QUALITY_INVALID_KEY} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
 	it('should not render when quality index is different of QUALITY_INVALID_KEY', () => {
-		const wrapper = shallow(<QualityIndicatorComponent qualityIndex={QUALITY_VALID_KEY} />);
+		const wrapper = shallow(<QualityIndicator qualityIndex={QUALITY_VALID_KEY} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});

--- a/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultCellRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultCellRenderer.test.js.snap
@@ -4,7 +4,7 @@ exports[`#DefaultCellRenderer should render DefaultCellRenderer 1`] = `
 <div
   className="theme-td-cell td-cell"
 >
-  <withI18nextTranslation(QualityIndicatorComponent)
+  <QualityIndicator
     qualityIndex={0}
   />
   <AvroRenderer
@@ -34,6 +34,6 @@ exports[`#DefaultCellRenderer should render the default cell on loading state 1`
 <div
   className="theme-td-cell td-cell"
 >
-  <withI18nextTranslation(Skeleton) />
+  <Skeleton />
 </div>
 `;

--- a/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultValueRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultCellRenderer/__snapshots__/DefaultValueRenderer.test.js.snap
@@ -5,7 +5,7 @@ exports[`#DefaultValueRenderer should render DefaultValueRenderer (custom render
   className="theme-td-default-cell td-default-cell"
   onMouseOver={[Function]}
 >
-  <withI18nextTranslation(FormatValueComponent)
+  <FormatValueComponent
     value=" loreum "
   />
 </div>
@@ -16,7 +16,7 @@ exports[`#DefaultValueRenderer should render DefaultValueRenderer (custom render
   className="theme-td-default-cell td-default-cell"
   onMouseOver={[Function]}
 >
-  <withI18nextTranslation(FormatValueComponent)
+  <FormatValueComponent
     value=" loreum "
   />
 </div>
@@ -90,7 +90,7 @@ exports[`#DefaultValueRenderer should render the leading/trailing special charac
   className="theme-td-default-cell td-default-cell"
   onMouseOver={[Function]}
 >
-  <withI18nextTranslation(FormatValueComponent)
+  <FormatValueComponent
     value=" loreum "
   />
 </div>

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/QualityBar.component.js
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/QualityBar.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import I18N_DOMAIN_DATAGRID from '../../constant';
 import getDefaultT from '../../translate';
@@ -24,14 +24,15 @@ export function formatNumber(value) {
 	return parts.join('.');
 }
 
-export function QualityBarComponent(props) {
+function QualityBar(props) {
+	const { t = getDefaultT() } = useTranslation(I18N_DOMAIN_DATAGRID);
 	return (
 		<div className={classNames(theme['td-quality-bar'], 'td-quality-bar')}>
 			{!!props.invalid.total && (
 				<span
 					className={classNames(theme['td-quality-bar-invalid'], 'td-quality-bar-invalid')}
 					style={{ width: `${props.invalid.percentage}%`, minWidth: `${QUALITY_BAR_MIN_WIDTH}%` }}
-					title={props.t('QUALITY_BAR_INVALID', {
+					title={t('QUALITY_BAR_INVALID', {
 						count: props.invalid.total,
 						defaultValue: '{{total}} invalid values ({{percentage}}%)',
 						percentage: props.invalid.percentage,
@@ -43,7 +44,7 @@ export function QualityBarComponent(props) {
 				<span
 					className={classNames(theme['td-quality-bar-empty'], 'td-quality-bar-empty')}
 					style={{ width: `${props.empty.percentage}%`, minWidth: `${QUALITY_BAR_MIN_WIDTH}%` }}
-					title={props.t('QUALITY_BAR_EMPTY', {
+					title={t('QUALITY_BAR_EMPTY', {
 						count: props.empty.total,
 						defaultValue: '{{total}} empty values ({{percentage}}%)',
 						percentage: props.empty.percentage,
@@ -55,7 +56,7 @@ export function QualityBarComponent(props) {
 				<span
 					className={classNames(theme['td-quality-bar-valid'], 'td-quality-bar-valid')}
 					style={{ width: `${props.valid.percentage}%`, minWidth: `${QUALITY_BAR_MIN_WIDTH}%` }}
-					title={props.t('QUALITY_BAR_VALID', {
+					title={t('QUALITY_BAR_VALID', {
 						count: props.valid.total,
 						total: formatNumber(props.valid.total),
 						percentage: props.valid.percentage,
@@ -72,15 +73,10 @@ export const QUALITY_PROPTYPE = {
 	percentage: PropTypes.number,
 };
 
-QualityBarComponent.propTypes = {
+QualityBar.propTypes = {
 	valid: PropTypes.shape(QUALITY_PROPTYPE),
 	empty: PropTypes.shape(QUALITY_PROPTYPE),
 	invalid: PropTypes.shape(QUALITY_PROPTYPE),
-	t: PropTypes.func,
 };
 
-QualityBarComponent.defaultProps = {
-	t: getDefaultT(),
-};
-
-export default withTranslation(I18N_DOMAIN_DATAGRID)(QualityBarComponent);
+export default QualityBar;

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/QualityBar.test.js
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/QualityBar.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import { QualityBarComponent, formatNumber } from './QualityBar.component';
+import QualityBar, { formatNumber } from './QualityBar.component';
 
 function quality(total, percentage) {
 	return {
@@ -13,11 +13,7 @@ function quality(total, percentage) {
 describe('#QualityBar', () => {
 	it('should render QualityBar', () => {
 		const wrapper = shallow(
-			<QualityBarComponent
-				invalid={quality(999, 32)}
-				empty={quality(1000, 33)}
-				valid={quality(1001, 35)}
-			/>,
+			<QualityBar invalid={quality(999, 32)} empty={quality(1000, 33)} valid={quality(1001, 35)} />,
 		);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -25,11 +21,7 @@ describe('#QualityBar', () => {
 
 	it('should render QualityBar without invalid value', () => {
 		const wrapper = shallow(
-			<QualityBarComponent
-				invalid={quality(0, 0)}
-				empty={quality(1000, 49)}
-				valid={quality(1001, 51)}
-			/>,
+			<QualityBar invalid={quality(0, 0)} empty={quality(1000, 49)} valid={quality(1001, 51)} />,
 		);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -37,11 +29,7 @@ describe('#QualityBar', () => {
 
 	it('should render QualityBar without empty value', () => {
 		const wrapper = shallow(
-			<QualityBarComponent
-				invalid={quality(1000, 49)}
-				empty={quality(0, 0)}
-				valid={quality(1001, 51)}
-			/>,
+			<QualityBar invalid={quality(1000, 49)} empty={quality(0, 0)} valid={quality(1001, 51)} />,
 		);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -49,11 +37,7 @@ describe('#QualityBar', () => {
 
 	it('should render QualityBar without valid value', () => {
 		const wrapper = shallow(
-			<QualityBarComponent
-				invalid={quality(1000, 49)}
-				empty={quality(1001, 51)}
-				valid={quality(0, 0)}
-			/>,
+			<QualityBar invalid={quality(1000, 49)} empty={quality(1001, 51)} valid={quality(0, 0)} />,
 		);
 
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/__snapshots__/DefaultHeaderRenderer.test.js.snap
@@ -29,7 +29,7 @@ exports[`#DefaultHeaderGrid should render DefaultHeaderGrid 1`] = `
       </div>
     </span>
   </button>
-  <withI18nextTranslation(QualityBarComponent)
+  <QualityBar
     empty={33}
     invalid={33}
     valid={34}

--- a/test-setup.js
+++ b/test-setup.js
@@ -6,76 +6,96 @@
 // import { configure } from 'enzyme';
 // import dateMock from './mocks/dateMock';
 
+import i18n from 'i18next';
+import reactI18n from 'react-i18next';
+
 /**
  * lets mock i18next for all tests
  */
-jest.mock('i18next', () => {
-	const noop = () => {};
-	const i18n = {
-		t: (msg, options) => {
-			let buff = options.defaultValue || msg;
-			const split = buff.split('}}');
-			if (split.length > 1) {
-				buff = split.reduce((acc, current) => {
-					const sub = current.split('{{');
-					let value = sub.length > 1 ? options[sub[1].trim()] : '';
-					if (value === undefined) {
-						value = '';
-					}
-					return `${acc}${sub[0]}${value}`;
-				}, '');
+// jest.mock('i18next', () => {
+// 	const noop = () => {};
+// 	const i18n = {
+// 		t: (msg, options) => {
+// 			let buff = options.defaultValue || msg;
+// 			const split = buff.split('}}');
+// 			if (split.length > 1) {
+// 				buff = split.reduce((acc, current) => {
+// 					const sub = current.split('{{');
+// 					let value = sub.length > 1 ? options[sub[1].trim()] : '';
+// 					if (value === undefined) {
+// 						value = '';
+// 					}
+// 					return `${acc}${sub[0]}${value}`;
+// 				}, '');
+// 			}
+// 			return buff;
+// 		},
+// 		isMock: true,
+// 		getFixedT: () => i18n.t,
+// 		options: {},
+// 		language: 'en',
+// 		languages: ['en'],
+// 		isInitialized: true,
+// 		init: noop,
+// 		on: noop,
+// 		off: noop,
+// 		loadNamespaces: noop,
+// 		hasResourceBundle: () => false,
+// 		services: {
+// 			resourceStore: {
+// 				data: {},
+// 			},
+// 			backendConnector: {},
+// 		},
+// 		store: {
+// 			data: {},
+// 			on: noop,
+// 			off: noop,
+// 		},
+// 		changeLanguage: noop,
+// 	};
+// 	i18n.createInstance = () => i18n;
+// 	return i18n;
+// });
+
+// jest.mock('react-i18next', () => {
+// 	const mock = jest.genMockFromModule('react-i18next');
+// 	mock.useTranslation = () => ({
+// 		t: (key, options) => {
+// 			let buff = options.defaultValue || key;
+// 			const split = buff.split('}}');
+// 			if (split.length > 1) {
+// 				buff = split.reduce((acc, current) => {
+// 					const sub = current.split('{{');
+// 					let value = sub.length > 1 ? options[sub[1].trim()] : '';
+// 					if (value === undefined) {
+// 						value = '';
+// 					}
+// 					return `${acc}${sub[0]}${value}`;
+// 				}, '');
+// 			}
+// 			return buff;
+// 		},
+// 	});
+
+// 	return mock;
+// });
+i18n.t = (key, options) => {
+	let buff = options.defaultValue || key;
+	const split = buff.split('}}');
+	if (split.length > 1) {
+		buff = split.reduce((acc, current) => {
+			const sub = current.split('{{');
+			let value = sub.length > 1 ? options[sub[1].trim()] : '';
+			if (value === undefined) {
+				value = '';
 			}
-			return buff;
-		},
-		isMock: true,
-		getFixedT: () => i18n.t,
-		options: {},
-		language: 'en',
-		languages: ['en'],
-		isInitialized: true,
-		on: noop,
-		off: noop,
-		loadNamespaces: noop,
-		hasResourceBundle: () => false,
-		services: {
-			resourceStore: {
-				data: {},
-			},
-			backendConnector: {},
-		},
-		store: {
-			data: {},
-			on: noop,
-			off: noop,
-		},
-		changeLanguage: noop,
-	};
-	i18n.init = () => {};
-	return {
-		...i18n,
-		createInstance: () => i18n,
-	};
-});
-
-// function getMajorVersion() {
-// 	if (!process.env.REACT_VERSION) {
-// 		return '16';
-// 	}
-// 	return process.env.REACT_VERSION.replace('^', '').split('.')[0];
-// }
-
-// const REACT_VERSION = getMajorVersion();
-
-// let AdapterReact;
-// if (REACT_VERSION === '15') {
-// 	AdapterReact = require('enzyme-adapter-react-15');
-// } else if (REACT_VERSION === '16') {
-// 	AdapterReact = require('enzyme-adapter-react-16');
-// } else {
-// 	throw new Error(`Unsupported version of React: ${REACT_VERSION}`);
-// }
-
-// configure({ adapter: new AdapterReact() });
+			return `${acc}${sub[0]}${value}`;
+		}, '');
+	}
+	return buff;
+};
+reactI18n.useTranslation = () => ({ t: i18n.t });
 
 // // define fetch
 // const fetch = jest.fn(


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Datagrid tests fails with the @talend/script usage.

**What is the chosen solution to this problem?**
Fix them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
