### PR TITLE
fix(Layout): Drawer with layout 1 column

### DIFF
--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -443,7 +443,7 @@ storiesOf('Layout/Drawer', module)
 			);
 		}
 		return (
-			<Layout header={header} mode="OneColumns" drawers={[<CustomDrawer />]}>
+			<Layout header={header} mode="TwoColumns" drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
 				<IconsProvider defaultIcons={icons} />
 			</Layout>

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -273,7 +273,14 @@ for (let index = 0; index < 20; index++) {
 	twentyRows.push(<p key={index}>The content dictate the width</p>);
 }
 storiesOf('Layout/Drawer', module)
-	.add('Default', () => (
+	.add('Layout 1 column', () => (
+		<Layout header={header} mode="OneColumns" drawers={drawers}>
+			<span>zone with drawer</span>
+			{twentyRows}
+			<IconsProvider defaultIcons={icons} />
+		</Layout>
+	))
+	.add('Layout 2 columns', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
@@ -436,7 +443,7 @@ storiesOf('Layout/Drawer', module)
 			);
 		}
 		return (
-			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
+			<Layout header={header} mode="OneColumns" drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
 				<IconsProvider defaultIcons={icons} />
 			</Layout>

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -443,7 +443,7 @@ storiesOf('Layout/Drawer', module)
 			);
 		}
 		return (
-			<Layout header={header} mode="TwoColumns" drawers={[<CustomDrawer />]}>
+			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
 				<IconsProvider defaultIcons={icons} />
 			</Layout>

--- a/packages/components/src/Layout/OneColumn/OneColumn.scss
+++ b/packages/components/src/Layout/OneColumn/OneColumn.scss
@@ -5,4 +5,5 @@
 	min-height: 0;
 	overflow: auto;
 	height: 100vh;
+	position: relative;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Layout in 1-column mode doesn't contain its content well, the drawers is position is absolute and takes 100% of the page height instead of 100% of the main height.

![image](https://user-images.githubusercontent.com/10761073/83411383-6a6e3800-a418-11ea-9bd7-8bac6ed637af.png)


**What is the chosen solution to this problem?**
2-column mode has a `position:relative` on the main box to contains that. Let's add it in 1-column mode too

![image](https://user-images.githubusercontent.com/10761073/83411523-b4efb480-a418-11ea-9d6f-8c335ee44f0f.png)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
