### PR TITLE
fix(forms/datalist): improve datalist async tests

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,9 +5,6 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.container.js
   94:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
-  253:9  error  'wrapper' was used before it was defined  @typescript-eslint/no-use-before-define
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
   255:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
@@ -21,5 +18,5 @@
   283:8   error  Curly braces are unnecessary here  react/jsx-curly-brace-presence
   287:11  error  Curly braces are unnecessary here  react/jsx-curly-brace-presence
 
-✖ 8 problems (8 errors, 0 warnings)
+✖ 7 problems (7 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
@@ -194,23 +194,15 @@ describe('Datalist component', () => {
 	});
 
 	describe('onFocus', () => {
-		it('should call onTrigger when triggers has onEvent="focus"', done => {
+		it('should call onTrigger when triggers has onEvent="focus"', async ()  => {
 			// given
 			const data = { titleMap: [{ name: 'Foo', value: 'foo' }] };
 			const props = {
 				onChange: jest.fn(),
 				onFinish: jest.fn(),
-				onTrigger: jest.fn(
-					event =>
-						new Promise(resolve => {
-							// hack: to be sure we catch the setState after the promise
-							setTimeout(() => {
-								expect(event.target.state.isLoading).toBe(false);
-								done();
-							}, 0);
-							return resolve(data);
-						}),
-				),
+				onTrigger: jest.fn(() => {
+					return new Promise(resolve => resolve(data));
+				}),
 				schema: {
 					type: 'string',
 					schema: {
@@ -230,35 +222,25 @@ describe('Datalist component', () => {
 			wrapper.find(DatalistComponent).props().onFocus(event);
 
 			// then
-			expect(props.onTrigger).toBeCalledWith(event, {
+			await expect(props.onTrigger).toBeCalledWith(event, {
 				trigger: props.schema.triggers[0],
 				schema: props.schema,
 				errors: props.errors,
 				properties: props.properties,
 			});
-			expect(wrapper.state('isLoading')).toBe(true);
+			await expect(wrapper.state('isLoading')).toBe(true);
+			await expect(wrapper.state('isLoading')).toBe(false);
 		});
 
-		it('should call get titleMap from trigger and send it in onChange', done => {
+		it('should call get titleMap from trigger and send it in onChange', async () => {
 			// given
 			const data = { titleMap: [{ name: 'Foo', value: 'foo' }] };
 			const props = {
 				onChange: jest.fn(),
 				onFinish: jest.fn(),
-				onTrigger: jest.fn(
-					event =>
-						new Promise(resolve => {
-							// hack: to be sure we catch the setState after the promise
-							setTimeout(() => {
-								wrapper.instance().onChange(event, undefined);
-								expect(props.onChange).toHaveBeenCalledWith(event, {
-									schema: { ...props.schema, titleMap: data.titleMap },
-								});
-								done();
-							}, 0);
-							return resolve(data);
-						}),
-				),
+				onTrigger: jest.fn(() => {
+					return new Promise(resolve => resolve(data));
+				}),
 				schema: {
 					type: 'string',
 					schema: {
@@ -271,9 +253,15 @@ describe('Datalist component', () => {
 					],
 				},
 			};
+
 			const wrapper = shallow(<Datalist {...props} />);
 			const event = { type: 'focus', target: wrapper.instance() };
-			wrapper.find(DatalistComponent).props().onFocus(event);
+			await wrapper.find(DatalistComponent).props().onFocus(event);
+			await expect(props.onTrigger).toHaveBeenCalled();
+			await wrapper.instance().onChange(event, undefined);
+			await expect(props.onChange).toHaveBeenCalledWith(event, {
+				schema: { ...props.schema, titleMap: data.titleMap },
+			});
 		});
 	});
 

--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.test.js
@@ -194,7 +194,7 @@ describe('Datalist component', () => {
 	});
 
 	describe('onFocus', () => {
-		it('should call onTrigger when triggers has onEvent="focus"', async ()  => {
+		it('should call onTrigger when triggers has onEvent="focus"', async () => {
 			// given
 			const data = { titleMap: [{ name: 'Foo', value: 'foo' }] };
 			const props = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Datalist async tests are using a setTimeout trick

**What is the chosen solution to this problem?**

Use jest async tests

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
