### PR TITLE
fix(TCCUI-178) - show suggestions when clicking on the datalist

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -32,7 +32,8 @@
   34:5  warning  React Hook useLayoutEffect has a missing dependency: 'measure'. Either include it or remove the dependency array. If 'measure' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/Datalist/Datalist.component.js
-  41:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
+   42:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
+  116:10  error  'event' is defined but never used                                                                                                                                                                                                                                                                            @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/Manager/Manager.component.js
   31:5  warning  React Hook useEffect has missing dependencies: 'getDateOptions' and 'state.date'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
@@ -330,4 +331,4 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/VirtualizedList.component.js
   70:5  warning  React Hook useEffect has missing dependencies: 'children' and 'setWidths'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-✖ 155 problems (134 errors, 21 warnings)
+✖ 156 problems (135 errors, 21 warnings)

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -32,8 +32,7 @@
   34:5  warning  React Hook useLayoutEffect has a missing dependency: 'measure'. Either include it or remove the dependency array. If 'measure' changes too often, find the parent component that defines it and wrap that definition in useCallback  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/Datalist/Datalist.component.js
-   42:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-  116:10  error  'event' is defined but never used                                                                                                                                                                                                                                                                            @typescript-eslint/no-unused-vars
+  42:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/Manager/Manager.component.js
   31:5  warning  React Hook useEffect has missing dependencies: 'getDateOptions' and 'state.date'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
@@ -331,4 +330,4 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/VirtualizedList.component.js
   70:5  warning  React Hook useEffect has missing dependencies: 'children' and 'setWidths'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-✖ 156 problems (135 errors, 21 warnings)
+✖ 155 problems (134 errors, 21 warnings)

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -113,7 +113,7 @@ class Datalist extends Component {
 	 * Display suggestions on click
 	 * @param event the click event
 	 */
-	onClick(event) {
+	onClick() {
 		if (!this.state.suggestions) {
 			// display all suggestions when they are not displayed
 			this.updateSuggestions();
@@ -449,6 +449,7 @@ if (process.env.NODE_ENV !== 'production') {
 		onBlur: PropTypes.func,
 		onChange: PropTypes.func.isRequired,
 		onFocus: PropTypes.func,
+		onClick: PropTypes.func,
 		onLiveChange: PropTypes.func,
 		disabled: PropTypes.bool,
 		multiSection: PropTypes.bool,

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -21,6 +21,7 @@ class Datalist extends Component {
 		this.onBlur = this.onBlur.bind(this);
 		this.onChange = this.onChange.bind(this);
 		this.onFocus = this.onFocus.bind(this);
+		this.onClick = this.onClick.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);
 		this.onSelect = this.onSelect.bind(this);
 		this.resetSuggestions = this.resetSuggestions.bind(this);
@@ -106,6 +107,18 @@ class Datalist extends Component {
 		event.target.select();
 		this.updateSuggestions();
 		this.updateSelectedIndexes(this.state.value);
+	}
+
+	/**
+	 * Display suggestions on click
+	 * @param event the click event
+	 */
+	onClick(event) {
+		if (!this.state.suggestions) {
+			// display all suggestions when they are not displayed
+			this.updateSuggestions();
+			this.updateSelectedIndexes(this.state.value);
+		}
 	}
 
 	/**
@@ -410,6 +423,7 @@ class Datalist extends Component {
 					onBlur={this.onBlur}
 					onChange={this.onChange}
 					onFocus={this.onFocus}
+					onClick={this.onClick}
 					onKeyDown={this.onKeyDown}
 					onSelect={this.onSelect}
 					theme={this.theme}

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -602,17 +602,26 @@ describe('Datalist component', () => {
 		expect(instance.updateSelectedIndexes).toHaveBeenCalled();
 	});
 
-	it('should call props.onClick when clicking on the datalist', () => {
-		const onClick = jest.fn();
-		const wrapper = shallow(<Datalist {...props} onClick={onClick} onChange={jest.fn()} />);
-
-		// when
-		const event = { type: 'foo', target: { select: jest.fn() } };
+	it('should update suggestions when clicking on the datalist', () => {
+		const wrapper = mount(
+			<Datalist
+				id="my-datalist"
+				isValid
+				errorMessage="This should be correct"
+				onChange={jest.fn()}
+				{...props}
+				value="foobar"
+			/>,
+		);
 		const instance = wrapper.instance();
 		instance.updateSuggestions = jest.fn();
 		instance.updateSelectedIndexes = jest.fn();
-		instance.onClick(event);
-		expect(onClick).toHaveBeenCalledWith(event);
+
+		// when
+		const input = wrapper.find('input').at(0);
+		input.simulate('click');
+
+		// then
 		expect(instance.updateSuggestions).toHaveBeenCalled();
 		expect(instance.updateSelectedIndexes).toHaveBeenCalled();
 	});

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -602,6 +602,21 @@ describe('Datalist component', () => {
 		expect(instance.updateSelectedIndexes).toHaveBeenCalled();
 	});
 
+	it('should call props.onClick when clicking on the datalist', () => {
+		const onClick = jest.fn();
+		const wrapper = shallow(<Datalist {...props} onClick={onClick} onChange={jest.fn()} />);
+
+		// when
+		const event = { type: 'foo', target: { select: jest.fn() } };
+		const instance = wrapper.instance();
+		instance.updateSuggestions = jest.fn();
+		instance.updateSelectedIndexes = jest.fn();
+		instance.onClick(event);
+		expect(onClick).toHaveBeenCalledWith(event);
+		expect(instance.updateSuggestions).toHaveBeenCalled();
+		expect(instance.updateSelectedIndexes).toHaveBeenCalled();
+	});
+
 	it('should call onLiveChange when user type in the input', () => {
 		// given
 		const onLiveChange = jest.fn();

--- a/packages/components/src/Datalist/__snapshots__/Datalist.component.test.js.snap
+++ b/packages/components/src/Datalist/__snapshots__/Datalist.component.test.js.snap
@@ -19,6 +19,7 @@ exports[`Datalist component should render a typeahead 1`] = `
     noResultText="there is nothing ..."
     onBlur={[Function]}
     onChange={[Function]}
+    onClick={[Function]}
     onFocus={[Function]}
     onKeyDown={[Function]}
     onSelect={[Function]}

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -191,6 +191,7 @@ Typeahead.propTypes = {
 	onBlur: PropTypes.func,
 	onChange: PropTypes.func,
 	onFocus: PropTypes.func,
+	onClick: PropTypes.func,
 	placeholder: PropTypes.string,
 	readOnly: PropTypes.bool,
 	value: PropTypes.string,

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -95,6 +95,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			onBlur: rest.onBlur,
 			onChange: rest.onChange && (event => rest.onChange(event, { value: event.target.value })),
 			onFocus: rest.onFocus,
+			onClick: rest.onClick,
 			onKeyDown: rest.onKeyDown,
 			placeholder: rest.placeholder,
 			readOnly: rest.readOnly,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TCCUI-178
There is a regression with the datalist after the recent changes with the DataList component.
Suggestions are not displayed on click when the focus is already within the datalist

Regression from,
https://github.com/Talend/ui/pull/2753
and
https://github.com/Talend/ui/pull/2741

![datalist_error](https://user-images.githubusercontent.com/34709414/87053964-d8b9cd80-c202-11ea-9f63-4cdfce0e2fe1.gif)


**What is the chosen solution to this problem?**
show suggestions when clicking on the datalist
http://2886.talend.surge.sh/components/?path=/story/form-controls-datalist--default-multisection

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
