### PR TITLE
fix(ListComposition): selection with lazy loaded list (2)

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
@@ -23,6 +23,10 @@ export default function useCollectionSelection(
 	}, [collection, filterSelectionFromCollection]);
 
 	function isSelected(item) {
+		if (!item) {
+			return false;
+		}
+
 		const itemId = item[idKey];
 		return selectedIds.some(itemKey => itemKey === itemId);
 	}

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.test.js
@@ -117,6 +117,29 @@ describe('useCollectionSelection', () => {
 		expect(isSelected(collection[4])).toBe(true);
 	});
 
+	it('should provide a function to check an item selection that supports unloaded items', () => {
+		// given
+		const initialSelectedIds = [1, 4];
+
+		// when
+		const wrapper = mount(
+			<SelectionComponent
+				collection={[...collection, null]}
+				initialSelectedIds={initialSelectedIds}
+				idKey="number"
+			/>,
+		);
+
+		// then
+		const isSelected = wrapper.find('#mainChild').prop('isSelected');
+		expect(isSelected(collection[0])).toBe(false);
+		expect(isSelected(collection[1])).toBe(true);
+		expect(isSelected(collection[2])).toBe(false);
+		expect(isSelected(collection[3])).toBe(false);
+		expect(isSelected(collection[4])).toBe(true);
+		expect(isSelected(collection[6])).toBe(false);
+	});
+
 	it('should set new item selection', () => {
 		// given
 		const wrapper = mount(<SelectionComponent collection={collection} idKey="number" />);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The `isSelected` method exposed by the hook may throw an error when using lazy loaded list

This method is passed down to `react-virtualized` that uses this method to define wether or not an item is checked.

In the case of lazy loaded lists, there might be a case where this method is called on undefined entries (that case where I noticed the issue : reloading the whole collection but only reloading a specific chunk of the collection, meaning the collection looks like the following snippet 👇).

```
[
    0: null,

     ... // (items 0 to 150 are not loaded)

    150 : null,
    151 : { my: 'item' },
    152 : { my: 'item' },
   ...
]
```

**What is the chosen solution to this problem?**
Support unloaded items.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
