### PR TITLE
feat(CollapsibleFieldset/TMDM-14604): display description

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -4,6 +4,7 @@ import classNames from 'classnames';
 import CollapsiblePanel, { TYPE_ACTION } from '@talend/react-components/lib/CollapsiblePanel';
 import get from 'lodash/get';
 import Widget from '../../Widget';
+import { generateDescriptionId } from '../../Message/generateId';
 
 import theme from './CollapsibleFieldset.scss';
 
@@ -83,6 +84,7 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 			...action,
 			displayMode: TYPE_ACTION,
 		}));
+		const descriptionId = generateDescriptionId(id);
 
 		return (
 			<fieldset
@@ -94,6 +96,11 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 					onToggle={toggle}
 					expanded={!value.isClosed}
 				>
+					<div>
+						<p key="description" className="help-block" id={descriptionId}>
+							{schema.description ? schema.description : ''}
+						</p>
+					</div>
 					{items.map((itemSchema, index) => (
 						<Widget {...restProps} id={id} key={index} schema={itemSchema} value={value} />
 					))}

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -84,7 +84,6 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 			...action,
 			displayMode: TYPE_ACTION,
 		}));
-		const descriptionId = generateDescriptionId(id);
 
 		return (
 			<fieldset
@@ -96,11 +95,15 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 					onToggle={toggle}
 					expanded={!value.isClosed}
 				>
-					<div>
-						<p key="description" className="help-block" id={descriptionId}>
-							{schema.description ? schema.description : ''}
-						</p>
-					</div>
+					{schema.description ? (
+						<div>
+							<p key="description" className="help-block" id={generateDescriptionId(id)}>
+								{schema.description}
+							</p>
+						</div>
+					) : (
+						''
+					)}
 					{items.map((itemSchema, index) => (
 						<Widget {...restProps} id={id} key={index} schema={itemSchema} value={value} />
 					))}

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -108,10 +108,7 @@ describe('CollapsibleFieldset', () => {
 			/>,
 		);
 		// when
-		wrapper
-			.find(CollapsiblePanel)
-			.getElement()
-			.props.onToggle(event);
+		wrapper.find(CollapsiblePanel).getElement().props.onToggle(event);
 
 		// then
 		expect(event.stopPropagation).toBeCalled();
@@ -136,10 +133,7 @@ describe('CollapsibleFieldset', () => {
 				actions={actions}
 			/>,
 		);
-		const header = wrapper
-			.find(CollapsiblePanel)
-			.dive()
-			.getElement().props.header;
+		const header = wrapper.find(CollapsiblePanel).dive().getElement().props.header;
 		expect(header.length).toBe(2);
 		expect(header[1].length).toBe(2);
 		expect(header[1][0].id).toBe('action1');

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -12,6 +12,7 @@ function customTitle(value, schema) {
 
 const schema = {
 	title: 'Basic',
+	description: 'This is description',
 	items: [
 		{
 			key: ['firstname'],
@@ -21,7 +22,7 @@ const schema = {
 		},
 		{
 			key: ['lastname'],
-			title: 'FirstName',
+			title: 'LastName',
 			schema: { type: 'string' },
 			type: 'string',
 		},
@@ -157,6 +158,7 @@ describe('CollapsibleFieldset', () => {
 
 		expect(wrapper.exists('Actions')).toEqual(false);
 	});
+
 	it('should concat values in case it is used in array', () => {
 		const CollapsibleFieldset = createCollapsibleFieldset();
 		const onChange = jest.fn();
@@ -167,6 +169,18 @@ describe('CollapsibleFieldset', () => {
 		const panel = wrapper.find('CollapsiblePanel');
 
 		expect(panel.props().header[0].label).toEqual(`${value.firstname}, ${value.lastname}`);
+	});
+
+	it('should display description', () => {
+		// given
+		const CollapsibleFieldset = createCollapsibleFieldset();
+		const onChange = jest.fn();
+		// when
+		const wrapper = mount(
+			<CollapsibleFieldset id="my-fieldset" onChange={onChange} schema={schema} />,
+		);
+		// then
+		expect(wrapper.find('#my-fieldset-description').text()).toBe('This is description');
 	});
 });
 

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/README.md
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/README.md
@@ -10,6 +10,7 @@ It is possible to customize the title displayed as header.
   "jsonSchema": {
     "type": "object",
     "title": "Comment",
+    "description": "Description",
     "properties": {
       "lastname": {
         "type": "string"
@@ -37,6 +38,7 @@ It is possible to customize the title displayed as header.
 |---|---|---|
 | key | Mandatory, it indicates where to set the `isClosed` state flag. |  |
 | title | The default `CollapsiblePanel` displays this title in the header. |  |
+| description | The default `CollapsiblePanel` displays this description in the body. |  |
 | items | The UI schema of its body. |  |
 | widget | The widget to use. | `collapsibleFieldset` |
 
@@ -46,6 +48,7 @@ It is possible to customize the title displayed as header.
     "widget": "collapsibleFieldset",
     "key": "technical.basic",
     "title": "Basic",
+    "description": "Description",
     "items": [
       {
         "key": "lastname",
@@ -104,6 +107,7 @@ import { UIForms } from '@talend/react-forms';
     "widget": "myCustomCollapsibleFieldset",
     "key": "technical.basic",
     "title": "Basic title",
+    "description": "Basic description",
     "items": [
       {
         "key": "lastname",

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
@@ -17,6 +17,14 @@ exports[`CollapsibleFieldset should render a collapsed fieldset (header only) 1`
     id="my-fieldset"
     onToggle={[Function]}
   >
+    <div>
+      <p
+        className="help-block"
+        id="my-fieldset-description"
+      >
+        This is description
+      </p>
+    </div>
     <Widget
       id="my-fieldset"
       schema={
@@ -50,7 +58,7 @@ exports[`CollapsibleFieldset should render a collapsed fieldset (header only) 1`
           "schema": Object {
             "type": "string",
           },
-          "title": "FirstName",
+          "title": "LastName",
           "type": "string",
         }
       }
@@ -84,6 +92,14 @@ exports[`CollapsibleFieldset should render a custom title 1`] = `
     id="my-fieldset"
     onToggle={[Function]}
   >
+    <div>
+      <p
+        className="help-block"
+        id="my-fieldset-description"
+      >
+        This is description
+      </p>
+    </div>
     <Widget
       id="my-fieldset"
       schema={
@@ -117,7 +133,7 @@ exports[`CollapsibleFieldset should render a custom title 1`] = `
           "schema": Object {
             "type": "string",
           },
-          "title": "FirstName",
+          "title": "LastName",
           "type": "string",
         }
       }
@@ -151,6 +167,14 @@ exports[`CollapsibleFieldset should render a full fieldset (header and body) 1`]
     id="my-fieldset"
     onToggle={[Function]}
   >
+    <div>
+      <p
+        className="help-block"
+        id="my-fieldset-description"
+      >
+        This is description
+      </p>
+    </div>
     <Widget
       id="my-fieldset"
       schema={
@@ -184,7 +208,7 @@ exports[`CollapsibleFieldset should render a full fieldset (header and body) 1`]
           "schema": Object {
             "type": "string",
           },
-          "title": "FirstName",
+          "title": "LastName",
           "type": "string",
         }
       }
@@ -218,6 +242,14 @@ exports[`CollapsibleFieldset should render without value 1`] = `
     id="my-fieldset"
     onToggle={[Function]}
   >
+    <div>
+      <p
+        className="help-block"
+        id="my-fieldset-description"
+      >
+        This is description
+      </p>
+    </div>
     <Widget
       id="my-fieldset"
       schema={
@@ -249,7 +281,7 @@ exports[`CollapsibleFieldset should render without value 1`] = `
           "schema": Object {
             "type": "string",
           },
-          "title": "FirstName",
+          "title": "LastName",
           "type": "string",
         }
       }

--- a/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
@@ -66,6 +66,24 @@
           "validationMessage": "Don't be greedy!"
         }
       ]
+    },
+    {
+      "widget": "collapsibleFieldset",
+      "key": "technical.description",
+      "title": "Description",
+      "description": "Hint: this is the description",
+      "items": [
+        {
+          "key": "lastname",
+          "title": "Last Name (with description)",
+          "description": "Hint: this is the last name"
+        },
+        {
+          "key": "firstname",
+          "title": "First Name (with description)",
+          "description": "Hint: this is the first name"
+        }
+      ]
     }
   ],
   "properties": {


### PR DESCRIPTION
https://jira.talendforge.org/browse/TMDM-14604
**What is the problem this PR is trying to solve?**
- `CollapsibleFieldset` not support description

**What is the chosen solution to this problem?**
- Reference widget `Message` to display description for `CollapsibleFieldset`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

* [ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
