### PR TITLE
fix(components): ActionIconToggle now handle the ref to the button

### DIFF
--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.component.js
@@ -19,6 +19,7 @@ function ActionIconToggle(props) {
 		id,
 		label,
 		tooltipPlacement,
+		buttonRef,
 		...rest
 	} = props;
 
@@ -38,6 +39,7 @@ function ActionIconToggle(props) {
 				aria-label={label}
 				aria-pressed={active}
 				bsStyle="link"
+				ref={buttonRef}
 			>
 				<Icon name={icon} transform={iconTransform} />
 			</Button>
@@ -55,6 +57,7 @@ ActionIconToggle.propTypes = {
 	label: PropTypes.string.isRequired,
 	onClick: PropTypes.func,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,
+	buttonRef: PropTypes.func,
 };
 
 ActionIconToggle.defaultProps = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Unlike `ActionButton` or `ActionDropdown`, the `ActionIconToggle` component does not manage the ref to the button.
But for example, if you want to use this kind of button with a popover, the ref is needed to display the popover at the right place.

**What is the chosen solution to this problem?**
Add the missing `buttonRef` prop to `ActionIconToggle`, keeping the name used in other components.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
