### PR TITLE
fix(Components): tests with @talend/scripts

### DIFF
--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,6 +1,0 @@
-const defaults = require('../../node_modules/@talend/scripts-config-jest/jest.config.js');
-
-module.exports = {
-	...defaults,
-	setupFilesAfterEnv: [...defaults.setupFilesAfterEnv, '../../test-setup.js'],
-};

--- a/packages/components/jest.config.js
+++ b/packages/components/jest.config.js
@@ -1,0 +1,6 @@
+const defaults = require('../../node_modules/@talend/scripts-config-jest/jest.config.js');
+
+module.exports = {
+	...defaults,
+	setupFilesAfterEnv: [...defaults.setupFilesAfterEnv, '../../test-setup.js'],
+};

--- a/packages/components/src/AboutDialog/AboutDialog.snapshot.test.js
+++ b/packages/components/src/AboutDialog/AboutDialog.snapshot.test.js
@@ -23,24 +23,22 @@ describe('AboutDialog', () => {
 	});
 
 	it('should render', () => {
-		const wrapper = shallow(<AboutDialog.WrappedComponent {...props} />);
+		const wrapper = shallow(<AboutDialog {...props} />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
 	it('should render with custom copyright', () => {
-		const wrapper = shallow(
-			<AboutDialog.WrappedComponent copyrights="custom copyrights" {...props} />,
-		);
+		const wrapper = shallow(<AboutDialog copyrights="custom copyrights" {...props} />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
 	it('should render services', () => {
-		const wrapper = shallow(<AboutDialog.WrappedComponent {...props} expanded />);
+		const wrapper = shallow(<AboutDialog {...props} expanded />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
 	it('should render in loading mode', () => {
-		const wrapper = shallow(<AboutDialog.WrappedComponent {...props} loading />);
+		const wrapper = shallow(<AboutDialog {...props} loading />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/ActionBar/ActionBar.snapshot.test.js
+++ b/packages/components/src/ActionBar/ActionBar.snapshot.test.js
@@ -63,8 +63,8 @@ describe('ActionBar', () => {
 			},
 		};
 		// when
-		const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
-		const wrapperMounted = mount(<ActionBar.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionBar {...props} />);
+		const wrapperMounted = mount(<ActionBar {...props} />);
 		// then
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 		const switchActions = wrapperMounted.find(ActionBar.SwitchActions).first();
@@ -82,7 +82,7 @@ describe('ActionBar', () => {
 			},
 		};
 		// when
-		const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionBar {...props} />);
 		// then
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
@@ -96,7 +96,7 @@ describe('ActionBar', () => {
 			},
 		};
 		// when
-		const wrapper = mount(<ActionBar.WrappedComponent {...props} />).find('nav');
+		const wrapper = mount(<ActionBar {...props} />).find('nav');
 		// then
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
@@ -111,7 +111,7 @@ describe('ActionBar', () => {
 			},
 		};
 		// when
-		const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionBar {...props} />);
 		// then
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
@@ -130,7 +130,7 @@ describe('ActionBar', () => {
 				},
 			};
 			// when
-			const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
+			const wrapper = shallow(<ActionBar {...props} />);
 			// then
 			expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 		},
@@ -146,7 +146,7 @@ describe('ActionBar', () => {
 			},
 		};
 		// when
-		const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionBar {...props} />);
 		// then
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
@@ -157,7 +157,7 @@ describe('ActionBar', () => {
 				left: [btnGroupAction],
 			},
 		};
-		const wrapper = shallow(<ActionBar.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionBar {...props} />);
 		expect(toJsonWithoutI18n(wrapper)).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
+++ b/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
@@ -202,6 +202,7 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
       Object {
         "before-actions": <Count
           selected={1}
+          t={[Function]}
         />,
       }
     }
@@ -234,6 +235,7 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
       Object {
         "before-actions": <Count
           selected={1}
+          t={[Function]}
         />,
       }
     }
@@ -304,6 +306,7 @@ exports[`ActionBar should render selected count and multi-selected actions, coun
       Object {
         "before-actions": <Count
           selected={1}
+          t={[Function]}
         />,
       }
     }

--- a/packages/components/src/ActionIntercom/Intercom.component.test.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.test.js
@@ -45,7 +45,7 @@ describe('Intercom button', () => {
 
 	it('should render a button', () => {
 		// when
-		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		const wrapper = mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 
@@ -58,7 +58,7 @@ describe('Intercom button', () => {
 		expect(IntercomService.boot).not.toBeCalled();
 
 		// when
-		mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 
@@ -68,7 +68,7 @@ describe('Intercom button', () => {
 
 	it('should update intercom on config change', () => {
 		// given
-		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		const wrapper = mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 		expect(IntercomService.boot.mock.calls.length).toBe(1);
@@ -88,7 +88,7 @@ describe('Intercom button', () => {
 
 	it('should shutdown intercom at unmount', () => {
 		// given
-		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		const wrapper = mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 		expect(IntercomService.shutdown).not.toBeCalled();
@@ -102,7 +102,7 @@ describe('Intercom button', () => {
 
 	it('should change label on open/close', () => {
 		// given
-		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		const wrapper = mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 		const onShow = IntercomService.onShow.mock.calls[0][0];
@@ -130,7 +130,7 @@ describe('Intercom button', () => {
 		expect(IntercomService.setPosition).not.toBeCalled();
 
 		// when
-		mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 
@@ -140,7 +140,7 @@ describe('Intercom button', () => {
 
 	it('should focus on trigger button on hide', () => {
 		// given
-		const wrapper = mount(<Intercom.WrappedComponent id="my-intercom" config={config} />, {
+		const wrapper = mount(<Intercom id="my-intercom" config={config} />, {
 			attachTo: insertionElement,
 		});
 		const onShow = IntercomService.onShow.mock.calls[0][0];

--- a/packages/components/src/ActionIntercom/Intercom.component.test.js
+++ b/packages/components/src/ActionIntercom/Intercom.component.test.js
@@ -50,7 +50,7 @@ describe('Intercom button', () => {
 		});
 
 		// then
-		expect(toJson(wrapper)).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should boot intercom at mount', () => {

--- a/packages/components/src/ActionIntercom/__snapshots__/Intercom.component.test.js.snap
+++ b/packages/components/src/ActionIntercom/__snapshots__/Intercom.component.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Intercom button should render a button 1`] = `
-<Intercom
+<withI18nextTranslation(Intercom)
   config={
     Object {
       "app_id": "a218987bc6f",
@@ -51,5 +51,5 @@ exports[`Intercom button should render a button 1`] = `
       </Icon>
     </button>
   </TooltipTrigger>
-</Intercom>
+</withI18nextTranslation(Intercom)>
 `;

--- a/packages/components/src/ActionIntercom/__snapshots__/Intercom.component.test.js.snap
+++ b/packages/components/src/ActionIntercom/__snapshots__/Intercom.component.test.js.snap
@@ -1,55 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Intercom button should render a button 1`] = `
-<withI18nextTranslation(Intercom)
-  config={
-    Object {
-      "app_id": "a218987bc6f",
-      "company": Object {
-        "id": "1",
-        "name": "talend",
-      },
-      "email": "jsomsanith@talend.com",
-      "name": "Jimmy Somsanith",
-    }
-  }
-  id="my-intercom"
-  t={[Function]}
-  tooltipPlacement="bottom"
+<button data-feature="ipc.open"
+        id="my-intercom"
+        class="btn btn-link tc-intercom theme-tc-intercom"
+        aria-describedby="42"
 >
-  <TooltipTrigger
-    label="Chat with Talend Support"
-    tooltipPlacement="bottom"
+  <svg name="talend-bubbles"
+       class="theme-tc-svg-icon tc-svg-icon"
+       focusable="false"
+       aria-hidden="true"
   >
-    <button
-      aria-describedby={42}
-      className="btn btn-link tc-intercom theme-tc-intercom"
-      data-feature="ipc.open"
-      id="my-intercom"
-      key=".0"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onKeyPress={[Function]}
-      onMouseOut={[Function]}
-      onMouseOver={[Function]}
-    >
-      <Icon
-        name="talend-bubbles"
-      >
-        <svg
-          aria-hidden="true"
-          className="theme-tc-svg-icon tc-svg-icon"
-          focusable="false"
-          name="talend-bubbles"
-          title={null}
-        >
-          <use
-            xlinkHref="#talend-bubbles"
-          />
-        </svg>
-      </Icon>
-    </button>
-  </TooltipTrigger>
-</withI18nextTranslation(Intercom)>
+    <use xlink:href="#talend-bubbles">
+    </use>
+  </svg>
+</button>
 `;

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -22,7 +22,7 @@ function OverlayComponent() {
 describe('Action', () => {
 	it('should render a button', () => {
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent {...myAction} />);
+		const wrapper = shallow(<ActionButton {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -30,7 +30,7 @@ describe('Action', () => {
 
 	it('should render a button with loading state', () => {
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent loading />);
+		const wrapper = shallow(<ActionButton loading />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -38,7 +38,7 @@ describe('Action', () => {
 
 	it('should render a link button with loading state', () => {
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent link loading />);
+		const wrapper = shallow(<ActionButton link loading />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -48,7 +48,7 @@ describe('Action', () => {
 		// given
 		const onClick = jest.fn();
 		const props = { ...myAction, onClick };
-		const wrapper = shallow(<ActionButton.WrappedComponent extra="extra" {...props} />);
+		const wrapper = shallow(<ActionButton extra="extra" {...props} />);
 
 		// when
 		wrapper.simulate('click', {});
@@ -74,7 +74,7 @@ describe('Action', () => {
 		const onMouseEnter = jest.fn();
 		const onMouseLeave = jest.fn();
 		const props = { ...myAction, onMouseEnter, onMouseLeave };
-		const wrapper = shallow(<ActionButton.WrappedComponent extra="extra" {...props} />);
+		const wrapper = shallow(<ActionButton extra="extra" {...props} />);
 
 		wrapper.simulate('mouseenter', {});
 
@@ -115,7 +115,7 @@ describe('Action', () => {
 		// given
 		const onClick = jest.fn();
 		const props = { ...myAction, overlayComponent: OverlayComponent, onClick };
-		const wrapper = shallow(<ActionButton.WrappedComponent extra="extra" {...props} />);
+		const wrapper = shallow(<ActionButton extra="extra" {...props} />);
 
 		// when
 		wrapper.simulate('click', {});
@@ -141,7 +141,7 @@ describe('Action', () => {
 		const onMouseEnter = jest.fn();
 		const onMouseLeave = jest.fn();
 		const props = { ...myAction, overlayComponent: OverlayComponent, onMouseEnter, onMouseLeave };
-		const wrapper = shallow(<ActionButton.WrappedComponent extra="extra" {...props} />);
+		const wrapper = shallow(<ActionButton extra="extra" {...props} />);
 
 		wrapper.simulate('mouseenter', {});
 
@@ -180,9 +180,7 @@ describe('Action', () => {
 
 	it('should pass all props to the Button', () => {
 		// when
-		const wrapper = shallow(
-			<ActionButton.WrappedComponent className="navbar-btn" notExisting {...myAction} />,
-		);
+		const wrapper = shallow(<ActionButton className="navbar-btn" notExisting {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -190,9 +188,7 @@ describe('Action', () => {
 
 	it('should display a Progress indicator if set', () => {
 		// when
-		const wrapper = shallow(
-			<ActionButton.WrappedComponent className="navbar-btn" inProgress {...myAction} />,
-		);
+		const wrapper = shallow(<ActionButton className="navbar-btn" inProgress {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -200,9 +196,7 @@ describe('Action', () => {
 
 	it('should display a disabled Icon', () => {
 		// when
-		const wrapper = shallow(
-			<ActionButton.WrappedComponent className="navbar-btn" disabled {...myAction} />,
-		);
+		const wrapper = shallow(<ActionButton className="navbar-btn" disabled {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -210,7 +204,7 @@ describe('Action', () => {
 
 	it('should reverse icon/label', () => {
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent iconPosition="right" {...myAction} />);
+		const wrapper = shallow(<ActionButton iconPosition="right" {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -218,9 +212,7 @@ describe('Action', () => {
 
 	it('should apply transformation on icon', () => {
 		// when
-		const wrapper = shallow(
-			<ActionButton.WrappedComponent iconTransform={'rotate-180'} {...myAction} />,
-		);
+		const wrapper = shallow(<ActionButton iconTransform={'rotate-180'} {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -228,7 +220,7 @@ describe('Action', () => {
 
 	it('should render action with html property name = props.name if set', () => {
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent name="custom_name" {...myAction} />);
+		const wrapper = shallow(<ActionButton name="custom_name" {...myAction} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -236,7 +228,7 @@ describe('Action', () => {
 
 	it('should trigger action if set up onMouseDown event', () => {
 		// given
-		const wrapper = shallow(<ActionButton.WrappedComponent extra="extra" {...mouseDownAction} />);
+		const wrapper = shallow(<ActionButton extra="extra" {...mouseDownAction} />);
 
 		// when
 		wrapper.simulate('mouseDown');
@@ -251,7 +243,7 @@ describe('Action', () => {
 	});
 
 	it('should not render action if props.available=false', () => {
-		const wrapper = shallow(<ActionButton.WrappedComponent available={false} />);
+		const wrapper = shallow(<ActionButton available={false} />);
 		expect(wrapper.type()).toBe(null);
 	});
 
@@ -264,7 +256,7 @@ describe('Action', () => {
 		};
 
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionButton {...props} />);
 
 		// then
 		expect(wrapper.find('OverlayTrigger').length).toBe(0);
@@ -280,7 +272,7 @@ describe('Action', () => {
 		};
 
 		// when
-		const wrapper = shallow(<ActionButton.WrappedComponent {...props} />);
+		const wrapper = shallow(<ActionButton {...props} />);
 
 		// then
 		expect(wrapper.find('OverlayTrigger').length).toBe(1);
@@ -297,7 +289,7 @@ describe('Action', () => {
 			overlayId: 'myOverlayId',
 		};
 		// when
-		mount(<ActionButton.WrappedComponent {...props} />);
+		mount(<ActionButton {...props} />);
 
 		// then
 		expect(myRefFunc).toHaveBeenCalled();
@@ -306,7 +298,7 @@ describe('Action', () => {
 		// Given
 		const myRefFunc = jest.fn();
 		// when
-		mount(<ActionButton.WrappedComponent {...myAction} buttonRef={myRefFunc} />);
+		mount(<ActionButton {...myAction} buttonRef={myRefFunc} />);
 
 		// then
 		expect(myRefFunc).toHaveBeenCalled();

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -42,6 +42,7 @@ exports[`Action should display a Progress indicator if set 1`] = `
 >
   <withI18nextTranslation(CircularProgress)
     size="small"
+    t={[Function]}
   />
   <span>
     Click me
@@ -157,7 +158,7 @@ exports[`Action should render a button with a overlay component 1`] = `
 `;
 
 exports[`Action should render a button with loading state 1`] = `
-<withI18nextTranslation(Skeleton)
+<Skeleton
   type="button"
 />
 `;
@@ -181,6 +182,7 @@ exports[`Action should render a button without an overlay component if inProgres
 >
   <withI18nextTranslation(CircularProgress)
     size="small"
+    t={[Function]}
   />
   <span>
     Click me
@@ -201,12 +203,12 @@ exports[`Action should render a link button with loading state 1`] = `
   onMouseDown={[Function]}
   role="link"
 >
-  <withI18nextTranslation(Skeleton)
+  <Skeleton
     className="theme-tc-action-button-skeleton-circle tc-action-button-skeleton-circle"
     size="small"
     type="circle"
   />
-  <withI18nextTranslation(Skeleton)
+  <Skeleton
     size="medium"
     type="text"
   />

--- a/packages/components/src/DateTimePickers/Date/Picker/Picker.component.test.js
+++ b/packages/components/src/DateTimePickers/Date/Picker/Picker.component.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import { DateContext } from '../Context';
 import Picker from './Picker.component';
+import CalendarPicker from '../../pickers/CalendarPicker';
 
 describe('Date.Picker', () => {
 	it('should render', () => {
@@ -25,7 +26,7 @@ describe('Date.Picker', () => {
 		);
 
 		// then
-		expect(wrapper.find('CalendarPicker').props()).toMatchObject({
+		expect(wrapper.find(CalendarPicker).props()).toMatchObject({
 			manageFocus: true,
 			onSubmit: managerValue.pickerManagement.onSubmit,
 			other: 'custom props',
@@ -54,7 +55,7 @@ describe('Date.Picker', () => {
 		expect(managerValue.pickerManagement.onSubmit).not.toBeCalled();
 
 		// when
-		wrapper.find('CalendarPicker').prop('onSubmit')();
+		wrapper.find(CalendarPicker).prop('onSubmit')();
 
 		// then
 		expect(managerValue.pickerManagement.onSubmit).toBeCalled();

--- a/packages/components/src/DateTimePickers/DateRange/Picker/Picker.component.test.js
+++ b/packages/components/src/DateTimePickers/DateRange/Picker/Picker.component.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import { DateRangeContext } from '../Context';
 import Picker from './Picker.component';
+import CalendarPicker from '../../pickers/CalendarPicker';
 
 describe('DateRange.Picker', () => {
 	it('should render', () => {
@@ -27,12 +28,7 @@ describe('DateRange.Picker', () => {
 		);
 
 		// then
-		expect(
-			wrapper
-				.find('CalendarPicker')
-				.at(0)
-				.props(),
-		).toMatchObject({
+		expect(wrapper.find(CalendarPicker).at(0).props()).toMatchObject({
 			manageFocus: true,
 			onSubmit: managerValue.pickerManagement.onStartChange,
 			other: 'custom props',
@@ -65,7 +61,7 @@ describe('DateRange.Picker', () => {
 		expect(managerValue.pickerManagement.onStartChange).not.toBeCalled();
 
 		// when
-		wrapper.find('CalendarPicker').prop('onSubmit')();
+		wrapper.find(CalendarPicker).prop('onSubmit')();
 
 		// then
 		expect(managerValue.pickerManagement.onStartChange).toBeCalled();

--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.test.js
@@ -67,10 +67,7 @@ describe('InputTimePicker', () => {
 			expect(getOverlay(wrapper).exists()).toBe(true);
 
 			// when
-			wrapper
-				.find('button[role="listitem"]')
-				.first()
-				.simulate('click');
+			wrapper.find('button[role="listitem"]').first().simulate('click');
 
 			// then
 			expect(getOverlay(wrapper).exists()).toBe(false);
@@ -119,15 +116,12 @@ describe('InputTimePicker', () => {
 
 		it('should focus on time option if it is open with input DOWN', () => {
 			// given
-			const wrapper = mount(<InputTimePicker id="my-picker" />);
+			const wrapper = mount(<InputTimePicker id="my-picker" />, { attachTo: document.body });
 			wrapper.simulate('focus');
 			const event = { keyCode: keycode.codes.down };
 
 			// when
-			wrapper
-				.find('input')
-				.first()
-				.simulate('keydown', event);
+			wrapper.find('input').first().simulate('keydown', event);
 
 			// then
 			expect(document.activeElement.classList.contains('tc-time-picker-time')).toBe(true);

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
@@ -86,15 +86,12 @@ describe('InputDateTimePicker', () => {
 
 		it('should focus on calendar day if it is open with input DOWN', () => {
 			// given
-			const wrapper = mount(<InputDateTimePicker id="my-picker" />);
+			const wrapper = mount(<InputDateTimePicker id="my-picker" />, { attachTo: document.body });
 			wrapper.simulate('focus');
 			const event = { keyCode: keycode.codes.down };
 
 			// when
-			wrapper
-				.find('input')
-				.first()
-				.simulate('keydown', event);
+			wrapper.find('input').first().simulate('keydown', event);
 
 			// then
 			expect(document.activeElement.classList.contains('tc-date-picker-day')).toBe(true);
@@ -139,10 +136,7 @@ describe('InputDateTimePicker', () => {
 				expect(getOverlay(wrapper).exists()).toBe(true);
 
 				// when
-				wrapper
-					.find('.tc-date-picker-day')
-					.first()
-					.simulate('click');
+				wrapper.find('.tc-date-picker-day').first().simulate('click');
 
 				// then
 				expect(getOverlay(wrapper).exists()).toBe(expectedOverlay);
@@ -189,10 +183,7 @@ describe('InputDateTimePicker', () => {
 			expect(getOverlay(wrapper).exists()).toBe(true);
 
 			// when
-			wrapper
-				.find('.tc-date-picker-day')
-				.last()
-				.simulate('click');
+			wrapper.find('.tc-date-picker-day').last().simulate('click');
 			wrapper.find('form').simulate('submit');
 
 			// then

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.test.js
@@ -4,14 +4,15 @@ import startOfDay from 'date-fns/start_of_day';
 import DateTimePicker from './DateTimePicker.component';
 import DateTimeView from '../../views/DateTimeView';
 import MonthYearView from '../../views/MonthYearView';
+import dateMock from '../../../../../../../mocks/dateMock';
 
 describe('DateTimePicker', () => {
 	afterEach(() => {
-		global.dateMock.restore();
+		dateMock.restore();
 	});
 
 	it('should render', () => {
-		global.dateMock.mock(new Date(2018, 5, 12));
+		dateMock.mock(new Date(2018, 5, 12));
 		const wrapper = shallow(<DateTimePicker onSubmit={() => {}} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -19,7 +20,7 @@ describe('DateTimePicker', () => {
 
 	it('should initialize calendar view to current date', () => {
 		// given
-		global.dateMock.mock(new Date(2016, 4, 12));
+		dateMock.mock(new Date(2016, 4, 12));
 
 		// when
 		const wrapper = shallow(<DateTimePicker onSubmit={() => {}} />);
@@ -235,10 +236,7 @@ describe('DateTimePicker', () => {
 			wrapper.setState({ isDateTimeView: false });
 
 			// when
-			wrapper
-				.find({ label: 'Today' })
-				.at(0)
-				.simulate('click');
+			wrapper.find({ label: 'Today' }).at(0).simulate('click');
 
 			// then
 			expect(wrapper.state('isDateTimeView')).toBe(true);

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/__snapshots__/DateTimePicker.test.js.snap
@@ -18,6 +18,7 @@ exports[`DateTimePicker should render 1`] = `
     onSelectMonthYear={[Function]}
     onSelectTime={[Function]}
     onTitleClick={[Function]}
+    t={[Function]}
   />
   <div
     className="theme-footer theme-date-padding"

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -1,16 +1,17 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import dateMock from '../../../../../../../mocks/dateMock';
 
 import YearPicker from './YearPicker.component';
 
 describe('YearPicker', () => {
 	afterEach(() => {
-		global.dateMock.restore();
+		dateMock.restore();
 	});
 
 	it('should render', () => {
 		// given
-		global.dateMock.mock(new Date(2015, 11, 31));
+		dateMock.mock(new Date(2015, 11, 31));
 
 		// when
 		const wrapper = shallow(<YearPicker selectedYear={2012} onSelect={jest.fn()} />).shallow();
@@ -21,7 +22,7 @@ describe('YearPicker', () => {
 
 	it('should default render with current year in middle when "selectedYear" prop is not provided', () => {
 		// given
-		global.dateMock.mock(new Date(2025, 1, 20));
+		dateMock.mock(new Date(2025, 1, 20));
 
 		// when
 		const wrapper = shallow(<YearPicker onSelect={jest.fn()} />).shallow();
@@ -43,10 +44,7 @@ describe('YearPicker', () => {
 		const event = { target: {} };
 
 		// when
-		wrapper
-			.find('.tc-date-picker-year')
-			.at(0)
-			.simulate('click', event);
+		wrapper.find('.tc-date-picker-year').at(0).simulate('click', event);
 
 		expect(onSelect).toBeCalledWith(event, firstSelectableYear);
 	});
@@ -54,56 +52,31 @@ describe('YearPicker', () => {
 	it('should scroll up by 1 year', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		// when
 		wrapper.find('button.tc-date-picker-scroll-up').simulate('click');
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2008');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2008');
 	});
 
 	it('should scroll down by 1 year', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		// when
 		wrapper.find('button.tc-date-picker-scroll-down').simulate('click');
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2010');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2010');
 	});
 
 	it('should scroll down via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 600.00131424, preventDefault: jest.fn() };
 
@@ -111,23 +84,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2012');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2012');
 	});
 
 	it('should scroll up via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: -600.00131424, preventDefault: jest.fn() };
 
@@ -135,23 +98,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2006');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2006');
 	});
 
 	it('should scroll slowly via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 4.00131424, preventDefault: jest.fn() };
 
@@ -159,23 +112,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2010');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2010');
 	});
 
 	it('should scroll fastly via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 800.00131424, preventDefault: jest.fn() };
 
@@ -183,11 +126,6 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2012');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2012');
 	});
 });

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/DateTimeView/__snapshots__/DateTimeView.test.js.snap
@@ -50,7 +50,7 @@ exports[`DateTimeView should render 1`] = `
         onClick={[Function]}
         tabIndex="-1"
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         button={
           Object {
             "aria-label": "Switch to month and year pickers view",
@@ -59,7 +59,6 @@ exports[`DateTimeView should render 1`] = `
           }
         }
         monthIndex={5}
-        t={[Function]}
         year={2006}
       />,
       "rightElement": <Action
@@ -111,7 +110,7 @@ exports[`DateTimeView should render without timePicker 1`] = `
         onClick={[Function]}
         tabIndex="-1"
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         button={
           Object {
             "aria-label": "Switch to month and year pickers view",
@@ -120,7 +119,6 @@ exports[`DateTimeView should render without timePicker 1`] = `
           }
         }
         monthIndex={5}
-        t={[Function]}
         year={2006}
       />,
       "rightElement": <Action

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -6,7 +6,6 @@ import setMonth from 'date-fns/set_month';
 import format from 'date-fns/format';
 import theme from './HeaderTitle.scss';
 import { getPickerLocale } from '../../generator';
-import getDefaultT from '../../../../translate';
 import { ActionDropdown, Action } from '../../../../Actions';
 import YearPicker from '../../pickers/YearPicker';
 
@@ -54,12 +53,7 @@ HeaderTitle.propTypes = {
 	year: PropTypes.number.isRequired,
 	button: PropTypes.object,
 	className: PropTypes.string,
-	t: PropTypes.func,
 	onSelectYear: PropTypes.func,
-};
-
-HeaderTitle.defaultProps = {
-	t: getDefaultT(),
 };
 
 export default HeaderTitle;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/index.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/index.js
@@ -1,5 +1,3 @@
-import { withTranslation } from 'react-i18next';
 import HeaderTitle from './HeaderTitle.component';
-import I18N_DOMAIN_COMPONENTS from '../../../../constants';
 
-export default withTranslation(I18N_DOMAIN_COMPONENTS)(HeaderTitle);
+export default HeaderTitle;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -21,10 +21,9 @@ exports[`MonthYearView should render 1`] = `
         onClick={[MockFunction]}
         tabIndex={0}
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         monthIndex={8}
         onSelectYear={[MockFunction]}
-        t={[Function]}
         year={2012}
       />,
     }

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.test.js
@@ -4,14 +4,15 @@ import startOfDay from 'date-fns/start_of_day';
 import CalendarPicker from './CalendarPicker.component';
 import DateView from '../../views/DateView';
 import MonthYearView from '../../views/MonthYearView';
+import dateMock from '../../../../../../../mocks/dateMock';
 
 describe('CalendarPicker', () => {
 	afterEach(() => {
-		global.dateMock.restore();
+		dateMock.restore();
 	});
 
 	it('should render', () => {
-		global.dateMock.mock(new Date(2018, 5, 12));
+		dateMock.mock(new Date(2018, 5, 12));
 		const wrapper = shallow(<CalendarPicker onSubmit={() => {}} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -19,7 +20,7 @@ describe('CalendarPicker', () => {
 
 	it('should initialize calendar view to current date', () => {
 		// given
-		global.dateMock.mock(new Date(2016, 4, 12));
+		dateMock.mock(new Date(2016, 4, 12));
 
 		// when
 		const wrapper = shallow(<CalendarPicker onSubmit={() => {}} />);
@@ -196,10 +197,7 @@ describe('CalendarPicker', () => {
 			wrapper.setState({ isDateView: false });
 
 			// when
-			wrapper
-				.find({ label: 'Today' })
-				.at(0)
-				.simulate('click');
+			wrapper.find({ label: 'Today' }).at(0).simulate('click');
 
 			// then
 			expect(wrapper.state('isDateView')).toBe(true);

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.test.js
@@ -4,7 +4,7 @@ import startOfDay from 'date-fns/start_of_day';
 import CalendarPicker from './CalendarPicker.component';
 import DateView from '../../views/DateView';
 import MonthYearView from '../../views/MonthYearView';
-import dateMock from '../../../../../../../mocks/dateMock';
+import dateMock from '../../../../../../mocks/dateMock';
 
 describe('CalendarPicker', () => {
 	afterEach(() => {

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
@@ -17,6 +17,7 @@ exports[`CalendarPicker should render 1`] = `
     onSelectDate={[Function]}
     onSelectMonthYear={[Function]}
     onTitleClick={[Function]}
+    t={[Function]}
   />
   <div
     className="theme-footer theme-date-padding"

--- a/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.component.test.js
@@ -5,7 +5,7 @@ import { TimePicker } from './TimePicker.component';
 
 describe('TimePicker component', () => {
 	it('should render', () => {
-		const wrapper = shallow(<TimePicker onSubmit={jest.fn()} />);
+		const wrapper = shallow(<TimePicker onChange={jest.fn()} onSubmit={jest.fn()} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -16,10 +16,7 @@ describe('TimePicker component', () => {
 			const event = expect.anything();
 			const wrapper = mount(<TimePicker onChange={onChange} />);
 			// when
-			wrapper
-				.find('button')
-				.at(3)
-				.simulate('click');
+			wrapper.find('button').at(3).simulate('click');
 			// then
 			expect(onChange).toBeCalledWith(event, {
 				textInput: '03:00',
@@ -30,23 +27,20 @@ describe('TimePicker component', () => {
 			// when
 			const scrollIntoViewMock = jest.fn();
 			window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-			const wrapper = mount(<TimePicker onSubmit={jest.fn()} textInput="12:00" />);
+			const wrapper = mount(
+				<TimePicker onChange={jest.fn()} onSubmit={jest.fn()} textInput="12:00" />,
+			);
 			wrapper.update();
 			// then
 			expect(scrollIntoViewMock).toBeCalledWith({ block: 'center' });
-			expect(
-				wrapper
-					.find('button')
-					.at(12)
-					.hasClass('highlight'),
-			).toBe(true);
+			expect(wrapper.find('button').at(12).hasClass('highlight')).toBe(true);
 		});
 		it('should scroll the first match into view when user inputs', () => {
 			// given
 			const onSubmit = jest.fn();
 			const scrollIntoViewMock = jest.fn();
 			window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
-			const wrapper = mount(<TimePicker onSubmit={onSubmit} />);
+			const wrapper = mount(<TimePicker onChange={jest.fn()} onSubmit={onSubmit} />);
 
 			// when
 			wrapper.setProps({ textInput: '20' });
@@ -54,12 +48,7 @@ describe('TimePicker component', () => {
 
 			// then
 			expect(scrollIntoViewMock).toBeCalledWith({ block: 'center' });
-			expect(
-				wrapper
-					.find('button')
-					.at(20)
-					.hasClass('highlight'),
-			).toBe(true);
+			expect(wrapper.find('button').at(20).hasClass('highlight')).toBe(true);
 		});
 	});
 });

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.test.js
@@ -2,15 +2,16 @@ import React from 'react';
 import { mount, shallow } from 'enzyme';
 
 import YearPicker from './YearPicker.component';
+import dateMock from '../../../../../../mocks/dateMock';
 
 describe('YearPicker', () => {
 	afterEach(() => {
-		global.dateMock.restore();
+		dateMock.restore();
 	});
 
 	it('should render', () => {
 		// given
-		global.dateMock.mock(new Date(2015, 11, 31));
+		dateMock.mock(new Date(2015, 11, 31));
 
 		// when
 		const wrapper = shallow(<YearPicker selectedYear={2012} onSelect={jest.fn()} />).shallow();
@@ -21,7 +22,7 @@ describe('YearPicker', () => {
 
 	it('should default render with current year in middle when "selectedYear" prop is not provided', () => {
 		// given
-		global.dateMock.mock(new Date(2025, 1, 20));
+		dateMock.mock(new Date(2025, 1, 20));
 
 		// when
 		const wrapper = shallow(<YearPicker onSelect={jest.fn()} />).shallow();
@@ -43,10 +44,7 @@ describe('YearPicker', () => {
 		const event = { target: {} };
 
 		// when
-		wrapper
-			.find('.tc-date-picker-year')
-			.at(0)
-			.simulate('click', event);
+		wrapper.find('.tc-date-picker-year').at(0).simulate('click', event);
 
 		expect(onSelect).toBeCalledWith(event, firstSelectableYear);
 	});
@@ -54,56 +52,31 @@ describe('YearPicker', () => {
 	it('should scroll up by 1 year', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		// when
 		wrapper.find('button.tc-date-picker-scroll-up').simulate('click');
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2008');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2008');
 	});
 
 	it('should scroll down by 1 year', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		// when
 		wrapper.find('button.tc-date-picker-scroll-down').simulate('click');
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2010');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2010');
 	});
 
 	it('should scroll down via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 600.00131424, preventDefault: jest.fn() };
 
@@ -111,23 +84,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2012');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2012');
 	});
 
 	it('should scroll up via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: -600.00131424, preventDefault: jest.fn() };
 
@@ -135,23 +98,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2006');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2006');
 	});
 
 	it('should scroll slowly via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 4.00131424, preventDefault: jest.fn() };
 
@@ -159,23 +112,13 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2010');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2010');
 	});
 
 	it('should scroll fastly via mouse', () => {
 		// given
 		const wrapper = mount(<YearPicker selectedYear={2012} onSelect={jest.fn()} />);
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2009');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2009');
 
 		const event = { deltaY: 800.00131424, preventDefault: jest.fn() };
 
@@ -183,11 +126,6 @@ describe('YearPicker', () => {
 		wrapper.find('ol').simulate('wheel', event);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-year')
-				.at(0)
-				.text(),
-		).toBe('2012');
+		expect(wrapper.find('.tc-date-picker-year').at(0).text()).toBe('2012');
 	});
 });

--- a/packages/components/src/DateTimePickers/views/DateView/__snapshots__/DateView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateView/__snapshots__/DateView.test.js.snap
@@ -35,7 +35,7 @@ exports[`DateView should render 1`] = `
         onClick={[Function]}
         tabIndex="-1"
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         button={
           Object {
             "aria-label": "Switch to month and year pickers view",
@@ -44,7 +44,6 @@ exports[`DateView should render 1`] = `
           }
         }
         monthIndex={5}
-        t={[Function]}
         year={2006}
       />,
       "rightElement": <Action
@@ -96,7 +95,7 @@ exports[`DateView should render without timePicker 1`] = `
         onClick={[Function]}
         tabIndex="-1"
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         button={
           Object {
             "aria-label": "Switch to month and year pickers view",
@@ -105,7 +104,6 @@ exports[`DateView should render without timePicker 1`] = `
           }
         }
         monthIndex={5}
-        t={[Function]}
         year={2006}
       />,
       "rightElement": <Action

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.component.js
@@ -6,7 +6,6 @@ import setMonth from 'date-fns/set_month';
 import format from 'date-fns/format';
 import theme from './HeaderTitle.scss';
 import { getPickerLocale } from '../../generator';
-import getDefaultT from '../../../translate';
 import { ActionDropdown, Action } from '../../../Actions';
 import YearPicker from '../../pickers/YearPicker';
 
@@ -54,12 +53,7 @@ HeaderTitle.propTypes = {
 	year: PropTypes.number.isRequired,
 	button: PropTypes.object,
 	className: PropTypes.string,
-	t: PropTypes.func,
 	onSelectYear: PropTypes.func,
-};
-
-HeaderTitle.defaultProps = {
-	t: getDefaultT(),
 };
 
 export default HeaderTitle;

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/index.js
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/index.js
@@ -1,5 +1,3 @@
-import { withTranslation } from 'react-i18next';
 import HeaderTitle from './HeaderTitle.component';
-import I18N_DOMAIN_COMPONENTS from '../../../constants';
 
-export default withTranslation(I18N_DOMAIN_COMPONENTS)(HeaderTitle);
+export default HeaderTitle;

--- a/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/MonthYearView/__snapshots__/MonthYearView.test.js.snap
@@ -21,10 +21,9 @@ exports[`MonthYearView should render 1`] = `
         onClick={[MockFunction]}
         tabIndex={0}
       />,
-      "middleElement": <withI18nextTranslation(HeaderTitle)
+      "middleElement": <HeaderTitle
         monthIndex={8}
         onSelectYear={[MockFunction]}
-        t={[Function]}
         year={2012}
       />,
     }

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -40,19 +40,6 @@
     "react-dom": "^16.8.6",
     "redux-saga-tester": "^1.0.345"
   },
-  "jest": {
-    "collectCoverageFrom": [
-      "src/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!**/__snapshots__/**"
-    ],
-    "roots": [
-      "src"
-    ],
-    "setupFilesAfterEnv": [
-      "./test-setup.js"
-    ]
-  },
   "publishConfig": {
     "access": "public"
   }

--- a/test-setup.js
+++ b/test-setup.js
@@ -6,7 +6,7 @@ import 'mutationobserver-shim';
 // import 'raf/polyfill';
 // import { Headers } from 'node-fetch';
 // import { configure } from 'enzyme';
-// import dateMock from './mocks/dateMock';
+import dateMock from './mocks/dateMock';
 
 // // define fetch
 // const fetch = jest.fn(
@@ -55,4 +55,4 @@ import 'mutationobserver-shim';
 // 	return null;
 // };
 
-// global.dateMock = dateMock;
+global.dateMock = dateMock;


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Components tests must be adapted to talend/scripts jest/enzyme/mock versions

**What is the chosen solution to this problem?**
Fix a part of them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
