### PR TITLE
feat(forms/Text): allow user set autoComplete in schema

### DIFF
--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -9,6 +9,7 @@ import { convertValue } from '../../utils/properties';
 export default function Text(props) {
 	const { id, isValid, errorMessage, onChange, onFinish, schema, value, valueIsUpdating } = props;
 	const {
+		autoComplete,
 		autoFocus,
 		description,
 		disabled = false,
@@ -39,6 +40,7 @@ export default function Text(props) {
 		>
 			<input
 				id={id}
+				autoComplete={autoComplete}
 				autoFocus={autoFocus}
 				className="form-control"
 				disabled={disabled || valueIsUpdating}
@@ -70,6 +72,7 @@ if (process.env.NODE_ENV !== 'production') {
 		onChange: PropTypes.func.isRequired,
 		onFinish: PropTypes.func.isRequired,
 		schema: PropTypes.shape({
+			autoComplete: PropTypes.string,
 			autoFocus: PropTypes.bool,
 			description: PropTypes.string,
 			disabled: PropTypes.bool,

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -275,4 +275,23 @@ describe('Text field', () => {
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+	it('should pass autoComplete to input', () => {
+		// given
+		const autoCompleteSchema = {
+			...schema,
+			autoComplete: 'off',
+		};
+
+		// when
+		const wrapper = shallow(
+			<Text
+				id={'myForm'}
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={autoCompleteSchema}
+				value={'toto'}
+			/>,
+		);
+		expect(wrapper.find('input').prop('autoComplete')).toBe('off');
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In TMC, we have a custom widget built on Text, we would like to disable browser's auto completion for it but couldn't.
**What is the chosen solution to this problem?**
Pass `autoComplete` prop to input as specified in schema.
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
