### PR TITLE
fix(http): Fix import generator documentation

### DIFF
--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -54,7 +54,7 @@ async function test() {
 
 ```javascript
 import { call } from 'redux-saga/effects';
-import { http } from '@talend/http/generators';
+import { http } from '@talend/http/lib/generators';
 
 export function* test() {
 	return yield call(http.get, '/api/v1/my-resource');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the http package, documentation about using generator is a little bit wrong: We can't do an `import { http } from '@talend/http/generators'`, it's missing a `/lib`.

**What is the chosen solution to this problem?**
Just fix the Readme

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
