### PR TITLE
fix(containers/SidePanel): improve management of metakey and ctrlkey

### DIFF
--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -57,8 +57,10 @@ function getActionsWrapped(actions) {
 			return {
 				...action,
 				onClick: event => {
-					event.preventDefault();
-					event.stopPropagation();
+					if (!event.metaKey && !event.ctrlKey) {
+						event.preventDefault();
+						event.stopPropagation();
+					}
 				},
 				onClickDispatch: {
 					type: ACTION_TYPE_LINK,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On Mac if we try to use the shortcut CMD+Click to open the link to another tab, it does not work.
**What is the chosen solution to this problem?**
in the function onClick add a condition to not execute preventDefault and stopPropagation if the metakey or the ctrlkey is set to true

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
