### PR TITLE
fix(component): Fix TabBar with Dropdown

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -59,9 +59,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
   4:8  error  'Container' is defined but never used  no-unused-vars
 
-/home/travis/build/Talend/ui/packages/components/src/TabBar/TabBar.component.js
-  209:20  error  'tooltipPlacement' PropType is defined but prop is never used  react/no-unused-prop-types
-
 /home/travis/build/Talend/ui/packages/components/src/Toggle/Checkbox.js
   3:1  error  Prefer default export  import/prefer-default-export
 
@@ -75,6 +72,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 29 problems (27 errors, 2 warnings)
+✖ 28 problems (26 errors, 2 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -107,7 +107,7 @@ function TabBar(props) {
 		}
 	}
 
-	const { className, id, items, selectedKey, children, generateChildId } = props;
+	const { className, id, items, selectedKey, children, generateChildId, tooltipPlacement } = props;
 	const hasChildren = children || items.some(item => item.children);
 	const tabContent = hasChildren && (
 		<Tab.Content>
@@ -120,40 +120,7 @@ function TabBar(props) {
 		</Tab.Content>
 	);
 
-	let tabMenu = (
-		<Nav
-			bsStyle="tabs"
-			className={classnames(
-				theme['tc-tab-bar'],
-				'tc-tab-bar',
-				responsive && theme['tc-tab-bar-responsive'],
-				responsive && 'tc-tab-bar-responsive',
-			)}
-			ref={tabBarRef}
-		>
-			{items.map(({ icon, ...item }) => (
-				<NavItem
-					className={classnames(theme['tc-tab-bar-item'], 'tc-tab-bar-item')}
-					{...item}
-					eventKey={item.key}
-					componentClass="button"
-				>
-					<TooltipTrigger label={item.label} tooltipPlacement={props.tooltipPlacement}>
-						<React.Fragment>
-							{icon && (
-								<Icon
-									className={classnames(theme['tc-tab-bar-item-icon'], 'tc-tab-bar-item-icon')}
-									{...icon}
-								/>
-							)}
-							{item.label}
-						</React.Fragment>
-					</TooltipTrigger>
-				</NavItem>
-			))}
-		</Nav>
-	);
-
+	let tabMenu;
 	if (responsive && showDropdown) {
 		const selectedItem = items.find(item => item.key === selectedKey) || items[0];
 		tabMenu = (
@@ -170,7 +137,42 @@ function TabBar(props) {
 				link
 			/>
 		);
+	} else {
+		tabMenu = (
+			<Nav
+				bsStyle="tabs"
+				className={classnames(
+					theme['tc-tab-bar'],
+					'tc-tab-bar',
+					responsive && theme['tc-tab-bar-responsive'],
+					responsive && 'tc-tab-bar-responsive',
+				)}
+				ref={tabBarRef}
+			>
+				{items.map(({ icon, ...item }) => (
+					<NavItem
+						className={classnames(theme['tc-tab-bar-item'], 'tc-tab-bar-item')}
+						{...item}
+						eventKey={item.key}
+						componentClass="button"
+					>
+						<TooltipTrigger label={item.label} tooltipPlacement={tooltipPlacement}>
+							<React.Fragment>
+								{icon && (
+									<Icon
+										className={classnames(theme['tc-tab-bar-item-icon'], 'tc-tab-bar-item-icon')}
+										{...icon}
+									/>
+								)}
+								{item.label}
+							</React.Fragment>
+						</TooltipTrigger>
+					</NavItem>
+				))}
+			</Nav>
+		);
 	}
+
 	return (
 		<Tab.Container
 			id={id}

--- a/packages/components/src/TabBar/TabBar.component.js
+++ b/packages/components/src/TabBar/TabBar.component.js
@@ -120,24 +120,55 @@ function TabBar(props) {
 		</Tab.Content>
 	);
 
+	let tabMenu = (
+		<Nav
+			bsStyle="tabs"
+			className={classnames(
+				theme['tc-tab-bar'],
+				'tc-tab-bar',
+				responsive && theme['tc-tab-bar-responsive'],
+				responsive && 'tc-tab-bar-responsive',
+			)}
+			ref={tabBarRef}
+		>
+			{items.map(({ icon, ...item }) => (
+				<NavItem
+					className={classnames(theme['tc-tab-bar-item'], 'tc-tab-bar-item')}
+					{...item}
+					eventKey={item.key}
+					componentClass="button"
+				>
+					<TooltipTrigger label={item.label} tooltipPlacement={props.tooltipPlacement}>
+						<React.Fragment>
+							{icon && (
+								<Icon
+									className={classnames(theme['tc-tab-bar-item-icon'], 'tc-tab-bar-item-icon')}
+									{...icon}
+								/>
+							)}
+							{item.label}
+						</React.Fragment>
+					</TooltipTrigger>
+				</NavItem>
+			))}
+		</Nav>
+	);
+
 	if (responsive && showDropdown) {
 		const selectedItem = items.find(item => item.key === selectedKey) || items[0];
-		return (
-			<React.Fragment>
-				<ActionDropdown
-					id={id}
-					className={classnames(theme['tc-tab-bar-dropdown'], 'tc-tab-bar-dropdown')}
-					label={selectedItem.label}
-					icon={selectedItem.icon && selectedItem.icon.name}
-					onSelect={(event, { key }) => handleSelect(key, event)}
-					items={items.map(item => ({
-						...item,
-						icon: item.icon && item.icon.name,
-					}))}
-					link
-				/>
-				{tabContent}
-			</React.Fragment>
+		tabMenu = (
+			<ActionDropdown
+				id={id}
+				className={classnames(theme['tc-tab-bar-dropdown'], 'tc-tab-bar-dropdown')}
+				label={selectedItem.label}
+				icon={selectedItem.icon && selectedItem.icon.name}
+				onSelect={(event, { key }) => handleSelect(key, event)}
+				items={items.map(item => ({
+					...item,
+					icon: item.icon && item.icon.name,
+				}))}
+				link
+			/>
 		);
 	}
 	return (
@@ -150,37 +181,7 @@ function TabBar(props) {
 			generateChildId={generateChildId}
 		>
 			<div ref={tabBarContainerRef}>
-				<Nav
-					bsStyle="tabs"
-					className={classnames(
-						theme['tc-tab-bar'],
-						'tc-tab-bar',
-						responsive && theme['tc-tab-bar-responsive'],
-						responsive && 'tc-tab-bar-responsive',
-					)}
-					ref={tabBarRef}
-				>
-					{items.map(({ icon, ...item }) => (
-						<NavItem
-							className={classnames(theme['tc-tab-bar-item'], 'tc-tab-bar-item')}
-							{...item}
-							eventKey={item.key}
-							componentClass="button"
-						>
-							<TooltipTrigger label={item.label} tooltipPlacement={props.tooltipPlacement}>
-								<React.Fragment>
-									{icon && (
-										<Icon
-											className={classnames(theme['tc-tab-bar-item-icon'], 'tc-tab-bar-item-icon')}
-											{...icon}
-										/>
-									)}
-									{item.label}
-								</React.Fragment>
-							</TooltipTrigger>
-						</NavItem>
-					))}
-				</Nav>
+				{tabMenu}
 				{tabContent}
 			</div>
 		</Tab.Container>

--- a/packages/components/src/TabBar/TabBar.scss
+++ b/packages/components/src/TabBar/TabBar.scss
@@ -28,5 +28,5 @@
 }
 
 :global(.dropdown) + :global(.tab-content) {
-	padding-top: 20px;
+	padding-top: $padding-large;
 }

--- a/packages/components/src/TabBar/TabBar.scss
+++ b/packages/components/src/TabBar/TabBar.scss
@@ -26,3 +26,7 @@
 		}
 	}
 }
+
+:global(.dropdown) + :global(.tab-content) {
+	padding-top: 20px;
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we use the TabBar component in responsive mode, it use a Dropdown instead of a classic Nav.
But in this mode, the tab content is no longer displayed.

A gif can be seen in this Jira: https://jira.talendforge.org/browse/TFD-10784

**What is the chosen solution to this problem?**
The issue was caused by the fact that we don't have the Tab.Container when using Dropdown. Without the active key management it provides, tabs were not aware of it.
So I modified the component to always have this container.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
