### PR TITLE
feat(TDC-3908): Add badge tags in faceted-search

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Added
+
+- [feat](https://github.com/Talend/ui/pull/2828): Add badge tags support
+
 ## [0.9.1]
 
 ### Fixed

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
@@ -44,6 +44,7 @@ exports[`BadgeFaceted should render the html output by default 1`] = `
     <button role="button"
             aria-label="Remove filter"
             id="tc-badge-delete-my-id"
+            data-feature="filter.remove"
             aria-describedby="42"
             type="button"
             class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -45,17 +45,21 @@ export const BadgeTags = ({
 	useEffect(() => {
 		if (!callbacks.getTags) {
 			console.warn("get tags callback is not defined, tags can't be fetch from server");
+			return;
 		}
 
 		setIsLoading(true);
-		callbacks.getTags().then(data => {
-			setTagsValues(data.map(item => ({ id: item, label: item })));
-			setIsLoading(false);
-		});
+		callbacks
+			.getTags()
+			.then(data => {
+				setTagsValues(data.map(item => ({ id: item, label: item })));
+			})
+			.finally(() => {
+				setIsLoading(false);
+			});
 	}, []);
 
-	const currentOperators = useMemo(() => operators, [operators]);
-	const currentOperator = operator || (currentOperators && currentOperators[0]);
+	const currentOperator = operator || (operators && operators[0]);
 	const badgeTagsId = `${id}-badge-tags`;
 	const badgeLabel = useMemo(() => getSelectBadgeLabel(value, t), [value, t]);
 	return (
@@ -67,7 +71,7 @@ export const BadgeTags = ({
 			labelCategory={label}
 			labelValue={badgeLabel}
 			operator={currentOperator}
-			operators={currentOperators}
+			operators={operators}
 			size={size}
 			t={t}
 			value={value || []}

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -1,0 +1,112 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import PropTypes from 'prop-types';
+import Badge from '@talend/react-components/lib/Badge';
+import { BadgeTagsForm } from './BadgeTagsForm.component';
+import { BadgeFaceted } from '../BadgeFaceted';
+import {
+	callbacksPropTypes,
+	operatorPropTypes,
+	operatorsPropTypes,
+} from '../../facetedSearch.propTypes';
+
+const getSelectBadgeLabel = (value, t) => {
+	const labelAll = t('FACETED_SEARCH_VALUE_ALL', { defaultValue: 'All' });
+	if (value) {
+		const checkedCheckboxes = value.filter(v => v.checked);
+		if (checkedCheckboxes.length > 3) {
+			return t('FACETED_SEARCH_VALUES_COUNT', {
+				count: checkedCheckboxes.length,
+				defaultValue: '{{count}} values',
+			});
+		} else if (!checkedCheckboxes.length) {
+			return labelAll;
+		}
+		return checkedCheckboxes.map(val => val.label);
+	}
+	return labelAll;
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export const BadgeTags = ({
+	id,
+	label,
+	initialOperatorOpened,
+	initialValueOpened,
+	operator,
+	operators,
+	size,
+	value,
+	category,
+	callbacks,
+	t,
+}) => {
+	const [tagsValues, setTagsValues] = useState([]);
+	const [isLoading, setIsLoading] = useState(true);
+	useEffect(() => {
+		if (!callbacks.getTags) {
+			console.warn("get tags callback is not defined, tags can't be fetch from server");
+		}
+
+		setIsLoading(true);
+		callbacks.getTags().then(data => {
+			setTagsValues(data.map(item => ({ id: item, label: item })));
+			setIsLoading(false);
+		});
+	}, []);
+
+	const currentOperators = useMemo(() => operators, [operators]);
+	const currentOperator = operator || (currentOperators && currentOperators[0]);
+	const badgeTagsId = `${id}-badge-tags`;
+	const badgeLabel = useMemo(() => getSelectBadgeLabel(value, t), [value, t]);
+	return (
+		<BadgeFaceted
+			badgeId={id}
+			id={badgeTagsId}
+			initialOperatorOpened={initialOperatorOpened}
+			initialValueOpened={initialValueOpened}
+			labelCategory={label}
+			labelValue={badgeLabel}
+			operator={currentOperator}
+			operators={currentOperators}
+			size={size}
+			t={t}
+			value={value || []}
+		>
+			{({ onSubmitBadge, onChangeValue, badgeValue }) => (
+				<BadgeTagsForm
+					id={badgeTagsId}
+					onChange={onChangeValue}
+					onSubmit={onSubmitBadge}
+					value={badgeValue}
+					tagsValues={tagsValues}
+					feature={category || label}
+					isLoading={isLoading}
+					t={t}
+				/>
+			)}
+		</BadgeFaceted>
+	);
+};
+
+BadgeTags.propTypes = {
+	label: PropTypes.string.isRequired,
+	id: PropTypes.string.isRequired,
+	initialOperatorOpened: PropTypes.bool,
+	initialValueOpened: PropTypes.bool,
+	operator: operatorPropTypes,
+	operators: operatorsPropTypes,
+	size: PropTypes.oneOf(Object.values(Badge.SIZES)),
+	category: PropTypes.string,
+	value: PropTypes.oneOfType([
+		PropTypes.string,
+		PropTypes.arrayOf(
+			PropTypes.shape({
+				checked: PropTypes.bool,
+				id: PropTypes.string.isRequired,
+				label: PropTypes.string.isRequired,
+			}),
+		),
+	]),
+	callbacks: callbacksPropTypes,
+	t: PropTypes.func.isRequired,
+};

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
@@ -1,10 +1,10 @@
 .fs-badge-tags-form {
 	:global(.tc-tooltip-body) {
-		margin: 1.2rem 0 0;
-		padding: 0.5rem 2rem 2rem;
+		margin: $padding-normal 0 0;
+		padding: $padding-smaller $padding-large $padding-large;
 		overflow-y: auto;
 		background: #fcfcfc;
-		border-top: 0.1rem solid #ededed;
+		border-top: 1px solid $gallery;
 	}
 
 	&-body {

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
@@ -1,0 +1,49 @@
+.fs-badge-tags-form {
+  :global(.tc-tooltip-body) {
+    margin: 1.2rem 0 0;
+    padding: 0.5rem 2rem 2rem;
+    overflow-y: auto;
+    background: #fcfcfc;
+    border-top: 0.1rem solid #ededed;
+  }
+
+  &-body {
+    width: inherit;
+  }
+
+  &-content {
+    display: flex;
+  }
+
+  &-empty {
+    font-size: $font-size-base;
+    align-self: center;
+    margin: 4rem 0;
+    text-align: center;
+    font-style: italic;
+  }
+
+  &-footer {
+    display: flex;
+    justify-content: flex-end;
+  }
+
+  &-left-button,
+  &-left-button:focus{
+    text-transform: none;
+    color: $st-tropaz;
+    font-weight: 600;
+  }
+
+  &-loading {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 24rem;
+    min-width: 34rem;
+  }
+
+  :global(.tc-tooltip-content) {
+    flex-direction: column;
+  }
+}

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.scss
@@ -1,49 +1,49 @@
 .fs-badge-tags-form {
-  :global(.tc-tooltip-body) {
-    margin: 1.2rem 0 0;
-    padding: 0.5rem 2rem 2rem;
-    overflow-y: auto;
-    background: #fcfcfc;
-    border-top: 0.1rem solid #ededed;
-  }
+	:global(.tc-tooltip-body) {
+		margin: 1.2rem 0 0;
+		padding: 0.5rem 2rem 2rem;
+		overflow-y: auto;
+		background: #fcfcfc;
+		border-top: 0.1rem solid #ededed;
+	}
 
-  &-body {
-    width: inherit;
-  }
+	&-body {
+		width: inherit;
+	}
 
-  &-content {
-    display: flex;
-  }
+	&-content {
+		display: flex;
+	}
 
-  &-empty {
-    font-size: $font-size-base;
-    align-self: center;
-    margin: 4rem 0;
-    text-align: center;
-    font-style: italic;
-  }
+	&-empty {
+		font-size: $font-size-base;
+		align-self: center;
+		margin: 4rem 0;
+		text-align: center;
+		font-style: italic;
+	}
 
-  &-footer {
-    display: flex;
-    justify-content: flex-end;
-  }
+	&-footer {
+		display: flex;
+		justify-content: flex-end;
+	}
 
-  &-left-button,
-  &-left-button:focus{
-    text-transform: none;
-    color: $st-tropaz;
-    font-weight: 600;
-  }
+	&-left-button,
+	&-left-button:focus {
+		text-transform: none;
+		color: $st-tropaz;
+		font-weight: 600;
+	}
 
-  &-loading {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    min-height: 24rem;
-    min-width: 34rem;
-  }
+	&-loading {
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		min-height: 24rem;
+		min-width: 34rem;
+	}
 
-  :global(.tc-tooltip-content) {
-    flex-direction: column;
-  }
+	:global(.tc-tooltip-content) {
+		flex-direction: column;
+	}
 }

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTagsForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTagsForm.component.js
@@ -1,0 +1,184 @@
+import React, { useState, useCallback, useMemo } from 'react';
+import PropTypes from 'prop-types';
+import get from 'lodash/get';
+import Action from '@talend/react-components/lib/Actions/Action';
+import FilterBar from '@talend/react-components/lib/FilterBar';
+import RichLayout from '@talend/react-components/lib/RichTooltip/RichLayout';
+import Loader from '@talend/react-components/lib/Loader';
+import { CIRCULAR_PROGRESS_SIZE } from '@talend/react-components/lib/constants';
+import { Checkbox } from '@talend/react-components/lib/Toggle';
+import { getTheme } from '@talend/react-components/lib/theme';
+import cssModule from './BadgeTags.scss';
+import { getApplyDataFeature } from '../../../helpers/usage.helpers';
+
+const theme = getTheme(cssModule);
+
+const BadgeTag = ({ checked, id, label, onChange }) => {
+	const describedby = `${id}-${label}`;
+	const onChangeTag = event => {
+		onChange(event, id);
+	};
+	return (
+		<React.Fragment>
+			<Checkbox
+				onChange={onChangeTag}
+				aria-describedby={describedby}
+				id={`${id}-checkbox`}
+				label={label}
+				checked={checked}
+			/>
+			<div id={describedby} className="sr-only">
+				{label}
+			</div>
+		</React.Fragment>
+	);
+};
+
+BadgeTag.propTypes = {
+	id: PropTypes.string.isRequired,
+	label: PropTypes.string.isRequired,
+	onChange: PropTypes.func.isRequired,
+	checked: PropTypes.bool,
+};
+
+const createTagEntity = value => checkbox => {
+	const entity = value.find(v => v.id === checkbox.id);
+	return {
+		id: checkbox.id,
+		label: checkbox.label,
+		checked: entity ? entity.checked : checkbox.checked || false,
+	};
+};
+
+const getTags = (tagsValues, value, filterValue, showAll) => {
+	const formatFilterValue = filterValue.trim().toLocaleLowerCase();
+
+	return tagsValues
+		.filter(checkbox => get(checkbox, 'label', '').toLocaleLowerCase().includes(formatFilterValue))
+		.map(createTagEntity(value))
+		.filter(tag => (showAll ? true : tag.checked));
+};
+
+const BadgeTagsForm = ({ tagsValues, id, onChange, onSubmit, value, feature, isLoading, t }) => {
+	const [filter, setFilter] = useState('');
+	const [showAll, setShowAll] = useState(true);
+
+	const badgeTagsFormId = `${id}-tags-form`;
+	const tags = useCallback(getTags(tagsValues, value, filter, showAll), [
+		tagsValues,
+		value,
+		filter,
+		showAll,
+	]);
+	const tagsSelected = useCallback(
+		tags.filter(tag => tag.checked),
+		[tags],
+	);
+	const applyDataFeature = useMemo(() => getApplyDataFeature(feature), [feature]);
+
+	const onChangeTags = (event, checkboxId) => {
+		const entity = tags.find(checkboxValue => checkboxValue.id === checkboxId);
+		if (entity) {
+			entity.checked = event.target.checked;
+		}
+		onChange(
+			event,
+			tags.filter(c => c.checked),
+		);
+	};
+
+	const leftBtnLabel = showAll
+		? t('SELECTED_TAGS', { count: tagsSelected.length, defaultValue: '{{count}} selected' })
+		: t('SHOW_ALL_TAGS', { defaultValue: 'Show all' });
+
+	return (
+		<React.Fragment>
+			<FilterBar
+				autoFocus={false}
+				dockable={false}
+				docked={false}
+				iconAlwaysVisible
+				id={`${badgeTagsFormId}-filter`}
+				placeholder={t('FIND_TAG_FILTER_PLACEHOLDER', {
+					defaultValue: 'Find a tag',
+				})}
+				onToggle={() => setFilter('')}
+				onFilter={(_, filterValue) => setFilter(filterValue)}
+				value={filter}
+				disabled={isLoading}
+			/>
+			{isLoading && (
+				<div className={theme('fs-badge-tags-form-loading')}>
+					<Loader size={CIRCULAR_PROGRESS_SIZE.default} />
+				</div>
+			)}
+			{!isLoading && (
+				<form
+					className={theme('fs-badge-tags-form')}
+					id={`${badgeTagsFormId}-form`}
+					onSubmit={onSubmit}
+				>
+					<RichLayout.Body id={badgeTagsFormId} className={theme('fs-badge-tags-form-body')}>
+						{!tags.length && (
+							<span className={theme('fs-badge-tags-form-empty')}>
+								{t('TAG_FACET_NO_RESULT', {
+									defaultValue: 'No result found',
+								})}
+							</span>
+						)}
+
+						{tags.map(checkbox => (
+							<BadgeTag
+								key={checkbox.id}
+								id={checkbox.id}
+								onChange={onChangeTags}
+								label={checkbox.label}
+								checked={checkbox.checked}
+							/>
+						))}
+					</RichLayout.Body>
+					<RichLayout.Footer id={id} className={theme('fs-badge-tags-form-footer')}>
+						<div>
+							{tagsSelected.length > 0 && (
+								<Action
+									type="button"
+									onClick={() => setShowAll(!showAll)}
+									label={leftBtnLabel}
+									bsStyle="link"
+									className={theme('fs-badge-tags-form-left-button')}
+								/>
+							)}
+						</div>
+						<Action
+							data-feature={applyDataFeature}
+							type="submit"
+							label={t('APPLY', { defaultValue: 'Apply' })}
+							bsStyle="info"
+							disabled={tagsSelected.length === 0}
+						/>
+					</RichLayout.Footer>
+				</form>
+			)}
+		</React.Fragment>
+	);
+};
+
+BadgeTagsForm.propTypes = {
+	tagsValues: PropTypes.arrayOf(
+		PropTypes.shape({
+			checked: PropTypes.bool,
+			id: PropTypes.string.isRequired,
+			label: PropTypes.string.isRequired,
+		}),
+	),
+	id: PropTypes.string.isRequired,
+	onChange: PropTypes.func,
+	onSubmit: PropTypes.func.isRequired,
+	value: PropTypes.array,
+	feature: PropTypes.string.isRequired,
+	isLoading: PropTypes.bool.isRequired,
+	t: PropTypes.func.isRequired,
+};
+
+// eslint-disable-next-line import/prefer-default-export
+export { BadgeTagsForm };

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTagsForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTagsForm.component.js
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from 'react';
+import React, { useState, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 import Action from '@talend/react-components/lib/Actions/Action';
@@ -50,9 +50,7 @@ const createTagEntity = value => checkbox => {
 	};
 };
 
-const getTags = (tagsValues, value) => {
-	return tagsValues.map(createTagEntity(value));
-};
+const getTags = (tagsValues, value) => tagsValues.map(createTagEntity(value));
 
 const getVisibleTags = (tags, filterValue, showAll) => {
 	const formatFilterValue = filterValue.trim().toLocaleLowerCase();
@@ -68,8 +66,8 @@ const BadgeTagsForm = ({ tagsValues, id, onChange, onSubmit, value, feature, isL
 
 	const badgeTagsFormId = `${id}-tags-form`;
 
-	const tags = useCallback(getTags(tagsValues, value, filter), [tagsValues, value]);
-	const visibleTags = useCallback(getVisibleTags(tags, filter, showAll), [tags, filter, showAll]);
+	const tags = useMemo(() => getTags(tagsValues, value), [tagsValues, value]);
+	const visibleTags = useMemo(() => getVisibleTags(tags, filter, showAll), [tags, filter, showAll]);
 
 	const applyDataFeature = useMemo(() => getApplyDataFeature(feature), [feature]);
 
@@ -85,7 +83,7 @@ const BadgeTagsForm = ({ tagsValues, id, onChange, onSubmit, value, feature, isL
 	};
 
 	const leftBtnLabel = showAll
-		? t('SELECTED_TAGS', { count: value.length, defaultValue: '{{count}} selected' })
+		? t('NB_SELECTED_TAGS', { count: value.length, defaultValue: '{{count}} selected' })
 		: t('SHOW_ALL_TAGS', { defaultValue: 'Show all' });
 
 	return (
@@ -118,7 +116,7 @@ const BadgeTagsForm = ({ tagsValues, id, onChange, onSubmit, value, feature, isL
 					<RichLayout.Body id={badgeTagsFormId} className={theme('fs-badge-tags-form-body')}>
 						{!visibleTags.length && (
 							<span className={theme('fs-badge-tags-form-empty')}>
-								{t('TAG_FACET_NO_RESULT', {
+								{t('FIND_TAG_NO_RESULT', {
 									defaultValue: 'No result found',
 								})}
 							</span>

--- a/packages/faceted-search/src/components/Badges/BadgeTags/index.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/index.js
@@ -1,0 +1,4 @@
+import { BadgeTags } from './BadgeTags.component';
+
+// eslint-disable-next-line import/prefer-default-export
+export { BadgeTags };

--- a/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
@@ -44,6 +44,7 @@ exports[`BadgeText should mount a default badge 1`] = `
     <button role="button"
             aria-label="Remove filter"
             id="tc-badge-delete-myId-badge-text"
+            data-feature="filter.remove"
             aria-describedby="42"
             type="button"
             class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/BadgesGenerator/BadgesGenerator.component.js
+++ b/packages/faceted-search/src/components/BadgesGenerator/BadgesGenerator.component.js
@@ -4,7 +4,7 @@ import get from 'lodash/get';
 
 import { badgesFacetedPropTypes } from '../facetedSearch.propTypes';
 
-const BadgesGenerator = ({ badges, badgesDictionary, getBadgeFromDict, t }) =>
+const BadgesGenerator = ({ badges, badgesDictionary, getBadgeFromDict, callbacks, t }) =>
 	badges.reduce((acc, { properties, metadata }) => {
 		const BadgeComponent = getBadgeFromDict(badgesDictionary, get(properties, 'type'));
 		if (BadgeComponent) {
@@ -12,6 +12,7 @@ const BadgesGenerator = ({ badges, badgesDictionary, getBadgeFromDict, t }) =>
 				<BadgeComponent
 					{...metadata}
 					{...properties}
+					callbacks={callbacks}
 					id={metadata.badgeId}
 					key={metadata.badgeId}
 					t={t}

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -18,7 +18,11 @@ import {
 } from '../../dictionary/badge.dictionary';
 import { createOperatorsDict, getOperatorsFromDict } from '../../dictionary/operator.dictionary';
 import { useFacetedBadges, BADGES_ACTIONS } from '../../hooks/facetedBadges.hook';
-import { badgesFacetedPropTypes, operatorsPropTypes } from '../facetedSearch.propTypes';
+import {
+	badgesFacetedPropTypes,
+	callbacksPropTypes,
+	operatorsPropTypes,
+} from '../facetedSearch.propTypes';
 
 import theme from './BasicSearch.scss';
 import { USAGE_TRACKING_TAGS } from '../../constants';
@@ -35,6 +39,7 @@ const BasicSearch = ({
 	initialFilterValue,
 	onSubmit,
 	setBadgesFaceted,
+	callbacks,
 }) => {
 	const { id, t } = useFacetedSearchContext();
 	const operatorsDictionary = useMemo(() => createOperatorsDict(t, customOperatorsDictionary));
@@ -69,6 +74,7 @@ const BasicSearch = ({
 						badgesDictionary={badgesDictionary}
 						getBadgeFromDict={getBadgesFromDict}
 						id={basicSearchId}
+						callbacks={callbacks}
 						t={t}
 					/>
 				</BadgeFacetedProvider>
@@ -117,6 +123,7 @@ BasicSearch.propTypes = {
 	initialFilterValue: PropTypes.string,
 	onSubmit: PropTypes.func.isRequired,
 	setBadgesFaceted: PropTypes.func,
+	callbacks: callbacksPropTypes,
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -96,6 +96,7 @@ exports[`BasicSearch should render the default html output with some badges 1`] 
         <button role="button"
                 aria-label="Remove filter"
                 id="tc-badge-delete-name-7bc9bd07-3b46-4b8c-a406-a08b6263de5b-badge-text"
+                data-feature="filter.remove"
                 aria-describedby="42"
                 type="button"
                 class="tc-badge-delete-icon theme-tc-badge-delete-icon btn-icon-only btn btn-link"

--- a/packages/faceted-search/src/components/facetedSearch.propTypes.js
+++ b/packages/faceted-search/src/components/facetedSearch.propTypes.js
@@ -42,6 +42,10 @@ const badgeFacetedPropTypes = PropTypes.shape({
 
 const badgesFacetedPropTypes = PropTypes.arrayOf(badgeFacetedPropTypes);
 
+const callbacksPropTypes = PropTypes.shape({
+	getTags: PropTypes.func,
+});
+
 export {
 	badgeDefinitionRawDataPropTypes,
 	badgesDefinitionsRawDataPropTypes,
@@ -49,4 +53,5 @@ export {
 	badgesFacetedPropTypes,
 	operatorPropTypes,
 	operatorsPropTypes,
+	callbacksPropTypes,
 };

--- a/packages/faceted-search/src/dictionary/badge.dictionary.js
+++ b/packages/faceted-search/src/dictionary/badge.dictionary.js
@@ -1,17 +1,20 @@
 import { BadgeText } from '../components/Badges/BadgeText/BadgeText.component';
 import { BadgeCheckboxes } from '../components/Badges/BadgeCheckboxes/BadgeCheckboxes.component';
 import { BadgeNumber } from '../components/Badges/BadgeNumber/BadgeNumber.component';
+import { BadgeTags } from '../components/Badges/BadgeTags/BadgeTags.component';
 
 const standardBadgeTypeNames = {
 	text: 'text',
 	checkbox: 'checkbox',
 	number: 'number',
+	tags: 'tags',
 };
 
 const standardBadges = {
 	[standardBadgeTypeNames.text]: BadgeText,
 	[standardBadgeTypeNames.checkbox]: BadgeCheckboxes,
 	[standardBadgeTypeNames.number]: BadgeNumber,
+	[standardBadgeTypeNames.tags]: BadgeTags,
 };
 
 export const filterBadgeDefinitionsWithDictionary = (badgesDictionary, badgeDefinition) => {

--- a/packages/faceted-search/stories/badgesDefinitions.story.js
+++ b/packages/faceted-search/stories/badgesDefinitions.story.js
@@ -75,7 +75,7 @@ export const badgeTags = {
 		type: 'tags',
 	},
 	metadata: {
-		badgePerFacet: 'N',
+		badgePerFacet: '1',
 		entitiesPerBadge: 'N',
 		operators: ['in'],
 	},

--- a/packages/faceted-search/stories/facetedSearch.story.js
+++ b/packages/faceted-search/stories/facetedSearch.story.js
@@ -20,7 +20,7 @@ import {
 	badgePriceAsCustomAttribute,
 } from './badgesDefinitions.story';
 
-const badgesDefinitions = [badgeName, badgeConnectionType, badgePrice];
+const badgesDefinitions = [badgeName, badgeConnectionType, badgeTags, badgePrice];
 const lotsOfBadgesDefinitions = [];
 let i = 0;
 while (i < 50) {
@@ -28,6 +28,29 @@ while (i < 50) {
 	i += 1;
 }
 
+const callbacks = {
+	getTags: () =>
+		new Promise(resolve =>
+			setTimeout(resolve, 2000, [
+				'clean',
+				'production',
+				'last chunk',
+				'salesforce',
+				'outdated',
+				'extracted',
+				'security',
+				'in processing',
+				'deep learning',
+				'sql',
+				'cluster',
+				'visualization',
+				'analytics',
+				'users',
+				'warehouse',
+				'api',
+			]),
+		),
+};
 const badgesFaceted = {
 	badges: [
 		{
@@ -110,6 +133,7 @@ storiesOf('FacetedSearch', module)
 					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.BASIC && (
 						<FacetedSearch.BasicSearch
 							badgesDefinitions={badgesDefinitions}
+							callbacks={callbacks}
 							onSubmit={action('onSubmit')}
 						/>
 					))
@@ -130,6 +154,7 @@ storiesOf('FacetedSearch', module)
 							badgesDefinitions={badgesDefinitions}
 							badgesFaceted={badgesFaceted}
 							onSubmit={action('onSubmit')}
+							callbacks={callbacks}
 						/>
 					))
 				}
@@ -143,6 +168,7 @@ storiesOf('FacetedSearch', module)
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={lotsOfBadgesDefinitions}
 					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
 				/>
 			</FacetedSearch.Faceted>
 		</div>
@@ -154,6 +180,7 @@ storiesOf('FacetedSearch', module)
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeWithVeryLongName, badgeConnectionType, badgeName, badgePrice]}
 					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
 				/>
 			</FacetedSearch.Faceted>
 		</div>
@@ -165,6 +192,7 @@ storiesOf('FacetedSearch', module)
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeEnumWithLotOfValues]}
 					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
 				/>
 			</FacetedSearch.Faceted>
 		</div>
@@ -185,6 +213,7 @@ storiesOf('FacetedSearch', module)
 						...times(2, () => badgeTextAsCategory),
 					]}
 					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
 				/>
 			</FacetedSearch.Faceted>
 		</div>
@@ -196,6 +225,7 @@ storiesOf('FacetedSearch', module)
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeName, badgeEmptyLabel]}
 					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
 				/>
 			</FacetedSearch.Faceted>
 		</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We want to add a new badge for handle tags with this specific behavior:
- An async callback to get the values on mount (handle by the host application, mock in storybook)
- An action button to show all or to show only selected values.

Screenshots can be find on the JIRA: [https://jira.talendforge.org/browse/TDC-3908](https://jira.talendforge.org/browse/TDC-3908)

**What is the chosen solution to this problem?**
Add the new badge in faceted-search package, based on the existing badges.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
