### PR TITLE
feat(components/slider): improve slider api

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -244,8 +244,8 @@
   83:5  warning  React Hook useEffect has a missing dependency: 'animation'. Either include it or remove the dependency array                                                                                                                                                               react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/Slider/Slider.component.js
-  299:2  error  defaultProp "min" defined for isRequired propType  react/default-props-match-prop-types
-  300:2  error  defaultProp "max" defined for isRequired propType  react/default-props-match-prop-types
+  306:2  error  defaultProp "min" defined for isRequired propType  react/default-props-match-prop-types
+  307:2  error  defaultProp "max" defined for isRequired propType  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Stepper/Stepper.component.js
   171:5  warning  React Hook useEffect has missing dependencies: 'children' and 'transitionState'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

--- a/packages/components/src/Slider/Slider.component.js
+++ b/packages/components/src/Slider/Slider.component.js
@@ -16,7 +16,7 @@ const noFormat = value => value;
 export const SLIDER_MODE = {
 	GREATER_THAN: 'greaterThan',
 	EQUALS: 'equals',
-	EXCLUSIVE: 'exclusive'
+	EXCLUSIVE: 'exclusive',
 };
 
 /**
@@ -185,7 +185,7 @@ function getCaption(
  * Function to set the tooltip
  * @param {function} captionsFormat the function to format the caption
  */
-function getHandle(captionsFormat, getTooltipContainer) {
+function getHandle(captionsFormat, getTooltipContainer, hideTooltip) {
 	// https://github.com/react-component/slider/issues/502
 	function Handle({ dragging, ...rest }) {
 		return (
@@ -193,7 +193,7 @@ function getHandle(captionsFormat, getTooltipContainer) {
 				prefixCls="rc-slider-tooltip"
 				overlay={captionsFormat(rest.value)}
 				getTooltipContainer={getTooltipContainer}
-				visible
+				visible={!hideTooltip}
 				placement="top"
 				key={rest.index}
 			>
@@ -226,15 +226,17 @@ class Slider extends React.Component {
 		captionTextStepNumber: PropTypes.number,
 		min: PropTypes.number.isRequired,
 		max: PropTypes.number.isRequired,
+		step: PropTypes.number,
 		mode: PropTypes.string,
 		captionsFormat: PropTypes.func,
 		disabled: PropTypes.bool,
+		hideTooltip: PropTypes.bool,
 	};
 
 	constructor(props) {
 		super(props);
 		this.state = {
-			handle: getHandle(props.captionsFormat, props.getTooltipContainer),
+			handle: getHandle(props.captionsFormat, props.getTooltipContainer, props.hideTooltip),
 		};
 	}
 
@@ -248,6 +250,7 @@ class Slider extends React.Component {
 			captionsFormat,
 			min,
 			max,
+			step,
 			mode,
 			onChange,
 			disabled,
@@ -263,16 +266,20 @@ class Slider extends React.Component {
 						value={value}
 						min={min}
 						max={max}
+						step={step}
 						handle={noValue ? undefined : this.state.handle}
 						className={classnames(
 							theme['tc-slider-rc-slider'],
-							{[theme['tc-slider-rc-slider--track-equals']]: mode === SLIDER_MODE.EQUALS},
-							{[theme['tc-slider-rc-slider--track-exclusive']]: mode === SLIDER_MODE.EXCLUSIVE},
-							{[theme['tc-slider-rc-slider--track-greater-than']]: mode === SLIDER_MODE.GREATER_THAN},
+							{ [theme['tc-slider-rc-slider--track-equals']]: mode === SLIDER_MODE.EQUALS },
+							{ [theme['tc-slider-rc-slider--track-exclusive']]: mode === SLIDER_MODE.EXCLUSIVE },
+							{
+								[theme['tc-slider-rc-slider--track-greater-than']]:
+									mode === SLIDER_MODE.GREATER_THAN,
+							},
 							'tc-slider-rc-slider',
-							{'tc-slider-rc-slider--track-equals': mode === SLIDER_MODE.EQUALS},
-							{'tc-slider-rc-slider--track-exclusive': mode === SLIDER_MODE.EXCLUSIVE},
-							{'tc-slider-rc-slider--track-greater-than': mode === SLIDER_MODE.GREATER_THAN}
+							{ 'tc-slider-rc-slider--track-equals': mode === SLIDER_MODE.EQUALS },
+							{ 'tc-slider-rc-slider--track-exclusive': mode === SLIDER_MODE.EXCLUSIVE },
+							{ 'tc-slider-rc-slider--track-greater-than': mode === SLIDER_MODE.GREATER_THAN },
 						)}
 						onChange={onChange}
 						disabled={disabled}
@@ -298,6 +305,7 @@ class Slider extends React.Component {
 Slider.defaultProps = {
 	min: 0,
 	max: 100,
+	step: 1,
 	captionsFormat: noFormat,
 };
 

--- a/packages/components/src/Slider/index.js
+++ b/packages/components/src/Slider/index.js
@@ -1,3 +1,4 @@
-import Slider from './Slider.component';
+import Slider, { SLIDER_MODE } from './Slider.component';
 
+export { SLIDER_MODE };
 export default Slider;

--- a/packages/containers/src/Slider/__snapshots__/Slider.test.js.snap
+++ b/packages/containers/src/Slider/__snapshots__/Slider.test.js.snap
@@ -17,5 +17,6 @@ exports[`Filter container should render 1`] = `
       "id": "filter",
     }
   }
+  step={1}
 />
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`SLIDER_MODE` was not exported
`step` was not passed to `rc-slider`
It was not possible to hide the tooltip

**What is the chosen solution to this problem?**

Export `SLIDER_MODE`
Add `step` prop
Add `hideTooltip` prop

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
