### PR TITLE
fix(BadgeOperator/TMDM-14276) IE11 : Center icons faceted

### DIFF
--- a/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
@@ -13,14 +13,16 @@ $circle-size-small: 1.8rem !default;
 	align-items: center;
 	background: white;
 	border-radius: 10rem;
-	display: flex;
+	display: inline-flex;
 	justify-content: center;
 	margin: 0 $padding-smaller 0 $padding-smaller;
 
 	&-button {
 		padding: 0;
+		display: inline-flex;
 		> button:hover,
 		> button {
+			padding: 0;
 			text-decoration: none;
 			text-transform: none;
 		}


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14276
**What is the problem this PR is trying to solve?**
As with jira TMDM-14276, The Web UI has a display issue for IE11.

**What is the chosen solution to this problem?**
Add new CSS style that only effect IE11 and Edge to fix the issue. 
For the display effect, pls see the attachment in jira(https://jira.talendforge.org/browse/TMDM-14276)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
