### PR TITLE
feat(List): Boolean Cell with Icon

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -63,7 +63,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   3:1  error  Prefer default export  import/prefer-default-export
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
-  9:8  error  'Action' is defined but never used  no-unused-vars
+  3:8  error  'classnames' is defined but never used  no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   177:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -62,9 +62,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/Toggle/Checkbox.js
   3:1  error  Prefer default export  import/prefer-default-export
 
-/home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
-  3:8  error  'classnames' is defined but never used  no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   177:3  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
@@ -75,6 +72,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 29 problems (27 errors, 2 warnings)
+✖ 28 problems (26 errors, 2 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/List/ListComposition/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition/ListComposition.stories.js
@@ -27,6 +27,11 @@ function CustomList(props) {
 			<List.VList.Text label="Id" dataKey="id" />
 			<List.VList.Title label="Name" dataKey="name" columnData={titleProps} />
 			<List.VList.Boolean label="Valid" dataKey="isValid" />
+			<List.VList.Boolean
+				label="ValidWithIcon"
+				dataKey="isValid"
+				columnData={{ displayMode: List.VList.Boolean.displayMode.ICON }}
+			/>
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />
 			<List.VList.Text label="Author" dataKey="author" />

--- a/packages/components/src/VirtualizedList/CellBoolean/BooleanColumn.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/BooleanColumn.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { defaultColumnConfiguration } from '../Content.component';
-import CellBoolean from './CellBoolean.component';
+import CellBoolean, { DISPLAY_MODE } from './CellBoolean.component';
 
 export const cellType = 'texticon';
 export const booleanColumnConfiguration = {
@@ -12,6 +12,7 @@ export const booleanColumnConfiguration = {
 export default function BooleanColumn() {
 	return null;
 }
+BooleanColumn.displayMode = DISPLAY_MODE;
 
 BooleanColumn.defaultProps = {
 	...defaultColumnConfiguration,

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
@@ -2,12 +2,19 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classnames from 'classnames';
 import { withTranslation } from 'react-i18next';
+import Icon from '../../Icon';
 
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
+import { getTheme } from '../../theme';
 
-import Action from '../../Actions/Action';
-import styles from './CellBoolean.scss';
+import theme from './CellBoolean.scss';
+
+const css = getTheme(theme);
+export const DISPLAY_MODE = {
+	TEXT: 'TEXT',
+	ICON: 'ICON',
+};
 
 /**
  * Cell renderer that displays a boolean
@@ -18,13 +25,26 @@ class CellBoolean extends React.Component {
 	}
 
 	render() {
-		const { cellData, t } = this.props;
+		const { cellData, t, columnData } = this.props;
+
+		if (columnData.displayMode === DISPLAY_MODE.TEXT) {
+			return (
+				<React.Fragment>
+					{cellData === true && t('BOOLEAN_VALUE_TRUE', { defaultValue: 'Yes' })}
+					{cellData === false && t('BOOLEAN_VALUE_FALSE', { defaultValue: 'No' })}
+				</React.Fragment>
+			);
+		}
 
 		return (
-			<div className={classnames('cell-boolean-container', styles['cell-boolean-container'])}>
-				{cellData === true && t('BOOLEAN_VALUE_TRUE', { defaultValue: 'Yes' })}
-				{cellData === false && t('BOOLEAN_VALUE_FALSE', { defaultValue: 'No' })}
-			</div>
+			cellData && (
+				<div className={css('cell-boolean-container')}>
+					<Icon
+						name="talend-check-circle"
+						title={t('CAD_LIST_MANDATORY_REQUIRED', { defaultValue: 'Required' })}
+					/>
+				</div>
+			)
 		);
 	}
 }
@@ -34,10 +54,16 @@ CellBoolean.propTypes = {
 	// The cell value : props.rowData[props.dataKey]
 	cellData: PropTypes.bool,
 	t: PropTypes.func,
+	columnData: PropTypes.shape({
+		displayMode: PropTypes.oneOf(Object.values(DISPLAY_MODE)),
+	}).isRequired,
 };
 
 CellBoolean.defaultProps = {
 	t: getDefaultT(),
+	columnData: {
+		displayMode: DISPLAY_MODE.TEXT,
+	},
 };
 
 export default withTranslation(I18N_DOMAIN_COMPONENTS)(CellBoolean);

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
@@ -27,24 +27,25 @@ class CellBoolean extends React.Component {
 	render() {
 		const { cellData, t, columnData } = this.props;
 
-		if (columnData.displayMode === DISPLAY_MODE.TEXT) {
-			return (
-				<React.Fragment>
-					{cellData === true && t('BOOLEAN_VALUE_TRUE', { defaultValue: 'Yes' })}
-					{cellData === false && t('BOOLEAN_VALUE_FALSE', { defaultValue: 'No' })}
-				</React.Fragment>
-			);
+		if (columnData.displayMode === DISPLAY_MODE.ICON) {
+			if (cellData) {
+				return (
+					<div className={css('cell-boolean-container')}>
+						<Icon
+							name="talend-check-circle"
+							title={t('CAD_LIST_MANDATORY_REQUIRED', { defaultValue: 'Required' })}
+						/>
+					</div>
+				);
+			}
+			return null;
 		}
 
 		return (
-			cellData && (
-				<div className={css('cell-boolean-container')}>
-					<Icon
-						name="talend-check-circle"
-						title={t('CAD_LIST_MANDATORY_REQUIRED', { defaultValue: 'Required' })}
-					/>
-				</div>
-			)
+			<React.Fragment>
+				{cellData === true && t('BOOLEAN_VALUE_TRUE', { defaultValue: 'Yes' })}
+				{cellData === false && t('BOOLEAN_VALUE_FALSE', { defaultValue: 'No' })}
+			</React.Fragment>
 		);
 	}
 }

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import classnames from 'classnames';
 import { withTranslation } from 'react-i18next';
 import Icon from '../../Icon';
 

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.scss
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.scss
@@ -1,3 +1,5 @@
-.cell-icon-container {
+.cell-boolean-container {
 	display: flex;
+	width: 100%;
+	justify-content: center;
 }

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.test.js
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.test.js
@@ -1,11 +1,25 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 
-import CellBoolean from './CellBoolean.component';
+import CellBoolean, { DISPLAY_MODE } from './CellBoolean.component';
 
 describe('CellBoolean', () => {
 	it('should render an empty cell', () => {
 		const wrapper = shallow(<CellBoolean />);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render an icon cell in a truthy case', () => {
+		const wrapper = shallow(
+			<CellBoolean cellData columnData={{ displayMode: DISPLAY_MODE.ICON }} />,
+		);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render an icon cell in a falsy case', () => {
+		const wrapper = shallow(<CellBoolean columnData={{ displayMode: DISPLAY_MODE.ICON }} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});

--- a/packages/components/src/VirtualizedList/CellBoolean/__snapshots__/CellBoolean.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellBoolean/__snapshots__/CellBoolean.test.js.snap
@@ -3,6 +3,11 @@
 exports[`CellBoolean should render a falsy value 1`] = `
 <VirtualizedList(CellBoolean)
   cellData={false}
+  columnData={
+    Object {
+      "displayMode": "TEXT",
+    }
+  }
   i18n={
     Object {
       "changeLanguage": [Function],
@@ -46,6 +51,11 @@ exports[`CellBoolean should render a falsy value 1`] = `
 exports[`CellBoolean should render a truthy value 1`] = `
 <VirtualizedList(CellBoolean)
   cellData={true}
+  columnData={
+    Object {
+      "displayMode": "TEXT",
+    }
+  }
   i18n={
     Object {
       "changeLanguage": [Function],
@@ -88,6 +98,106 @@ exports[`CellBoolean should render a truthy value 1`] = `
 
 exports[`CellBoolean should render an empty cell 1`] = `
 <VirtualizedList(CellBoolean)
+  columnData={
+    Object {
+      "displayMode": "TEXT",
+    }
+  }
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
+    }
+  }
+  t={[Function]}
+  tReady={true}
+/>
+`;
+
+exports[`CellBoolean should render an icon cell in a falsy case 1`] = `
+<VirtualizedList(CellBoolean)
+  columnData={
+    Object {
+      "displayMode": "ICON",
+    }
+  }
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
+    }
+  }
+  t={[Function]}
+  tReady={true}
+/>
+`;
+
+exports[`CellBoolean should render an icon cell in a truthy case 1`] = `
+<VirtualizedList(CellBoolean)
+  cellData={true}
+  columnData={
+    Object {
+      "displayMode": "ICON",
+    }
+  }
   i18n={
     Object {
       "changeLanguage": [Function],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On a TDC view (Custom Attributes) we have to show the booleans values with a icon this way.
Let's put that in common

![image](https://user-images.githubusercontent.com/2909671/80595651-6324ca80-8a25-11ea-9958-acb01d182cb2.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
