### PR TITLE
feat(ListComposition/useCollectionSelection): Expose setSelectedIds

### DIFF
--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSelection.hook.js
@@ -57,5 +57,6 @@ export default function useCollectionSelection(
 		selectedIds,
 		onToggleAll,
 		onToggleItem,
+		setSelectedIds,
 	};
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a lazy loaded list is filtered/sorted, the selection is supposed to be cleared, so we need a way to reset that selection.

**What is the chosen solution to this problem?**
Expose `setSelectedIds`.
Did not add test because that would equal testing `useState`'s setter.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
