### PR TITLE
fix(steppers): show actions when the steppers has aborted steps

### DIFF
--- a/packages/components/src/Stepper/Stepper.component.js
+++ b/packages/components/src/Stepper/Stepper.component.js
@@ -39,8 +39,7 @@ export const isErrorInSteps = steps =>
 export const isAllSuccessful = steps =>
 	steps.every(
 		step =>
-			step.status === LOADING_STEP_STATUSES.SUCCESS ||
-			step.status === LOADING_STEP_STATUSES.ABORTED,
+			[LOADING_STEP_STATUSES.SUCCESS, LOADING_STEP_STATUSES.ABORTED].includes(step.status)
 	);
 
 /**

--- a/packages/components/src/Stepper/Stepper.component.js
+++ b/packages/components/src/Stepper/Stepper.component.js
@@ -25,6 +25,8 @@ export const LOADING_STEP_STATUSES = {
 	FAILURE: 'failure',
 };
 
+const isStepAborted = steps => steps.some(step => step.status === LOADING_STEP_STATUSES.ABORTED);
+
 /**
  * This function tells if there is an error in the steps
  * @param {array} steps array of steps
@@ -44,7 +46,7 @@ export const isAllSuccessful = steps =>
  * @param {array} steps array of steps
  */
 export const isStepsLoading = steps =>
-	steps.length !== 0 && !isAllSuccessful(steps) && !isErrorInSteps(steps);
+	steps.length !== 0 && !isAllSuccessful(steps) && !isErrorInSteps(steps) && !isStepAborted(steps);
 
 /**
  * This function returns a label for some status
@@ -149,6 +151,7 @@ const transitionEmptyToLoading = transition(TRANSITION_STATE.STEPS, DEFAULT_TRAN
 
 function Stepper({ steps, title, renderActions, children }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
+	const stepAborted = isStepAborted(steps);
 	const isInError = isErrorInSteps(steps);
 	const [transitionState, setTransitionState] = useState(
 		isStepsLoading(steps) || !children ? TRANSITION_STATE.STEPS : TRANSITION_STATE.CHILD,
@@ -179,15 +182,15 @@ function Stepper({ steps, title, renderActions, children }) {
 				<div className={getClass('stepper')}>
 					<div
 						className={getClass('loading-content-steps', {
-							'stepper-content-error': isInError,
+							'stepper-content-error': isInError || stepAborted,
 						})}
 					>
 						{title && <h2>{title}</h2>}
 						<ol className={getClass('stepper-steps')}>
 							{steps.map((step, index, array) => showStep(t, step, index, array))}
 						</ol>
-						{renderActions && renderActions(isInError) ? (
-							<div>{renderActions(isInError)}</div>
+						{renderActions && renderActions(isInError || stepAborted) ? (
+							<div>{renderActions(isInError || stepAborted)}</div>
 						) : null}
 					</div>
 				</div>

--- a/packages/components/src/Stepper/Stepper.component.js
+++ b/packages/components/src/Stepper/Stepper.component.js
@@ -25,8 +25,6 @@ export const LOADING_STEP_STATUSES = {
 	FAILURE: 'failure',
 };
 
-const isStepAborted = steps => steps.some(step => step.status === LOADING_STEP_STATUSES.ABORTED);
-
 /**
  * This function tells if there is an error in the steps
  * @param {array} steps array of steps
@@ -39,14 +37,18 @@ export const isErrorInSteps = steps =>
  * @param {array} steps array of steps
  */
 export const isAllSuccessful = steps =>
-	steps.every(step => step.status === LOADING_STEP_STATUSES.SUCCESS);
+	steps.every(
+		step =>
+			step.status === LOADING_STEP_STATUSES.SUCCESS ||
+			step.status === LOADING_STEP_STATUSES.ABORTED,
+	);
 
 /**
  * This function tells if the loading is done, by an error, a success ot not started
  * @param {array} steps array of steps
  */
 export const isStepsLoading = steps =>
