### PR TITLE
feat(component): Allow to customize RecordsViewer types render

### DIFF
--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -91,6 +91,18 @@ stories
 				</div>
 			</Provider>
 		);
+	})
+	.add('DataTree with type display on records', () => {
+		return (
+			<div style={{ height: '100%' }}>
+				<RecordsViewer
+					componentId="RecordsViewer"
+					sample={hierarchicSample}
+					displayTypes
+					typesRenderer={schema => <>- of type {schema.type[0].type}</>}
+				/>
+			</div>
+		);
 	});
 
 /**

--- a/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Branch/__snapshots__/ModelViewerBranch.test.js.snap
@@ -25,6 +25,7 @@ exports[`ModelViewerBranch render ModelViewerBranch 1`] = `
       formattedKey="myValueValue"
       formattedValue="myKeyValue"
       separator=" "
+      typesRenderer={[Function]}
     />
   </span>
 </div>
@@ -55,6 +56,7 @@ exports[`ModelViewerBranch render ModelViewerBranch as a union 1`] = `
       formattedKey="myValueValue"
       formattedValue="({...})"
       separator=" "
+      typesRenderer={[Function]}
     />
   </span>
 </div>

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
@@ -14,6 +14,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf 1`] = `
     displayTypes={false}
     formattedKey="toto"
     separator=" "
+    typesRenderer={[Function]}
     value=""
   />
   <span
@@ -35,6 +36,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf highlighted 1`] = `
   <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     separator=" "
+    typesRenderer={[Function]}
     value="(typeSem)*"
   />
   <span
@@ -56,6 +58,7 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf with additional data 1`] 
   <ForwardRef(SimpleTextKeyValue)
     displayTypes={false}
     separator=" "
+    typesRenderer={[Function]}
     value="(typeSem)*"
   />
   <span

--- a/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Leaf/RecordsViewerLeaf.component.js
@@ -15,6 +15,7 @@ export function RecordsViewerLeaf({
 	className,
 	nodeHighlighted,
 	displayTypes,
+	typesRenderer,
 	measure,
 	t,
 }) {
@@ -70,6 +71,7 @@ export function RecordsViewerLeaf({
 				value={value.data}
 				schema={value.schema}
 				displayTypes={displayTypes}
+				typesRenderer={typesRenderer}
 				isValueOverflown={isValueOverflown}
 				isLongValueToggled={isLongValueExpanded}
 			/>
@@ -87,6 +89,7 @@ RecordsViewerLeaf.propTypes = {
 	}),
 	renderLeafAdditionalValue: PropTypes.func,
 	displayTypes: PropTypes.bool,
+	typesRenderer: PropTypes.func,
 	measure: PropTypes.func.isRequired,
 	t: PropTypes.func,
 };

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -123,7 +123,7 @@ const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
 	if (displayTypes && schema && value) {
 		types = (
 			<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>
-				{typesRenderer ? typesRenderer(schema) : `- ${schema.type.type}`}
+				{typesRenderer(schema)}
 			</span>
 		);
 	}
@@ -180,6 +180,7 @@ SimpleTextKeyValue.propTypes = {
 
 SimpleTextKeyValue.defaultProps = {
 	displayTypes: false,
+	typesRenderer: schema => `- ${schema.type.type}`,
 };
 
 export default SimpleTextKeyValue;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -113,11 +113,21 @@ const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
 		style,
 		value,
 		displayTypes,
+		typesRenderer,
 		isValueOverflown,
 		isLongValueToggled,
 	},
 	ref,
 ) {
+	let types;
+	if (displayTypes && schema && value) {
+		types = (
+			<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>
+				{typesRenderer ? typesRenderer(schema) : `- ${schema.type.type}`}
+			</span>
+		);
+	}
+
 	return (
 		<span
 			ref={ref}
@@ -128,11 +138,7 @@ const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
 				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
 					{formattedKey}
 					{separator}
-					{displayTypes && schema && value && (
-						<span className={classNames(theme['tc-simple-text-type'], 'tc-simple-text-type')}>
-							- {schema.type.type || value.unionKey}
-						</span>
-					)}
+					{types}
 				</span>
 			)}
 			{!schema && value && (
@@ -167,6 +173,7 @@ SimpleTextKeyValue.propTypes = {
 	separator: PropTypes.string,
 	style: PropTypes.object,
 	displayTypes: PropTypes.bool,
+	typesRenderer: PropTypes.func,
 	isValueOverflown: PropTypes.bool,
 	isLongValueToggled: PropTypes.bool,
 };

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
@@ -49,4 +49,45 @@ describe('SimpleTextKeyValue', () => {
 		const wrapper = shallow(<SimpleTextKeyValue value="myValue" />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+	it('should render the type', () => {
+		const schema = {
+			type: {
+				type: 'int',
+			},
+		};
+		const data = {
+			value: '',
+		};
+		const wrapper = shallow(
+			<SimpleTextKeyValue
+				className="myCLass"
+				formattedKey="myKey"
+				value={data}
+				schema={schema}
+				displayTypes
+			/>,
+		);
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+	it('should render the type with a custom render', () => {
+		const schema = {
+			type: {
+				type: 'int',
+			},
+		};
+		const data = {
+			value: '',
+		};
+		const wrapper = shallow(
+			<SimpleTextKeyValue
+				className="myCLass"
+				formattedKey="myKey"
+				value={data}
+				schema={schema}
+				displayTypes
+				typesRenderer={s => <span>And the type is {s.type.type}</span>}
+			/>,
+		);
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
 });

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
@@ -88,6 +88,6 @@ describe('SimpleTextKeyValue', () => {
 				typesRenderer={s => <span>And the type is {s.type.type}</span>}
 			/>,
 		);
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.find('.tc-simple-text-type').text()).toBe('And the type is int');
 	});
 });

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.test.js
@@ -67,7 +67,7 @@ describe('SimpleTextKeyValue', () => {
 				displayTypes
 			/>,
 		);
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.find('.tc-simple-text-type').text()).toBe('- int');
 	});
 	it('should render the type with a custom render', () => {
 		const schema = {

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -49,39 +49,3 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
   </span>
 </span>
 `;
-
-exports[`SimpleTextKeyValue should render the type with a custom render 1`] = `
-<span
-  className="theme-tc-simple-text tc-simple-text myCLass"
->
-  <span
-    className="theme-tc-simple-text-key tc-simple-text-key"
-  >
-    myKey
-    <span
-      className="theme-tc-simple-text-type tc-simple-text-type"
-    >
-      <span>
-        And the type is 
-        int
-      </span>
-    </span>
-  </span>
-  <AvroRenderer
-    colDef={
-      Object {
-        "avro": Object {
-          "type": Object {
-            "type": "int",
-          },
-        },
-      }
-    }
-    data={
-      Object {
-        "value": "",
-      }
-    }
-  />
-</span>
-`;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -49,3 +49,72 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
   </span>
 </span>
 `;
+
+exports[`SimpleTextKeyValue should render the type 1`] = `
+<span
+  className="theme-tc-simple-text tc-simple-text myCLass"
+>
+  <span
+    className="theme-tc-simple-text-key tc-simple-text-key"
+  >
+    myKey
+    <span
+      className="theme-tc-simple-text-type tc-simple-text-type"
+    >
+      - int
+    </span>
+  </span>
+  <AvroRenderer
+    colDef={
+      Object {
+        "avro": Object {
+          "type": Object {
+            "type": "int",
+          },
+        },
+      }
+    }
+    data={
+      Object {
+        "value": "",
+      }
+    }
+  />
+</span>
+`;
+
+exports[`SimpleTextKeyValue should render the type with a custom render 1`] = `
+<span
+  className="theme-tc-simple-text tc-simple-text myCLass"
+>
+  <span
+    className="theme-tc-simple-text-key tc-simple-text-key"
+  >
+    myKey
+    <span
+      className="theme-tc-simple-text-type tc-simple-text-type"
+    >
+      <span>
+        And the type is 
+        int
+      </span>
+    </span>
+  </span>
+  <AvroRenderer
+    colDef={
+      Object {
+        "avro": Object {
+          "type": Object {
+            "type": "int",
+          },
+        },
+      }
+    }
+    data={
+      Object {
+        "value": "",
+      }
+    }
+  />
+</span>
+`;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -50,39 +50,6 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
 </span>
 `;
 
-exports[`SimpleTextKeyValue should render the type 1`] = `
-<span
-  className="theme-tc-simple-text tc-simple-text myCLass"
->
-  <span
-    className="theme-tc-simple-text-key tc-simple-text-key"
-  >
-    myKey
-    <span
-      className="theme-tc-simple-text-type tc-simple-text-type"
-    >
-      - int
-    </span>
-  </span>
-  <AvroRenderer
-    colDef={
-      Object {
-        "avro": Object {
-          "type": Object {
-            "type": "int",
-          },
-        },
-      }
-    }
-    data={
-      Object {
-        "value": "",
-      }
-    }
-  />
-</span>
-`;
-
 exports[`SimpleTextKeyValue should render the type with a custom render 1`] = `
 <span
   className="theme-tc-simple-text tc-simple-text myCLass"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can choose to display or not type of data. But we can't customise it.

**What is the chosen solution to this problem?**
Add the possibility to use a custom render to display types.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
