### PR TITLE
chore(components): some refacto for forms snapshots

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -174,21 +174,21 @@ class ActionDropdown extends React.Component {
 
 	render() {
 		const {
-			bsStyle,
+			bsStyle = 'default',
 			hideLabel,
 			icon,
-			items,
+			items = [],
 			label,
 			link,
 			onSelect,
-			tooltipPlacement,
+			tooltipPlacement = 'top',
 			tooltipLabel,
 			getComponent,
 			components,
 			className,
 			loading,
 			children,
-			t,
+			t = getDefaultT(),
 			...rest
 		} = this.props;
 
@@ -287,7 +287,7 @@ ActionDropdown.propTypes = {
 			}),
 		),
 		ImmutablePropTypes.list,
-	]).isRequired,
+	]),
 	label: PropTypes.string.isRequired,
 	link: PropTypes.bool,
 	loading: PropTypes.bool,
@@ -303,13 +303,6 @@ ActionDropdown.propTypes = {
 	}),
 	t: PropTypes.func,
 	children: PropTypes.node,
-};
-
-ActionDropdown.defaultProps = {
-	bsStyle: 'default',
-	tooltipPlacement: 'top',
-	items: [],
-	t: getDefaultT(),
 };
 
 export { getMenuItem, InjectDropdownMenuItem };

--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -1,9 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { withTranslation } from 'react-i18next';
 
-import I18N_DOMAIN_COMPONENTS from '../constants';
-import getDefaultT from '../translate';
 import badgeCssModule from './Badge.scss';
 import { getTheme } from '../theme';
 
@@ -16,7 +13,7 @@ const SIZES = {
 	small: 'small',
 };
 
-const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete, t }) => (
+const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete }) => (
 	<React.Fragment>
 		{category && <BadgeLib.Category label={category} />}
 		{category && <BadgeLib.Separator />}
@@ -24,7 +21,7 @@ const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete, t
 			{icon && <BadgeLib.Icon name={icon} />}
 		</BadgeLib.Label>
 		{icon && onDelete && <BadgeLib.Separator iconSeparator />}
-		{onDelete && <BadgeLib.DeleteAction id={id} onClick={onDelete} disabled={disabled} t={t} />}
+		{onDelete && <BadgeLib.DeleteAction id={id} onClick={onDelete} disabled={disabled} />}
 	</React.Fragment>
 );
 
