### PR TITLE
fix(faceted-search): cannot apply filter for a decimal field in IE11

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -24,6 +24,10 @@ Types of changes
 - `Fixed` for any bug fixes.
 - `Security` in case of vulnerabilities.
 
+## [unreleased]
+
+- [fixed](https://github.com/Talend/ui/pull/2910): IE11 : update input type number to numberDecimal
+
 ## [0.10.3]
 
 - [fixed](https://github.com/Talend/ui/pull/2881): IE11: hide scrollbar for BasicSearch

--- a/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumberForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumberForm.component.js
@@ -19,7 +19,7 @@ const BadgeNumberForm = ({ id, onChange, onSubmit, value, feature, t }) => {
 	const schema = {
 		autoFocus: true,
 		disabled: false,
-		type: 'number',
+		type: 'numberDecimal',
 		placeholder: t('TYPE_HERE', { defaultValue: 'Type here' }),
 	};
 

--- a/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumberForm.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumberForm.component.test.js
@@ -47,7 +47,7 @@ describe('BadgeNumberForm', () => {
 			</BadgeFacetedProvider>,
 		);
 		// Then
-		expect(wrapper.find('input[type="number"]').first().props().value).toEqual('i230982903');
+		expect(wrapper.find('input[type="numberDecimal"]').first().props().value).toEqual('i230982903');
 
 		const submitButton = wrapper.find('button[type="submit"]').first();
 		submitButton.simulate('submit');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Can not apply filter for a decimal field
**What is the chosen solution to this problem?**
Update input type number to numberDecimal
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
