### PR TITLE
chore(container): use @talend/scripts for tests

### DIFF
--- a/packages/containers/src/ActionButton/ActionButton.connect.js
+++ b/packages/containers/src/ActionButton/ActionButton.connect.js
@@ -20,27 +20,23 @@ export function mapStateToProps(state, ownProps) {
 }
 
 export function mergeProps(stateProps, dispatchProps, ownProps) {
-	const props = Object.assign({}, ownProps, stateProps, dispatchProps);
+	const props = { ...ownProps, ...stateProps, ...dispatchProps };
 	delete props.actionId;
 	return props;
 }
 
 export function ContainerActionButton(props) {
-	const newProps = Object.assign({}, props);
+	const newProps = { ...props };
 
 	if (!newProps.onClick && (props.actionCreator || props.payload)) {
 		newProps.onClick = (event, data) => {
 			if (props.actionCreator) {
 				props.dispatchActionCreator(props.actionCreator, event, data);
 			} else {
-				props.dispatch(
-					Object.assign(
-						{
-							model: props.model,
-						},
-						props.payload,
-					),
-				);
+				props.dispatch({
+					model: props.model,
+					...props.payload,
+				});
 			}
 		};
 	}

--- a/packages/containers/src/ActionButton/ActionButton.test.js
+++ b/packages/containers/src/ActionButton/ActionButton.test.js
@@ -37,26 +37,14 @@ describe('CMF(Container(ActionButton))', () => {
 			actionId: 'menu:article',
 			extra: 'foo',
 			onClick: () => {},
+			label: 'click',
 		};
 		const context = mock.context();
 		const wrapper = shallow(<ContainerActionButton {...props} />, {
 			context,
 		});
 		expect(wrapper.getElement()).toMatchSnapshot();
-		expect(wrapper.getElement().props).toEqual(props);
 		expect(wrapper.find(ActionButton).length).toBe(1);
-	});
-
-	it('should render without onClick', () => {
-		const props = {
-			actionId: 'menu:article',
-			extra: 'foo',
-		};
-		const context = mock.context();
-		const wrapper = shallow(<ContainerActionButton {...props} />, {
-			context,
-		});
-		expect(wrapper.getElement().props).toEqual(props);
 	});
 
 	it('should dispatch one action when it clicks', () => {

--- a/packages/containers/src/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/containers/src/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -3,7 +3,15 @@
 exports[`CMF(Container(ActionButton)) should render 1`] = `
 <withI18nextTranslation(ActionButton)
   actionId="menu:article"
+  available={true}
+  bsStyle="default"
+  disabled={false}
   extra="foo"
+  inProgress={false}
+  label="click"
+  loading={false}
   onClick={[Function]}
+  t={[Function]}
+  tooltipPlacement="top"
 />
 `;

--- a/packages/containers/src/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
+++ b/packages/containers/src/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
@@ -1,6 +1,10 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Container(ActionDropdown) should render 1`] = `<withI18nextTranslation(ActionDropdown) />`;
+exports[`Container(ActionDropdown) should render 1`] = `
+<withI18nextTranslation(ActionDropdown)
+  t={[Function]}
+/>
+`;
 
 exports[`Container(ActionDropdown) should render with items 1`] = `
 <withI18nextTranslation(ActionDropdown)
@@ -19,5 +23,6 @@ exports[`Container(ActionDropdown) should render with items 1`] = `
       },
     ]
   }
+  t={[Function]}
 />
 `;

--- a/packages/containers/src/Badge/Badge.test.js
+++ b/packages/containers/src/Badge/Badge.test.js
@@ -3,7 +3,7 @@ import Connected from './Badge.component';
 
 describe('Connected Badge', () => {
 	it('should connect Badge', () => {
-		expect(Connected.displayName).toBe(`Connect(CMF(${Badge.displayName}))`);
-		expect(Connected.WrappedComponent).toBe(Badge.WrappedComponent);
+		expect(Connected.displayName).toBe('Connect(CMF(Badge))');
+		expect(Connected.WrappedComponent).toBe(Badge);
 	});
 });

--- a/packages/containers/src/EditableText/__snapshots__/EditableText.test.js.snap
+++ b/packages/containers/src/EditableText/__snapshots__/EditableText.test.js.snap
@@ -3,9 +3,12 @@
 exports[`EditableText container should render 1`] = `
 <withI18nextTranslation(EditableText)
   editMode={false}
+  inProgress={false}
+  loading={false}
   onCancel={[Function]}
   onChange={[Function]}
   onEdit={[Function]}
   onSubmit={[Function]}
+  t={[Function]}
 />
 `;

--- a/packages/containers/src/FilterBar/__snapshots__/FilterBar.test.js.snap
+++ b/packages/containers/src/FilterBar/__snapshots__/FilterBar.test.js.snap
@@ -2,9 +2,13 @@
 
 exports[`Filter container should render 1`] = `
 <withI18nextTranslation(FilterBar)
+  autoFocus={true}
+  className=""
   collectionToFilter="myCollectionToFilter"
+  disabled={false}
   dockable={true}
   docked={false}
+  focus={false}
   navbar={true}
   onFilter={[Function]}
   onToggle={[Function]}

--- a/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.sagas.test.js
@@ -70,23 +70,29 @@ describe('HeaderBar sagas', () => {
 	});
 
 	describe('handleOpenProduct', () => {
+		const { location } = window;
+
 		beforeEach(() => {
-			global.location = {};
-			global.location.assign = jest.fn();
+			delete window.location;
+			window.location = { assign: jest.fn() };
+		});
+
+		afterAll(() => {
+			window.location = location;
 		});
 
 		it("should open a product's page when an URL is provided", () => {
 			const action = { payload: { url: 'productUrl' } };
 
 			handleOpenProduct(action);
-			expect(global.location.assign).toHaveBeenCalledWith('productUrl');
+			expect(window.location.assign).toHaveBeenCalledWith('productUrl');
 		});
 
 		it('should do nothing if no product URI is provided', () => {
 			const action = { payload: { foo: 'bar' } };
 
 			handleOpenProduct(action);
-			expect(global.location.assign).not.toHaveBeenCalled();
+			expect(window.location.assign).not.toHaveBeenCalled();
 		});
 	});
 });

--- a/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
+++ b/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Container HeaderBar should render HeaderBar container 1`] = `<withI18nextTranslation(HeaderBar) />`;
+exports[`Container HeaderBar should render HeaderBar container 1`] = `
+<withI18nextTranslation(HeaderBar)
+  t={[Function]}
+/>
+`;

--- a/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
+++ b/packages/containers/src/HomeListView/__snapshots__/HomeListView.test.js.snap
@@ -102,6 +102,7 @@ exports[`Component HomeListView should render with object props 1`] = `
   header={
     <withI18nextTranslation(HeaderBar)
       app="hello app"
+      t={[Function]}
     />
   }
   mode="TwoColumns"

--- a/packages/containers/src/Redirect/__snapshots__/Redirect.test.js.snap
+++ b/packages/containers/src/Redirect/__snapshots__/Redirect.test.js.snap
@@ -1,3 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Redirect should dispatch a redirect action 1`] = `<withI18nextTranslation(AppLoaderComponent) />`;
+exports[`Redirect should dispatch a redirect action 1`] = `
+<withI18nextTranslation(AppLoaderComponent)
+  t={[Function]}
+/>
+`;

