### PR TITLE
fix(TCCUI-135) - show date value if specified without time

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -27,10 +27,10 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   186:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
-  74:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
-  75:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
-  77:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
-  78:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+  78:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
+  79:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
+  81:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
+  82:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
   281:43  error  'footerActions' is already declared in the upper scope  no-shadow

--- a/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
+++ b/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
@@ -33,6 +33,8 @@ function ContextualManager(props) {
 		if (props.value !== state.datetime) {
 			const nextState = extractParts(props.value, getDateOptions());
 			setState(nextState);
+			// Triggering onChange will propagate the error to the outside world when the
+			// new input is invalid and different then the default dateTime input.
 			if (nextState.errors && nextState.errors.length > 0) {
 				onChange(null, nextState);
 			}

--- a/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
+++ b/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
@@ -22,19 +22,23 @@ function ContextualManager(props) {
 	const initialState = extractParts(props.value, getDateOptions());
 	const [state, setState] = useState(initialState);
 
-	useEffect(() => {
-		if (props.value !== state.datetime) {
-			const nextState = extractParts(props.value, getDateOptions());
-			setState(nextState);
-		}
-	}, [props.value]);
-
 	function onChange(event, payload) {
 		if (props.onChange) {
 			const { datetime, textInput, errors, errorMessage } = payload;
 			props.onChange(event, { datetime, textInput, errors, errorMessage });
 		}
 	}
+
+	useEffect(() => {
+		if (props.value !== state.datetime) {
+			const nextState = extractParts(props.value, getDateOptions());
+			setState(nextState);
+			if (nextState.errors && nextState.errors.length > 0) {
+				onChange(null, nextState);
+			}
+		}
+	}, [props.value]);
+
 	function onDateChange(event, payload) {
 		const time = state.time || props.defaultTimeValue;
 		const newState = updatePartsOnDateChange(payload, time, getDateOptions());

--- a/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.test.js
+++ b/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.test.js
@@ -432,6 +432,42 @@ describe('DateTime.Manager', () => {
 				expect(args[1].errors).toEqual([]);
 				expect(args[1].errorMessage).toBe(null);
 			});
+			it('shouldn\'t trigger props.onChange if the default datetime is valid', () => {
+				const onChange = jest.fn();
+				const textInput = '2015-01-15 11:11';
+				const wrapper = mount(
+					<Manager id={DEFAULT_ID} onChange={onChange} value={textInput}>
+						<DateTimeConsumer />
+					</Manager>,
+				);
+				expect(onChange).not.toBeCalled();
+				const contextValue = wrapper.find('DateTimeConsumerDiv').props();
+				expect(contextValue.date).toEqual('2015-01-15');
+				expect(contextValue.time).toEqual('11:11');
+			});
+			it('should trigger props.onChange when default datetime is changed', () => {
+				const onChange = jest.fn();
+				const textInput = '2015-01-15';
+				mount(
+					<Manager id={DEFAULT_ID} onChange={onChange} value={textInput}>
+						<DateTimeConsumer />
+					</Manager>,
+				);
+				expect(onChange).toHaveBeenCalledTimes(1);
+			});
+			it('should propagate error via props.onChange for invalid datetime text input', () => {
+				// given
+				let data = null;
+				const onChange = (event, payload) => { data = payload; };
+				const textInput = '2015-01-15';
+				mount(
+					<Manager id={DEFAULT_ID} onChange={onChange} value={textInput}>
+						<DateTimeConsumer />
+					</Manager>,
+				);
+				expect(data.errors.length).toEqual(1);
+				expect(data.errors[0].code).toEqual('INVALID_TIME_EMPTY');
+			});
 			it('should trigger props.onChange with invalid time', () => {
 				// given
 				const onChange = jest.fn();

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
@@ -6,8 +6,6 @@ import getErrorMessage from '../shared/error-messages';
 import { convertDateToTimezone, extractDateOnly } from '../Date/date-extraction';
 import { checkTime, pad, timeToStr, strToTime } from '../Time/time-extraction';
 
-const splitDateAndTimePartsRegex = new RegExp(/^\s*(.*)\s+((.*):(.*)(:.*)?)\s*$/);
-
 const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
 
 export function DateTimePickerException(code, message) {
@@ -162,15 +160,12 @@ function extractPartsFromTextInput(textInput, options) {
 	let errors = [];
 
 	try {
-		const splitMatches = textInput.match(splitDateAndTimePartsRegex) || [];
-		if (!splitMatches.length) {
-			throw new DateTimePickerException('DATETIME_INVALID_FORMAT', 'DATETIME_INVALID_FORMAT');
-		} else {
-			date = splitMatches[1];
-			time = splitMatches[2];
-			datetime = dateAndTimeToDateTime(date, time, options);
-		}
+		const splitMatches = textInput.split(/\s/);
+		date = splitMatches[0];
+		time = splitMatches[1];
+		datetime = dateAndTimeToDateTime(date, time, options);
 	} catch (error) {
+		datetime = INTERNAL_INVALID_DATE;
 		errors = [error];
 	}
 

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
@@ -76,6 +76,20 @@ describe('Date extraction', () => {
 				errorMessage: null,
 			});
 		});
+
+		it('should return error for string without time', () => {
+			// given
+			const value = '2015-09-15';
+			const options = { dateFormat: 'YYYY-MM-DD' };
+
+			// when
+			const parts = extractParts(value, options);
+
+			// then
+			expect(parts.date).toEqual('2015-09-15');
+			expect(parts.time).toBeFalsy();
+			expect(parts.errors[0].code).toEqual('INVALID_TIME_EMPTY');
+		});
 	});
 
 	describe('extractPartsFromDateTime', () => {

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
@@ -34,6 +34,15 @@ storiesOf('Form/Controls/DatePicker/DateTime', module)
 			value={new Date(2018, 4, 13, 12, 30, 44)}
 		/>
 	))
+	.add('Text Input', () => (
+		<InputDateTimePicker
+			id="my-date-picker"
+			name="datetime"
+			onBlur={action('onBlur')}
+			onChange={action('onChange')}
+			value="2020-12-31 10:10"
+		/>
+	))
 	.add('Default time ', () => (
 		<InputDateTimePicker
 			id="my-date-picker"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
1. Date value is not shown in the Date field if time is not specified.
2. Form submit doesn't show any error in such case.
The issue is only with the string DateTime input.
https://jira.talendforge.org/browse/TCCUI-135

**What is the chosen solution to this problem?**
show date value if specified without time and also throw error if validation fails
http://2800.talend.surge.sh/components/?path=/story/form-controls-datepicker-datetime--text-input

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
