### PR TITLE
fix(TCCUI-178) - datalist onselect not triggered on mouse down event

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -27,10 +27,13 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   186:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
-  80:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
-  81:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
-  83:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
-  84:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+  79:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
+  80:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
+  82:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
+  83:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+
+/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Time/Manager/Manager.component.js
+  70:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
   281:43  error  'footerActions' is already declared in the upper scope  no-shadow
@@ -73,6 +76,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 29 problems (26 errors, 3 warnings)
+✖ 30 problems (27 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -140,8 +140,18 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...inputProps,
 		items: getItems(rest.items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
-			onMouseDown: rest.onSelect,
-			onClick: rest.onSelect,
+			// onBlur shouldn't be called before onClick but the general order is (mouseDown, Blur, Click)
+			// so we require preventDefault after mouseDown event
+			onMouseDown: event => event.preventDefault(),
+			// onClick is required to track the element usage in pendo
+			onClick: (event, data) => {
+				rest.onSelect(event, data);
+				// onBlur is needed to focus out from the dataList after selection which lets the user
+				// to open the options without having to click outside of the element after selection
+				setTimeout(() => {
+					document.activeElement.blur();
+				});
+			},
 			'aria-disabled': rest.items[itemIndex] && rest.items[itemIndex].disabled,
 		}),
 	};

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -140,7 +140,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...inputProps,
 		items: getItems(rest.items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
-			onMouseDown: event => event.preventDefault(),
+			onMouseDown: rest.onSelect,
 			onClick: rest.onSelect,
 			'aria-disabled': rest.items[itemIndex] && rest.items[itemIndex].disabled,
 		}),

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -76,6 +76,8 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-0"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -99,6 +101,8 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-1"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -213,6 +217,8 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -260,6 +266,8 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -347,6 +355,8 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -540,6 +550,8 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -570,6 +582,8 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -628,6 +642,8 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
+            onClick={[Function]}
+            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -723,6 +739,8 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-0"
+          onClick={[Function]}
+          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >
@@ -747,6 +765,8 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-1"
+          onClick={[Function]}
+          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -76,7 +76,6 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-0"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -100,7 +99,6 @@ exports[`Typeahead injection should use render props to inject extra components 
           <li
             aria-selected={false}
             id="react-autowhatever-my-search--item-1"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -215,7 +213,6 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -263,7 +260,6 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -351,7 +347,6 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -545,7 +540,6 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -576,7 +570,6 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-1"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -635,7 +628,6 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           <li
             aria-selected={false}
             id="react-autowhatever-my-search-section-1-item-0"
-            onMouseDown={[Function]}
             role="option"
             style={Object {}}
           >
@@ -731,7 +723,6 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-0"
-          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >
@@ -756,7 +747,6 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
         <li
           aria-selected={false}
           id="react-autowhatever-my-search--item-1"
-          onMouseDown={[Function]}
           role="option"
           style={Object {}}
         >

--- a/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
+++ b/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
@@ -13,6 +13,7 @@ exports[`Action Icon Toggle should render 1`] = `
       "type": "TOGGLE-MY-AWESOME-ACTION",
     }
   }
+  tick={false}
   tooltipPlacement="top"
 />
 `;

--- a/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
+++ b/packages/containers/src/ActionIconToggle/__snapshots__/ActionIconToggle.test.js.snap
@@ -13,7 +13,6 @@ exports[`Action Icon Toggle should render 1`] = `
       "type": "TOGGLE-MY-AWESOME-ACTION",
     }
   }
-  tick={false}
   tooltipPlacement="top"
 />
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TCCUI-178
There is a regression with the datalist after the recent changes with the DataList component.
OnSelect not triggered on mousedown when the focus is already within the datalist.

Regression from,
https://github.com/Talend/ui/pull/2753
and
https://github.com/Talend/ui/pull/2741

![datalist_focus_issue](https://user-images.githubusercontent.com/34709414/85057272-d5ea3080-b1a0-11ea-8323-76132c74714f.gif)


**What is the chosen solution to this problem?**
Instead of event.preventDefault() we can use the same onSelect when the mouseDown event is triggered
http://2859.talend.surge.sh/components/?path=/story/form-controls-datalist--default-multisection

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
