### PR TITLE
feat(DataViewer): Dataset should leverage the new name in avro format

### DIFF
--- a/packages/components/src/DataViewer/ModelViewer/ModelViewer.container.js
+++ b/packages/components/src/DataViewer/ModelViewer/ModelViewer.container.js
@@ -76,6 +76,7 @@ export function filterNullUnion(union) {
 		type: typeWithoutNull.length === 1 ? head(typeWithoutNull) : typeWithoutNull,
 		optional: typeWithoutNull.length < union.type.length,
 		path: union.path,
+		'talend.component.label': union['talend.component.label'],
 	};
 }
 

--- a/packages/components/src/DataViewer/ModelViewer/ModelViewer.parser.test.js
+++ b/packages/components/src/DataViewer/ModelViewer/ModelViewer.parser.test.js
@@ -110,12 +110,18 @@ describe('#defaultGetDisplayKey', () => {
 
 describe('#filterOptionalUnion', () => {
 	it('should return one type without null value and parent name / path', () => {
-		const union = { name: 'name', type: [{ type: 'Toto' }, { type: 'null' }], path: 'name' };
+		const union = {
+			name: 'name',
+			type: [{ type: 'Toto' }, { type: 'null' }],
+			path: 'name',
+			'talend.component.label': 'readable label',
+		};
 		expect(filterNullUnion(union)).toEqual({
 			name: union.name,
 			optional: true,
 			type: { type: 'Toto', name: union.name, path: union.path },
 			path: union.path,
+			'talend.component.label': 'readable label',
 		});
 	});
 	it('should return one type without null value', () => {
@@ -123,12 +129,14 @@ describe('#filterOptionalUnion', () => {
 			name: 'name',
 			type: [{ name: 'customTypeToto', type: 'Toto' }, { type: 'null' }],
 			path: 'name',
+			'talend.component.label': 'readable label',
 		};
 		expect(filterNullUnion(union)).toEqual({
 			name: union.name,
 			optional: true,
 			type: { type: 'Toto', name: 'customTypeToto' },
 			path: union.path,
+			'talend.component.label': 'readable label',
 		});
 	});
 	it('should return an array of type without null value and parent name / path ', () => {
@@ -136,6 +144,7 @@ describe('#filterOptionalUnion', () => {
 			name: 'name',
 			path: 'name',
 			type: [{ type: 'Toto' }, { type: 'Tata' }, { type: 'null' }],
+			'talend.component.label': 'readable label',
 		};
 		expect(filterNullUnion(union)).toEqual({
 			name: union.name,
@@ -145,6 +154,7 @@ describe('#filterOptionalUnion', () => {
 				{ type: 'Toto', name: union.name, path: union.path },
 				{ type: 'Tata', name: union.name, path: union.path },
 			],
+			'talend.component.label': 'readable label',
 		});
 	});
 });

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import isNull from 'lodash/isNull';
+import get from 'lodash/get';
 import DefaultValueRenderer from './DefaultValueRenderer.component';
 import theme from './SimpleTextKeyValue.scss';
 
@@ -126,7 +127,7 @@ const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
 		>
 			{!isNull(formattedKey) && (
 				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
-					{formattedKey}
+					{get(schema, 'talend.component.label', formattedKey)}
 					{separator}
 					{displayTypes && schema && value && (
 						<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
@@ -27,7 +27,8 @@ describe('SimpleTextKeyValue', () => {
 				style={{ padding: 0 }}
 			/>,
 		);
-		expect(wrapper.getElement()).toMatchSnapshot();
+
+		expect(wrapper.find('.tc-simple-text-key').text()).toBe('readable value : ');
 	});
 	it('should render the value by the datagrid avroRenderer', () => {
 		const schema = {

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
@@ -15,6 +15,20 @@ describe('SimpleTextKeyValue', () => {
 		);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+
+	it('should render the key by the talend.component.label property', () => {
+		const wrapper = shallow(
+			<SimpleTextKeyValue
+				className="myCLass"
+				formattedKey="non readable value"
+				schema={{ 'talend.component.label': 'readable value' }}
+				value="myValue"
+				separator=" : "
+				style={{ padding: 0 }}
+			/>,
+		);
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
 	it('should render the value by the datagrid avroRenderer', () => {
 		const schema = {
 			type: {

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -49,31 +49,3 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
   </span>
 </span>
 `;
-
-exports[`SimpleTextKeyValue should render the key by the talend.component.label property 1`] = `
-<span
-  className="theme-tc-simple-text tc-simple-text myCLass"
-  style={
-    Object {
-      "padding": 0,
-    }
-  }
->
-  <span
-    className="theme-tc-simple-text-key tc-simple-text-key"
-  >
-    readable value
-     : 
-  </span>
-  <AvroRenderer
-    colDef={
-      Object {
-        "avro": Object {
-          "talend.component.label": "readable value",
-        },
-      }
-    }
-    data="myValue"
-  />
-</span>
-`;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -49,3 +49,31 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
   </span>
 </span>
 `;
+
+exports[`SimpleTextKeyValue should render the key by the talend.component.label property 1`] = `
+<span
+  className="theme-tc-simple-text tc-simple-text myCLass"
+  style={
+    Object {
+      "padding": 0,
+    }
+  }
+>
+  <span
+    className="theme-tc-simple-text-key tc-simple-text-key"
+  >
+    readable value
+     : 
+  </span>
+  <AvroRenderer
+    colDef={
+      Object {
+        "avro": Object {
+          "talend.component.label": "readable value",
+        },
+      }
+    }
+    data="myValue"
+  />
+</span>
+`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the schema provides a new property talend.component.label to show the label for a row

**What is the chosen solution to this problem?**
handle this property

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
