### PR TITLE
fix(theme): Fix box-shadow on Safari

### DIFF
--- a/packages/theme/src/theme/_visual-helpers.scss
+++ b/packages/theme/src/theme/_visual-helpers.scss
@@ -130,7 +130,7 @@
 			.btn {
 				&:hover,
 				&:focus {
-					box-shadow: 0 200px 100px -100px rgba(255, 255, 255, 0.12) inset;
+					box-shadow: 0 0 0 200px rgba(255, 255, 255, 0.12) inset;
 				}
 			}
 		}
@@ -170,7 +170,7 @@
 			&:hover {
 				&:not([aria-current]) {
 					background: none;
-					box-shadow: 0 200px 100px -100px rgba(255, 255, 255, 0.12) inset;
+					box-shadow: 0 0 0 200px rgba(255, 255, 255, 0.12) inset;
 				}
 			}
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We currently have a broken display on Safari. Buttons in the header bar or the side panel (at least) have a box-shadow effect that goes completly wild on Safari. We have white blocks over the content instead of a nice shadow effect.

There is some screenshots in the following Jira: https://jira.talendforge.org/browse/TFD-10461

You can see it yourself in SB with any of the themed story of the header bar (like http://localhost:6006/?path=/story/navigation-headerbar--%F0%9F%8E%A8-portal-headerbar)

**What is the chosen solution to this problem?**
The issue seems related to some huge values in the box-shadow definition, leading to this strange interpretation by Safari.

I have changed the values to have more relevant values and have the same final effect (i.e. an inset transparent shadow over all the element).

I used this online tool to experiment : https://www.cssmatic.com/box-shadow

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
