### PR TITLE
fix(Components): tests with @talend/scripts

### DIFF
--- a/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
+++ b/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
@@ -46,40 +46,28 @@ describe('TextFilter', () => {
 			textFilter: '',
 			setTextFilter: jest.fn(),
 		};
+		const event = { target: { value: 'my-filter-value' } };
 
 		// when
 		let wrapper;
 		act(() => {
 			wrapper = mount(
 				<ListContext.Provider value={context}>
-					<TextFilter id="myTextFilter" initialDocked />
+					<TextFilter id="myTextFilter" initialDocked debounceTimeout={0} />
 				</ListContext.Provider>,
 			);
 
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onFilter')({}, 'my-filter-value');
+			wrapper.find('button#myTextFilter').simulate('click');
 		});
 		wrapper.update();
+		wrapper.find('input').at(0).simulate('change', event);
 
 		// then
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('docked'),
-		).toBe(false);
 		expect(context.setTextFilter).toHaveBeenCalledWith('my-filter-value');
 	});
 
-	it('should call the change callbacks when they are provided (controlled mode)', () => {
+	it('should call the toggle callback when they are provided (controlled mode)', () => {
 		// given
-		const onChange = jest.fn();
 		const onToggle = jest.fn();
 
 		// when
@@ -87,23 +75,39 @@ describe('TextFilter', () => {
 		act(() => {
 			wrapper = mount(
 				<ListContext.Provider value={defaultContext}>
-					<TextFilter id="myTextFilter" onChange={onChange} onToggle={onToggle} />
+					<TextFilter id="myTextFilter" initialDocked onToggle={onToggle} />
 				</ListContext.Provider>,
 			);
 
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onFilter')({}, 'my-filter-value');
+			wrapper.find('button#myTextFilter').simulate('click');
 		});
+		wrapper.update();
 
 		// then
 		expect(onToggle).toHaveBeenCalled();
-		expect(onChange).toHaveBeenCalledWith({}, 'my-filter-value');
+	});
+
+	it('should call the callback on change (controlled mode)', () => {
+		// given
+		const onChange = jest.fn();
+		const event = { target: { value: 'my-filter-value' } };
+		const wrapper = mount(
+			<ListContext.Provider value={defaultContext}>
+				<TextFilter
+					id="myTextFilter"
+					initialDocked={false}
+					onChange={onChange}
+					debounceTimeout={0}
+					value="lol"
+				/>
+			</ListContext.Provider>,
+		);
+
+		// when
+		wrapper.find('input').at(0).simulate('change', event);
+
+		// then
+		expect(onChange).toHaveBeenCalledWith(expect.anything(), 'my-filter-value');
 	});
 
 	it('should not be docked when text filter is not empty', () => {
@@ -123,43 +127,24 @@ describe('TextFilter', () => {
 				</ListContext.Provider>,
 			);
 
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
+			wrapper.find('button#myTextFilter').simulate('click');
 		});
 		wrapper.update();
 
 		// then
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('docked'),
-		).toBe(false);
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('value'),
-		).toBe('my-filter-value');
+		expect(wrapper.find('button#myTextFilter').length).toBe(0);
+		expect(wrapper.find('input').length).toBe(1);
+		expect(wrapper.find('input').at(0).prop('value')).toBe('my-filter-value');
 
 		// when
 		act(() => {
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
+			wrapper.find('input').simulate('blur'); // blur with no input value toggles the search
 		});
 		wrapper.update();
 
 		// then
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('docked'),
-		).toBe(false);
+		expect(wrapper.find('button#myTextFilter').length).toBe(0);
+		expect(wrapper.find('input').length).toBe(1);
 	});
 
 	it('should be docked when text filter is empty', () => {
@@ -178,37 +163,22 @@ describe('TextFilter', () => {
 					<TextFilter id="myTextFilter" initialDocked />
 				</ListContext.Provider>,
 			);
-
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
+			wrapper.find('button#myTextFilter').simulate('click');
 		});
 		wrapper.update();
 
 		// then
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('docked'),
-		).toBe(false);
+		expect(wrapper.find('button#myTextFilter').length).toBe(0);
+		expect(wrapper.find('input').length).toBe(1);
 
 		// when
 		act(() => {
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('onToggle')();
+			wrapper.find('input').simulate('blur'); // blur with no input value toggles the search
 		});
 		wrapper.update();
 
 		// then
