### PR TITLE
feat(TDC-1501/components/slider): add support for new operator modes

### DIFF
--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -218,6 +218,8 @@ class Slider extends React.Component {
 		captionTextStepNumber: PropTypes.number,
 		min: PropTypes.number.isRequired,
 		max: PropTypes.number.isRequired,
+		rightTrack: PropTypes.bool,
+		noTrack: PropTypes.bool,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
 	};
@@ -239,6 +241,8 @@ class Slider extends React.Component {
 			captionsFormat,
 			min,
 			max,
+			rightTrack,
+			noTrack,
 			onChange,
 			disabled,
 			...rest
@@ -254,7 +258,14 @@ class Slider extends React.Component {
 						min={min}
 						max={max}
 						handle={noValue ? undefined : this.state.handle}
-						className={classnames(theme['tc-slider-rc-slider'], 'tc-slider-rc-slider')}
+						className={classnames(
+							theme['tc-slider-rc-slider'],
+							{[theme['tc-slider-rc-slider--track-right']]: rightTrack},
+							{[theme['tc-slider-rc-slider--track-none']]: noTrack},
+							'tc-slider-rc-slider',
+							{'tc-slider-rc-slider--track-right': rightTrack},
+							{'tc-slider-rc-slider--track-none': noTrack}
+						)}
 						onChange={onChange}
 						disabled={disabled}
 						{...rest}

--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -48,6 +48,29 @@ export function getCaptionsValue(captionsLength, min, max) {
 }
 
 /**
+ * Return correct modifier styles for usage mode
+ * @param {string} mode
+ * @param {number} value
+ */
+export function getModeStyles(mode, value) {
+	if (Array.isArray(value)) {
+		if (mode === 'exclusive') {
+			return 'exclusive';
+		} else {
+			return false;
+		}
+	} else {
+		if (mode === 'greaterThan') {
+			return 'greaterThan';
+		} else if (mode === 'equals') {
+			return 'equals';
+		} else {
+			return false;
+		}
+	}
+}
+
+/**
  * This function allow to get the actions components
  * @param {array} actions
  * @param {number} value
@@ -218,8 +241,7 @@ class Slider extends React.Component {
 		captionTextStepNumber: PropTypes.number,
 		min: PropTypes.number.isRequired,
 		max: PropTypes.number.isRequired,
-		rightTrack: PropTypes.bool,
-		noTrack: PropTypes.bool,
+		mode: PropTypes.bool,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
 	};
@@ -241,14 +263,14 @@ class Slider extends React.Component {
 			captionsFormat,
 			min,
 			max,
-			rightTrack,
-			noTrack,
+			mode,
 			onChange,
 			disabled,
 			...rest
 		} = this.props;
 		const noValue = value === null || value === undefined;
 		const Component = Array.isArray(value) ? Range : RcSlider;
+		const modeStyles = getModeStyles(mode, value);
 		return (
 			<div>
 				<div className={classnames(theme['tc-slider'], 'tc-slider')} key="slider">
@@ -260,11 +282,13 @@ class Slider extends React.Component {
 						handle={noValue ? undefined : this.state.handle}
 						className={classnames(
 							theme['tc-slider-rc-slider'],
-							{[theme['tc-slider-rc-slider--track-right']]: rightTrack},
-							{[theme['tc-slider-rc-slider--track-none']]: noTrack},
+							{[theme['tc-slider-rc-slider--track-equals']]: modeStyles === 'equals'},
+							{[theme['tc-slider-rc-slider--track-exclusive']]: modeStyles === 'exclusive'},
+							{[theme['tc-slider-rc-slider--track-greater-than']]: modeStyles === 'greaterThan'},
 							'tc-slider-rc-slider',
-							{'tc-slider-rc-slider--track-right': rightTrack},
-							{'tc-slider-rc-slider--track-none': noTrack}
+							{'tc-slider-rc-slider--track-equals': modeStyles === 'equals'},
+							{'tc-slider-rc-slider--track-exclusive': modeStyles === 'exclusive'},
+							{'tc-slider-rc-slider--track-greater-than': modeStyles === 'greaterThan'}
 						)}
 						onChange={onChange}
 						disabled={disabled}

--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -10,6 +10,14 @@ import theme from './Slider.scss';
 import Action from '../Actions/Action';
 
 const noFormat = value => value;
+/**
+ * Options for controlling slider operator display mode
+ */
+export const SLIDER_MODE = {
+	GREATER_THAN: 'greaterThan',
+	EQUALS: 'equals',
+	EXCLUSIVE: 'exclusive'
+};
 
 /**
  * this function check if we have icons to display
@@ -45,29 +53,6 @@ export function getCaptionsValue(captionsLength, min, max) {
 	const captionsValue = range(min, max, interval);
 	captionsValue.push(max);
 	return captionsValue;
-}
-
-/**
- * Return correct modifier styles for usage mode
- * @param {string} mode
- * @param {number} value
- */
-export function getModeStyles(mode, value) {
-	if (Array.isArray(value)) {
-		if (mode === 'exclusive') {
-			return 'exclusive';
-		} else {
-			return false;
-		}
-	} else {
-		if (mode === 'greaterThan') {
-			return 'greaterThan';
-		} else if (mode === 'equals') {
-			return 'equals';
-		} else {
-			return false;
-		}
-	}
 }
 
 /**
@@ -241,7 +226,7 @@ class Slider extends React.Component {
 		captionTextStepNumber: PropTypes.number,
 		min: PropTypes.number.isRequired,
 		max: PropTypes.number.isRequired,
-		mode: PropTypes.bool,
+		mode: PropTypes.string,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
 	};
@@ -270,7 +255,6 @@ class Slider extends React.Component {
 		} = this.props;
 		const noValue = value === null || value === undefined;
 		const Component = Array.isArray(value) ? Range : RcSlider;
-		const modeStyles = getModeStyles(mode, value);
 		return (
 			<div>
 				<div className={classnames(theme['tc-slider'], 'tc-slider')} key="slider">
@@ -282,13 +266,13 @@ class Slider extends React.Component {
 						handle={noValue ? undefined : this.state.handle}
 						className={classnames(
 							theme['tc-slider-rc-slider'],
-							{[theme['tc-slider-rc-slider--track-equals']]: modeStyles === 'equals'},
-							{[theme['tc-slider-rc-slider--track-exclusive']]: modeStyles === 'exclusive'},
-							{[theme['tc-slider-rc-slider--track-greater-than']]: modeStyles === 'greaterThan'},
+							{[theme['tc-slider-rc-slider--track-equals']]: mode === SLIDER_MODE.EQUALS},
+							{[theme['tc-slider-rc-slider--track-exclusive']]: mode === SLIDER_MODE.EXCLUSIVE},
+							{[theme['tc-slider-rc-slider--track-greater-than']]: mode === SLIDER_MODE.GREATER_THAN},
 							'tc-slider-rc-slider',
-							{'tc-slider-rc-slider--track-equals': modeStyles === 'equals'},
-							{'tc-slider-rc-slider--track-exclusive': modeStyles === 'exclusive'},
-							{'tc-slider-rc-slider--track-greater-than': modeStyles === 'greaterThan'}
+							{'tc-slider-rc-slider--track-equals': mode === SLIDER_MODE.EQUALS},
+							{'tc-slider-rc-slider--track-exclusive': mode === SLIDER_MODE.EXCLUSIVE},
+							{'tc-slider-rc-slider--track-greater-than': mode === SLIDER_MODE.GREATER_THAN}
 						)}
 						onChange={onChange}
 						disabled={disabled}

--- a/packages/components/src/Slider/Slider.scss
+++ b/packages/components/src/Slider/Slider.scss
@@ -86,4 +86,25 @@ $tc-slider-line-height: 24px;
 			}
 		}
 	}
+
+  &-rc-slider--track-right {
+		:global(.rc-slider-rail) {
+			background-color: $brand-primary;
+		}
+		:global(.rc-slider-track) {
+			background-color: $alto;
+		}
+	}
+
+	&-rc-slider--track-none {
+		:global(.rc-slider-rail),
+		:global(.rc-slider-track) {
+			background-color: $alto;
+		}
+
+		:global(.rc-slider-handle) {
+			box-shadow: $tc-slider-thumb-shadow;
+			background-color: $brand-primary;
+		}
+	}
 }

--- a/packages/components/src/Slider/Slider.scss
+++ b/packages/components/src/Slider/Slider.scss
@@ -86,7 +86,8 @@ $tc-slider-line-height: 24px;
 			}
 		}
 
-		&--track-greater-than {
+		&--track-greater-than,
+		&--track-exclusive {
 			:global {
 				.rc-slider-rail {
 					background-color: $brand-primary;
@@ -107,17 +108,6 @@ $tc-slider-line-height: 24px;
 				.rc-slider-handle {
 					box-shadow: $tc-slider-thumb-shadow;
 					background-color: $brand-primary;
-				}
-			}
-		}
-
-		&--track-exclusive {
-			:global {
-				.rc-slider-rail {
-					background-color: $brand-primary;
-				}
-				.rc-slider-track {
-					background-color: $alto;
 				}
 			}
 		}

--- a/packages/components/src/Slider/Slider.scss
+++ b/packages/components/src/Slider/Slider.scss
@@ -85,26 +85,41 @@ $tc-slider-line-height: 24px;
 				box-shadow: $tc-slider-thumb-shadow-focused;
 			}
 		}
-	}
 
-  &-rc-slider--track-right {
-		:global(.rc-slider-rail) {
-			background-color: $brand-primary;
-		}
-		:global(.rc-slider-track) {
-			background-color: $alto;
-		}
-	}
-
-	&-rc-slider--track-none {
-		:global(.rc-slider-rail),
-		:global(.rc-slider-track) {
-			background-color: $alto;
+		&--track-greater-than {
+			:global {
+				.rc-slider-rail {
+					background-color: $brand-primary;
+				}
+				.rc-slider-track {
+					background-color: $alto;
+				}
+			}
 		}
 
-		:global(.rc-slider-handle) {
-			box-shadow: $tc-slider-thumb-shadow;
-			background-color: $brand-primary;
+		&--track-equals {
+			:global {
+				.rc-slider-rail,
+				.rc-slider-track {
+					background-color: $alto;
+				}
+
+				.rc-slider-handle {
+					box-shadow: $tc-slider-thumb-shadow;
+					background-color: $brand-primary;
+				}
+			}
+		}
+
+		&--track-exclusive {
+			:global {
+				.rc-slider-rail {
+					background-color: $brand-primary;
+				}
+				.rc-slider-track {
+					background-color: $alto;
+				}
+			}
 		}
 	}
 }

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -2,8 +2,9 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import Slider from './Slider.component';
+import Slider, {SLIDER_MODE} from './Slider.component';
 import IconsProvider from '../IconsProvider';
+// import SLIDER_MODE from './Slider.component';
 
 const icons = [
 	'talend-activity',
@@ -22,7 +23,6 @@ const delimiterStyle = {
 	paddingBottom: '25px',
 	borderBottom: '1px dashed grey',
 };
-
 
 const actions = [
 	{
@@ -90,7 +90,7 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 				<Slider
 					max={10}
 					min={0}
-					mode={'greaterThan'}
+					mode={SLIDER_MODE.GREATER_THAN}
 					onChange={action('onChange')}
 					value={3}
 				/>
@@ -100,7 +100,7 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 				<Slider
 					max={10}
 					min={0}
-					mode={'equals'}
+					mode={SLIDER_MODE.EQUALS}
 					onChange={action('onChange')}
 					value={5}
 				/>
@@ -151,7 +151,7 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 					onChange={action('onChange')}
 					min={0}
 					max={100}
-					mode={'exclusive'}
+					mode={SLIDER_MODE.EXCLUSIVE}
 					value={[25, 75]}
 					allowCross={false}
 				/>

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -79,6 +79,26 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 				<Slider onChange={action('onChange')} />
 			</div>
 			<div style={delimiterStyle}>
+				<p>Track on the right</p>
+				<Slider
+					max={10}
+					min={0}
+					rightTrack={true}
+					onChange={action('onChange')}
+					value={3}
+				/>
+			</div>
+			<div style={delimiterStyle}>
+				<p>No track</p>
+				<Slider
+					max={10}
+					min={0}
+					noTrack={true}
+					onChange={action('onChange')}
+					value={5}
+				/>
+			</div>
+			<div style={delimiterStyle}>
 				<p>With disabled</p>
 				<Slider onChange={action('onChange')} disabled />
 			</div>

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -79,21 +79,28 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 				<Slider onChange={action('onChange')} />
 			</div>
 			<div style={delimiterStyle}>
-				<p>Track on the right</p>
+				<p>With value</p>
+				<Slider
+					onChange={action('onChange')}
+					value={10}
+				/>
+			</div>
+			<div style={delimiterStyle}>
+				<p>Greater than usage</p>
 				<Slider
 					max={10}
 					min={0}
-					rightTrack={true}
+					mode={'greaterThan'}
 					onChange={action('onChange')}
 					value={3}
 				/>
 			</div>
 			<div style={delimiterStyle}>
-				<p>No track</p>
+				<p>Equals</p>
 				<Slider
 					max={10}
 					min={0}
-					noTrack={true}
+					mode={'equals'}
 					onChange={action('onChange')}
 					value={5}
 				/>
@@ -129,11 +136,22 @@ storiesOf('Form/Controls/Slider', module).add('default', () => (
 				/>
 			</div>
 			<div style={delimiterStyle}>
-				<p>with range</p>
+				<p>with range (inclusive)</p>
 				<Slider
 					onChange={action('onChange')}
 					min={0}
 					max={100}
+					value={[25, 75]}
+					allowCross={false}
+				/>
+			</div>
+			<div style={delimiterStyle}>
+				<p>with range (exclusive)</p>
+				<Slider
+					onChange={action('onChange')}
+					min={0}
+					max={100}
+					mode={'exclusive'}
 					value={[25, 75]}
 					allowCross={false}
 				/>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The slider component currently only supports highlighting of its track to a specific index from a start point on left of the scale. In the future, the slider will be used to select values of a specific index only or starting from an index up to an end value. In these cases, the slider component needs to be able to highlight the relevant part of its track based on the usage/context scenario.

**What is the chosen solution to this problem?**
The slider will now support additional usage contexts through the addition of two parameters. These parameters will activate modifier CSS classes which change the visual appearance of the slider track. The change is a visual one only and the functional behaviour of the slider is unchanged. The new parameters are invisible unless passed as true. The do not require default values.

Style guide reference: http://guidelines.talend.com/document/92132#/specific-features/rating-sliders

- Add override styles for slider track style
- Add new parameters to enable new styles
- Include new styles in Storybook

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR


