### PR TITLE
fix(faceted-search): Avoid error when there is no callbacks props

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,10 @@ Types of changes
 
 ## [unreleased]
 
+### Fixed
+
+- [fixed](https://github.com/Talend/ui/pull/2842): Avoid error when there is no callbacks props
+
 ## [0.10.0]
 
 ### Added

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -43,7 +43,9 @@ export const BadgeTags = ({
 	const [tagsValues, setTagsValues] = useState([]);
 	const [isLoading, setIsLoading] = useState(true);
 	useEffect(() => {
-		if (!callbacks.getTags) {
+		if (!callbacks || !callbacks.getTags) {
+			setIsLoading(false);
+
 			console.warn("get tags callback is not defined, tags can't be fetch from server");
 			return;
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a regression in last version: faceted-search: An error is up if there is no callbacks props to BasicSearch.

**What is the chosen solution to this problem?**
Just improve the condition before trying to access in a function from callbacks object.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
