### PR TITLE
Add available property for permission visibilty

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,6 +2,10 @@
 /home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.component.js
   32:66  warning  React Hook useLayoutEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
+/home/travis/build/Talend/ui/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+  191:4  error  'available' is missing in props validation                          react/prop-types
+  316:2  error  defaultProp "available" has no corresponding propTypes declaration  react/default-props-match-prop-types
+
 /home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
   142:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
 
@@ -330,4 +334,4 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/VirtualizedList.component.js
   70:5  warning  React Hook useEffect has missing dependencies: 'children' and 'setWidths'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-✖ 155 problems (134 errors, 21 warnings)
+✖ 157 problems (136 errors, 21 warnings)

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,10 +2,6 @@
 /home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.component.js
   32:66  warning  React Hook useLayoutEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
-  191:4  error  'available' is missing in props validation                          react/prop-types
-  316:2  error  defaultProp "available" has no corresponding propTypes declaration  react/default-props-match-prop-types
-
 /home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
   142:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
 
@@ -334,4 +330,4 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/VirtualizedList.component.js
   70:5  warning  React Hook useEffect has missing dependencies: 'children' and 'setWidths'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-✖ 157 problems (136 errors, 21 warnings)
+✖ 155 problems (134 errors, 21 warnings)

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -188,9 +188,14 @@ class ActionDropdown extends React.Component {
 			className,
 			loading,
 			children,
+			available,
 			t = getDefaultT(),
 			...rest
 		} = this.props;
+
+		if (!available) {
+			return null;
+		}
 
 		const Renderers = Inject.getAll(getComponent, { MenuItem, DropdownButton });
 		const injected = Inject.all(getComponent, components, InjectDropdownMenuItem);
@@ -306,6 +311,10 @@ ActionDropdown.propTypes = {
 	t: PropTypes.func,
 	children: PropTypes.node,
 };
+
+ActionDropdown.defaultProps = {
+	available: true,
+}
 
 export { getMenuItem, InjectDropdownMenuItem };
 export default withTranslation(I18N_DOMAIN_COMPONENTS)(ActionDropdown);

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -314,7 +314,7 @@ ActionDropdown.propTypes = {
 
 ActionDropdown.defaultProps = {
 	available: true,
-}
+};
 
 export { getMenuItem, InjectDropdownMenuItem };
 export default withTranslation(I18N_DOMAIN_COMPONENTS)(ActionDropdown);

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -310,6 +310,7 @@ ActionDropdown.propTypes = {
 	}),
 	t: PropTypes.func,
 	children: PropTypes.node,
+	available: PropTypes.bool,
 };
 
 ActionDropdown.defaultProps = {

--- a/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
+++ b/packages/components/src/Breadcrumbs/__snapshots__/Breadcrumbs.snapshot.test.js.snap
@@ -87,6 +87,7 @@ exports[`Breadcrumbs should render items with a dropdown menu if default max ite
     >
       <withI18nextTranslation(ActionDropdown)
         aria-label="Open first links menu"
+        available={true}
         id="42-ellipsis"
         items={
           Array [

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
@@ -22,6 +22,7 @@ exports[`HeaderTitle should render a span and ActionDropdown 1`] = `
     </span>
   </div>
   <withI18nextTranslation(ActionDropdown)
+    available={true}
     className="btn-tertiary btn-info"
     label="2012"
     t={[Function]}

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/__snapshots__/HeaderTitle.test.js.snap
@@ -22,6 +22,7 @@ exports[`HeaderTitle should render a span and ActionDropdown 1`] = `
     </span>
   </div>
   <withI18nextTranslation(ActionDropdown)
+    available={true}
     className="btn-tertiary btn-info"
     label="2012"
     t={[Function]}

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
@@ -40,6 +40,7 @@ exports[`CellTitleActions should display 2 actions and the rest in an ellipsis d
       onClick={[MockFunction]}
     />
     <withI18nextTranslation(ActionDropdown)
+      available={true}
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       id="my-actions-ellispsis-actions"
@@ -220,6 +221,7 @@ exports[`CellTitleActions should extract dropdown actions, completed with simple
       pullRight={true}
     />
     <withI18nextTranslation(ActionDropdown)
+      available={true}
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       id="my-actions-ellispsis-actions"
@@ -328,6 +330,7 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
       link={true}
     />
     <withI18nextTranslation(ActionDropdown)
+      available={true}
       className="cell-title-actions-menu theme-cell-title-actions-menu"
       hideLabel={true}
       id="my-actions-ellispsis-actions"

--- a/packages/containers/src/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
+++ b/packages/containers/src/ActionDropdown/__snapshots__/ActionDropdown.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Container(ActionDropdown) should render 1`] = `
 <withI18nextTranslation(ActionDropdown)
+  available={true}
   t={[Function]}
 />
 `;
@@ -13,6 +14,7 @@ exports[`Container(ActionDropdown) should render with items 1`] = `
       "menu:article",
     ]
   }
+  available={true}
   foo="extra"
   items={
     Array [

--- a/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
@@ -82,6 +82,7 @@ exports[`Comparator field should render disabled Comparator 1`] = `
   className="theme-comparator"
 >
   <withI18nextTranslation(ActionDropdown)
+    available={true}
     disabled={true}
     hideLabel={false}
     items={

--- a/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Comparator/__snapshots__/Comparator.component.test.js.snap
@@ -5,6 +5,7 @@ exports[`Comparator field should render default Comparator 1`] = `
   className="theme-comparator"
 >
   <withI18nextTranslation(ActionDropdown)
+    available={true}
     hideLabel={false}
     items={
       Array [

--- a/packages/forms/src/UIForm/fields/Enumeration/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Enumeration/__snapshots__/EnumerationWidget.test.js.snap
@@ -2249,6 +2249,7 @@ exports[`EnumerationWidget upload file should add a upload icon and set data-fea
                         </withI18nextTranslation(ActionButton)>
                       </Action>
                       <withI18nextTranslation(ActionDropdown)
+                        available={true}
                         btooltipPlacement="bottom"
                         data-feature="file.import"
                         displayMode="dropdown"

--- a/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
@@ -8872,6 +8872,7 @@ exports[`EnumerationWidget upload file should add a upload icon and set data-fea
                   </withI18nextTranslation(ActionButton)>
                 </Action>
                 <withI18nextTranslation(ActionDropdown)
+                  available={true}
                   btooltipPlacement="bottom"
                   data-feature="file.import"
                   displayMode="dropdown"
@@ -11276,6 +11277,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                   </withI18nextTranslation(ActionButton)>
                 </Action>
                 <withI18nextTranslation(ActionDropdown)
+                  available={true}
                   btooltipPlacement="bottom"
                   displayMode="dropdown"
                   hideLabel={true}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
* fix the issue not able to change the visibility on ActionDropdown Component for permission
Linked feature: https://jira.talendforge.org/browse/TMC-18767  

**What is the chosen solution to this problem?**
* introduce available property

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