-		expect(
-			wrapper
-				.find('FilterBar')
-				.at(0)
-				.prop('docked'),
-		).toBe(true);
+		expect(wrapper.find('button#myTextFilter').length).toBe(1);
+		expect(wrapper.find('input').length).toBe(0);
 	});
 });

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import Component from './ColumnChooser.component';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/ColumnChooserBody.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/ColumnChooserBody.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserFooter/ColumnChooserFooter.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserFooter/ColumnChooserFooter.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import getDefaultT from '../../../../../translate';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import getDefaultT from '../../../../../translate';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserRow/RowCheckbox/RowCheckbox.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserRow/RowCheckbox/RowCheckbox.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import Component from './RowCheckbox.component';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserRow/RowLabel/RowLabel.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserRow/RowLabel/RowLabel.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import Component from './RowLabel.component';

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/SelectAllColumnsCheckbox/SelectAllColumnsCheckbox.component.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/SelectAllColumnsCheckbox/SelectAllColumnsCheckbox.component.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
 import { mount } from 'enzyme';
 import { act } from 'react-dom/test-utils';

--- a/packages/components/src/ResourceList/Toolbar/SortOptions/SortOptions.snap.test.js
+++ b/packages/components/src/ResourceList/Toolbar/SortOptions/SortOptions.snap.test.js
@@ -9,7 +9,7 @@ describe('SortOptions component snaps', () => {
 			onChange: () => {},
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -23,7 +23,7 @@ describe('SortOptions component snaps', () => {
 			},
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -37,7 +37,7 @@ describe('SortOptions component snaps', () => {
 			},
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -52,7 +52,7 @@ describe('SortOptions component snaps', () => {
 			types: [TYPES.DATE],
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -67,7 +67,7 @@ describe('SortOptions component snaps', () => {
 			types: [TYPES.NAME],
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -82,7 +82,7 @@ describe('SortOptions component snaps', () => {
 			types: [],
 		};
 
-		const wrapper = shallow(<SortOptions.WrappedComponent {...props} />);
+		const wrapper = shallow(<SortOptions {...props} />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});

--- a/packages/components/src/Skeleton/Skeleton.test.js
+++ b/packages/components/src/Skeleton/Skeleton.test.js
@@ -10,23 +10,21 @@ describe('Skeleton', () => {
 		return options.defaultValue || msgid;
 	}
 	it('should render span with aria label', () => {
-		const wrapper = mount(<Skeleton.WrappedComponent type="text" t={t} />);
+		const wrapper = mount(<Skeleton type="text" t={t} />);
 		const element = wrapper.find('.tc-skeleton');
 		expect(element.type()).toBe('span');
 		expect(element.props()['aria-label']).toBe('text (loading)');
 	});
 	it('should use style to apply with/height', () => {
-		const wrapper = mount(<Skeleton.WrappedComponent type="text" t={t} width={80} height={30} />);
+		const wrapper = mount(<Skeleton type="text" t={t} width={80} height={30} />);
 		expect(wrapper.find('.tc-skeleton').props().style).toEqual({ height: 30, width: 80 });
 	});
 	it('should use className to apply size', () => {
-		const wrapper = mount(
-			<Skeleton.WrappedComponent type="text" t={t} size={Skeleton.SIZES.small} />,
-		);
+		const wrapper = mount(<Skeleton type="text" t={t} size={Skeleton.SIZES.small} />);
 		expect(wrapper.find('.tc-skeleton-text-small')).not.toBeUndefined();
 	});
 	it('should render icon for type=icon', () => {
-		const wrapper = mount(<Skeleton.WrappedComponent type="icon" name="test-icon" t={t} />);
+		const wrapper = mount(<Skeleton type="icon" name="test-icon" t={t} />);
 		expect(wrapper.find('Icon')).not.toBeUndefined();
 	});
 });

--- a/packages/components/src/translate.test.js
+++ b/packages/components/src/translate.test.js
@@ -11,7 +11,6 @@ describe('getCurrentLanguage', () => {
 		i18next.language = originalLang;
 	});
 	it('should return the locale', () => {
-		expect(i18next.language).toBe('en');
 		expect(getCurrentLanguage()).toBe('en');
 
 		i18next.language = 'fr';


### PR DESCRIPTION
_WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master._

**What is the problem this PR is trying to solve?**
Components tests must be adapted to talend/scripts jest/enzyme/mock versions

**What is the chosen solution to this problem?**
Fix a part of them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
