### PR TITLE
Fix(Components): AppSwitcher not visible if label not defined

### DIFF
--- a/packages/components/src/AppSwitcher/AppSwitcher.component.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.js
@@ -14,10 +14,6 @@ const theme = getTheme(AppSwitcherCSSModule);
 export default function AppSwitcher({ label, isSeparated, onClick, ...props }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
-	if (!label) {
-		return null;
-	}
-
 	const className = theme('tc-app-switcher-action', {
 		separated: isSeparated,
 	});

--- a/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
@@ -63,10 +63,4 @@ describe('AppSwitcher', () => {
 
 		expect(wrapper.find('li').prop('className').includes('separated')).toBeTruthy();
 	});
-
-	it('should hide the AppSwitcher', () => {
-		const wrapper = mount(<AppSwitcher />);
-
-		expect(wrapper.html()).toBe(null);
-	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The AppSwitcher is not visible if a label is not defined
More details here: https://talend.slack.com/archives/C2N95B1KN/p1593508240037100

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
