### PR TITLE
fix(faceted): hide delete icon if no filters

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -27,10 +27,13 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   186:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
-  80:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
-  81:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
-  83:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
-  84:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+  79:12  error  'onChange' PropType is defined but prop is never used    react/no-unused-prop-types
+  80:12  error  'required' PropType is defined but prop is never used    react/no-unused-prop-types
+  82:14  error  'useSeconds' PropType is defined but prop is never used  react/no-unused-prop-types
+  83:10  error  'useUTC' PropType is defined but prop is never used      react/no-unused-prop-types
+
+/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Time/Manager/Manager.component.js
+  70:12  error  'onChange' PropType is defined but prop is never used  react/no-unused-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
   281:43  error  'footerActions' is already declared in the upper scope  no-shadow
@@ -73,6 +76,6 @@ The react/require-extension rule is deprecated. Please use the import/extensions
   42:3  warning  Unexpected console statement  no-console
   73:2  error    Mixed spaces and tabs         no-mixed-spaces-and-tabs
 
-✖ 29 problems (26 errors, 3 warnings)
+✖ 30 problems (27 errors, 3 warnings)
   1 error, 0 warnings potentially fixable with the `--fix` option.
 

--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,9 @@ Types of changes
 
 ## [unreleased]
 
+- [fixed](https://github.com/Talend/ui/pull/2862): Hide delete icon if no filters
+
+
 ## [0.10.2]
 
 - [fixed](https://github.com/Talend/ui/pull/2847): Check badge existence before trying to set it

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -65,6 +65,7 @@ const BasicSearch = ({
 	};
 	const basicSearchId = `${id}-basic-search`;
 	const badgeFacetedContextValue = { state, dispatch, onSubmit };
+
 	return (
 		<div id={basicSearchId} className={css('tc-basic-search')}>
 			<div className={css('tc-basic-search-content')}>
@@ -99,16 +100,18 @@ const BasicSearch = ({
 				</BadgeOverlay>
 			</div>
 
-			<ActionButton
-				className={css('tc-basic-search-clear-button')}
-				tooltipLabel={t('FACETED_SEARCH_BASIC_CLEAR', { defaultValue: 'Remove all filters' })}
-				data-feature={USAGE_TRACKING_TAGS.BASIC_CLEAR}
-				icon="talend-trash"
-				onClick={() => dispatch(BADGES_ACTIONS.deleteAll())}
-				link
-				label=""
-				disabled={state.badges.length === 0}
-			/>
+			{state.badges.length > 0 && (
+				<ActionButton
+					className={css('tc-basic-search-clear-button')}
+					tooltipLabel={t('FACETED_SEARCH_BASIC_CLEAR', { defaultValue: 'Remove all filters' })}
+					data-feature={USAGE_TRACKING_TAGS.BASIC_CLEAR}
+					icon="talend-trash"
+					onClick={() => dispatch(BADGES_ACTIONS.deleteAll())}
+					link
+					label=""
+					disabled={state.badges.length === 0}
+				/>
+			)}
 		</div>
 	);
 };

--- a/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -26,25 +26,6 @@ exports[`BasicSearch should render the default html output with no badges 1`] = 
       </button>
     </div>
   </div>
-  <button disabled
-          role="link"
-          aria-label="Remove all filters"
-          data-feature="filter.basic.clear"
-          aria-describedby="42"
-          type="button"
-          class="tc-basic-search-clear-button theme-tc-basic-search-clear-button btn-icon-only theme-btn-disabled btn btn-link"
-  >
-    <svg name="talend-trash"
-         class="theme-tc-svg-icon tc-svg-icon"
-         focusable="false"
-         aria-hidden="true"
-    >
-      <use xlink:href="#talend-trash">
-      </use>
-    </svg>
-    <span>
-    </span>
-  </button>
 </div>
 `;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Delete icon is present even if no filters are applied

**What is the chosen solution to this problem?**

Hide it when there are no filters 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
