### PR TITLE
fix(Components): tests with @talend/scripts

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -1,10 +1,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { withTranslation } from 'react-i18next';
+import { useTranslation } from 'react-i18next';
 import { Action, Actions, ActionDropdown, ActionSplitDropdown } from '../Actions';
 import Inject from '../Inject';
-import getDefaultT from '../translate';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import css from './ActionBar.scss';
 
@@ -141,7 +140,7 @@ function SwitchActions({ actions, left, right, center, getComponent, components 
 	);
 }
 SwitchActions.propTypes = {
-	actions: PropTypes.arrayOf(PropTypes.shape(actionsShape)).isRequired,
+	actions: PropTypes.arrayOf(PropTypes.shape(actionsShape)),
 	left: PropTypes.bool,
 	right: PropTypes.bool,
 	center: PropTypes.bool,
@@ -150,10 +149,11 @@ SwitchActions.propTypes = {
 };
 SwitchActions.defaultProps = {
 	actions: [],
-	t: getDefaultT(),
 };
 
-function Count({ selected, t }) {
+function Count({ selected }) {
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
+
 	if (!selected) {
 		return null;
 	}
@@ -165,7 +165,6 @@ function Count({ selected, t }) {
 }
 Count.propTypes = {
 	selected: PropTypes.number,
-	t: PropTypes.func,
 };
 
 function defineComponentLeft(parentComponentLeft, selected, t) {
@@ -182,7 +181,7 @@ function defineComponentLeft(parentComponentLeft, selected, t) {
 	return undefined;
 }
 
-export function ActionBarComponent(props) {
+export function ActionBar(props) {
 	const { left, right, center } = getActionsToRender(props);
 	const cssClass = classNames(
 		css['tc-actionbar-container'],
@@ -223,24 +222,22 @@ export function ActionBarComponent(props) {
 	);
 }
 
-ActionBarComponent.propTypes = {
+ActionBar.propTypes = {
 	selected: PropTypes.number,
 	children: PropTypes.node,
 	className: PropTypes.string,
 	getComponent: PropTypes.func,
-	t: PropTypes.func,
 	components: PropTypes.object,
 };
-ActionBarComponent.defaultProps = {
+ActionBar.defaultProps = {
 	components: {},
 };
-ActionBarComponent.displayName = 'ActionBar';
+ActionBar.displayName = 'ActionBar';
 
-const TranslatedActionBar = withTranslation(I18N_DOMAIN_COMPONENTS)(ActionBarComponent);
-TranslatedActionBar.DISPLAY_MODES = DISPLAY_MODES;
-TranslatedActionBar.Count = Count;
-TranslatedActionBar.SwitchActions = SwitchActions;
-TranslatedActionBar.getActionsToRender = getActionsToRender;
-TranslatedActionBar.Content = Content;
-TranslatedActionBar.getContentClassName = getContentClassName;
-export default TranslatedActionBar;
+ActionBar.DISPLAY_MODES = DISPLAY_MODES;
+ActionBar.Count = Count;
+ActionBar.SwitchActions = SwitchActions;
+ActionBar.getActionsToRender = getActionsToRender;
+ActionBar.Content = Content;
+ActionBar.getContentClassName = getContentClassName;
+export default ActionBar;

--- a/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
+++ b/packages/components/src/ActionBar/__snapshots__/ActionBar.snapshot.test.js.snap
@@ -28,19 +28,16 @@ exports[`ActionBar should render a btn-group 1`] = `
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -84,19 +81,16 @@ exports[`ActionBar should render no-selected actions, all on left  1`] = `
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -120,13 +114,11 @@ exports[`ActionBar should render no-selected actions, some on left, the other on
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={
@@ -157,7 +149,6 @@ exports[`ActionBar should render no-selected actions, some on left, the other on
     }
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -202,25 +193,21 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
       Object {
         "before-actions": <Count
           selected={1}
-          t={[Function]}
         />,
       }
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -235,19 +222,16 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
       Object {
         "before-actions": <Count
           selected={1}
-          t={[Function]}
         />,
       }
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={
@@ -283,7 +267,6 @@ exports[`ActionBar should render selected count and multi-selected actions, all 
     }
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -306,19 +289,16 @@ exports[`ActionBar should render selected count and multi-selected actions, coun
       Object {
         "before-actions": <Count
           selected={1}
-          t={[Function]}
         />,
       }
     }
     key="0"
     left={true}
-    t={[Function]}
   />
   <SwitchActions
     actions={Array []}
     center={true}
     key="1"
-    t={[Function]}
   />
   <SwitchActions
     actions={
@@ -349,7 +329,6 @@ exports[`ActionBar should render selected count and multi-selected actions, coun
     }
     key="2"
     right={true}
-    t={[Function]}
   />
 </div>
 `;
@@ -358,7 +337,7 @@ exports[`ActionBar.Count should render if selected 1`] = `
 <span
   className="theme-tc-actionbar-selected-count tc-actionbar-selected-count"
 >
-  1 ACTION_BAR_COUNT_SELECTED
+  1 selected
 </span>
 `;
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.test.js
@@ -7,7 +7,7 @@ import { ActionDropdown } from '../../../../Actions';
 describe('HeaderTitle', () => {
 	it('should render a span and ActionDropdown', () => {
 		// When
-		const wrapper = shallow(<HeaderTitle monthIndex={8} year={2012} />);
+		const wrapper = shallow(<HeaderTitle monthIndex={8} year={2012} onSelectYear={jest.fn()} />);
 
 		// Then
 		expect(wrapper.name()).toEqual('div');
@@ -19,7 +19,12 @@ describe('HeaderTitle', () => {
 	it('should render a button', () => {
 		// When
 		const wrapper = shallow(
-			<HeaderTitle monthIndex={8} year={2012} button={{ whateverButtonProp: 'whateverValue' }} />,
+			<HeaderTitle
+				monthIndex={8}
+				year={2012}
+				button={{ whateverButtonProp: 'whateverValue' }}
+				onSelectYear={jest.fn()}
+			/>,
 		);
 
 		// Then
@@ -28,22 +33,19 @@ describe('HeaderTitle', () => {
 	});
 
 	it('should render the correct date and format', () => {
-		const wrapperSpanAction = shallow(<HeaderTitle monthIndex={2} year={2001} />);
-		const wrapperButton = shallow(
-			<HeaderTitle monthIndex={11} year={2002} button={{ whateverButtonProp: 'whateverValue' }} />,
+		const wrapperSpanAction = shallow(
+			<HeaderTitle monthIndex={2} year={2001} onSelectYear={jest.fn()} />,
 		);
-		expect(
-			wrapperSpanAction
-				.find('span')
-				.first()
-				.text(),
-		).toEqual('March');
-		expect(
-			wrapperSpanAction
-				.find(ActionDropdown)
-				.first()
-				.props().label,
-		).toEqual('2001');
+		const wrapperButton = shallow(
+			<HeaderTitle
+				monthIndex={11}
+				year={2002}
+				button={{ whateverButtonProp: 'whateverValue' }}
+				onSelectYear={jest.fn()}
+			/>,
+		);
+		expect(wrapperSpanAction.find('span').first().text()).toEqual('March');
+		expect(wrapperSpanAction.find(ActionDropdown).first().props().label).toEqual('2001');
 		expect(wrapperButton.prop('label')).toBe('December 2002');
 	});
 });

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
@@ -29,6 +29,7 @@ exports[`HeaderTitle should render a span and ActionDropdown 1`] = `
     <withI18nextTranslation(YearPicker)
       data-feature="actiondropdown.items"
       id="year-picker-in-datetime-header"
+      onSelect={[MockFunction]}
       t={[Function]}
     />
   </withI18nextTranslation(ActionDropdown)>

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -164,6 +164,7 @@ describe('Drawer', () => {
 				<h1>Hello world</h1>
 			</Drawer>,
 		);
+
 		expect(wrapper.find('ActionBar')).toHaveLength(1);
 		expect(toJsonWithoutI18n(wrapper.find('ActionBar'))).toMatchSnapshot();
 	});
@@ -220,18 +221,8 @@ describe('Drawer', () => {
 
 		expect(wrapper.find('TabBar')).toHaveLength(0);
 		expect(wrapper.find('CustomTabBar')).toHaveLength(1);
-		expect(
-			wrapper
-				.find('DrawerTitle')
-				.dive()
-				.find('Action'),
-		).toHaveLength(0);
-		expect(
-			wrapper
-				.find('DrawerTitle')
-				.dive()
-				.find('CustomAction'),
-		).toHaveLength(1);
+		expect(wrapper.find('DrawerTitle').dive().find('Action')).toHaveLength(0);
+		expect(wrapper.find('DrawerTitle').dive().find('CustomAction')).toHaveLength(1);
 	});
 
 	it('render children event if there is no title', () => {

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -302,9 +302,6 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
   }
   className="tc-drawer-actionbar theme-tc-drawer-actionbar"
   components={Object {}}
-  i18n={Object {}}
-  t={[Function]}
-  tReady={true}
 >
   <div
     className="theme-tc-actionbar-container tc-actionbar-container nav tc-drawer-actionbar theme-tc-drawer-actionbar"
@@ -313,7 +310,6 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
       actions={Array []}
       key="0"
       left={true}
-      t={[Function]}
     />
     <SwitchActions
       actions={
@@ -327,7 +323,6 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
       }
       center={true}
       key="1"
-      t={[Function]}
     >
       <Content
         center={true}
@@ -341,53 +336,46 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
             label="ActionCenter-tab-2"
           >
             <withI18nextTranslation(ActionButton)
+              available={true}
+              bsStyle="default"
+              disabled={false}
               id="view-center-tab-2"
+              inProgress={false}
               label="ActionCenter-tab-2"
+              loading={false}
+              t={[Function]}
+              tooltipPlacement="top"
             >
-              <ActionButton
-                available={true}
+              <Button
+                active={false}
+                aria-label="ActionCenter-tab-2"
+                block={false}
+                bsClass="btn"
                 bsStyle="default"
+                className=""
                 disabled={false}
-                i18n={Object {}}
                 id="view-center-tab-2"
-                inProgress={false}
-                label="ActionCenter-tab-2"
-                loading={false}
-                t={[Function]}
-                tReady={true}
-                tooltipPlacement="top"
+                onClick={[Function]}
+                onMouseDown={[Function]}
+                role={null}
               >
-                <Button
-                  active={false}
+                <button
                   aria-label="ActionCenter-tab-2"
-                  block={false}
-                  bsClass="btn"
-                  bsStyle="default"
-                  className=""
+                  className="btn btn-default"
                   disabled={false}
                   id="view-center-tab-2"
                   onClick={[Function]}
                   onMouseDown={[Function]}
                   role={null}
+                  type="button"
                 >
-                  <button
-                    aria-label="ActionCenter-tab-2"
-                    className="btn btn-default"
-                    disabled={false}
-                    id="view-center-tab-2"
-                    onClick={[Function]}
-                    onMouseDown={[Function]}
-                    role={null}
-                    type="button"
+                  <span
+                    key="label"
                   >
-                    <span
-                      key="label"
-                    >
-                      ActionCenter-tab-2
-                    </span>
-                  </button>
-                </Button>
-              </ActionButton>
+                    ActionCenter-tab-2
+                  </span>
+                </button>
+              </Button>
             </withI18nextTranslation(ActionButton)>
           </Action>
         </div>
@@ -397,7 +385,6 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
       actions={Array []}
       key="2"
       right={true}
-      t={[Function]}
     />
   </div>
 </ActionBar>

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -131,7 +131,9 @@ describe('FilterBar', () => {
 	it('should call onToggle on ENTER keydown', () => {
 		// given
 		const props = { ...defaultProps };
-		const filterInstance = mount(<FilterBarComponent {...props} id={'filter'} />);
+		const filterInstance = mount(<FilterBarComponent {...props} id="filter" />, {
+			attachTo: document.body,
+		});
 		expect(document.activeElement.id).toBe('filter-input');
 
 		// when
@@ -139,6 +141,7 @@ describe('FilterBar', () => {
 
 		// then
 		expect(document.activeElement.id).toBe('');
+		filterInstance.detach();
 	});
 
 	it('should call onFilter with debounce options', done => {

--- a/packages/components/src/Gesture/withCalendarGesture.test.js
+++ b/packages/components/src/Gesture/withCalendarGesture.test.js
@@ -73,7 +73,7 @@ describe('withCalendarGesture', () => {
 	describe('LEFT keydown', () => {
 		it('should focus on previous day in same week', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -83,11 +83,12 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('13');
+			wrapper.detach();
 		});
 
 		it('should focus on previous day in the week before', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -97,12 +98,15 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('11');
+			wrapper.detach();
 		});
 
 		it('should focus on previous day in the month before', () => {
 			// given
 			const goToPreviousMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToPreviousMonth).not.toBeCalled();
 
 			// when
@@ -114,13 +118,14 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToPreviousMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('28'); // 2018-02-28
+			wrapper.detach();
 		});
 	});
 
 	describe('RIGHT keydown', () => {
 		it('should focus on next day in same week', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -130,11 +135,12 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('15');
+			wrapper.detach();
 		});
 
 		it('should focus on next day in the week after', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -144,12 +150,15 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('19');
+			wrapper.detach();
 		});
 
 		it('should focus on next day in the month after', () => {
 			// given
 			const goToNextMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToNextMonth).not.toBeCalled();
 
 			// when
@@ -161,13 +170,14 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToNextMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('1'); // 2018-04-01
+			wrapper.detach();
 		});
 	});
 
 	describe('UP keydown', () => {
 		it('should focus on previous week', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -177,12 +187,15 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('7'); // 2018-03-07
+			wrapper.detach();
 		});
 
 		it('should focus on previous week in the month before', () => {
 			// given
 			const goToPreviousMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToPreviousMonth).not.toBeCalled();
 
 			// when
@@ -194,13 +207,14 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToPreviousMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('27'); // 2018-02-27
+			wrapper.detach();
 		});
 	});
 
 	describe('DOWN keydown', () => {
 		it('should focus on next week', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -210,12 +224,15 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('21'); // 2018-03-21
+			wrapper.detach();
 		});
 
 		it('should focus on next week in the month after', () => {
 			// given
 			const goToNextMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToNextMonth).not.toBeCalled();
 
 			// when
@@ -227,13 +244,14 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToNextMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('4'); // 2018-04-04
+			wrapper.detach();
 		});
 	});
 
 	describe('HOME keydown', () => {
 		it('should focus on first day of the month', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -243,13 +261,14 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('1'); // 2018-03-01
+			wrapper.detach();
 		});
 	});
 
 	describe('END keydown', () => {
 		it('should focus on last day of the month', () => {
 			// given
-			const wrapper = mount(<DayCalendarWithGesture />);
+			const wrapper = mount(<DayCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -259,6 +278,7 @@ describe('withCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('31'); // 2018-03-31
+			wrapper.detach();
 		});
 	});
 
@@ -266,7 +286,9 @@ describe('withCalendarGesture', () => {
 		it('should go to previous month and focus on the same day', () => {
 			// given
 			const goToPreviousMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToPreviousMonth).not.toBeCalled();
 
 			// when
@@ -278,12 +300,15 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToPreviousMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('14'); // 2018-02-14
+			wrapper.detach();
 		});
 
 		it('should go to previous month and focus on the last day if same day does not exist', () => {
 			// given
 			const goToPreviousMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToPreviousMonth={goToPreviousMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToPreviousMonth).not.toBeCalled();
 
 			// when
@@ -295,6 +320,7 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToPreviousMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('28'); // 2018-02-28
+			wrapper.detach();
 		});
 	});
 
@@ -302,7 +328,9 @@ describe('withCalendarGesture', () => {
 		it('should go to next month and focus on the same day', () => {
 			// given
 			const goToNextMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToNextMonth).not.toBeCalled();
 
 			// when
@@ -314,12 +342,15 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToNextMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('14'); // 2018-04-14
+			wrapper.detach();
 		});
 
 		it('should go to next month and focus on the last day if same day does not exist', () => {
 			// given
 			const goToNextMonth = jest.fn();
-			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />);
+			const wrapper = mount(<DayCalendarWithGesture goToNextMonth={goToNextMonth} />, {
+				attachTo: document.body,
+			});
 			expect(goToNextMonth).not.toBeCalled();
 
 			// when
@@ -331,6 +362,7 @@ describe('withCalendarGesture', () => {
 			// then
 			expect(goToNextMonth).toBeCalled();
 			expect(document.activeElement.innerHTML).toBe('30'); // 2018-04-30
+			wrapper.detach();
 		});
 	});
 });
@@ -346,7 +378,7 @@ describe('withMonthCalendarGesture', () => {
 	describe('LEFT keydown', () => {
 		it('should focus on previous month in the same set of months', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -356,11 +388,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('APR');
+			wrapper.detach();
 		});
 
 		it('should focus on the previous month in the previous set of months', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -370,11 +403,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('MAR');
+			wrapper.detach();
 		});
 
 		it('should block focus on first month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -384,13 +418,14 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('JAN');
+			wrapper.detach();
 		});
 	});
 
 	describe('RIGHT keydown', () => {
 		it('should focus on next month in the same set of months', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -400,11 +435,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('JUN');
+			wrapper.detach();
 		});
 
 		it('should focus on the next month in the next set of months', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -414,11 +450,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('JULY');
+			wrapper.detach();
 		});
 
 		it('should block focus on last month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -428,13 +465,14 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('DEC');
+			wrapper.detach();
 		});
 	});
 
 	describe('UP keydown', () => {
 		it('should focus on previous set of month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -444,11 +482,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('FEB');
+			wrapper.detach();
 		});
 
 		it('should block focus when there is no previous set of month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 			// when
 			wrapper
 				.find('button')
@@ -457,13 +496,14 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('JAN');
+			wrapper.detach();
 		});
 	});
 
 	describe('DOWN keydown', () => {
 		it('should focus on next set of month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -473,11 +513,12 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('AUG');
+			wrapper.detach();
 		});
 
 		it('should block focus when there is no following set of month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -487,13 +528,14 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('DEC');
+			wrapper.detach();
 		});
 	});
 
 	describe('HOME keydown', () => {
 		it('should focus on first month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -503,13 +545,14 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('JAN');
+			wrapper.detach();
 		});
 	});
 
 	describe('END keydown', () => {
 		it('should focus on last month', () => {
 			// given
-			const wrapper = mount(<MonthCalendarWithGesture />);
+			const wrapper = mount(<MonthCalendarWithGesture />, { attachTo: document.body });
 
 			// when
 			wrapper
@@ -519,6 +562,7 @@ describe('withMonthCalendarGesture', () => {
 
 			// then
 			expect(document.activeElement.innerHTML).toBe('DEC');
+			wrapper.detach();
 		});
 	});
 });

--- a/packages/components/src/Gesture/withDynamicListGesture.test.js
+++ b/packages/components/src/Gesture/withDynamicListGesture.test.js
@@ -54,7 +54,7 @@ class ComponentWithGesture extends React.Component {
 describe('List Gesture HOC', () => {
 	function testFocus({ elementIndex, expectedActiveIndex, keyCode }) {
 		// given
-		const wrapper = mount(<ComponentWithGesture />);
+		const wrapper = mount(<ComponentWithGesture />, { attachTo: document.body });
 		const event = { keyCode };
 		const element = wrapper.find(`#item-${elementIndex}`);
 
@@ -63,6 +63,7 @@ describe('List Gesture HOC', () => {
 
 		// then
 		expect(document.activeElement.getAttribute('id')).toBe(`item-${expectedActiveIndex}`);
+		wrapper.detach();
 	}
 
 	cases('focus', testFocus, [

--- a/packages/components/src/Gesture/withListGesture.test.js
+++ b/packages/components/src/Gesture/withListGesture.test.js
@@ -5,12 +5,10 @@ import cases from 'jest-in-case';
 import withListGesture from './withListGesture';
 import List from '../../__mocks__/list';
 
-
 function getComponentWithGesture(loop) {
 	const ComponentWithGesture = withListGesture(List, loop);
 	return ComponentWithGesture;
 }
-
 
 describe('List Gesture HOC', () => {
 	it('should wrap Tree component', () => {
@@ -21,7 +19,7 @@ describe('List Gesture HOC', () => {
 	function testFocus({ elementPosition, expectedActivePosition, keyCode, loop }) {
 		// given
 		const ComponentWithGesture = getComponentWithGesture(loop);
-		const wrapper = mount(<ComponentWithGesture />);
+		const wrapper = mount(<ComponentWithGesture />, { attachTo: document.body });
 		const event = { keyCode };
 		const element = wrapper.find(`#item-${elementPosition}`);
 
@@ -30,6 +28,7 @@ describe('List Gesture HOC', () => {
 
 		// then
 		expect(document.activeElement.getAttribute('id')).toBe(`item-${expectedActivePosition}`);
+		wrapper.detach();
 	}
 
 	/**

--- a/packages/components/src/Gesture/withTreeGesture.test.js
+++ b/packages/components/src/Gesture/withTreeGesture.test.js
@@ -149,7 +149,7 @@ describe('TreeGesture HOC', () => {
 
 	function testFocus({ elementPosition, expectedActivePosition, keyCode }) {
 		// given
-		const wrapper = mount(<ComponentWithGesture {...treeProps} />);
+		const wrapper = mount(<ComponentWithGesture {...treeProps} />, { attachTo: document.body });
 		const event = { keyCode };
 		const element = wrapper.find(getSelector(elementPosition));
 		const expectedActiveElementId = wrapper
@@ -162,6 +162,7 @@ describe('TreeGesture HOC', () => {
 
 		// then
 		expect(document.activeElement.getAttribute('id')).toBe(expectedActiveElementId);
+		wrapper.detach();
 	}
 
 	/**

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -4,7 +4,7 @@ import HeaderBarComponent from './HeaderBar.component';
 
 describe('HeaderBar', () => {
 	it('should render', () => {
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent />);
+		const wrapper = mount(<HeaderBarComponent />);
 		expect(wrapper.find('HeaderBar')).toBeDefined();
 	});
 
@@ -14,7 +14,7 @@ describe('HeaderBar', () => {
 			label: 'My App',
 			onClick: jest.fn(),
 		};
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent logo={logo} />);
+		const wrapper = mount(<HeaderBarComponent logo={logo} />);
 		const element = wrapper.find('Logo').at(0).find('Button').at(0);
 		expect(element).not.toBeUndefined();
 		element.simulate('click');
@@ -27,7 +27,7 @@ describe('HeaderBar', () => {
 			label: 'My App',
 			onClick: jest.fn(),
 		};
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent brand={brand} />);
+		const wrapper = mount(<HeaderBarComponent brand={brand} />);
 		const element = wrapper.find('Brand').at(0).find('Button').at(0);
 		expect(element).not.toBeUndefined();
 		element.simulate('click');
@@ -46,7 +46,7 @@ describe('HeaderBar', () => {
 				tooltipPlacement: 'bottom',
 			},
 		};
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent search={search} />);
+		const wrapper = mount(<HeaderBarComponent search={search} />);
 		const element = wrapper.find('Button[role="search"]');
 		expect(element).not.toBeUndefined();
 		element.simulate('click');
@@ -59,7 +59,7 @@ describe('HeaderBar', () => {
 			onClick: jest.fn(),
 			icon: 'talend-icon',
 		};
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent help={help} />);
+		const wrapper = mount(<HeaderBarComponent help={help} />);
 		const element = wrapper.find('Action#help');
 		expect(element).not.toBeUndefined();
 		element.simulate('click');
@@ -81,10 +81,9 @@ describe('HeaderBar', () => {
 			firstName: 'John',
 			lastName: 'Doe',
 		};
-		const wrapper = mount(<HeaderBarComponent.WrappedComponent user={user} />);
-		const element = wrapper.find('ActionDropdown#user');
-		element.simulate('click');
-		element.find('a#settings').simulate('click');
+		const wrapper = mount(<HeaderBarComponent user={user} />);
+		wrapper.find('button#user').simulate('click');
+		wrapper.find('a#settings').simulate('click');
 		expect(user.items[0].onClick).toHaveBeenCalled();
 	});
 
@@ -115,11 +114,8 @@ describe('HeaderBar', () => {
 			label: 'My App',
 			onClick: jest.fn(),
 		};
-		const wrapper = mount(
-			<HeaderBarComponent.WrappedComponent brand={brand} products={products} />,
-		);
-		const element = wrapper.find('button#brand');
-		element.simulate('click');
+		const wrapper = mount(<HeaderBarComponent brand={brand} products={products} />);
+		wrapper.find('button#brand').simulate('click');
 		wrapper.find('a#tdp').simulate('click');
 		expect(products.onSelect).toHaveBeenCalled();
 	});
@@ -127,8 +123,8 @@ describe('HeaderBar', () => {
 	it('should render intercom', () => {
 		// when
 		const wrapper = shallow(
-			<HeaderBarComponent.WrappedComponent
-				intercom={{ id: 'my-intercom', config: { app_id: 'e19c98d' } }}
+			<HeaderBarComponent
+				intercom={{ id: 'my-intercom', config: { app_id: 'e19c98d', email: 'lol@lol.com' } }}
 			/>,
 		);
 
@@ -138,10 +134,12 @@ describe('HeaderBar', () => {
 			.dive()
 			.find('withI18nextTranslation(Intercom)');
 		expect(intercomTrigger.length).toBe(1);
-		expect(intercomTrigger.props()).toEqual({
-			className: 'btn btn-link',
-			id: 'my-intercom',
-			config: { app_id: 'e19c98d', vertical_padding: 70 },
+		expect(intercomTrigger.prop('className')).toEqual('btn btn-link');
+		expect(intercomTrigger.prop('id')).toEqual('my-intercom');
+		expect(intercomTrigger.prop('config')).toEqual({
+			app_id: 'e19c98d',
+			email: 'lol@lol.com',
+			vertical_padding: 70,
 		});
 	});
 });

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.test.js
@@ -7,7 +7,7 @@ import SkipLinks from './SkipLinks.component';
 describe('Skip links', () => {
 	it('should render only main link', () => {
 		// when
-		const wrapper = mount(<SkipLinks.WrappedComponent mainId="#my-custom-main-id" />);
+		const wrapper = mount(<SkipLinks mainId="#my-custom-main-id" />);
 
 		// then
 		expect(toJson(wrapper)).toMatchSnapshot();
@@ -16,7 +16,7 @@ describe('Skip links', () => {
 	it('should render navigation link', () => {
 		// when
 		const wrapper = mount(
-			<SkipLinks.WrappedComponent mainId="#my-custom-main-id" navigationId="#my-custom-nav-id" />,
+			<SkipLinks mainId="#my-custom-main-id" navigationId="#my-custom-nav-id" />,
 		);
 
 		// then

--- a/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
+++ b/packages/components/src/Layout/SkipLinks/__snapshots__/SkipLinks.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Skip links should render navigation link 1`] = `
-<SkipLinks
+<withI18nextTranslation(SkipLinks)
   mainId="#my-custom-main-id"
   navigationId="#my-custom-nav-id"
   t={[Function]}
@@ -89,11 +89,11 @@ exports[`Skip links should render navigation link 1`] = `
       </li>
     </ul>
   </nav>
-</SkipLinks>
+</withI18nextTranslation(SkipLinks)>
 `;
 
 exports[`Skip links should render only main link 1`] = `
-<SkipLinks
+<withI18nextTranslation(SkipLinks)
   mainId="#my-custom-main-id"
   t={[Function]}
 >
@@ -142,5 +142,5 @@ exports[`Skip links should render only main link 1`] = `
       </li>
     </ul>
   </nav>
-</SkipLinks>
+</withI18nextTranslation(SkipLinks)>
 `;

--- a/packages/components/src/ResourceList/Resource/Resource.snap.test.js
+++ b/packages/components/src/ResourceList/Resource/Resource.snap.test.js
@@ -25,7 +25,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
@@ -50,7 +50,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 			expect(wrapper.find('.author').length).toBe(1);
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
@@ -74,7 +74,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 			expect(wrapper.find('.author').length).toBe(0);
 			expect(wrapper.find('.subtitle').length).toBe(1);
 			expect(wrapper.getElement()).toMatchSnapshot();
@@ -98,7 +98,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.find('.author').length).toBe(0);
 		});
@@ -122,7 +122,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
@@ -148,7 +148,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
@@ -174,7 +174,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});
@@ -200,7 +200,7 @@ describe('Resource component snaps', () => {
 				index: 0,
 			};
 
-			const wrapper = shallow(<Resource.WrappedComponent {...props} />);
+			const wrapper = shallow(<Resource {...props} />);
 
 			expect(wrapper.getElement()).toMatchSnapshot();
 		});

--- a/packages/components/src/ResourceList/Toolbar/StateFilter/StateFilter.snap.test.js
+++ b/packages/components/src/ResourceList/Toolbar/StateFilter/StateFilter.snap.test.js
@@ -11,7 +11,7 @@ describe('StateFilter component snaps', () => {
 			onChange: () => {},
 		};
 
-		const wrapper = shallow(<StateFilter.WrappedComponent {...props} />);
+		const wrapper = shallow(<StateFilter {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -23,7 +23,7 @@ describe('StateFilter component snaps', () => {
 			onChange: () => {},
 		};
 
-		const wrapper = shallow(<StateFilter.WrappedComponent {...props} />);
+		const wrapper = shallow(<StateFilter {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -35,7 +35,7 @@ describe('StateFilter component snaps', () => {
 			types: [TYPES.FAVORITES],
 		};
 
-		const wrapper = shallow(<StateFilter.WrappedComponent {...props} />);
+		const wrapper = shallow(<StateFilter {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -47,7 +47,7 @@ describe('StateFilter component snaps', () => {
 			types: [TYPES.CERTIFIED],
 		};
 
-		const wrapper = shallow(<StateFilter.WrappedComponent {...props} />);
+		const wrapper = shallow(<StateFilter {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});

--- a/packages/components/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
+++ b/packages/components/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
@@ -4,10 +4,9 @@ exports[`SubHeaderBar should render without i18n 1`] = `
 <header
   className="theme-tc-subheader tc-subheader myClassName"
 >
-  <withI18nextTranslation(ActionBar)
+  <ActionBar
     className="theme-tc-subheader-navbar tc-subheader-navbar"
     components={Object {}}
-    t={[Function]}
   >
     <SubHeaderBarActions
       left={true}
@@ -74,6 +73,6 @@ exports[`SubHeaderBar should render without i18n 1`] = `
         onClick={[MockFunction]}
       />
     </SubHeaderBarActions>
-  </withI18nextTranslation(ActionBar)>
+  </ActionBar>
 </header>
 `;


### PR DESCRIPTION
WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master.

**What is the problem this PR is trying to solve?**
Components tests must be adapted to talend/scripts jest/enzyme/mock versions

**What is the chosen solution to this problem?**
Fix a part of them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
