### PR TITLE
chore: install dependencies before trying to build demo in gh release action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,4 +52,4 @@ jobs:
           body: ${{ env.CHANGELOG }}
           draft: false
           prerelease: false
-      - run: yarn build-demo && npx surge --project .static --domain ${{ env.DEMO_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+      - run: yarn && yarn build-demo && npx surge --project .static --domain ${{ env.DEMO_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
GH release action fails on building the demo because it doesn't resolve lerna: we don't install dependencies before

**What is the chosen solution to this problem?**
Install dependencies

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
