### PR TITLE
fix(TCCUI-170) - use panel title if collapsibleFieldSet contains array

### DIFF
--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -29,31 +29,8 @@ function getDrillKey(key) {
 	}, []);
 }
 
-function isCollapsibleArray(element, schema) {
-	if (!schema && element.items && !element.items.some(item => item.type === 'array')) {
-		return true;
-	}
-	const hasCollapsible = (element.items || []).reduce((acc, item) => {
-		if (item.items && isCollapsibleArray(item, element)) {
-			acc.push(true);
-		}
-		if (
-			acc.length === 0 &&
-			schema &&
-			(schema.items || []).some(data => data.widget === 'collapsibleFieldset')
-		) {
-			acc.push(true);
-		}
-		return acc;
-	}, []);
-	return hasCollapsible.length > 0;
-}
-
 export function defaultTitle(formData, schema, options) {
-	if (!isCollapsibleArray(schema)) {
-		return schema.title;
-	}
-	const title = (schema.items || []).reduce((acc, item) => {
+	const title = (schema.type !== 'array' && schema.items || []).reduce((acc, item) => {
 		let value;
 		if (item.key) {
 			const lastKey = getDrillKey(item.key);

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -29,7 +29,26 @@ function getDrillKey(key) {
 	}, []);
 }
 
+function isCollapsibleArray(element, schema) {
+	if (!schema && element.items && !element.items.some(item => item.type === 'array')) {
+		return true;
+	}
+	const hasCollapsible = (element.items || []).reduce((acc, item) => {
+		if (item.items && isCollapsibleArray(item, element)) {
+			acc.push(true);
+		}
+		if (acc.length === 0 && schema && (schema.items || []).some(data => data.widget === 'collapsibleFieldset')) {
+			acc.push(true);
+		}
+		return acc;
+	}, []);
+	return hasCollapsible.length > 0;
+}
+
 export function defaultTitle(formData, schema, options) {
+	if (!isCollapsibleArray(schema)) {
+		return schema.title;
+	}
 	const title = (schema.items || []).reduce((acc, item) => {
 		let value;
 		if (item.key) {

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -30,7 +30,7 @@ function getDrillKey(key) {
 }
 
 export function defaultTitle(formData, schema, options) {
-	const title = (schema.type !== 'array' && schema.items || []).reduce((acc, item) => {
+	const title = ((schema.type !== 'array' && schema.items) || []).reduce((acc, item) => {
 		let value;
 		if (item.key) {
 			const lastKey = getDrillKey(item.key);

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -37,7 +37,11 @@ function isCollapsibleArray(element, schema) {
 		if (item.items && isCollapsibleArray(item, element)) {
 			acc.push(true);
 		}
-		if (acc.length === 0 && schema && (schema.items || []).some(data => data.widget === 'collapsibleFieldset')) {
+		if (
+			acc.length === 0 &&
+			schema &&
+			(schema.items || []).some(data => data.widget === 'collapsibleFieldset')
+		) {
 			acc.push(true);
 		}
 		return acc;

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -207,7 +207,9 @@ describe('CollapsibleFieldset', () => {
 		);
 		const panel = wrapper.find('CollapsiblePanel');
 
-		expect(panel.props().header[0].label).toEqual([value.firstname, value.lastname, value.addressLine].join(', '));
+		expect(panel.props().header[0].label).toEqual(
+			[value.firstname, value.lastname, value.addressLine].join(', '),
+		);
 	});
 
 	it('should display description', () => {
@@ -231,7 +233,9 @@ describe('defaultTitle', () => {
 		expect(defaultTitle({}, schemaBasic)).toBe(schemaBasic.title);
 	});
 	it('should return concat values if used in an array', () => {
-		expect(defaultTitle(value, schema)).toBe([value.firstname, value.lastname, value.addressLine].join(', '));
+		expect(defaultTitle(value, schema)).toBe(
+			[value.firstname, value.lastname, value.addressLine].join(', '),
+		);
 	});
 	it('should support option in an array', () => {
 		expect(defaultTitle(value, schema, { separator: ' -- || -- ' })).toBe(

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -198,6 +198,7 @@ describe('CollapsibleFieldset', () => {
 
 		expect(wrapper.exists('Actions')).toEqual(false);
 	});
+
 	it('should concat values in case it is used in array', () => {
 		const CollapsibleFieldset = createCollapsibleFieldset();
 		const onChange = jest.fn();

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -10,6 +10,24 @@ function customTitle(value, schema) {
 	return `${schema.title}: ${value.firstname} ${value.lastname}`;
 }
 
+const schemaBasic = {
+	title: 'Basic',
+	items: [
+		{
+			key: ['firstname'],
+			title: 'FirstName',
+			schema: { type: 'string' },
+			type: 'string',
+		},
+		{
+			key: ['lastname'],
+			title: 'FirstName',
+			schema: { type: 'string' },
+			type: 'string',
+		},
+	],
+};
+
 const schema = {
 	title: 'Basic',
 	description: 'This is description',
@@ -26,12 +44,40 @@ const schema = {
 			schema: { type: 'string' },
 			type: 'string',
 		},
+		{
+			key: ['details.address'],
+			title: 'Address',
+			items: [
+				{
+					widget: 'collapsibleFieldset',
+					key: ['details.address[]'],
+					title: 'Primary address',
+					items: [
+						{
+							key: ['addressLine'],
+							title: 'Address line',
+						},
+						{
+							key: ['postCode'],
+							title: 'Post code',
+						},
+					],
+				},
+			],
+			schema: {
+				type: 'array',
+				items: {
+					type: 'string',
+				},
+			},
+		},
 	],
 };
 
 const value = {
 	firstname: 'Jimmy',
 	lastname: 'Somsanith',
+	addressLine: 'park avenue',
 };
 
 const defaultTitleMockData = {
@@ -152,7 +198,6 @@ describe('CollapsibleFieldset', () => {
 
 		expect(wrapper.exists('Actions')).toEqual(false);
 	});
-
 	it('should concat values in case it is used in array', () => {
 		const CollapsibleFieldset = createCollapsibleFieldset();
 		const onChange = jest.fn();
@@ -162,7 +207,7 @@ describe('CollapsibleFieldset', () => {
 		);
 		const panel = wrapper.find('CollapsiblePanel');
 
-		expect(panel.props().header[0].label).toEqual(`${value.firstname}, ${value.lastname}`);
+		expect(panel.props().header[0].label).toEqual([value.firstname, value.lastname, value.addressLine].join(', '));
 	});
 
 	it('should display description', () => {
@@ -183,25 +228,25 @@ describe('defaultTitle', () => {
 		// given not used in an array you have the schema.title
 		expect(defaultTitle({}, { title: 'Comment' })).toBe('Comment');
 		// given no value, you have the schema.title
-		expect(defaultTitle({}, schema)).toBe(schema.title);
+		expect(defaultTitle({}, schemaBasic)).toBe(schemaBasic.title);
 	});
 	it('should return concat values if used in an array', () => {
-		expect(defaultTitle(value, schema)).toBe(`${value.firstname}, ${value.lastname}`);
+		expect(defaultTitle(value, schema)).toBe([value.firstname, value.lastname, value.addressLine].join(', '));
 	});
 	it('should support option in an array', () => {
 		expect(defaultTitle(value, schema, { separator: ' -- || -- ' })).toBe(
-			`${value.firstname} -- || -- ${value.lastname}`,
+			[value.firstname, value.lastname, value.addressLine].join(' -- || -- '),
 		);
 		expect(defaultTitle(value, { ...schema, options: { separator: ' || ' } })).toBe(
-			`${value.firstname} || ${value.lastname}`,
+			[value.firstname, value.lastname, value.addressLine].join(' || '),
 		);
 	});
 	it('should support recursive call', () => {
 		expect(defaultTitle(value, schema, { separator: ' -- || -- ' })).toBe(
-			`${value.firstname} -- || -- ${value.lastname}`,
+			[value.firstname, value.lastname, value.addressLine].join(' -- || -- '),
 		);
 		expect(defaultTitle(value, { ...schema, options: { separator: ' || ' } })).toBe(
-			`${value.firstname} || ${value.lastname}`,
+			[value.firstname, value.lastname, value.addressLine].join(' || '),
 		);
 	});
 	it('should support recursive call on deeper objects', () => {

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
@@ -9,7 +9,7 @@ exports[`CollapsibleFieldset should render a collapsed fieldset (header only) 1`
     header={
       Array [
         Object {
-          "label": "Jimmy, Somsanith",
+          "label": "Jimmy, Somsanith, park avenue",
         },
         Array [],
       ]
@@ -41,6 +41,7 @@ exports[`CollapsibleFieldset should render a collapsed fieldset (header only) 1`
       }
       value={
         Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": true,
           "lastname": "Somsanith",
@@ -64,6 +65,56 @@ exports[`CollapsibleFieldset should render a collapsed fieldset (header only) 1`
       }
       value={
         Object {
+          "addressLine": "park avenue",
+          "firstname": "Jimmy",
+          "isClosed": true,
+          "lastname": "Somsanith",
+        }
+      }
+      widgets={Object {}}
+    />
+    <Widget
+      id="my-fieldset"
+      schema={
+        Object {
+          "items": Array [
+            Object {
+              "items": Array [
+                Object {
+                  "key": Array [
+                    "addressLine",
+                  ],
+                  "title": "Address line",
+                },
+                Object {
+                  "key": Array [
+                    "postCode",
+                  ],
+                  "title": "Post code",
+                },
+              ],
+              "key": Array [
+                "details.address[]",
+              ],
+              "title": "Primary address",
+              "widget": "collapsibleFieldset",
+            },
+          ],
+          "key": Array [
+            "details.address",
+          ],
+          "schema": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "title": "Address",
+        }
+      }
+      value={
+        Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": true,
           "lastname": "Somsanith",
@@ -116,6 +167,7 @@ exports[`CollapsibleFieldset should render a custom title 1`] = `
       }
       value={
         Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": false,
           "lastname": "Somsanith",
@@ -139,6 +191,56 @@ exports[`CollapsibleFieldset should render a custom title 1`] = `
       }
       value={
         Object {
+          "addressLine": "park avenue",
+          "firstname": "Jimmy",
+          "isClosed": false,
+          "lastname": "Somsanith",
+        }
+      }
+      widgets={Object {}}
+    />
+    <Widget
+      id="my-fieldset"
+      schema={
+        Object {
+          "items": Array [
+            Object {
+              "items": Array [
+                Object {
+                  "key": Array [
+                    "addressLine",
+                  ],
+                  "title": "Address line",
+                },
+                Object {
+                  "key": Array [
+                    "postCode",
+                  ],
+                  "title": "Post code",
+                },
+              ],
+              "key": Array [
+                "details.address[]",
+              ],
+              "title": "Primary address",
+              "widget": "collapsibleFieldset",
+            },
+          ],
+          "key": Array [
+            "details.address",
+          ],
+          "schema": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "title": "Address",
+        }
+      }
+      value={
+        Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": false,
           "lastname": "Somsanith",
@@ -159,7 +261,7 @@ exports[`CollapsibleFieldset should render a full fieldset (header and body) 1`]
     header={
       Array [
         Object {
-          "label": "Jimmy, Somsanith",
+          "label": "Jimmy, Somsanith, park avenue",
         },
         Array [],
       ]
@@ -191,6 +293,7 @@ exports[`CollapsibleFieldset should render a full fieldset (header and body) 1`]
       }
       value={
         Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": false,
           "lastname": "Somsanith",
@@ -214,6 +317,56 @@ exports[`CollapsibleFieldset should render a full fieldset (header and body) 1`]
       }
       value={
         Object {
+          "addressLine": "park avenue",
+          "firstname": "Jimmy",
+          "isClosed": false,
+          "lastname": "Somsanith",
+        }
+      }
+      widgets={Object {}}
+    />
+    <Widget
+      id="my-fieldset"
+      schema={
+        Object {
+          "items": Array [
+            Object {
+              "items": Array [
+                Object {
+                  "key": Array [
+                    "addressLine",
+                  ],
+                  "title": "Address line",
+                },
+                Object {
+                  "key": Array [
+                    "postCode",
+                  ],
+                  "title": "Post code",
+                },
+              ],
+              "key": Array [
+                "details.address[]",
+              ],
+              "title": "Primary address",
+              "widget": "collapsibleFieldset",
+            },
+          ],
+          "key": Array [
+            "details.address",
+          ],
+          "schema": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "title": "Address",
+        }
+      }
+      value={
+        Object {
+          "addressLine": "park avenue",
           "firstname": "Jimmy",
           "isClosed": false,
           "lastname": "Somsanith",
@@ -234,7 +387,7 @@ exports[`CollapsibleFieldset should render without value 1`] = `
     header={
       Array [
         Object {
-          "label": "Basic",
+          "label": "Primary address",
         },
         Array [],
       ]
@@ -283,6 +436,52 @@ exports[`CollapsibleFieldset should render without value 1`] = `
           },
           "title": "LastName",
           "type": "string",
+        }
+      }
+      value={
+        Object {
+          "isClosed": undefined,
+        }
+      }
+      widgets={Object {}}
+    />
+    <Widget
+      id="my-fieldset"
+      schema={
+        Object {
+          "items": Array [
+            Object {
+              "items": Array [
+                Object {
+                  "key": Array [
+                    "addressLine",
+                  ],
+                  "title": "Address line",
+                },
+                Object {
+                  "key": Array [
+                    "postCode",
+                  ],
+                  "title": "Post code",
+                },
+              ],
+              "key": Array [
+                "details.address[]",
+              ],
+              "title": "Primary address",
+              "widget": "collapsibleFieldset",
+            },
+          ],
+          "key": Array [
+            "details.address",
+          ],
+          "schema": Object {
+            "items": Object {
+              "type": "string",
+            },
+            "type": "array",
+          },
+          "title": "Address",
         }
       }
       value={

--- a/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
@@ -19,6 +19,19 @@
       "comment": {
         "type": "string",
         "maxLength": 20
+      },
+      "addressLine": {
+        "type": "string"
+      },
+      "postCode": {
+        "type": "string"
+      },
+      "fruits": {
+        "type": "string",
+        "enum": ["Apple", "Pine[apple]", "Banana", "Cher[ry", "Lemo}n", "Grapefruit"]
+      },
+      "city": {
+        "type": "string"
       }
     },
     "required": [
@@ -47,7 +60,7 @@
     },
     {
       "widget": "collapsibleFieldset",
-      "key": "technical.details",
+      "key": "details",
       "title": "Details",
       "items": [
         {
@@ -55,8 +68,47 @@
           "title": "Age"
         },
         {
-          "key": "address",
-          "title": "Adress"
+          "type": "array",
+          "key": "details.address",
+          "title": "Address",
+          "items": [
+            {
+              "widget": "collapsibleFieldset",
+              "key": "details.address[]",
+              "title": "Primary address",
+              "items": [
+                {
+                  "key": "addressLine",
+                  "title": "Address line"
+                },
+                {
+                  "key": "postCode",
+                  "title": "Post code"
+                }
+              ]
+            },
+            {
+              "widget": "collapsibleFieldset",
+              "key": "secondaryAddress",
+              "title": "Secondary address",
+              "items": [
+                {
+                  "key": "addressLine",
+                  "title": "Address line"
+                },
+                {
+                  "key": "postCode",
+                  "title": "Post code"
+                }
+              ]
+            }
+          ],
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         },
         {
           "key": "comment",
@@ -64,6 +116,61 @@
           "title": "Comment",
           "placeholder": "Make a comment",
           "validationMessage": "Don't be greedy!"
+        }
+      ]
+    },
+    {
+      "widget": "collapsibleFieldset",
+      "key": "extra",
+      "title": "Additional information",
+      "items": [
+        {
+          "key": "city",
+          "title": "Favourite city"
+        },
+        {
+          "type": "array",
+          "key": "extra.fruits",
+          "title": "Favourite fruits",
+          "items": [
+            {
+              "key": "extra.fruits[]",
+              "title": "Fruit",
+              "widget": "datalist",
+              "titleMap": [
+                {
+                  "name": "My Apple",
+                  "value": "Apple"
+                },
+                {
+                  "name": "My Pineapple",
+                  "value": "Pine[apple]"
+                },
+                {
+                  "name": "My Banana",
+                  "value": "Banana"
+                },
+                {
+                  "name": "My Cherry",
+                  "value": "Cher[ry"
+                },
+                {
+                  "name": "My Lemon",
+                  "value": "Lemo}n"
+                },
+                {
+                  "name": "My Grapefruit",
+                  "value": "Grapefruit"
+                }
+              ]
+            }
+          ],
+          "schema": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
         }
       ]
     },
@@ -87,6 +194,9 @@
     }
   ],
   "properties": {
-    "comment": "lol"
+    "comment": "lol",
+    "age": 33,
+    "lastname": "jackson",
+    "primaryAddress": "paris"
   }
 }

--- a/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
+++ b/packages/forms/stories-core/json/fieldsets/core-collapsibleFieldset.json
@@ -123,6 +123,7 @@
       "widget": "collapsibleFieldset",
       "key": "extra",
       "title": "Additional information",
+      "type": "array",
       "items": [
         {
           "key": "city",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
CollapsiblePanel title gets overridden with the last collpasibleFieldSet title if the widget contains arrays or multiple collpasibleFieldSet widgets
https://jira.talendforge.org/browse/TCCUI-170
http://talend.surge.sh/forms/?path=/story/uiform-v2-core-fieldsets--core-collapsiblefieldset

**What is the chosen solution to this problem?**
check if the collapsibleFieldSet contains arrays or multiple collapsible widgets and return the schema title
http://2841.talend.surge.sh/forms/?path=/story/uiform-v2-core-fieldsets--core-collapsiblefieldset

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
