### PR TITLE
feat(containers/forms): pass actual properties when change the definitionURL

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -15,7 +15,7 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   3:10  error  Prefer default export  import/prefer-default-export
 
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
-  91:5  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
+  88:5  error  Visible, non-interactive elements should not have mouse or keyboard event listeners  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Text/index.js
   3:10  error  Prefer default export  import/prefer-default-export
@@ -27,10 +27,10 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   186:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
-  78:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
-  79:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
-  81:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
-  82:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+  80:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
+  81:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
+  83:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
+  84:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
   281:43  error  'footerActions' is already declared in the upper scope  no-shadow

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -105,6 +105,7 @@ export class TCompForm extends React.Component {
 			this.props.dispatch({
 				type: TCompForm.ON_DEFINITION_URL_CHANGED,
 				...this.props,
+				properties: this.state.properties,
 			});
 		}
 	}

--- a/packages/containers/src/ComponentForm/ComponentForm.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.test.js
@@ -255,13 +255,13 @@ describe('ComponentForm', () => {
 			const dispatch = jest.fn();
 			const oldUrl = 'http://old';
 			const newUrl = 'http://new';
-			const properties = { properties: { name: 'old' } };
+			const componentState = { properties: { name: 'old' } };
 
 			// when
 			const wrapper = shallow(
 				<TCompForm state={state} definitionURL={oldUrl} dispatch={dispatch} />,
 			);
-			wrapper.setState(properties);
+			wrapper.setState(componentState);
 			wrapper.setProps({ definitionURL: newUrl });
 
 			// then
@@ -270,7 +270,7 @@ describe('ComponentForm', () => {
 				dispatch,
 				state,
 				type: TCompForm.ON_DEFINITION_URL_CHANGED,
-				...properties,
+				...componentState,
 			});
 		});
 	});

--- a/packages/containers/src/ComponentForm/ComponentForm.test.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.test.js
@@ -255,19 +255,22 @@ describe('ComponentForm', () => {
 			const dispatch = jest.fn();
 			const oldUrl = 'http://old';
 			const newUrl = 'http://new';
+			const properties = { properties: { name: 'old' } };
 
 			// when
 			const wrapper = shallow(
 				<TCompForm state={state} definitionURL={oldUrl} dispatch={dispatch} />,
 			);
+			wrapper.setState(properties);
 			wrapper.setProps({ definitionURL: newUrl });
 
 			// then
 			expect(dispatch).toBeCalledWith({
-				type: TCompForm.ON_DEFINITION_URL_CHANGED,
-				state,
 				definitionURL: newUrl,
 				dispatch,
+				state,
+				type: TCompForm.ON_DEFINITION_URL_CHANGED,
+				...properties,
 			});
 		});
 	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The container dispatches a event when the definitionURL changed. We want to save the data typed before by the user on the action ON_DEFINITION_URL_CHANGED.

**What is the chosen solution to this problem?**

pass the actual properties on the event 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
