### PR TITLE
feat(AppGuidedTour): Make demo content optional

### DIFF
--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -29,7 +29,7 @@ function AppGuidedTour({
 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const [isAlreadyViewed, setIsAlreadyViewed] = useLocalStorage(localStorageKey, false);
-	const [importDemoContent, setImportDemoContent] = useState(!isAlreadyViewed);
+	const [importDemoContent, setImportDemoContent] = useState(demoContentSteps && !isAlreadyViewed);
 	const [currentStep, setCurrentStep] = useState(0);
 
 	const isNavigationDisabled =

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -34,7 +34,7 @@ function AppGuidedTour({
 
 	const isNavigationDisabled =
 		importDemoContent && currentStep === DEMO_CONTENT_STEP_ID && isStepsLoading(demoContentSteps);
-	const isImportSuccessFul = demoContentSteps.length && isAllSuccessful(demoContentSteps);
+	const isImportSuccessFul = demoContentSteps?.length && isAllSuccessful(demoContentSteps);
 
 	useEffect(() => {
 		if (!isAlreadyViewed) {
@@ -89,18 +89,20 @@ function AppGuidedTour({
 									defaultValue: `If you're new, you may want to take a quick tour of the tool now.
 										 If not, you can replay the tour from the user menu.`,
 								})}
-								<form>
-									<Toggle
-										id="app-guided-tour__import-demo-content-toggle"
-										label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
-											defaultValue: 'Import demo content',
-										})}
-										onChange={event => {
-											setImportDemoContent(event.target.checked);
-										}}
-										checked={importDemoContent}
-									/>
-								</form>
+								{demoContentSteps && (
+									<form>
+										<Toggle
+											id="app-guided-tour__import-demo-content-toggle"
+											label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
+												defaultValue: 'Import demo content',
+											})}
+											onChange={event => {
+												setImportDemoContent(event.target.checked);
+											}}
+											checked={importDemoContent}
+										/>
+									</form>
+								)}
 							</div>
 						),
 					},
@@ -125,9 +127,9 @@ AppGuidedTour.propTypes = {
 	appName: PropTypes.string.isRequired,
 	localStorageKey: PropTypes.string,
 	steps: GuidedTour.propTypes.steps,
-	demoContentSteps: Stepper.propTypes.steps.isRequired,
+	demoContentSteps: Stepper.propTypes.steps,
 	onRequestOpen: PropTypes.func.isRequired,
-	onImportDemoContent: PropTypes.func.isRequired,
+	onImportDemoContent: PropTypes.func,
 	onRequestClose: PropTypes.func.isRequired,
 };
 

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -4,19 +4,28 @@ import AppGuidedTour from './AppGuidedTour.component';
 import { LOADING_STEP_STATUSES } from '../Stepper/Stepper.component';
 import IconsProvider from '../IconsProvider';
 
-function AppGuidedTourContainer() {
+// eslint-disable-next-line react/prop-types
+function AppGuidedTourContainer({ withDemoContent = false }) {
 	const [stepStatus, setStepStatus] = React.useState(LOADING_STEP_STATUSES.PENDING);
+	const demoContentProps = {
+		demoContentSteps: [
+			{
+				label: 'Importing datasets',
+				status: stepStatus,
+			},
+		],
+		onImportDemoContent: () => {
+			setStepStatus(LOADING_STEP_STATUSES.LOADING);
+			setTimeout(() => {
+				setStepStatus(LOADING_STEP_STATUSES.SUCCESS);
+			}, 2000);
+		},
+	};
 
 	return (
 		<AppGuidedTour
 			isOpen
 			appName="Data Preparation"
-			demoContentSteps={[
-				{
-					label: 'Importing datasets',
-					status: stepStatus,
-				},
-			]}
 			steps={[
 				{
 					content: {
@@ -27,12 +36,7 @@ function AppGuidedTourContainer() {
 			]}
 			onRequestOpen={() => {}}
 			onRequestClose={() => {}}
-			onImportDemoContent={() => {
-				setStepStatus(LOADING_STEP_STATUSES.LOADING);
-				setTimeout(() => {
-					setStepStatus(LOADING_STEP_STATUSES.SUCCESS);
-				}, 2000);
-			}}
+			{...(withDemoContent ? demoContentProps : {})}
 		/>
 	);
 }
@@ -44,4 +48,5 @@ storiesOf('Messaging & Communication/AppGuidedTour', module)
 			{fn()}
 		</>
 	))
-	.add('default', () => <AppGuidedTourContainer />);
+	.add('default', () => <AppGuidedTourContainer withDemoContent />)
+	.add('without demo content', () => <AppGuidedTourContainer />);

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
@@ -109,4 +109,16 @@ describe('AppGuidedTour', () => {
 		});
 		expect(localStorage.getItem(DEFAULT_LOCAL_STORAGE_KEY)).toBe('true');
 	});
+	it('Should not show demo content form if no step is provided', () => {
+		const onRequestOpenMock = jest.fn();
+		const wrapper = mount(
+			<AppGuidedTour
+				{...DEFAULT_PROPS}
+				isOpen={false}
+				onRequestOpen={onRequestOpenMock}
+				demoContentSteps={null}
+			/>,
+		);
+		expect(wrapper.find('Toggle')).toHaveLength(0);
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It not possible to use the component without providing demo content steps

**What is the chosen solution to this problem?**

Make the props optional and hide the toggle if not provided

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
