### PR TITLE
fix(TCCUI-167): change link left margin according to guidelines

### DIFF
--- a/packages/components/src/InlineMessage/InlineMessage.component.js
+++ b/packages/components/src/InlineMessage/InlineMessage.component.js
@@ -56,9 +56,9 @@ export function InlineMessage({ type, title, description, icon, link, withBackgr
 				<Icon name={icon} />
 			</span>
 			<div className={textClasses}>
-				{title && <span className={theme('tc-inline-message-title')}>{title}</span>}
+				{title && <span className={theme('tc-inline-message-title', 'tc-inline-message-text-item')}>{title}</span>}
 				{description && (
-					<span className={theme('tc-inline-message-description')}>{description}</span>
+					<span className={theme('tc-inline-message-description', 'tc-inline-message-text-item')}>{description}</span>
 				)}
 				{link && (
 					<a className={theme('tc-inline-message-link')} href={link.href} {...link.props}>

--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -26,9 +26,9 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 		line-height: $tc-inline-message-min-height;
 		min-height: $tc-inline-message-min-height;
 
-		span {
+		&-item {
 			&:after {
-				content: " ";
+				content: ' ';
 			}
 		}
 

--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -48,7 +48,9 @@ $tc-inline-message-link-margin: 0.35rem !default;
 	}
 
 	&-link {
-		margin-left: $tc-inline-message-link-margin;
+		&:before {
+			content: " ";
+		}
 	}
 
 	&-icon {

--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -3,6 +3,7 @@ $tc-inline-message-space-btn-icon-description: $padding-smaller !default;
 $tc-inline-message-min-height: 2.5rem !default;
 $tc-inline-message-border-radius: 0.4rem !default;
 $tc-inline-message-icon-offset: 0.4rem !default;
+$tc-inline-message-link-margin: 0.35rem !default;
 
 @mixin tc-background-highlight($color: $black) {
 	background-color: tint($color, 95);
@@ -47,7 +48,7 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 	}
 
 	&-link {
-		margin-left: 1ch;
+		margin-left: $tc-inline-message-link-margin;
 	}
 
 	&-icon {

--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -17,7 +17,7 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 
 	&-title {
 		font-weight: $font-weight-semi-bold;
-		margin-right: $padding-smaller;
+		// margin-right: $padding-smaller;
 	}
 
 	&-text {
@@ -26,6 +26,12 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 		border-radius: $tc-inline-message-border-radius;
 		line-height: $tc-inline-message-min-height;
 		min-height: $tc-inline-message-min-height;
+
+		span {
+			&:after {
+				content: " ";
+			}
+		}
 
 		&.background {
 			&.info {
@@ -43,12 +49,6 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 			&.warning {
 				@include tc-background-highlight($jaffa);
 			}
-		}
-	}
-
-	&-link {
-		&:before {
-			content: " ";
 		}
 	}
 

--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -3,7 +3,6 @@ $tc-inline-message-space-btn-icon-description: $padding-smaller !default;
 $tc-inline-message-min-height: 2.5rem !default;
 $tc-inline-message-border-radius: 0.4rem !default;
 $tc-inline-message-icon-offset: 0.4rem !default;
-$tc-inline-message-link-margin: 0.35rem !default;
 
 @mixin tc-background-highlight($color: $black) {
 	background-color: tint($color, 95);

--- a/packages/components/src/InlineMessage/__snapshots__/InlineMessage.snapshot.test.js.snap
+++ b/packages/components/src/InlineMessage/__snapshots__/InlineMessage.snapshot.test.js.snap
@@ -23,12 +23,12 @@ exports[`InlineMessage should render with higligthed background 1`] = `
     className="tc-inline-message-text theme-tc-inline-message-text success theme-success background theme-background"
   >
     <span
-      className="tc-inline-message-title theme-tc-inline-message-title"
+      className="tc-inline-message-title theme-tc-inline-message-title tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation title.
     </span>
     <span
-      className="tc-inline-message-description theme-tc-inline-message-description"
+      className="tc-inline-message-description theme-tc-inline-message-description tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation and successful messages
     </span>
@@ -60,7 +60,7 @@ exports[`InlineMessage should render with icon and description 1`] = `
   >
     
     <span
-      className="tc-inline-message-description theme-tc-inline-message-description"
+      className="tc-inline-message-description theme-tc-inline-message-description tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation and successful messages
     </span>
@@ -91,12 +91,12 @@ exports[`InlineMessage should render with icon, title and description 1`] = `
     className="tc-inline-message-text theme-tc-inline-message-text success theme-success"
   >
     <span
-      className="tc-inline-message-title theme-tc-inline-message-title"
+      className="tc-inline-message-title theme-tc-inline-message-title tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation title.
     </span>
     <span
-      className="tc-inline-message-description theme-tc-inline-message-description"
+      className="tc-inline-message-description theme-tc-inline-message-description tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation and successful messages
     </span>
@@ -127,12 +127,12 @@ exports[`InlineMessage should render with icon, title, description and link 1`] 
     className="tc-inline-message-text theme-tc-inline-message-text success theme-success"
   >
     <span
-      className="tc-inline-message-title theme-tc-inline-message-title"
+      className="tc-inline-message-title theme-tc-inline-message-title tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation title.
     </span>
     <span
-      className="tc-inline-message-description theme-tc-inline-message-description"
+      className="tc-inline-message-description theme-tc-inline-message-description tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation and successful messages
     </span>
@@ -163,12 +163,12 @@ exports[`InlineMessage should render with title and description 1`] = `
     className="tc-inline-message-text theme-tc-inline-message-text success theme-success"
   >
     <span
-      className="tc-inline-message-title theme-tc-inline-message-title"
+      className="tc-inline-message-title theme-tc-inline-message-title tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation title.
     </span>
     <span
-      className="tc-inline-message-description theme-tc-inline-message-description"
+      className="tc-inline-message-description theme-tc-inline-message-description tc-inline-message-text-item theme-tc-inline-message-text-item"
     >
       Validation and successful messages
     </span>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TCCUI-167
Link margin is too big, so was changed in guidelines
![image](https://user-images.githubusercontent.com/46000544/83769228-457ffc00-a688-11ea-89bc-2ff2eae7c0ea.png)

**What is the chosen solution to this problem?**
Change link margin-left from 1ch to 0.35rem
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
