### PR TITLE
fix(TCCUI-187) - add option to skip validation for nested form fields

### DIFF
--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-use-before-define */
+import get from 'lodash/get';
 import omit from 'lodash/omit';
 import { validate } from '@talend/json-schema-form-core';
 import { getValue } from './properties';
@@ -116,7 +117,7 @@ export function validateSimple(
 	const { key, items } = mergedSchema;
 	// do not break in case we do not have the key
 	// we need to keep deepValidation
-	if (key) {
+	if (key && !get(mergedSchema, 'options.skipParentValidation', false)) {
 		results[key] = validateValue(mergedSchema, value, properties, customValidationFn);
 	}
 

--- a/packages/forms/stories-core/json/concepts/core-simple.json
+++ b/packages/forms/stories-core/json/concepts/core-simple.json
@@ -27,8 +27,17 @@
       },
       "address": {
         "type": "object",
-        "properties": { "Address Line": { "type": "string" }, "postcode": { "type": "string" } },
-        "required": ["postcode"]
+        "properties": {
+          "addressLine": {
+            "type": "string"
+          },
+          "postcode": {
+            "type": "string"
+          }
+        },
+        "required": [
+          "postcode"
+        ]
       },
       "comment": {
         "type": "string",
@@ -81,9 +90,16 @@
     {
       "key": "address",
       "title": "Address",
-      "options": {
-        "skipParentValidation": true
-      }
+      "items": [
+        {
+          "key": "address.addressLine",
+          "title": "Address Line"
+        },
+        {
+          "key": "address.postcode" ,
+          "title": "postcode"
+        }
+      ]
     },
     {
       "key": "comment",

--- a/packages/forms/stories-core/json/concepts/core-simple.json
+++ b/packages/forms/stories-core/json/concepts/core-simple.json
@@ -25,6 +25,11 @@
         "type": "string",
         "pattern": "^\\S+@\\S+$"
       },
+      "address": {
+        "type": "object",
+        "properties": { "Address Line": { "type": "string" }, "postcode": { "type": "string" } },
+        "required": ["postcode"]
+      },
       "comment": {
         "type": "string",
         "maxLength": 20
@@ -72,6 +77,13 @@
       "key": "disabledField",
       "title": "Field (disabled mode)",
       "disabled": true
+    },
+    {
+      "key": "address",
+      "title": "Address",
+      "options": {
+        "skipParentValidation": true
+      }
     },
     {
       "key": "comment",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Form validation on submit fails when there are required nested fields in the form.
https://jira.talendforge.org/browse/TCCUI-187

**What is the chosen solution to this problem?**
Add an option to skip validation for parent elements of nested form fields

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
