### PR TITLE
fix(ActionFile): data-feature attribute is not forwarded

### DIFF
--- a/packages/components/src/Actions/ActionFile/ActionFile.component.js
+++ b/packages/components/src/Actions/ActionFile/ActionFile.component.js
@@ -80,6 +80,7 @@ class ActionFile extends React.Component {
 		tooltipPlacement: OverlayTrigger.propTypes.placement,
 		tooltip: PropTypes.bool,
 		tooltipLabel: PropTypes.string,
+		'data-feature': PropTypes.string,
 	};
 
 	static defaultProps = {
@@ -118,6 +119,7 @@ class ActionFile extends React.Component {
 			label,
 			tooltipPlacement,
 			accept,
+			'data-feature': dataFeature,
 		} = this.props;
 		if (!available) {
 			return null;
@@ -141,7 +143,7 @@ class ActionFile extends React.Component {
 					disabled={inProgress || disabled}
 					className={classNames(theme['action-file-input'], 'sr-only')}
 				/>
-				<label htmlFor={localId} className={labelClasses}>
+				<label htmlFor={localId} className={labelClasses} data-feature={dataFeature}>
 					{buttonContent}
 				</label>
 			</span>

--- a/packages/components/src/Actions/ActionFile/__snapshots__/ActionFile.test.js.snap
+++ b/packages/components/src/Actions/ActionFile/__snapshots__/ActionFile.test.js.snap
@@ -11,6 +11,7 @@ exports[`ActionFile should apply transformation on icon 1`] = `
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -37,6 +38,7 @@ exports[`ActionFile should display a Progress indicator if set 1`] = `
   />
   <label
     className="btn btn-default theme-btn-file disabled"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <withI18nextTranslation(CircularProgress)
@@ -62,6 +64,7 @@ exports[`ActionFile should display a disabled Icon 1`] = `
   />
   <label
     className="btn btn-default theme-btn-file disabled"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -87,6 +90,7 @@ exports[`ActionFile should pass all props to the Button 1`] = `
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -110,6 +114,7 @@ exports[`ActionFile should render a div with a input[type="file"] and a label to
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -135,6 +140,7 @@ exports[`ActionFile should render a div with a input[type="file"] with some clas
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -159,6 +165,7 @@ exports[`ActionFile should render action with html property name = props.name if
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <Icon
@@ -182,6 +189,7 @@ exports[`ActionFile should reverse icon/label 1`] = `
   />
   <label
     className="btn btn-default theme-btn-file"
+    data-feature="action.feature"
     htmlFor={42}
   >
     <span>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
data-feature attribute is not forwarded to label
```
<Action
    displayMode="file"
    data-feature="preparation.import"
/>
```

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
