### PR TITLE
fix(component): Remove wrong ways to discover schema

### DIFF
--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.js
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.js
@@ -8,11 +8,10 @@ import formatJSONPath from '../jsonPath';
 
 export function getNextSchemaItems(schema) {
 	return (
-		get(schema, 'type.items.fields') ||
+		get(schema, 'type.items') ||
 		get(schema, 'type.values.fields') ||
 		get(schema, 'type.values.items') ||
 		get(schema, 'type.fields') ||
-		get(schema, 'items.fields') ||
 		get(schema, 'values.items') ||
 		get(schema, 'fields') ||
 		get(schema, 'items') ||

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.js
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.js
@@ -9,10 +9,9 @@ import formatJSONPath from '../jsonPath';
 export function getNextSchemaItems(schema) {
 	return (
 		get(schema, 'type.items') ||
-		get(schema, 'type.values.fields') ||
-		get(schema, 'type.values.items') ||
+		get(schema, 'type.values') ||
 		get(schema, 'type.fields') ||
-		get(schema, 'values.items') ||
+		get(schema, 'values') ||
 		get(schema, 'fields') ||
 		get(schema, 'items') ||
 		get(schema, 'type') ||

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.test.js
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.test.js
@@ -13,38 +13,38 @@ import {
 
 describe('#getNextSchemaItems', () => {
 	describe('it should return the next schema', () => {
-		it('when schema.type.items.fields', () => {
-			const nextItems = [
-				{
-					name: 'name',
-					type: {
-						type: 'string',
-						dqType: '',
-						dqTypeKey: '',
-						'@talend-quality@': {
-							0: 0,
-							1: 24,
-							'-1': 0,
-							total: 24,
+		it('when schema.type.items', () => {
+			const nextItems = {
+				type: 'record',
+				name: 'devices',
+				fields: [
+					{
+						name: 'name',
+						type: {
+							type: 'string',
+							dqType: '',
+							dqTypeKey: '',
+							'@talend-quality@': {
+								0: 0,
+								1: 24,
+								'-1': 0,
+								total: 24,
+							},
 						},
 					},
+				],
+				'@talend-quality@': {
+					0: 0,
+					1: 24,
+					'-1': 0,
+					total: 24,
 				},
-			];
+			};
 			const schema = {
 				name: 'devices',
 				type: {
 					type: 'array',
-					items: {
-						type: 'record',
-						name: 'devices',
-						fields: nextItems,
-						'@talend-quality@': {
-							0: 0,
-							1: 24,
-							'-1': 0,
-							total: 24,
-						},
-					},
+					items: nextItems,
 					'@talend-quality@': {
 						0: 0,
 						1: 12,
@@ -188,54 +188,54 @@ describe('#getNextSchemaItems', () => {
 	});
 	it('when schema.type', () => {
 		const nextItems = {
-			type: 'array',
-			items: {
-				type: 'string',
-				dqType: '',
-				dqTypeKey: '',
-				'@talend-quality@': {
-					0: 595,
-					1: 603,
-					'-1': 0,
-					total: 1198,
-				},
-			},
+			type: 'string',
+			dqType: '',
+			dqTypeKey: '',
 			'@talend-quality@': {
-				0: 0,
-				1: 599,
+				0: 595,
+				1: 603,
 				'-1': 0,
-				total: 599,
+				total: 1198,
 			},
 		};
 		const schema = {
 			name: 'lines',
-			type: nextItems,
+			type: {
+				type: 'array',
+				items: nextItems,
+				'@talend-quality@': {
+					0: 0,
+					1: 599,
+					'-1': 0,
+					total: 599,
+				},
+			},
 		};
 		expect(getNextSchemaItems(schema)).toEqual(nextItems);
 	});
-	it('when schema.items.fields', () => {
-		const nextItems = [
-			{
-				name: 'anotherThing',
-				type: [
-					{
-						type: 'string',
-					},
-					{
-						type: 'null',
-					},
-				],
-			},
-		];
+	it('when schema.items', () => {
+		const nextItems = {
+			type: 'record',
+			name: 'something',
+			fields: [
+				{
+					name: 'anotherThing',
+					type: [
+						{
+							type: 'string',
+						},
+						{
+							type: 'null',
+						},
+					],
+				},
+			],
+		};
 
 		const schema = {
 			name: 'something',
 			type: 'array',
-			items: {
-				type: 'record',
-				name: 'something',
-				fields: nextItems,
-			},
+			items: nextItems,
 		};
 		expect(getNextSchemaItems(schema)).toEqual(nextItems);
 	});
@@ -588,23 +588,14 @@ describe('#transformArrayBranch', () => {
 				dataKey: 0,
 				value: {
 					schema: {
-						type: 'array',
-						items: {
-							type: 'string',
-							dqType: '',
-							dqTypeKey: '',
-							'@talend-quality@': {
-								0: 0,
-								1: 96,
-								'-1': 0,
-								total: 96,
-							},
-						},
+						type: 'string',
+						dqType: '',
+						dqTypeKey: '',
 						'@talend-quality@': {
 							0: 0,
-							1: 48,
+							1: 96,
 							'-1': 0,
-							total: 48,
+							total: 96,
 						},
 					},
 					data: {
@@ -617,23 +608,14 @@ describe('#transformArrayBranch', () => {
 				dataKey: 1,
 				value: {
 					schema: {
-						type: 'array',
-						items: {
-							type: 'string',
-							dqType: '',
-							dqTypeKey: '',
-							'@talend-quality@': {
-								0: 0,
-								1: 96,
-								'-1': 0,
-								total: 96,
-							},
-						},
+						type: 'string',
+						dqType: '',
+						dqTypeKey: '',
 						'@talend-quality@': {
 							0: 0,
-							1: 48,
+							1: 96,
 							'-1': 0,
-							total: 48,
+							total: 96,
 						},
 					},
 					data: {
@@ -862,14 +844,10 @@ describe('#getChilds', () => {
 					value: {
 						data: { quality: 1, value: 'deserunt enim est anim ea' },
 						schema: {
-							'@talend-quality@': { '-1': 0, 0: 0, 1: 48, total: 48 },
-							items: {
-								'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
-								dqType: '',
-								dqTypeKey: '',
-								type: 'string',
-							},
-							type: 'array',
+							'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
+							dqType: '',
+							dqTypeKey: '',
+							type: 'string',
 						},
 					},
 				},
@@ -881,14 +859,10 @@ describe('#getChilds', () => {
 							value: 'eiusmod laboris consequat exercitation labore',
 						},
 						schema: {
-							'@talend-quality@': { '-1': 0, 0: 0, 1: 48, total: 48 },
-							items: {
-								'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
-								dqType: '',
-								dqTypeKey: '',
-								type: 'string',
-							},
-							type: 'array',
+							'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
+							dqType: '',
+							dqTypeKey: '',
+							type: 'string',
 						},
 					},
 				},
@@ -897,14 +871,10 @@ describe('#getChilds', () => {
 					value: {
 						data: { quality: 1, value: 'aute voluptate exercitation elit consequat' },
 						schema: {
-							'@talend-quality@': { '-1': 0, 0: 0, 1: 48, total: 48 },
-							items: {
-								'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
-								dqType: '',
-								dqTypeKey: '',
-								type: 'string',
-							},
-							type: 'array',
+							'@talend-quality@': { '-1': 0, 0: 0, 1: 96, total: 96 },
+							dqType: '',
+							dqTypeKey: '',
+							type: 'string',
 						},
 					},
 				},

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.test.js
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.parser.test.js
@@ -55,8 +55,24 @@ describe('#getNextSchemaItems', () => {
 			};
 			expect(getNextSchemaItems(schema)).toEqual(nextItems);
 		});
-		it('when schema.type.values.fields', () => {
-			const nextItems = [{ name: 'device', type: { type: 'string' } }];
+		it('when schema.type.values', () => {
+			const nextItems = {
+				'@talend-quality@': {
+					0: 0,
+					1: 24,
+					'-1': 0,
+					total: 24,
+				},
+				fields: [
+					{
+						type: {
+							type: 'string',
+						},
+						name: 'device',
+					},
+				],
+				type: 'object',
+			};
 			const schema = {
 				name: 'devices',
 				type: {
@@ -77,6 +93,7 @@ describe('#getNextSchemaItems', () => {
 								name: 'device',
 							},
 						],
+						type: 'object',
 					},
 					'@talend-quality@': {
 						0: 0,
@@ -240,36 +257,7 @@ describe('#getNextSchemaItems', () => {
 		expect(getNextSchemaItems(schema)).toEqual(nextItems);
 	});
 	it('when there is no direct fields or type', () => {
-		const schema = [
-			{
-				name: 'id',
-				type: {
-					type: 'long',
-					dqType: '',
-					dqTypeKey: '',
-					'@talend-quality@': {
-						0: 0,
-						1: 12,
-						'-1': 0,
-						total: 12,
-					},
-				},
-			},
-			{
-				name: 'name',
-				type: {
-					type: 'string',
-					dqType: '',
-					dqTypeKey: '',
-					'@talend-quality@': {
-						0: 0,
-						1: 12,
-						'-1': 0,
-						total: 12,
-					},
-				},
-			},
-		];
+		const schema = 'string';
 		expect(getNextSchemaItems(schema)).toEqual(schema);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The function used to discover childs schema is returning the wrong schema part for arrays containing objects.
It goes too much deep and returns only a part of the expected schema.

An array has an `items` property in his type, defining the type of his elements.
An object has a `fields` property in his type, defining the type of his properties.

If you take the hierarchical view, when you display an array of object.
The first branch is an array, if you want the type of his childs (the elements), you need to take the `items` property. Here it go deeper and takes the `fields` property of the element. That's the bug.

**What is the chosen solution to this problem?**
Remove wrong cases.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
