### PR TITLE
fix(datagrid): Fix height calculation in Safari

### DIFF
--- a/packages/datagrid/src/components/DataGrid/DataGrid.scss
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.scss
@@ -63,6 +63,10 @@ $td-datagrid-skeleton-height: 9.6rem !default;
 	}
 
 	/* ==== BODY ==== */
+	:global(.ag-root-wrapper-body) {
+		height: 100%;
+	}
+
 	:global(.ag-pinned-left-cols-viewport) {
 		font-family: inherit;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TFD-11323
In Safari, `height: 100%` is more strict than in other browsers. So all "levels" in the dom should have the `heigth` property to allow percentage to be properly computed. It does not take in account flex properties when height is used.

So the default style 
```
.ag-root-wrapper-body.ag-layout-normal {
    flex: 1 1 auto;
    height: 0;
    min-height: 0;
}
```
is considered to have a heigth of 0. So children with `heigth: 100%` comes with a heigth of 0.
Chome and Firefox considers the flex heigth.

**What is the chosen solution to this problem?**
Add the `heigth` property to the missing internediate level.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
