### PR TITLE
feat(components): Handle long values in RecordsViewer

### DIFF
--- a/packages/components/src/DataViewer/Core/Tree/Tree.scss
+++ b/packages/components/src/DataViewer/Core/Tree/Tree.scss
@@ -14,6 +14,7 @@
 
 	&-node-border {
 		border-left: 1px solid $alto;
+		margin-left: -12px;
 		&:hover {
 			border-left-color: $silver-chalice;
 		}

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.scss
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.scss
@@ -6,6 +6,7 @@
 	:global(.tc-svg-anchor) {
 		background: transparent;
 		border: none;
+		padding: 0;
 		color: $brand-primary;
 		display: flex;
 		&:focus,

--- a/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
@@ -20,7 +20,7 @@ exports[`ModelViewerBranch render ModelViewerBranch 1`] = `
       opened={false}
       value={Object {}}
     />
-    <SimpleTextKeyValue
+    <ForwardRef(SimpleTextKeyValue)
       displayTypes={false}
       formattedKey="myValueValue"
       formattedValue="myKeyValue"
@@ -50,7 +50,7 @@ exports[`ModelViewerBranch render ModelViewerBranch as a union 1`] = `
       opened={true}
       value={Object {}}
     />
-    <SimpleTextKeyValue
+    <ForwardRef(SimpleTextKeyValue)
       displayTypes={false}
       formattedKey="myValueValue"
       formattedValue="({...})"

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
@@ -10,7 +10,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf 1`] = `
     onClick={[Function]}
     title="toto"
   />
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     formattedKey="toto"
     separator=" "
@@ -32,7 +32,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf highlighted 1`] = `
     onClick={[Function]}
     title=" (typeSem)*"
   />
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     separator=" "
     value="(typeSem)*"
@@ -53,7 +53,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf with additional data 1`] 
     onClick={[Function]}
     title=" (typeSem)*"
   />
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     separator=" "
     value="(typeSem)*"

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
@@ -8,8 +8,8 @@ import { LengthBadge } from '../../Badges';
 import { TreeBranchIcon } from '../../Icons';
 import theme from '../RecordsViewer.scss';
 
-const ICON_MARGIN_PLUS = -12;
-const ICON_MARGIN_CARET = -10;
+const ICON_MARGIN_PLUS = -17;
+const ICON_MARGIN_CARET = -17;
 
 /**
  * Used with the lazy loading to allow the render of the skeleton.

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
@@ -8,8 +8,6 @@ import { LengthBadge } from '../../Badges';
 import { TreeBranchIcon } from '../../Icons';
 import theme from '../RecordsViewer.scss';
 
-const ICON_MARGIN = -17;
-
 /**
  * Used with the lazy loading to allow the render of the skeleton.
  * @param {object} value
@@ -108,9 +106,6 @@ export class RecordsViewerBranch extends React.Component {
 						jsonpath={this.props.jsonpath}
 						onToggle={this.props.onToggle}
 						opened={opened}
-						style={{
-							marginLeft: ICON_MARGIN,
-						}}
 						useCustomIcon={type === 'object'}
 						value={value}
 					/>

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
@@ -8,8 +8,7 @@ import { LengthBadge } from '../../Badges';
 import { TreeBranchIcon } from '../../Icons';
 import theme from '../RecordsViewer.scss';
 
-const ICON_MARGIN_PLUS = -17;
-const ICON_MARGIN_CARET = -17;
+const ICON_MARGIN = -17;
 
 /**
  * Used with the lazy loading to allow the render of the skeleton.
@@ -110,7 +109,7 @@ export class RecordsViewerBranch extends React.Component {
 						onToggle={this.props.onToggle}
 						opened={opened}
 						style={{
-							marginLeft: type === 'object' ? ICON_MARGIN_PLUS : ICON_MARGIN_CARET,
+							marginLeft: ICON_MARGIN,
 						}}
 						useCustomIcon={type === 'object'}
 						value={value}

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
@@ -20,7 +20,7 @@ exports[`RecordsViewerBranch should render the branch with additional value 1`] 
       opened={false}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}
@@ -92,7 +92,7 @@ exports[`RecordsViewerBranch should render the branch with children 1`] = `
       opened={true}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}
@@ -142,7 +142,7 @@ exports[`RecordsViewerBranch should render the branch with length badge 1`] = `
       onToggle={[MockFunction]}
       style={
         Object {
-          "marginLeft": -10,
+          "marginLeft": -17,
         }
       }
       useCustomIcon={false}

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/__snapshots__/RecordsViewerBranch.test.js.snap
@@ -18,11 +18,6 @@ exports[`RecordsViewerBranch should render the branch with additional value 1`] 
       jsonpath="$"
       onToggle={[MockFunction]}
       opened={false}
-      style={
-        Object {
-          "marginLeft": -17,
-        }
-      }
       useCustomIcon={false}
       value={
         Object {
@@ -90,11 +85,6 @@ exports[`RecordsViewerBranch should render the branch with children 1`] = `
       jsonpath="$"
       onToggle={[MockFunction]}
       opened={true}
-      style={
-        Object {
-          "marginLeft": -17,
-        }
-      }
       useCustomIcon={false}
       value={
         Object {
@@ -140,11 +130,6 @@ exports[`RecordsViewerBranch should render the branch with length badge 1`] = `
       index={0}
       jsonpath="$"
       onToggle={[MockFunction]}
-      style={
-        Object {
-          "marginLeft": -17,
-        }
-      }
       useCustomIcon={false}
       value={
         Object {

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -16,7 +16,7 @@ export function RecordsViewerLeaf({
 }) {
 	const ref = React.createRef();
 	const [isValueOverflown, setIsValueOverflown] = useState(false);
-	const [isLongValueToggled, setIsLongValueToggled] = useState(false);
+	const [isLongValueExpanded, setIsLongValueExpanded] = useState(false);
 
 	useLayoutEffect(() => {
 		if (ref.current.offsetParent.offsetWidth < ref.current.scrollWidth) {
@@ -26,7 +26,7 @@ export function RecordsViewerLeaf({
 
 	useLayoutEffect(() => {
 		measure();
-	}, [isLongValueToggled]);
+	}, [isLongValueExpanded]);
 
 	return (
 		<div
@@ -41,16 +41,16 @@ export function RecordsViewerLeaf({
 				>
 					<Icon
 						className={classNames(theme['tc-leaf-overflow-icon-chevron'], {
-							[theme['tc-leaf-overflow-icon-chevron-filled']]: isLongValueToggled,
+							[theme['tc-leaf-overflow-icon-chevron-filled']]: isLongValueExpanded,
 						})}
 						key="Icon"
 						name="talend-chevron-left"
 						onClick={e => {
 							e.stopPropagation();
-							setIsLongValueToggled(val => !val);
+							setIsLongValueExpanded(val => !val);
 						}}
 						title=""
-						transform={isLongValueToggled ? 'rotate-90' : 'rotate-270'}
+						transform={isLongValueExpanded ? 'rotate-90' : 'rotate-270'}
 					/>
 				</span>
 			)}
@@ -62,7 +62,7 @@ export function RecordsViewerLeaf({
 				schema={value.schema}
 				displayTypes={displayTypes}
 				isValueOverflown={isValueOverflown}
-				isLongValueToggled={isLongValueToggled}
+				isLongValueToggled={isLongValueExpanded}
 			/>
 		</div>
 	);

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -1,8 +1,9 @@
-import React from 'react';
+import React, { useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import theme from '../RecordsViewer.scss';
 import { SimpleTextKeyValue } from '../../Text';
+import Icon from '../../../Icon';
 
 export function RecordsViewerLeaf({
 	dataKey,
@@ -11,7 +12,22 @@ export function RecordsViewerLeaf({
 	className,
 	nodeHighlighted,
 	displayTypes,
+	measure,
 }) {
+	const ref = React.createRef();
+	const [isValueOverflown, setIsValueOverflown] = useState(false);
+	const [isLongValueToggled, setIsLongValueToggled] = useState(false);
+
+	useLayoutEffect(() => {
+		if (ref.current.offsetParent.offsetWidth < ref.current.scrollWidth) {
+			setIsValueOverflown(true);
+		}
+	}, []);
+
+	useLayoutEffect(() => {
+		measure();
+	}, [isLongValueToggled]);
+
 	return (
 		<div
 			className={classNames(theme['tc-records-viewer-leaf'], 'tc-records-viewer-leaf', className, {
@@ -19,12 +35,34 @@ export function RecordsViewerLeaf({
 				'tc-records-viewer-leaf-highlighted': nodeHighlighted,
 			})}
 		>
+			{isValueOverflown && (
+				<span
+					className={classNames(theme['tc-leaf-overflow-icon'], 'tc-leaf-overflow-icon', className)}
+				>
+					<Icon
+						className={classNames(theme['tc-leaf-overflow-icon-chevron'], {
+							[theme['tc-leaf-overflow-icon-chevron-filled']]: isLongValueToggled,
+						})}
+						key="Icon"
+						name="talend-chevron-left"
+						onClick={e => {
+							e.stopPropagation();
+							setIsLongValueToggled(val => !val);
+						}}
+						title=""
+						transform={isLongValueToggled ? 'rotate-90' : 'rotate-270'}
+					/>
+				</span>
+			)}
 			{renderLeafAdditionalValue && renderLeafAdditionalValue(value)}
 			<SimpleTextKeyValue
+				ref={ref}
 				formattedKey={dataKey}
 				value={value.data}
 				schema={value.schema}
 				displayTypes={displayTypes}
+				isValueOverflown={isValueOverflown}
+				isLongValueToggled={isLongValueToggled}
 			/>
 		</div>
 	);
@@ -40,6 +78,7 @@ RecordsViewerLeaf.propTypes = {
 	}),
 	renderLeafAdditionalValue: PropTypes.func,
 	displayTypes: PropTypes.bool,
+	measure: PropTypes.func.isRequired,
 };
 
 export default RecordsViewerLeaf;

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -1,9 +1,12 @@
 import React, { useLayoutEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import theme from '../RecordsViewer.scss';
+import { withTranslation } from 'react-i18next';
+import I18N_DOMAIN_COMPONENTS from '../../../constants';
+import getDefaultT from '../../../translate';
 import { SimpleTextKeyValue } from '../../Text';
-import Icon from '../../../Icon';
+import { ActionButton } from '../../../Actions';
+import theme from '../RecordsViewer.scss';
 
 export function RecordsViewerLeaf({
 	dataKey,
@@ -13,6 +16,7 @@ export function RecordsViewerLeaf({
 	nodeHighlighted,
 	displayTypes,
 	measure,
+	t,
 }) {
 	const ref = React.createRef();
 	const [isValueOverflown, setIsValueOverflown] = useState(false);
@@ -28,6 +32,10 @@ export function RecordsViewerLeaf({
 		measure();
 	}, [isLongValueExpanded]);
 
+	const label = isLongValueExpanded
+		? t('RECORDS_LEAF_LONG_VALUE_LABEL_COLLAPSE', { defaultValue: 'Collapse the value' })
+		: t('RECORDS_LEAF_LONG_VALUE_LABEL_EXPAND', { defaultValue: 'Expand the value' });
+
 	return (
 		<div
 			className={classNames(theme['tc-records-viewer-leaf'], 'tc-records-viewer-leaf', className, {
@@ -39,18 +47,19 @@ export function RecordsViewerLeaf({
 				<span
 					className={classNames(theme['tc-leaf-overflow-icon'], 'tc-leaf-overflow-icon', className)}
 				>
-					<Icon
+					<ActionButton
+						icon="talend-chevron-left"
+						iconTransform={isLongValueExpanded ? 'rotate-90' : 'rotate-270'}
+						link
+						hideLabel
+						label={label}
 						className={classNames(theme['tc-leaf-overflow-icon-chevron'], {
 							[theme['tc-leaf-overflow-icon-chevron-filled']]: isLongValueExpanded,
 						})}
-						key="Icon"
-						name="talend-chevron-left"
 						onClick={e => {
 							e.stopPropagation();
 							setIsLongValueExpanded(val => !val);
 						}}
-						title=""
-						transform={isLongValueExpanded ? 'rotate-90' : 'rotate-270'}
 					/>
 				</span>
 			)}
@@ -79,6 +88,11 @@ RecordsViewerLeaf.propTypes = {
 	renderLeafAdditionalValue: PropTypes.func,
 	displayTypes: PropTypes.bool,
 	measure: PropTypes.func.isRequired,
+	t: PropTypes.func,
 };
 
-export default RecordsViewerLeaf;
+RecordsViewerLeaf.defaultProps = {
+	t: getDefaultT(),
+};
+
+export default withTranslation(I18N_DOMAIN_COMPONENTS)(RecordsViewerLeaf);

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
@@ -1,97 +1,224 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Component should render the leaf 1`] = `
-<div
-  className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
->
-  <ForwardRef(SimpleTextKeyValue)
-    displayTypes={false}
-    formattedKey="myDataKey"
-    isLongValueToggled={false}
-    isValueOverflown={false}
-    schema={
-      Object {
-        "type": "int",
-      }
+<RecordsViewerLeaf
+  dataKey="myDataKey"
+  getQuality={[MockFunction]}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
     }
-    value={
-      Object {
+  }
+  level={0}
+  t={[Function]}
+  tReady={true}
+  value={
+    Object {
+      "data": Object {
         "value": "myValue",
-      }
+      },
+      "schema": Object {
+        "type": "int",
+      },
     }
-  />
-</div>
+  }
+/>
 `;
 
 exports[`Component should render the leaf highlighted 1`] = `
-<div
-  className="theme-tc-records-viewer-leaf tc-records-viewer-leaf theme-tc-records-viewer-leaf-highlighted tc-records-viewer-leaf-highlighted"
->
-  <ForwardRef(SimpleTextKeyValue)
-    displayTypes={false}
-    formattedKey="myDataKey"
-    isLongValueToggled={false}
-    isValueOverflown={false}
-    schema={
-      Object {
-        "type": "int",
-      }
+<RecordsViewerLeaf
+  dataKey="myDataKey"
+  getQuality={[MockFunction]}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
     }
-    value={
-      Object {
+  }
+  level={0}
+  nodeHighlighted={true}
+  t={[Function]}
+  tReady={true}
+  value={
+    Object {
+      "data": Object {
         "value": "myValue",
-      }
+      },
+      "schema": Object {
+        "type": "int",
+      },
     }
-  />
-</div>
+  }
+/>
 `;
 
 exports[`Component should render the leaf with additional value 1`] = `
-<div
-  className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
->
-  <div>
-    Additional render for what you want, you can use the value : 
-    myValue
-  </div>
-  <ForwardRef(SimpleTextKeyValue)
-    displayTypes={false}
-    formattedKey="myDataKey"
-    isLongValueToggled={false}
-    isValueOverflown={false}
-    schema={
-      Object {
-        "type": "int",
-      }
+<RecordsViewerLeaf
+  dataKey="myDataKey"
+  getQuality={[MockFunction]}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
     }
-    value={
-      Object {
+  }
+  level={0}
+  renderLeafAdditionalValue={[Function]}
+  t={[Function]}
+  tReady={true}
+  value={
+    Object {
+      "data": Object {
         "value": "myValue",
-      }
+      },
+      "schema": Object {
+        "type": "int",
+      },
     }
-  />
-</div>
+  }
+/>
 `;
 
 exports[`Component should render the leaf with padding offset 1`] = `
-<div
-  className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
->
-  <ForwardRef(SimpleTextKeyValue)
-    displayTypes={false}
-    formattedKey="myDataKey"
-    isLongValueToggled={false}
-    isValueOverflown={false}
-    schema={
-      Object {
-        "type": "int",
-      }
+<RecordsViewerLeaf
+  dataKey="myDataKey"
+  getQuality={[MockFunction]}
+  i18n={
+    Object {
+      "changeLanguage": [Function],
+      "getFixedT": [Function],
+      "hasResourceBundle": [Function],
+      "init": [Function],
+      "isInitialized": true,
+      "isMock": true,
+      "language": "en",
+      "languages": Array [
+        "en",
+      ],
+      "loadNamespaces": [Function],
+      "off": [Function],
+      "on": [Function],
+      "options": Object {},
+      "reportNamespaces": ReportNamespaces {
+        "usedNamespaces": Object {
+          "tui-components": true,
+        },
+      },
+      "services": Object {
+        "backendConnector": Object {},
+        "resourceStore": Object {
+          "data": Object {},
+        },
+      },
+      "store": Object {
+        "data": Object {},
+        "off": [Function],
+        "on": [Function],
+      },
+      "t": [Function],
     }
-    value={
-      Object {
+  }
+  level={1}
+  paddingOffset={30}
+  t={[Function]}
+  tReady={true}
+  value={
+    Object {
+      "data": Object {
         "value": "myValue",
-      }
+      },
+      "schema": Object {
+        "type": "int",
+      },
     }
-  />
-</div>
+  }
+/>
 `;

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/__snapshots__/RecordsViewerLeaf.test.js.snap
@@ -4,9 +4,11 @@ exports[`Component should render the leaf 1`] = `
 <div
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
 >
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     formattedKey="myDataKey"
+    isLongValueToggled={false}
+    isValueOverflown={false}
     schema={
       Object {
         "type": "int",
@@ -25,9 +27,11 @@ exports[`Component should render the leaf highlighted 1`] = `
 <div
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf theme-tc-records-viewer-leaf-highlighted tc-records-viewer-leaf-highlighted"
 >
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     formattedKey="myDataKey"
+    isLongValueToggled={false}
+    isValueOverflown={false}
     schema={
       Object {
         "type": "int",
@@ -50,9 +54,11 @@ exports[`Component should render the leaf with additional value 1`] = `
     Additional render for what you want, you can use the value : 
     myValue
   </div>
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     formattedKey="myDataKey"
+    isLongValueToggled={false}
+    isValueOverflown={false}
     schema={
       Object {
         "type": "int",
@@ -71,9 +77,11 @@ exports[`Component should render the leaf with padding offset 1`] = `
 <div
   className="theme-tc-records-viewer-leaf tc-records-viewer-leaf"
 >
-  <SimpleTextKeyValue
+  <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     formattedKey="myDataKey"
+    isLongValueToggled={false}
+    isValueOverflown={false}
     schema={
       Object {
         "type": "int",

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -29,6 +29,10 @@ $border-size: 0.1rem;
 		:global(.ReactVirtualized__Grid__innerScrollContainer) {
 			overflow: initial !important;
 		}
+		:global(.tc-svg-icon) {
+			height: 1.2rem;
+			width: 1.2rem;
+		}
 		&-border {
 			border-bottom: $border-size solid $alto;
 		}
@@ -44,19 +48,22 @@ $border-size: 0.1rem;
 	&-branch,
 	&-leaf {
 		display: flex;
-		flex-direction: column;
-		justify-content: center;
+		// flex-direction: column;
+		// justify-content: center;
 		margin-left: $padding-larger;
 		position: relative;
 	}
 
 	&-leaf {
+		justify-content: flex-start;
+		align-items: baseline;
+
 		&-highlighted {
 			&::before {
 				@include selection($background-highlight);
 			}
 		}
-		height: $records-node-height;
+		min-height: $records-node-height;
 		&-quality {
 			display: inline-flex;
 			margin-left: -$padding-larger;
@@ -66,6 +73,9 @@ $border-size: 0.1rem;
 		}
 	}
 	&-branch {
+		flex-direction: column;
+		justify-content: center;
+
 		&-highlighted::before {
 			@include selection($background-highlight);
 		}
@@ -117,4 +127,40 @@ $border-size: 0.1rem;
 
 :global(.tc-tree-branch-icon) + .tc-records-viewer-branch-text {
 	margin-left: $padding-smaller;
+}
+
+@mixin chevron($color) {
+	border: 1px solid $scooter;
+	padding: 3px;
+	border-radius: 10px;
+	color: $color;
+}
+
+.tc-leaf-overflow-icon {
+	margin-left: -17px;
+	margin-right: $padding-smaller;
+	&-chevron {
+		height: $svg-sm-size;
+		width: $svg-sm-size;
+		svg {
+			@include chevron($scooter);
+		}
+		&-filled {
+			svg {
+				@include chevron($white);
+				background-color: $scooter;
+			}
+		}
+	}
+	:global(.tc-svg-anchor) {
+		background: transparent;
+		border: none;
+		padding: 0;
+		color: $brand-primary;
+		display: flex;
+		&:focus,
+		&:hover {
+			color: $scooter;
+		}
+	}
 }

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -48,8 +48,6 @@ $border-size: 0.1rem;
 	&-branch,
 	&-leaf {
 		display: flex;
-		// flex-direction: column;
-		// justify-content: center;
 		margin-left: $padding-larger;
 		position: relative;
 	}

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -78,6 +78,7 @@ $border-size: 0.1rem;
 			@include selection($background-highlight);
 		}
 		&-content {
+			position: relative;
 			align-items: center;
 			display: inline-flex;
 			height: $records-node-height;
@@ -103,6 +104,10 @@ $border-size: 0.1rem;
 		}
 
 		&-icon {
+			position: absolute;
+			left: 0;
+			top: 50%;
+			transform: translate(-150%, -50%);
 			color: $brand-primary;
 			height: $svg-sm-size;
 			width: $svg-sm-size;
@@ -123,10 +128,6 @@ $border-size: 0.1rem;
 	}
 }
 
-:global(.tc-tree-branch-icon) + .tc-records-viewer-branch-text {
-	margin-left: $padding-smaller;
-}
-
 @mixin chevron($color) {
 	border: 1px solid $scooter;
 	padding: 3px;
@@ -135,7 +136,10 @@ $border-size: 0.1rem;
 }
 
 .tc-leaf-overflow-icon {
-	margin-left: -17px;
+	position: absolute;
+	left: -1.7rem;
+	top: 50%;
+	transform: translateY(-50%);
 	margin-right: $padding-smaller;
 	&-chevron {
 		height: $svg-sm-size;

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -32,6 +32,8 @@ $border-size: 0.1rem;
 		:global(.tc-svg-icon) {
 			height: 1.2rem;
 			width: 1.2rem;
+			margin: 0;
+			vertical-align: baseline;
 		}
 		&-border {
 			border-bottom: $border-size solid $alto;
@@ -130,7 +132,7 @@ $border-size: 0.1rem;
 
 @mixin chevron($color) {
 	border: 1px solid $scooter;
-	padding: 3px;
+	padding: 2px;
 	border-radius: 10px;
 	color: $color;
 }
@@ -138,12 +140,11 @@ $border-size: 0.1rem;
 .tc-leaf-overflow-icon {
 	position: absolute;
 	left: -1.7rem;
-	top: 50%;
-	transform: translateY(-50%);
 	margin-right: $padding-smaller;
 	&-chevron {
-		height: $svg-sm-size;
-		width: $svg-sm-size;
+		padding: 0;
+		line-height: initial;
+		min-height: initial;
 		svg {
 			@include chevron($scooter);
 		}

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -114,3 +114,7 @@ $border-size: 0.1rem;
 		}
 	}
 }
+
+:global(.tc-tree-branch-icon) + .tc-records-viewer-branch-text {
+	margin-left: $padding-smaller;
+}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
@@ -24,32 +24,6 @@ export default class DefaultValueRenderer extends React.Component {
 		isLongValueToggled: PropTypes.bool,
 	};
 
-	// constructor(props) {
-	// 	super(props);
-
-	// 	this.state = {
-	// 		overflowing: false,
-	// 	};
-
-	// 	this.checkOverflow = this.checkOverflow.bind(this);
-	// 	this.setDOMElement = this.setDOMElement.bind(this);
-	// }
-
-	// setDOMElement(domElement) {
-	// 	this.domElement = domElement;
-	// }
-
-	// checkOverflow() {
-	// 	// use a  1.5 ratio to avoid to show the tooltip when the element has slighty overflowed
-	// 	const overflowing =
-	// 		this.domElement.scrollWidth > this.domElement.clientWidth ||
-	// 		this.domElement.scrollHeight > this.domElement.clientHeight * 1.5;
-
-	// 	if (this.state.overflowing !== overflowing) {
-	// 		this.setState({ overflowing });
-	// 	}
-	// }
-
 	render() {
 		let stringValue;
 
@@ -67,7 +41,6 @@ export default class DefaultValueRenderer extends React.Component {
 		const content = (
 			<div
 				ref={this.setDOMElement}
-				onMouseOver={this.checkOverflow}
 				className={classNames(theme['td-default-cell'], this.props.className, 'td-default-cell', {
 					[theme['shrink-value']]: this.props.isValueOverflown,
 					[theme['wrap-value']]: this.props.isLongValueToggled,

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
@@ -20,33 +20,35 @@ export default class DefaultValueRenderer extends React.Component {
 	static propTypes = {
 		className: PropTypes.string,
 		value: DEFAULT_VALUE_PROP_TYPES,
+		isValueOverflown: PropTypes.bool,
+		isLongValueToggled: PropTypes.bool,
 	};
 
-	constructor(props) {
-		super(props);
+	// constructor(props) {
+	// 	super(props);
 
-		this.state = {
-			overflowing: false,
-		};
+	// 	this.state = {
+	// 		overflowing: false,
+	// 	};
 
-		this.checkOverflow = this.checkOverflow.bind(this);
-		this.setDOMElement = this.setDOMElement.bind(this);
-	}
+	// 	this.checkOverflow = this.checkOverflow.bind(this);
+	// 	this.setDOMElement = this.setDOMElement.bind(this);
+	// }
 
-	setDOMElement(domElement) {
-		this.domElement = domElement;
-	}
+	// setDOMElement(domElement) {
+	// 	this.domElement = domElement;
+	// }
 
-	checkOverflow() {
-		// use a  1.5 ratio to avoid to show the tooltip when the element has slighty overflowed
-		const overflowing =
-			this.domElement.scrollWidth > this.domElement.clientWidth ||
-			this.domElement.scrollHeight > this.domElement.clientHeight * 1.5;
+	// checkOverflow() {
+	// 	// use a  1.5 ratio to avoid to show the tooltip when the element has slighty overflowed
+	// 	const overflowing =
+	// 		this.domElement.scrollWidth > this.domElement.clientWidth ||
+	// 		this.domElement.scrollHeight > this.domElement.clientHeight * 1.5;
 
-		if (this.state.overflowing !== overflowing) {
-			this.setState({ overflowing });
-		}
-	}
+	// 	if (this.state.overflowing !== overflowing) {
+	// 		this.setState({ overflowing });
+	// 	}
+	// }
 
 	render() {
 		let stringValue;
@@ -66,13 +68,16 @@ export default class DefaultValueRenderer extends React.Component {
 			<div
 				ref={this.setDOMElement}
 				onMouseOver={this.checkOverflow}
-				className={classNames(theme['td-default-cell'], this.props.className, 'td-default-cell')}
+				className={classNames(theme['td-default-cell'], this.props.className, 'td-default-cell', {
+					[theme['shrink-value']]: this.props.isValueOverflown,
+					[theme['wrap-value']]: this.props.isLongValueToggled,
+				})}
 			>
 				{formattedContent}
 			</div>
 		);
 
-		if (this.state.overflowing) {
+		if (this.props.isValueOverflown) {
 			return (
 				<TooltipTrigger tooltipPlacement="bottom" label={formattedContent}>
 					{content}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.scss
@@ -1,6 +1,18 @@
 .td-default-cell {
 	height: 100%;
+	// overflow: hidden;
+	// text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.shrink-value {
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: pre;
+}
+
+.wrap-value {
+	overflow: initial;
+	white-space: normal;
+	word-break: break-all;
 }

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.scss
@@ -1,7 +1,5 @@
 .td-default-cell {
 	height: 100%;
-	// overflow: hidden;
-	// text-overflow: ellipsis;
 	white-space: nowrap;
 }
 

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.test.js
@@ -40,43 +40,8 @@ describe('#DefaultValueRenderer', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should render DefaultValueRenderer (custom renderer) with the tooltip when the label overflow in width', () => {
-		const wrapper = shallow(<DefaultValueRenderer value=" loreum " />);
-		wrapper.instance().setDOMElement({
-			scrollWidth: 20,
-			clientWidth: 15,
-			scrollHeight: 10,
-			clientHeight: 10,
-		});
-
-		wrapper.find('div').at(0).simulate('focus');
-
-		wrapper.update();
-
-		expect(wrapper.getElement()).toMatchSnapshot();
-
-		wrapper.instance().setDOMElement({
-			scrollWidth: 10,
-			clientWidth: 15,
-			scrollHeight: 10,
-			clientHeight: 10,
-		});
-
-		wrapper.find('div').at(0).simulate('focus');
-
-		wrapper.update();
-		// should remove the tooltip
-		expect(wrapper.getElement()).toMatchSnapshot();
-	});
-
 	it('should render DefaultValueRenderer with the tooltip when the label overflow in width', () => {
-		const wrapper = shallow(<DefaultValueRenderer value="loreum" />);
-		wrapper.instance().setDOMElement({
-			scrollWidth: 20,
-			clientWidth: 15,
-			scrollHeight: 10,
-			clientHeight: 10,
-		});
+		const wrapper = shallow(<DefaultValueRenderer value="loreum" isValueOverflown />);
 
 		wrapper.find('div').at(0).simulate('focus');
 
@@ -84,40 +49,8 @@ describe('#DefaultValueRenderer', () => {
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 
-		wrapper.instance().setDOMElement({
-			scrollWidth: 10,
-			clientWidth: 15,
-			scrollHeight: 10,
-			clientHeight: 10,
-		});
-
-		wrapper.find('div').at(0).simulate('focus');
-
-		wrapper.update();
-		// should remove the tooltip
-		expect(wrapper.getElement()).toMatchSnapshot();
-	});
-
-	it('should render DefaultValueRenderer with the tooltip when the label overflow in height', () => {
-		const wrapper = shallow(<DefaultValueRenderer value="loreum" />);
-		wrapper.instance().setDOMElement({
-			scrollWidth: 10,
-			clientWidth: 15,
-			scrollHeight: 15,
-			clientHeight: 10,
-		});
-
-		wrapper.find('div').at(0).simulate('focus');
-
-		wrapper.update();
-
-		expect(wrapper.getElement()).toMatchSnapshot();
-
-		wrapper.instance().setDOMElement({
-			scrollWidth: 10,
-			clientWidth: 15,
-			scrollHeight: 14,
-			clientHeight: 10,
+		wrapper.setProps({
+			isValueOverflown: false,
 		});
 
 		wrapper.find('div').at(0).simulate('focus');

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -103,21 +103,22 @@ AvroRenderer.propTypes = {
 	isLongValueToggled: PropTypes.bool,
 };
 
-const SimpleTextKeyValue = React.forwardRef(
-	(
-		{
-			formattedKey,
-			className,
-			schema,
-			separator,
-			style,
-			value,
-			displayTypes,
-			isValueOverflown,
-			isLongValueToggled,
-		},
-		ref,
-	) => (
+// eslint-disable-next-line prefer-arrow-callback
+const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
+	{
+		formattedKey,
+		className,
+		schema,
+		separator,
+		style,
+		value,
+		displayTypes,
+		isValueOverflown,
+		isLongValueToggled,
+	},
+	ref,
+) {
+	return (
 		<span
 			ref={ref}
 			className={classNames(theme['tc-simple-text'], 'tc-simple-text', className)}
@@ -153,8 +154,10 @@ const SimpleTextKeyValue = React.forwardRef(
 				/>
 			)}
 		</span>
-	),
-);
+	);
+});
+
+SimpleTextKeyValue.displayName = 'SimpleTextKeyValue';
 
 SimpleTextKeyValue.propTypes = {
 	className: PropTypes.string,

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -39,7 +39,7 @@ function getTypeRenderer(schemaType) {
 	return schemaType.type;
 }
 
-export function AvroRenderer({ colDef, data }) {
+export function AvroRenderer({ colDef, data, isValueOverflown, isLongValueToggled }) {
 	const typeRenderer = getTypeRenderer(colDef.avro.type);
 
 	const dateToString = value => {
@@ -60,6 +60,8 @@ export function AvroRenderer({ colDef, data }) {
 			return (
 				<DefaultValueRenderer
 					value={data.value}
+					isValueOverflown={isValueOverflown}
+					isLongValueToggled={isLongValueToggled}
 					className={classNames(theme['td-cell-int'], 'td-cell-int')}
 				/>
 			);
@@ -70,12 +72,20 @@ export function AvroRenderer({ colDef, data }) {
 			return (
 				<DefaultValueRenderer
 					value={dateToString(data.value)}
+					isValueOverflown={isValueOverflown}
+					isLongValueToggled={isLongValueToggled}
 					className={classNames('td-cell-date')}
 				/>
 			);
 
 		default:
-			return <DefaultValueRenderer value={data.value} />;
+			return (
+				<DefaultValueRenderer
+					value={data.value}
+					isValueOverflown={isValueOverflown}
+					isLongValueToggled={isLongValueToggled}
+				/>
+			);
 	}
 }
 
@@ -89,19 +99,27 @@ AvroRenderer.propTypes = {
 		}),
 	}),
 	data: PropTypes.object,
+	isValueOverflown: PropTypes.bool,
+	isLongValueToggled: PropTypes.bool,
 };
 
-export default function SimpleTextKeyValue({
-	formattedKey,
-	className,
-	schema,
-	separator,
-	style,
-	value,
-	displayTypes,
-}) {
-	return (
+const SimpleTextKeyValue = React.forwardRef(
+	(
+		{
+			formattedKey,
+			className,
+			schema,
+			separator,
+			style,
+			value,
+			displayTypes,
+			isValueOverflown,
+			isLongValueToggled,
+		},
+		ref,
+	) => (
 		<span
+			ref={ref}
 			className={classNames(theme['tc-simple-text'], 'tc-simple-text', className)}
 			style={style}
 		>
@@ -117,25 +135,41 @@ export default function SimpleTextKeyValue({
 				</span>
 			)}
 			{!schema && value && (
-				<span className={classNames(theme['tc-simple-text-value'], 'tc-simple-text-value')}>
+				<span
+					className={classNames(theme['tc-simple-text-value'], 'tc-simple-text-value', {
+						[theme['shrink-value']]: isValueOverflown,
+						[theme['wrap-value']]: isLongValueToggled,
+					})}
+				>
 					{value}
 				</span>
 			)}
-			{schema && value && <AvroRenderer colDef={{ avro: schema }} data={value} />}
+			{schema && value && (
+				<AvroRenderer
+					colDef={{ avro: schema }}
+					data={value}
+					isValueOverflown={isValueOverflown}
+					isLongValueToggled={isLongValueToggled}
+				/>
+			)}
 		</span>
-	);
-}
+	),
+);
 
 SimpleTextKeyValue.propTypes = {
 	className: PropTypes.string,
 	formattedKey: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 	schema: PropTypes.object,
-	value: PropTypes.object,
+	value: PropTypes.any,
 	separator: PropTypes.string,
 	style: PropTypes.object,
 	displayTypes: PropTypes.bool,
+	isValueOverflown: PropTypes.bool,
+	isLongValueToggled: PropTypes.bool,
 };
 
 SimpleTextKeyValue.defaultProps = {
 	displayTypes: false,
 };
+
+export default SimpleTextKeyValue;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
+import isNull from 'lodash/isNull';
 import DefaultValueRenderer from './DefaultValueRenderer.component';
 import theme from './SimpleTextKeyValue.scss';
 
@@ -104,7 +105,7 @@ export default function SimpleTextKeyValue({
 			className={classNames(theme['tc-simple-text'], 'tc-simple-text', className)}
 			style={style}
 		>
-			{formattedKey && (
+			{!isNull(formattedKey) && (
 				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
 					{formattedKey}
 					{separator}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
@@ -5,14 +5,11 @@
 
 	&-key,
 	:global(.td-default-cell) {
-		overflow: hidden;
 		font-weight: 400;
 	}
 	&-key {
 		margin-right: $padding-smaller;
-		overflow: hidden;
 		white-space: nowrap;
-		text-overflow: ellipsis;
 		flex-shrink: 1;
 		color: $dove-gray;
 		vertical-align: top;
@@ -28,10 +25,20 @@
 		}
 		text-transform: lowercase;
 		white-space: nowrap;
+
+		&.shrink-value {
+			overflow: hidden;
+			text-overflow: ellipsis;
+		}
+
+		&.wrap-value {
+			overflow: initial;
+			white-space: normal;
+			word-break: break-all;
+		}
 	}
 
 	:global(.td-default-cell) {
-		white-space: nowrap;
 		display: inline-block;
 		color: $brand-primary;
 		font-family: 'Inconsolata';

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/DefaultValueRenderer.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/DefaultValueRenderer.test.js.snap
@@ -1,58 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`#DefaultValueRenderer should render DefaultValueRenderer (custom renderer) with the tooltip when the label overflow in width 1`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
->
-  <withI18nextTranslation(FormatValueComponent)
-    value=" loreum "
-  />
-</div>
-`;
-
-exports[`#DefaultValueRenderer should render DefaultValueRenderer (custom renderer) with the tooltip when the label overflow in width 2`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
->
-  <withI18nextTranslation(FormatValueComponent)
-    value=" loreum "
-  />
-</div>
-`;
-
-exports[`#DefaultValueRenderer should render DefaultValueRenderer with the tooltip when the label overflow in height 1`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
->
-  loreum
-</div>
-`;
-
-exports[`#DefaultValueRenderer should render DefaultValueRenderer with the tooltip when the label overflow in height 2`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
->
-  loreum
-</div>
-`;
-
 exports[`#DefaultValueRenderer should render DefaultValueRenderer with the tooltip when the label overflow in width 1`] = `
-<div
-  className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
+<TooltipTrigger
+  label="loreum"
+  tooltipPlacement="bottom"
 >
-  loreum
-</div>
+  <div
+    className="theme-td-default-cell td-default-cell theme-shrink-value"
+  >
+    loreum
+  </div>
+</TooltipTrigger>
 `;
 
 exports[`#DefaultValueRenderer should render DefaultValueRenderer with the tooltip when the label overflow in width 2`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   loreum
 </div>
@@ -61,7 +24,6 @@ exports[`#DefaultValueRenderer should render DefaultValueRenderer with the toolt
 exports[`#DefaultValueRenderer should render a boolean 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   false
 </div>
@@ -70,7 +32,6 @@ exports[`#DefaultValueRenderer should render a boolean 1`] = `
 exports[`#DefaultValueRenderer should render a bytes 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   ejfiejifje
 </div>
@@ -79,7 +40,6 @@ exports[`#DefaultValueRenderer should render a bytes 1`] = `
 exports[`#DefaultValueRenderer should render empty when the value is null 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   
 </div>
@@ -88,7 +48,6 @@ exports[`#DefaultValueRenderer should render empty when the value is null 1`] = 
 exports[`#DefaultValueRenderer should render the leading/trailing special character 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   <withI18nextTranslation(FormatValueComponent)
     value=" loreum "
@@ -99,7 +58,6 @@ exports[`#DefaultValueRenderer should render the leading/trailing special charac
 exports[`#DefaultValueRenderer should render without the tooltip 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
-  onMouseOver={[Function]}
 >
   loreum
 </div>

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -17,6 +17,9 @@ exports[`SimpleTextKeyValue should render only the value 1`] = `
   className="theme-tc-simple-text tc-simple-text"
 >
   <span
+    className="theme-tc-simple-text-key tc-simple-text-key"
+  />
+  <span
     className="theme-tc-simple-text-value tc-simple-text-value"
   >
     myValue

--- a/packages/components/src/DataViewer/Virtualized/TreeCellMeasurer/TreeCellMeasurer.component.js
+++ b/packages/components/src/DataViewer/Virtualized/TreeCellMeasurer/TreeCellMeasurer.component.js
@@ -4,6 +4,8 @@ import get from 'lodash/get';
 import { CellMeasurer } from 'react-virtualized';
 
 export default function TreeCellMeasurer({ index, key, parent, style, cellRenderer, className }) {
+	const ref = React.createRef();
+
 	return (
 		<CellMeasurer
 			cache={get(parent, 'props.cache')}

--- a/packages/components/src/DataViewer/Virtualized/TreeCellMeasurer/TreeCellMeasurer.component.js
+++ b/packages/components/src/DataViewer/Virtualized/TreeCellMeasurer/TreeCellMeasurer.component.js
@@ -4,8 +4,6 @@ import get from 'lodash/get';
 import { CellMeasurer } from 'react-virtualized';
 
 export default function TreeCellMeasurer({ index, key, parent, style, cellRenderer, className }) {
-	const ref = React.createRef();
-
 	return (
 		<CellMeasurer
 			cache={get(parent, 'props.cache')}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In hierarchical view, if a value is too long for the line, it is shrink with an ellipsis and the full value is shown in a tooltip. The property name is shrink too in some cases.

**What is the chosen solution to this problem?**
We want to have another behaviour. The property name should never be truncated, and if the value is too long for the remaining space, it is shrink with an ellipsis. But we have a new button available on the line to expand the value and display it fully.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
