### PR TITLE
feat(List): Have Icon with text renderer

### DIFF
--- a/packages/components/src/List/ListComposition/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition/ListComposition.stories.js
@@ -26,6 +26,7 @@ function CustomList(props) {
 		<List.VList id="my-vlist" {...props}>
 			<List.VList.Text label="Id" dataKey="id" />
 			<List.VList.Title label="Name" dataKey="name" columnData={titleProps} />
+			<List.VList.Content label="NameWithIcon" dataKey="nameWithIcon" />
 			<List.VList.Boolean label="Valid" dataKey="isValid" />
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -267,8 +267,7 @@ for (let i = 0; i < 100; i += 1) {
 		name: `Title with icon and actions ${i}`,
 		nameWithIcon: {
 			icon: 'talend-list',
-			label:
-				'list list list list list list list list list list list list list list list list list list list list list list list list list list ',
+			label: 'list',
 		},
 		isValid: [true, false, undefined][random(2)],
 		tag: 'test',

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -162,6 +162,10 @@ const complexCollection = [
 	{
 		id: 0,
 		name: 'Title with few actions',
+		nameWithIcon: {
+			icon: 'talend-list',
+			label: 'list',
+		},
 		tag: 'test',
 		created: '2016-09-22',
 		modified: '2016-09-22',
@@ -174,6 +178,10 @@ const complexCollection = [
 	{
 		id: 1,
 		name: 'Title with lot of actions',
+		nameWithIcon: {
+			icon: 'talend-text',
+			label: 'text',
+		},
 		tag: 'test',
 		created: '2016-09-22',
 		modified: '2016-09-22',
@@ -235,6 +243,10 @@ for (let i = complexCollection.length; i < 100; i += 1) {
 	complexCollection.push({
 		id: i,
 		name: `Title with icon and actions ${i}`,
+		nameWithIcon: {
+			icon: 'talend-list',
+			label: 'list',
+		},
 		tag: 'test',
 		created: 1474495200,
 		modified: 1474495200,
@@ -253,6 +265,11 @@ for (let i = 0; i < 100; i += 1) {
 	simpleCollection.push({
 		id: i,
 		name: `Title with icon and actions ${i}`,
+		nameWithIcon: {
+			icon: 'talend-list',
+			label:
+				'list list list list list list list list list list list list list list list list list list list list list list list list list list ',
+		},
 		isValid: [true, false, undefined][random(2)],
 		tag: 'test',
 		created: 1474495200,

--- a/packages/components/src/VirtualizedList/Content.component.js
+++ b/packages/components/src/VirtualizedList/Content.component.js
@@ -1,9 +1,22 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Column } from 'react-virtualized';
+import theme from './Content.scss';
+import { getTheme } from '../theme';
+import Icon from '../Icon';
+
+const css = getTheme(theme);
 
 function DefaultRenderer({ cellData }) {
-	return <div className="tc-virtualizedlist-default-cell">{cellData}</div>;
+	if (typeof cellData === 'object' && cellData !== null) {
+		return (
+			<div className={css('tc-virtualizedlist-default-cell')}>
+				<Icon name={cellData.icon} />
+				<span className={css('tc-virtualizedlist-default-cell-text')}>{cellData.label}</span>
+			</div>
+		);
+	}
+	return <div className={css('tc-virtualizedlist-default-cell-text')}>{cellData}</div>;
 }
 DefaultRenderer.propTypes = {
 	cellData: PropTypes.string,

--- a/packages/components/src/VirtualizedList/Content.component.js
+++ b/packages/components/src/VirtualizedList/Content.component.js
@@ -19,7 +19,13 @@ function DefaultRenderer({ cellData }) {
 	return <div className={css('tc-virtualizedlist-default-cell-text')}>{cellData}</div>;
 }
 DefaultRenderer.propTypes = {
-	cellData: PropTypes.string,
+	cellData: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.shape({
+			label: PropTypes.string,
+			icon: PropTypes.string,
+		}),
+	]),
 };
 
 export const defaultColumnConfiguration = {

--- a/packages/components/src/VirtualizedList/Content.scss
+++ b/packages/components/src/VirtualizedList/Content.scss
@@ -1,0 +1,13 @@
+.tc-virtualizedlist-default-cell {
+	display: flex;
+	:global(.tc-svg-icon) {
+		margin-right: $padding-small;
+	}
+
+	&-text {
+		min-width: 0;
+		text-overflow: ellipsis;
+		overflow: hidden;
+		white-space: nowrap;
+	}
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On the same list as the PR before, we'll have to get some cells with icons then a value
![image](https://user-images.githubusercontent.com/2909671/80601377-05e14700-8a2e-11ea-985a-d35a129f5c50.png)

**What is the chosen solution to this problem?**
If we passed an object with icon / label instead of a string for a default renderer, we could have it. 
Another way to do it would be de declare a new component, it's up to you

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