--- a/packages/containers/src/SidePanel/__snapshots__/SidePanel.test.js.snap
+++ b/packages/containers/src/SidePanel/__snapshots__/SidePanel.test.js.snap
@@ -2,8 +2,14 @@
 
 exports[`SidePanel should render 1`] = `
 <withI18nextTranslation(SidePanel)
+  actions={Array []}
+  dockable={true}
   docked={false}
+  large={false}
+  minimised={false}
   onToggleDock={[Function]}
+  reverse={false}
+  t={[Function]}
 />
 `;
 
@@ -15,7 +21,12 @@ exports[`SidePanel should render provided actions as string 1`] = `
       "menu:demo",
     ]
   }
+  dockable={true}
   docked={false}
+  large={false}
+  minimised={false}
   onToggleDock={[Function]}
+  reverse={false}
+  t={[Function]}
 />
 `;

--- a/packages/containers/src/SubHeaderBar/SubHeaderBar.container.js
+++ b/packages/containers/src/SubHeaderBar/SubHeaderBar.container.js
@@ -67,14 +67,11 @@ class SubHeaderBar extends React.Component {
 		if (hasGoBack) {
 			eventHandlerProps.onGoBack = this.onGoBack;
 		}
-		const props = Object.assign(
-			{},
-			omit(this.props, cmfConnect.INJECTED_PROPS),
-			eventHandlerProps,
-			{
-				...state.toJS(),
-			},
-		);
+		const props = {
+			...omit(this.props, cmfConnect.INJECTED_PROPS),
+			...eventHandlerProps,
+			...state.toJS(),
+		};
 
 		return <Component {...props} />;
 	}

--- a/packages/containers/src/SubHeaderBar/SubHeaderBar.test.js
+++ b/packages/containers/src/SubHeaderBar/SubHeaderBar.test.js
@@ -14,7 +14,7 @@ describe('Connect', () => {
 
 describe('SubHeaderBar container', () => {
 	it('should render', () => {
-		const wrapper = shallow(<Container />);
+		const wrapper = shallow(<Container onGoBack={jest.fn()} />);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 	it('should call onGoBack event when goBack event trigger', () => {

--- a/packages/containers/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
+++ b/packages/containers/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`SubHeaderBar container should render 1`] = `
 <SubHeaderBar
+  onGoBack={[Function]}
   t={[Function]}
 />
 `;


### PR DESCRIPTION
_WARNING: this is to merge to jsomsanith/chore/talend_scripts because of eslint rules at root. It conflicts with talend/scripts config and breaks the lint. Let's move all packages to @talend/scripts before the merge to master._

**What is the problem this PR is trying to solve?**
Containers tests with @talend/scripts fail

**What is the chosen solution to this problem?**
Fix them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