@@ -36,7 +33,6 @@ DefaultBadge.propTypes = {
 	id: PropTypes.string,
 	label: PropTypes.string,
 	onDelete: PropTypes.func,
-	t: PropTypes.func.isRequired,
 };
 
 const BadgeType = ({ disabled, onSelect, children, ...rest }) => {
@@ -65,16 +61,15 @@ function Badge({
 	category,
 	className,
 	children,
-	disabled,
+	disabled = false,
 	display = SIZES.large,
 	icon,
 	id,
 	label,
 	onDelete,
 	onSelect,
-	selected,
+	selected = false,
 	style,
-	t,
 	white,
 }) {
 	const displayClass =
@@ -108,7 +103,6 @@ function Badge({
 						id={id}
 						label={label}
 						onDelete={onDelete}
-						t={t}
 					/>
 				) : (
 					children
@@ -132,16 +126,8 @@ Badge.propTypes = {
 	onSelect: PropTypes.func,
 	selected: PropTypes.bool,
 	style: PropTypes.object,
-	t: PropTypes.func.isRequired,
 	white: PropTypes.bool,
 };
 
-Badge.defaultProps = {
-	selected: false,
-	disabled: false,
-	t: getDefaultT(),
-};
-
-const TranslatedBadge = withTranslation(I18N_DOMAIN_COMPONENTS)(Badge);
-TranslatedBadge.SIZES = SIZES;
-export default TranslatedBadge;
+Badge.SIZES = SIZES;
+export default Badge;

--- a/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDelete/BadgeDelete.component.js
@@ -1,26 +1,32 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { useTranslation } from 'react-i18next';
+
+import I18N_DOMAIN_COMPONENTS from '../../../constants';
 import Action from '../../../Actions/Action';
 import badgeCssModule from '../../Badge.scss';
 import { getTheme } from '../../../theme';
 
 const theme = getTheme(badgeCssModule);
 
-const BadgeDelete = ({ disabled, id, label, onClick, t, dataFeature }) => (
-	<Action
-		className={theme('tc-badge-delete-icon')}
-		disabled={disabled}
-		hideLabel
-		icon={'talend-cross'}
-		id={id && `tc-badge-delete-${id}`}
-		key="delete"
-		label={label || t('BADGE_DELETE', { defaultValue: 'Delete' })}
-		link
-		onClick={onClick}
-		role="button"
-		data-feature={dataFeature}
-	/>
-);
+function BadgeDelete({ disabled, id, label, onClick, dataFeature }) {
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
+	return (
+		<Action
+			className={theme('tc-badge-delete-icon')}
+			disabled={disabled}
+			hideLabel
+			icon={'talend-cross'}
+			id={id && `tc-badge-delete-${id}`}
+			key="delete"
+			label={label || t('BADGE_DELETE', { defaultValue: 'Delete' })}
+			link
+			onClick={onClick}
+			role="button"
+			data-feature={dataFeature}
+		/>
+	);
+}
 
 BadgeDelete.propTypes = {
 	disabled: PropTypes.bool,
@@ -28,7 +34,6 @@ BadgeDelete.propTypes = {
 	label: PropTypes.string,
 	onClick: PropTypes.func.isRequired,
 	dataFeature: PropTypes.string,
-	t: PropTypes.func,
 };
 
 export default BadgeDelete;

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
@@ -1,14 +1,13 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { Label, OverlayTrigger, Panel, Button } from 'react-bootstrap';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import Action from '../Actions/Action';
 import ActionIconToggle from '../Actions/ActionIconToggle';
 import { Status, getbsStyleFromStatus } from '../Status';
 import TooltipTrigger from './../TooltipTrigger';
-import getDefaultT from '../translate';
 
 import css from './CollapsiblePanel.scss';
 import I18N_DOMAIN_COMPONENTS from '../constants';
@@ -107,7 +106,8 @@ renderHeaderItem.propTypes = PropTypes.oneOfType([
 ]);
 
 function CollapsiblePanelHeader(props) {
-	const { header, content, id, onSelect, onToggle, expanded, t } = props;
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
+	const { header, content, id, onSelect, onToggle, expanded } = props;
 	const headerColumnClass = `col-${header.length}`;
 	const headerItems = header.map((headerItem, index) => {
 		const isHeaderItemArray = Array.isArray(headerItem);
@@ -244,9 +244,6 @@ function CollapsiblePanel(props) {
 }
 
 CollapsiblePanel.displayName = 'CollapsiblePanel';
-CollapsiblePanel.defaultProps = {
-	t: getDefaultT(),
-};
 
 if (process.env.NODE_ENV !== 'production') {
 	CollapsiblePanelHeader.propTypes = {
@@ -275,7 +272,6 @@ if (process.env.NODE_ENV !== 'production') {
 		onSelect: PropTypes.func,
 		/** Caret click callback function, needed for controlled panel */
 		onToggle: PropTypes.func,
-		t: PropTypes.func.isRequired,
 	};
 
 	CollapsiblePanel.propTypes = {
@@ -287,4 +283,4 @@ if (process.env.NODE_ENV !== 'production') {
 	};
 }
 
-export default withTranslation(I18N_DOMAIN_COMPONENTS)(CollapsiblePanel);
+export default CollapsiblePanel;

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import getDefaultT from '../translate';
@@ -18,13 +18,14 @@ function listviewClasses() {
 }
 
 function ListView(props) {
-	const noResultLabel = props.t('NO_RESULT_FOUND', { defaultValue: 'No result found.' });
-	const emptyLabel = props.t('LISTVIEW_EMPTY', { defaultValue: 'This list is empty.' });
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
+	const noResultLabel = t('NO_RESULT_FOUND', { defaultValue: 'No result found.' });
+	const emptyLabel = t('LISTVIEW_EMPTY', { defaultValue: 'This list is empty.' });
 	const label = props.displayMode === DISPLAY_MODE_SEARCH ? noResultLabel : emptyLabel;
 	return (
 		<div className={listviewClasses()}>
 			<HeaderListView {...props} />
-			{props.items && props.items.length ? (
+			{props.items.length ? (
 				<ItemsListView {...props} />
 			) : (
 				<span className={theme['empty-message']}>{label}</span>
@@ -36,13 +37,12 @@ function ListView(props) {
 ListView.displayName = 'ListView';
 
 ListView.propTypes = {
+	displayMode: PropTypes.string,
 	items: PropTypes.arrayOf(PropTypes.object),
-	t: PropTypes.func,
 };
 
 ListView.defaultProps = {
 	items: [],
-	isSwitchBox: false,
 };
 
 function ItemsListView(props) {
@@ -72,7 +72,6 @@ function HeaderListView(props) {
 		items,
 		required,
 		searchPlaceholder,
-		t,
 	} = props;
 
 	switch (displayMode) {
@@ -82,7 +81,6 @@ function HeaderListView(props) {
 				onInputChange,
 				onAddKeyDown,
 				inputPlaceholder: searchPlaceholder,
-				t,
 			};
 			return <HeaderInput {...propsInput} />;
 		}
@@ -93,7 +91,6 @@ function HeaderListView(props) {
 				required,
 				nbItems: items.length,
 				nbItemsSelected: items.filter(item => !!item.checked).length,
-				t,
 			};
 			return <Header {...propsDefault} />;
 		}
@@ -102,7 +99,6 @@ function HeaderListView(props) {
 
 HeaderListView.defaultProps = {
 	displayMode: DISPLAY_MODE_DEFAULT,
-	t: getDefaultT(),
 };
 
 HeaderListView.propTypes = {
@@ -115,7 +111,6 @@ HeaderListView.propTypes = {
 	onAddKeyDown: PropTypes.func,
 	required: PropTypes.bool,
 	searchPlaceholder: PropTypes.string,
-	t: PropTypes.func,
 };
 
-export default withTranslation(I18N_DOMAIN_COMPONENTS)(ListView);
+export default ListView;


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Forms have snapshots changes because it now ouputs defaultProps.
Talend/scripts comes with a react-i18next mock that impacts enzyme selectors, because it changes the name of the components that are wrapped in withTranslation HOC.

**What is the chosen solution to this problem?**
This is a little refacto
- replacing some defaultProps with js default value. This is ok as the react team plans to deprecate default props in the future in favor of default values.
- replace some withTranslation HOC by useTranslation hook

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
