### PR TITLE
feat(forms): parameterize id concatenation separator

### DIFF
--- a/packages/forms/__mocks__/data.js
+++ b/packages/forms/__mocks__/data.js
@@ -45,12 +45,9 @@ export const nestedData = {
 		type: 'object',
 		title: 'Comment',
 		properties: {
-			lastname: {
+			content: {
 				type: 'string',
 				minLength: 4,
-			},
-			firstname: {
-				type: 'string',
 			},
 			timestamp: {
 				type: 'object',
@@ -61,20 +58,13 @@ export const nestedData = {
 				},
 			},
 		},
-		required: ['firstname'],
 	},
 	uiSchema: [
 		{
-			key: 'lastname',
-			title: 'Last Name (with description)',
-			description: 'Hint: this is the last name',
+			key: 'content',
+			title: 'Content of the comment',
+			description: 'Hint: put you coment here',
 			autoFocus: true,
-		},
-		{
-			key: 'firstname',
-			title: 'First Name (with placeholder)',
-			placeholder: 'Enter your firstname here',
-			triggers: ['after'],
 		},
 		{
 			placeholder: 'timestampConfiguration',

--- a/packages/forms/__mocks__/data.js
+++ b/packages/forms/__mocks__/data.js
@@ -63,7 +63,7 @@ export const nestedData = {
 		{
 			key: 'content',
 			title: 'Content of the comment',
-			description: 'Hint: put you coment here',
+			description: 'Hint: put you comment here',
 			autoFocus: true,
 		},
 		{

--- a/packages/forms/__mocks__/data.js
+++ b/packages/forms/__mocks__/data.js
@@ -40,6 +40,65 @@ export const data = {
 	errors: {},
 };
 
+export const nestedData = {
+	jsonSchema: {
+		type: 'object',
+		title: 'Comment',
+		properties: {
+			lastname: {
+				type: 'string',
+				minLength: 4,
+			},
+			firstname: {
+				type: 'string',
+			},
+			timestamp: {
+				type: 'object',
+				title: 'Published at',
+				properties: {
+					value: { type: 'number' },
+					gmt: { type: 'string' },
+				},
+			},
+		},
+		required: ['firstname'],
+	},
+	uiSchema: [
+		{
+			key: 'lastname',
+			title: 'Last Name (with description)',
+			description: 'Hint: this is the last name',
+			autoFocus: true,
+		},
+		{
+			key: 'firstname',
+			title: 'First Name (with placeholder)',
+			placeholder: 'Enter your firstname here',
+			triggers: ['after'],
+		},
+		{
+			placeholder: 'timestampConfiguration',
+			required: true,
+			title: '',
+			widget: 'fieldset',
+			items: [
+				{
+					key: 'timestamp.value',
+					title: 'Published at ',
+					widget: 'text',
+				},
+				{
+					key: 'timestamp.gmt_offset',
+					title: '+ GMT offset ',
+					widget: 'text',
+				},
+			],
+		},
+	],
+	properties: {},
+	errors: {},
+};
+
 export const actions = [
 	{
 		title: 'Reset',

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -300,6 +300,7 @@ export class UIFormComponent extends React.Component {
 			this.state.mergedSchema.map((nextSchema, index) => (
 				<Widget
 					id={this.props.id}
+					idSeparator={this.props.idSeparator}
 					key={index}
 					onChange={this.onChange}
 					onFinish={this.onFinish}

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -23,10 +23,11 @@ describe('UIForm component', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should render form with ids concatenated with ;', () => {
+	it('should render form with ids concatenated with ; if nested', () => {
 		// when
 		const instance = mount(<UIFormComponent {...nestedData} {...props} idSeparator=";" />);
 		// then
+		expect(instance.find('Text[id="myFormId;content"]')).toHaveLength(1);
 		expect(instance.find('Text[id="timestamp;value"]')).toHaveLength(1);
 		expect(instance.find('Text[id="timestamp;gmt_offset"]')).toHaveLength(1);
 	});

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
 import tv4 from 'tv4';
-import { actions, data, mergedSchema, initProps } from '../../__mocks__/data';
+import { actions, data, nestedData, mergedSchema, initProps } from '../../__mocks__/data';
 import UIForm, { UIFormComponent } from './UIForm.component';
 
 describe('UIForm component', () => {
@@ -21,6 +21,14 @@ describe('UIForm component', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render form with ids concatenated with ;', () => {
+		// when
+		const instance = mount(<UIFormComponent {...nestedData} {...props} idSeparator=";" />);
+		// then
+		expect(instance.find('Text[id="timestamp;value"]')).toHaveLength(1);
+		expect(instance.find('Text[id="timestamp;gmt_offset"]')).toHaveLength(1);
 	});
 
 	it('should render form in text display mode', () => {

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -106,10 +106,7 @@ describe('UIForm component', () => {
 			const event = { target: { value: newValue } };
 
 			// when
-			wrapper
-				.find('input')
-				.at(0)
-				.simulate('change', event);
+			wrapper.find('input').at(0).simulate('change', event);
 
 			// then
 			expect(props.onChange).toBeCalledWith(expect.anything(), {
@@ -174,10 +171,7 @@ describe('UIForm component', () => {
 			props.onTrigger.mockReturnValueOnce(Promise.resolve({}));
 
 			// when
-			wrapper
-				.find('input')
-				.at(1)
-				.simulate('blur');
+			wrapper.find('input').at(1).simulate('blur');
 
 			// then
 			expect(props.onTrigger).not.toBeCalled();
@@ -263,10 +257,7 @@ describe('UIForm component', () => {
 			const wrapper = mount(<UIForm {...data} {...props} />);
 
 			// when
-			wrapper
-				.find('button')
-				.at(0)
-				.simulate('click');
+			wrapper.find('button').at(0).simulate('click');
 
 			// then
 			expect(props.onTrigger).toBeCalledWith(expect.anything(), {

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -27,9 +27,9 @@ describe('UIForm component', () => {
 		// when
 		const instance = mount(<UIFormComponent {...nestedData} {...props} idSeparator=";" />);
 		// then
-		expect(instance.find('Text[id="myFormId;content"]')).toHaveLength(1);
-		expect(instance.find('Text[id="timestamp;value"]')).toHaveLength(1);
-		expect(instance.find('Text[id="timestamp;gmt_offset"]')).toHaveLength(1);
+		expect(instance.find('Text').at(0).prop('id')).toEqual('myFormId;content');
+		expect(instance.find('Text').at(1).prop('id')).toEqual('timestamp;value');
+		expect(instance.find('Text').at(2).prop('id')).toEqual('timestamp;gmt_offset');
 	});
 
 	it('should render form in text display mode', () => {

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -56,7 +56,7 @@ export default function Widget(props) {
 		return <p className="text-danger">Widget not found {widgetId}</p>;
 	}
 
-	const id = sfPath.name(key, '_', props.id);
+	const id = sfPath.name(key, props.idSeparator || '_', props.id);
 	const error = getError(props.errors, props.schema);
 	const errorMessage = validationMessage || error;
 	const all = {
@@ -92,6 +92,7 @@ if (process.env.NODE_ENV !== 'production') {
 		displayMode: PropTypes.string,
 		errors: PropTypes.object,
 		id: PropTypes.string,
+		idSeparator: PropTypes.string,
 		properties: PropTypes.object,
 		schema: PropTypes.shape({
 			conditions: PropTypes.arrayOf(


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The separator is hard-coded to _ and it is annoying when the key property path contains values with _ within it.

**What is the chosen solution to this problem?**
The separator can be configured so a non-problematic value can be provided.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
