### PR TITLE
fix(router): linter ci loops

### DIFF
--- a/.travis/after_success_lint.sh
+++ b/.travis/after_success_lint.sh
@@ -12,7 +12,7 @@ if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
 	(lerna exec --scope=@talend/react-containers -- npm run lint:es -o output/containers.eslint.txt)
 	(lerna exec --scope=@talend/react-forms -- npm run lint:es -o output/forms.eslint.txt)
 	# not in lerna
-	cd packages/router/ && (yarn run lint:es | awk '{if(NR>2)print}') 1> ../../output/router.eslint.txt 2>/dev/null && cd ../../
+	cd packages/router/ && (yarn run lint:es -o ../../output/router.eslint.txt | awk '{if(NR>2)print}') 2>/dev/null && cd ../../
 
 	echo "Linting Sass files"
 	(lerna exec --scope=@talend/bootstrap-theme -- npm run lint:style | awk '{if(NR>2)print}') 1> output/theme.sasslint.txt 2>/dev/null


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In talend/scripts branch, the CI loops because it outputs the run time that changes everytime. It's due to router lint, that prints all the logs in a file.

**What is the chosen solution to this problem?**
Use eslint `-o` option to output the lint result instead

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
