### PR TITLE
feat(components/Enumeration): Support custom actions for Enumeration item

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -120,7 +120,7 @@
   12:3  error  Arrow function should not return assignment  no-return-assign
 
 /home/travis/build/Talend/ui/packages/components/src/Enumeration/Enumeration.component.js
-  221:2  error  defaultProp "t" defined for isRequired propType  react/default-props-match-prop-types
+  227:2  error  defaultProp "t" defined for isRequired propType  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/Enumeration/Header/HeaderInput.component.js
   89:5  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus

--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -73,8 +73,14 @@ EnumerationComponent.propTypes = {
 		onSelectItem: PropTypes.func,
 		onAbortItem: PropTypes.func,
 		onLoadData: PropTypes.func,
-		actionsDefault: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
-		actionsEdit: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+		actionsDefault: PropTypes.oneOfType([
+			PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+			PropTypes.func,
+		]),
+		actionsEdit: PropTypes.oneOfType([
+			PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+			PropTypes.func,
+		]),
 	}).isRequired,
 	onInputChange: PropTypes.func.isRequired,
 	onAddKeyDown: PropTypes.func,

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -288,6 +288,34 @@ const withClassProps = {
 	],
 };
 
+const withCustomActions = {
+	...props,
+	itemsProp: {
+		...props.itemsProp,
+		actionsDefault: item => {
+			if (item.index % 2 === 0) {
+				return [
+					{
+						label: 'Remove value',
+						icon: 'talend-trash',
+						id: 'delete',
+						onClick: action('item.onDelete'),
+					},
+				];
+			}
+			return [
+				{
+					disabled: false,
+					label: 'Edit',
+					icon: 'talend-pencil',
+					id: 'edit',
+					onClick: action('item.onEnterEditMode'),
+				},
+			];
+		},
+	},
+};
+
 storiesOf('Form/Controls/Enumeration', module)
 	.add('default', () => (
 		<div>
@@ -401,6 +429,25 @@ storiesOf('Form/Controls/Enumeration', module)
 			<p>With dynamic height: </p>
 			<IconsProvider />
 			<EnumerationDynamicHeight />
+		</div>
+	))
+	.add('with custom actions', () => (
+		<div>
+			<p>
+				With custom actions: <br />
+				You can pass a function to{' '}
+				<i>
+					<b>itemsProp.actionsDefault</b>
+				</i>{' '}
+				or{' '}
+				<i>
+					<b>itemsProp.actionsEdit</b>
+				</i>
+				<br />
+				The function takes a single argument, item data(including index). returns an array of actions.
+			</p>
+			<IconsProvider />
+			<Enumeration {...withCustomActions} />
 		</div>
 	));
 

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -444,7 +444,8 @@ storiesOf('Form/Controls/Enumeration', module)
 					<b>itemsProp.actionsEdit</b>
 				</i>
 				<br />
-				The function takes a single argument, item data(including index). returns an array of actions.
+				The function takes a single argument, item data(including index). returns an array of
+				actions.
 			</p>
 			<IconsProvider />
 			<Enumeration {...withCustomActions} />

--- a/packages/components/src/Enumeration/Items/Items.component.js
+++ b/packages/components/src/Enumeration/Items/Items.component.js
@@ -32,9 +32,13 @@ class Items extends React.PureComponent {
 
 		switch (item.displayMode) {
 			case DISPLAY_MODE_EDIT: {
+				let actions = this.props.itemsProp.actionsEdit;
+				if (typeof actions === 'function') {
+					actions = actions(itemWithIndex);
+				}
 				itemWithIndex.itemProps = {
 					key: this.props.itemsProp.key,
-					actions: this.props.itemsProp.actionsEdit,
+					actions,
 					onSubmitItem: this.props.itemsProp.onSubmitItem,
 					onAbortItem: this.props.itemsProp.onAbortItem,
 					onChangeItem: this.props.itemsProp.onChangeItem,
@@ -51,9 +55,13 @@ class Items extends React.PureComponent {
 				);
 			}
 			default: {
+				let actions = this.props.itemsProp.actionsDefault;
+				if (typeof actions === 'function') {
+					actions = actions(itemWithIndex);
+				}
 				const itemPropDefault = {
 					key: this.props.itemsProp.key,
-					actions: this.props.itemsProp.actionsDefault,
+					actions,
 					onSelectItem: this.props.itemsProp.onSelectItem,
 				};
 				itemWithIndex.itemProps = itemPropDefault;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In TMC we have a use case of Enumeration to custom actions base on item data. Currently Enumeration doesn't support custom actions, all items share actions props.
**What is the chosen solution to this problem?**
Let user pass in a function instead of array, which returns custom actions base on item data.
Story: http://2923.talend.surge.sh/components/?path=/story/form-controls-enumeration--with-custom-actions

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