-	steps.length !== 0 && !isAllSuccessful(steps) && !isErrorInSteps(steps) && !isStepAborted(steps);
+	steps.length !== 0 && !isAllSuccessful(steps) && !isErrorInSteps(steps);
 
 /**
  * This function returns a label for some status
@@ -151,7 +153,6 @@ const transitionEmptyToLoading = transition(TRANSITION_STATE.STEPS, DEFAULT_TRAN
 
 function Stepper({ steps, title, renderActions, children }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
-	const stepAborted = isStepAborted(steps);
 	const isInError = isErrorInSteps(steps);
 	const [transitionState, setTransitionState] = useState(
 		isStepsLoading(steps) || !children ? TRANSITION_STATE.STEPS : TRANSITION_STATE.CHILD,
@@ -182,15 +183,15 @@ function Stepper({ steps, title, renderActions, children }) {
 				<div className={getClass('stepper')}>
 					<div
 						className={getClass('loading-content-steps', {
-							'stepper-content-error': isInError || stepAborted,
+							'stepper-content-error': isInError,
 						})}
 					>
 						{title && <h2>{title}</h2>}
 						<ol className={getClass('stepper-steps')}>
 							{steps.map((step, index, array) => showStep(t, step, index, array))}
 						</ol>
-						{renderActions && renderActions(isInError || stepAborted) ? (
-							<div>{renderActions(isInError || stepAborted)}</div>
+						{renderActions && renderActions(isInError) ? (
+							<div>{renderActions(isInError)}</div>
 						) : null}
 					</div>
 				</div>

--- a/packages/components/src/Stepper/Stepper.component.test.js
+++ b/packages/components/src/Stepper/Stepper.component.test.js
@@ -51,7 +51,7 @@ describe('Stepper Component', () => {
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 
-		it('should render when there is an aborted in the steps', () => {
+		it('should render as ended when there is an aborted step', () => {
 			// given
 			const title = 'Test';
 			const steps = [

--- a/packages/components/src/Stepper/Stepper.component.test.js
+++ b/packages/components/src/Stepper/Stepper.component.test.js
@@ -50,5 +50,28 @@ describe('Stepper Component', () => {
 			expect(renderActions).toHaveBeenCalledWith(true);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
+
+		it('should render when there is an aborted in the steps', () => {
+			// given
+			const title = 'Test';
+			const steps = [
+				{
+					label: 'Fetch Sample',
+					status: LOADING_STEP_STATUSES.SUCCESS,
+				},
+				{ label: 'Flattening', status: LOADING_STEP_STATUSES.ABORTED },
+				{ label: 'Column Quality', status: LOADING_STEP_STATUSES.ABORTED },
+			];
+			const renderActions = jest.fn();
+			// when
+			const wrapper = shallow(
+				<Stepper steps={steps} title={title} renderActions={renderActions}>
+					Import successfull
+				</Stepper>,
+			);
+			// then
+			expect(renderActions).toHaveBeenCalledWith(true);
+			expect(wrapper.getElement()).toMatchSnapshot();
+		});
 	});
 });

--- a/packages/components/src/Stepper/Stepper.component.test.js
+++ b/packages/components/src/Stepper/Stepper.component.test.js
@@ -70,7 +70,7 @@ describe('Stepper Component', () => {
 				</Stepper>,
 			);
 			// then
-			expect(renderActions).toHaveBeenCalledWith(true);
+			expect(renderActions).toHaveBeenCalledWith(false);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
 	});

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -73,7 +73,7 @@ stories
 		];
 		return (
 			<Stepper steps={steps} title={title} renderActions={renderActions}>
-				Steppers finished
+				Stepper finished
 			</Stepper>
 		);
 	})

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -71,7 +71,11 @@ stories
 			},
 			{ label: 'Flattening', status: LOADING_STEP_STATUSES.ABORTED },
 		];
-		return <Stepper steps={steps} title={title} renderActions={renderActions} >Steppers finished</Stepper>;
+		return (
+			<Stepper steps={steps} title={title} renderActions={renderActions}>
+				Steppers finished
+			</Stepper>
+		);
 	})
 	.add('Stepper without steps', () => (
 		<Stepper title={title} renderActions={renderActions}>

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -62,6 +62,17 @@ stories
 		];
 		return <Stepper steps={steps} title={title} renderActions={renderActions} />;
 	})
+	.add('Stepper with aborted step', () => {
+		const steps = [
+			{
+				label: 'Fetch Sample',
+				status: LOADING_STEP_STATUSES.SUCCESS,
+				message: { label: 'Everything is fine 🔥🐶' },
+			},
+			{ label: 'Flattening', status: LOADING_STEP_STATUSES.ABORTED },
+		];
+		return <Stepper steps={steps} title={title} renderActions={renderActions} />;
+	})
 	.add('Stepper without steps', () => (
 		<Stepper title={title} renderActions={renderActions}>
 			<p>No step to display here, it means content is already loaded.</p>

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -71,7 +71,7 @@ stories
 			},
 			{ label: 'Flattening', status: LOADING_STEP_STATUSES.ABORTED },
 		];
-		return <Stepper steps={steps} title={title} renderActions={renderActions} />;
+		return <Stepper steps={steps} title={title} renderActions={renderActions} >Steppers finished</Stepper>;
 	})
 	.add('Stepper without steps', () => (
 		<Stepper title={title} renderActions={renderActions}>

--- a/packages/components/src/Stepper/__snapshots__/Stepper.component.test.js.snap
+++ b/packages/components/src/Stepper/__snapshots__/Stepper.component.test.js.snap
@@ -1,5 +1,75 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Stepper Component render should render when there is an aborted in the steps 1`] = `
+<React.Fragment>
+  <StepperTransition
+    active={true}
+  >
+    Import successfull
+  </StepperTransition>
+  <StepperTransition
+    active={false}
+  >
+    <div
+      className="stepper theme-stepper"
+    >
+      <div
+        className="loading-content-steps theme-loading-content-steps stepper-content-error theme-stepper-content-error"
+      >
+        <h2>
+          Test
+        </h2>
+        <ol
+          className="stepper-steps theme-stepper-steps"
+        >
+          <li
+            className="stepper-step theme-stepper-step stepper-step-success theme-stepper-step-success"
+          >
+            <div
+              className="stepper-step-infos theme-stepper-step-infos"
+            >
+              <Icon
+                className="stepper-icon-success theme-stepper-icon-success stepper-icon theme-stepper-icon"
+                name="talend-check"
+              />
+              Fetch Sample
+            </div>
+          </li>
+          <li
+            className="stepper-step theme-stepper-step stepper-step-aborted theme-stepper-step-aborted"
+          >
+            <div
+              className="stepper-step-infos theme-stepper-step-infos"
+            >
+              <Icon
+                className="stepper-icon-aborted theme-stepper-icon-aborted stepper-icon theme-stepper-icon"
+                name="talend-cross"
+              />
+              Flattening
+               (Aborted)
+            </div>
+          </li>
+          <li
+            className="stepper-step theme-stepper-step stepper-step-aborted theme-stepper-step-aborted"
+          >
+            <div
+              className="stepper-step-infos theme-stepper-step-infos"
+            >
+              <Icon
+                className="stepper-icon-aborted theme-stepper-icon-aborted stepper-icon theme-stepper-icon"
+                name="talend-cross"
+              />
+              Column Quality
+               (Aborted)
+            </div>
+          </li>
+        </ol>
+      </div>
+    </div>
+  </StepperTransition>
+</React.Fragment>
+`;
+
 exports[`Stepper Component render should render when there is an errors in the steps 1`] = `
 <React.Fragment>
   <StepperTransition

--- a/packages/components/src/Stepper/__snapshots__/Stepper.component.test.js.snap
+++ b/packages/components/src/Stepper/__snapshots__/Stepper.component.test.js.snap
@@ -14,7 +14,7 @@ exports[`Stepper Component render should render when there is an aborted in the 
       className="stepper theme-stepper"
     >
       <div
-        className="loading-content-steps theme-loading-content-steps stepper-content-error theme-stepper-content-error"
+        className="loading-content-steps theme-loading-content-steps"
       >
         <h2>
           Test


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the steppers has the state LOADING if a step is aborted

**What is the chosen solution to this problem?**

consider the step like successful when a step is aborted

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
