### PR TITLE
fix(faceted-search): check badge existence before trying to set it

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,8 @@ Types of changes
 
 ## [unreleased]
 
+- [fixed](https://github.com/Talend/ui/pull/2847): Check badge existence before trying to set it
+
 ## [0.10.1]
 
 ### Fixed

--- a/packages/faceted-search/src/CRUDBadges.js
+++ b/packages/faceted-search/src/CRUDBadges.js
@@ -21,11 +21,13 @@ const setBadgeValue = ({ properties, metadata }) => badge => ({
 
 const setBadge = (newProperties, newMetadata) => getIndexFn => badges => {
 	const index = getIndexFn(badges);
-	const newBadge = setBadgeValue({ properties: newProperties, metadata: newMetadata })(
-		getBadge(index)(badges),
-	);
-	// eslint-disable-next-line no-param-reassign
-	badges[index] = newBadge;
+	if (index >= 0) {
+		const newBadge = setBadgeValue({ properties: newProperties, metadata: newMetadata })(
+			getBadge(index)(badges),
+		);
+		// eslint-disable-next-line no-param-reassign
+		badges[index] = newBadge;
+	}
 	return badges;
 };
 const spliceBadge = getIndexFn => badges => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When adding a new badge and then deleting it in the faceted search component with IE11 or Edge, it throws an error. 
more details please check:
https://jira.talendforge.org/browse/TMDM-14668

**What is the chosen solution to this problem?**
Add checking for var index to ensure its value is valid for **setBadge** function.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
