### PR TITLE
feat(component/actionicontoggle): add tick

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
@@ -10,7 +10,17 @@ import getPropsFrom from '../../utils/getPropsFrom';
 import theme from './ActionIconToggle.scss';
 
 function ActionIconToggle(props) {
-	const { active, tick, className, icon, iconTransform, id, label, tooltipPlacement, ...rest } = props;
+	const {
+		active,
+		tick,
+		className,
+		icon,
+		iconTransform,
+		id,
+		label,
+		tooltipPlacement,
+		...rest
+	} = props;
 
 	const cn = classNames(className, 'tc-icon-toggle', theme['tc-icon-toggle'], {
 		[theme.active]: active,

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
@@ -10,11 +10,13 @@ import getPropsFrom from '../../utils/getPropsFrom';
 import theme from './ActionIconToggle.scss';
 
 function ActionIconToggle(props) {
-	const { active, className, icon, iconTransform, id, label, tooltipPlacement, ...rest } = props;
+	const { active, tick, className, icon, iconTransform, id, label, tooltipPlacement, ...rest } = props;
 
 	const cn = classNames(className, 'tc-icon-toggle', theme['tc-icon-toggle'], {
 		[theme.active]: active,
 		active,
+		[theme.tick]: tick,
+		tick,
 	});
 
 	return (
@@ -35,6 +37,7 @@ function ActionIconToggle(props) {
 
 ActionIconToggle.propTypes = {
 	active: PropTypes.bool,
+	tick: PropTypes.bool,
 	className: PropTypes.string,
 	icon: PropTypes.string.isRequired,
 	iconTransform: PropTypes.string,
@@ -46,6 +49,7 @@ ActionIconToggle.propTypes = {
 
 ActionIconToggle.defaultProps = {
 	active: false,
+	tick: false,
 	tooltipPlacement: 'top',
 };
 

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -1,6 +1,8 @@
 $tc-icon-toggle-size: 2.4rem !default;
 $tc-icon-toggle-icon-size: $svg-sm-size !default;
 $tc-icon-toggle-border: 1px solid $gray;
+$tc-icon-toggle-tick-size: 12px !default;
+$tc-icon-toggle-tick-border: 1px solid $white;
 
 @mixin tc-icon-toggle($btn-size: $tc-icon-toggle-size, $icon-size: $tc-icon-toggle-icon-size) {
 	height: $btn-size;
@@ -19,7 +21,7 @@ $tc-icon-toggle-border: 1px solid $gray;
 	display: flex;
 	justify-content: center;
 	align-items: center;
-
+	position: relative;
 	background-color: transparent;
 
 	box-shadow: none;
@@ -67,5 +69,17 @@ $tc-icon-toggle-border: 1px solid $gray;
 			background-color: $scooter;
 			border-color: $scooter;
 		}
+	}
+
+	&.tick:after {
+		content: '';
+		position: absolute;
+		width: $tc-icon-toggle-tick-size;
+		height: $tc-icon-toggle-tick-size;
+		border-radius: $tc-icon-toggle-tick-size / 2;
+		right: -0.4rem;
+		top: -0.4rem;
+		background: $scooter;
+		border: $tc-icon-toggle-tick-border;
 	}
 }

--- a/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
+++ b/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
@@ -87,6 +87,12 @@ storiesOf('Buttons/IconToggle', module)
 
 			<p>Active</p>
 			<ActionIconToggle {...activeIconToggle} />
+
+			<p>With tick</p>
+			<ActionIconToggle {...inactiveIconToggle} tick />
+
+			<p>Active with tick</p>
+			<ActionIconToggle {...activeIconToggle} tick />
 		</div>
 	))
 	.add('customize sizes', () => (

--- a/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/DisplayMode/__snapshots__/ListDisplayMode.component.test.js.snap
@@ -29,6 +29,7 @@ exports[`List DisplayMode should render 1`] = `
         key="table"
         label="Set Table as current display mode."
         onClick={[Function]}
+        tick={false}
         tooltipPlacement="top"
       >
         <TooltipTrigger
@@ -105,6 +106,7 @@ exports[`List DisplayMode should render 1`] = `
         key="large"
         label="Set Expanded as current display mode."
         onClick={[Function]}
+        tick={false}
         tooltipPlacement="top"
       >
         <TooltipTrigger

--- a/packages/components/src/List/Toolbar/DisplayModeToggle/__snapshots__/DisplayModeToggle.test.js.snap
+++ b/packages/components/src/List/Toolbar/DisplayModeToggle/__snapshots__/DisplayModeToggle.test.js.snap
@@ -12,6 +12,7 @@ exports[`DisplayModeToggle should render 1`] = `
     key="table"
     label="Set Table as current display mode."
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
   <ActionIconToggle
@@ -22,6 +23,7 @@ exports[`DisplayModeToggle should render 1`] = `
     key="large"
     label="Set Expanded as current display mode."
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
 </div>

--- a/packages/components/src/ResourceList/Toolbar/StateFilter/__snapshots__/StateFilter.snap.test.js.snap
+++ b/packages/components/src/ResourceList/Toolbar/StateFilter/__snapshots__/StateFilter.snap.test.js.snap
@@ -15,6 +15,7 @@ exports[`StateFilter component snaps should render in default mode 1`] = `
     icon="talend-check-circle"
     label="Selected"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
   <ActionIconToggle
@@ -23,6 +24,7 @@ exports[`StateFilter component snaps should render in default mode 1`] = `
     icon="talend-badge"
     label="Certified"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
   <ActionIconToggle
@@ -31,6 +33,7 @@ exports[`StateFilter component snaps should render in default mode 1`] = `
     icon="talend-star"
     label="Favorites"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
 </div>
@@ -51,6 +54,7 @@ exports[`StateFilter component snaps should render with only certified 1`] = `
     icon="talend-badge"
     label="Certified"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
 </div>
@@ -71,6 +75,7 @@ exports[`StateFilter component snaps should render with only favorites 1`] = `
     icon="talend-star"
     label="Favorites"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
 </div>
@@ -91,6 +96,7 @@ exports[`StateFilter component snaps should render with states to set to true 1`
     icon="talend-check-circle"
     label="Selected"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
   <ActionIconToggle
@@ -99,6 +105,7 @@ exports[`StateFilter component snaps should render with states to set to true 1`
     icon="talend-badge"
     label="Certified"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
   <ActionIconToggle
@@ -107,6 +114,7 @@ exports[`StateFilter component snaps should render with states to set to true 1`
     icon="talend-star"
     label="Favorites"
     onClick={[Function]}
+    tick={false}
     tooltipPlacement="top"
   />
 </div>

--- a/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
+++ b/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
@@ -13,6 +13,7 @@ exports[`Action Icon Toggle should render 1`] = `
       "type": "TOGGLE-MY-AWESOME-ACTION",
     }
   }
+  tick={false}
   tooltipPlacement="top"
 />
 `;

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
@@ -44,7 +44,6 @@ exports[`BadgeFaceted should render the html output by default 1`] = `
     <button role="button"
             aria-label="Remove filter"
             id="tc-badge-delete-my-id"
-            data-feature="filter.remove"
             aria-describedby="42"
             type="button"
             class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
@@ -44,7 +44,6 @@ exports[`BadgeText should mount a default badge 1`] = `
     <button role="button"
             aria-label="Remove filter"
             id="tc-badge-delete-myId-badge-text"
-            data-feature="filter.remove"
             aria-describedby="42"
             type="button"
             class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -96,7 +96,6 @@ exports[`BasicSearch should render the default html output with some badges 1`] 
         <button role="button"
                 aria-label="Remove filter"
                 id="tc-badge-delete-name-7bc9bd07-3b46-4b8c-a406-a08b6263de5b-badge-text"
-                data-feature="filter.remove"
                 aria-describedby="42"
                 type="button"
                 class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/FacetedSearchIcon/FacetedSearchIcon.component.js
+++ b/packages/faceted-search/src/components/FacetedSearchIcon/FacetedSearchIcon.component.js
@@ -11,7 +11,7 @@ import { I18N_DOMAIN_FACETED_SEARCH, USAGE_TRACKING_TAGS } from '../../constants
 const theme = getTheme(facetedSearchIconTheme);
 
 // eslint-disable-next-line import/prefer-default-export
-export function FacetedSearchIcon({ active, loading, onClick }) {
+export function FacetedSearchIcon({ active, tick, loading, onClick }) {
 	const { t } = useTranslation(I18N_DOMAIN_FACETED_SEARCH);
 	const dataFeature = active ? USAGE_TRACKING_TAGS.COLLAPSE : USAGE_TRACKING_TAGS.EXPAND;
 
@@ -22,6 +22,7 @@ export function FacetedSearchIcon({ active, loading, onClick }) {
 	return (
 		<ActionIconToggle
 			active={active}
+			tick={tick}
 			className={theme('faceted-search-icon')}
 			icon="talend-filter"
 			label={t('SHOW_FACETED_SEARCH', {
@@ -36,6 +37,7 @@ export function FacetedSearchIcon({ active, loading, onClick }) {
 
 FacetedSearchIcon.propTypes = {
 	active: PropTypes.bool,
+	tick: PropTypes.bool,
 	onClick: PropTypes.func.isRequired,
 	loading: PropTypes.bool,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We should be able to show a little _tick_ on the action icon toggle.

**What is the chosen solution to this problem?**

<img width="188" alt="image" src="https://user-images.githubusercontent.com/26482371/81581201-b5afa080-93ae-11ea-9398-bc90f504144e.png">
<img width="171" alt="image" src="https://user-images.githubusercontent.com/26482371/81581217-b9432780-93ae-11ea-9c7b-9fb6d4af26c8.png">


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
