### PR TITLE
fix(components/ColumnChooser): add key in columns config

### DIFF
--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -18,6 +18,7 @@ const changeVisibleToHidden = column => ({
 	hidden: !column.visible,
 	label: column.label,
 	order: column.order,
+	id: column.id,
 });
 const mapToColumnsList = columns => columns.map(changeVisibleToHidden);
 

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -18,7 +18,7 @@ const changeVisibleToHidden = column => ({
 	hidden: !column.visible,
 	label: column.label,
 	order: column.order,
-	id: column.id,
+	key: column.key,
 });
 const mapToColumnsList = columns => columns.map(changeVisibleToHidden);
 

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.test.js
@@ -58,12 +58,17 @@ describe('ColumnChooser', () => {
 		// Then
 		expect(onSubmit).toHaveBeenCalled();
 		expect(onSubmit.mock.calls[0][1]).toEqual([
-			{ hidden: false, label: 'Id', order: 1 },
-			{ hidden: false, label: 'Name', order: 2 },
-			{ hidden: false, label: 'Author', order: 3 },
-			{ hidden: false, label: 'Very long name long name long name long name long name', order: 4 },
-			{ hidden: true, label: 'Icon', order: 5 },
-			{ hidden: false, label: 'Created', order: 6 },
+			{ hidden: false, key: 'id', label: 'Id', order: 1 },
+			{ hidden: false, key: 'name', label: 'Name', order: 2 },
+			{ hidden: false, key: 'author', label: 'Author', order: 3 },
+			{
+				hidden: false,
+				key: 'modified',
+				label: 'Very long name long name long name long name long name',
+				order: 4,
+			},
+			{ hidden: true, key: 'icon', label: 'Icon', order: 5 },
+			{ hidden: false, key: 'created', label: 'Created', order: 6 },
 		]);
 	});
 	it('should filter the columns by name if an initial filter value is provided', () => {

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -33,6 +33,7 @@ const extractColumnValues = column => ({
 	visible: !column.hidden,
 	label: column.label,
 	order: column.order,
+	id: column.id,
 });
 
 /**

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -33,7 +33,7 @@ const extractColumnValues = column => ({
 	visible: !column.hidden,
 	label: column.label,
 	order: column.order,
-	id: column.id,
+	key: column.key,
 });
 
 /**

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
@@ -69,12 +69,12 @@ describe('useColumnChooserManager', () => {
 		// when mounting before each
 		// then
 		expect(columnChooserHook.columns).toEqual([
-			{ label: 'Id', locked: true, order: 1, visible: true },
-			{ label: 'Name', locked: true, order: 2, visible: true },
-			{ label: 'Author', order: 3, visible: true },
-			{ label: 'Modified', order: 4, visible: true },
-			{ label: 'Icon', order: 5, visible: true },
-			{ label: 'Created', order: 6, visible: true },
+			{ key: 'id', label: 'Id', locked: true, order: 1, visible: true },
+			{ key: 'name', label: 'Name', locked: true, order: 2, visible: true },
+			{ key: 'author', label: 'Author', order: 3, visible: true },
+			{ key: 'modified', label: 'Modified', order: 4, visible: true },
+			{ key: 'icon', label: 'Icon', order: 5, visible: true },
+			{ key: 'created', label: 'Created', order: 6, visible: true },
 		]);
 	});
 	it('should change the visible property of the third column', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We're doing a POC for using column chooser in one of the list in TMC([jira](https://jira.talendforge.org/browse/TMC-20889)). One issue I encounter is that there's no key in columns data submitted by column chooser when click 'Apply'. Without the key it's hard to identify the column.

**What is the chosen solution to this problem?**
Add key in columns data.
http://2838.talend.surge.sh/components/?path=/story/data-list-column-chooser--default

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
