### PR TITLE
chore(components): Fix display of RecordsViewer

### DIFF
--- a/packages/components/src/DataViewer/Core/Tree/Tree.scss
+++ b/packages/components/src/DataViewer/Core/Tree/Tree.scss
@@ -14,6 +14,7 @@
 
 	&-node-border {
 		border-left: 1px solid $alto;
+		margin-left: -12px;
 		&:hover {
 			border-left-color: $silver-chalice;
 		}

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
@@ -8,8 +8,8 @@ import { LengthBadge } from '../../Badges';
 import { TreeBranchIcon } from '../../Icons';
 import theme from '../RecordsViewer.scss';
 
-const ICON_MARGIN_PLUS = -12;
-const ICON_MARGIN_CARET = -10;
+const ICON_MARGIN_PLUS = -17;
+const ICON_MARGIN_CARET = -17;
 
 /**
  * Used with the lazy loading to allow the render of the skeleton.

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
@@ -20,7 +20,7 @@ exports[`RecordsViewerBranch should render the branch with additional value 1`] 
       opened={false}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}
@@ -92,7 +92,7 @@ exports[`RecordsViewerBranch should render the branch with children 1`] = `
       opened={true}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}
@@ -142,7 +142,7 @@ exports[`RecordsViewerBranch should render the branch with length badge 1`] = `
       onToggle={[MockFunction]}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -114,3 +114,7 @@ $border-size: 0.1rem;
 		}
 	}
 }
+
+:global(.tc-tree-branch-icon) + .tc-records-viewer-branch-text {
+	margin-left: $padding-smaller;
+}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import isNull from 'lodash/isNull';
 import DefaultValueRenderer from './DefaultValueRenderer.component';
 import theme from './SimpleTextKeyValue.scss';
 
@@ -104,7 +105,7 @@ export default function SimpleTextKeyValue({
 			className={classNames(theme['tc-simple-text'], 'tc-simple-text', className)}
 			style={style}
 		>
-			{formattedKey && (
+			{!isNull(formattedKey) && (
 				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
 					{formattedKey}
 					{separator}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -17,6 +17,9 @@ exports[`SimpleTextKeyValue should render only the value 1`] = `
   className="theme-tc-simple-text tc-simple-text"
 >
   <span
+    className="theme-tc-simple-text-key tc-simple-text-key"
+  />
+  <span
     className="theme-tc-simple-text-value tc-simple-text-value"
   >
     myValue


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icons and text for branches are not enough spaced.

**What is the chosen solution to this problem?**
Seen with UX, update the style accordingly.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
