### PR TITLE
feat(components/list): use natural sort order

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -165,7 +165,7 @@
   27:65  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
-  31:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
+  33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/ListView/Header/HeaderInput.component.js
   68:5  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus

--- a/packages/components/src/List/ListComposition/Manager/hooks/__snapshots__/useCollectionSort.hook.test.js.snap
+++ b/packages/components/src/List/ListComposition/Manager/hooks/__snapshots__/useCollectionSort.hook.test.js.snap
@@ -1,0 +1,30 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`useCollectionSort should use a natural sort order 1`] = `
+Array [
+  Object {
+    "label": "Demo 1",
+  },
+  Object {
+    "label": "Demo 2",
+  },
+  Object {
+    "label": "Demo 3",
+  },
+  Object {
+    "label": "Demo 10",
+  },
+  Object {
+    "label": "Demo 11",
+  },
+  Object {
+    "label": "Demo 20",
+  },
+  Object {
+    "label": "Demo 22",
+  },
+  Object {
+    "label": "Demo 102",
+  },
+]
+`;

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
@@ -10,7 +10,9 @@ function getDefaultSortFunction({ sortBy, isDescending }) {
 
 		const result =
 			isNaN(valueA) || isNaN(valueB)
-				? valueA.toString().localeCompare(valueB.toString())
+				? valueA
+						.toString()
+						.localeCompare(valueB.toString(), undefined, { numeric: true, sensitivity: 'base' })
 				: valueA - valueB;
 
 		return result * direction;

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.test.js
@@ -43,6 +43,17 @@ const collection = [
 	},
 ];
 
+const natural = [
+	{ label: 'Demo 3' },
+	{ label: 'Demo 10' },
+	{ label: 'Demo 102' },
+	{ label: 'Demo 11' },
+	{ label: 'Demo 1' },
+	{ label: 'Demo 20' },
+	{ label: 'Demo 2' },
+	{ label: 'Demo 22' },
+];
+
 describe('useCollectionSort', () => {
 	it('should not sort when no sort params is provided', () => {
 		// when
@@ -130,5 +141,14 @@ describe('useCollectionSort', () => {
 		expect(sortedCollection[2].firstName).toEqual('Luann');
 		expect(sortedCollection[3].firstName).toEqual('Conner');
 		expect(sortedCollection[4].firstName).toEqual('Shelly');
+	});
+
+	it('should use a natural sort order', () => {
+		const sortParams = {
+			sortBy: 'label',
+			isDescending: false,
+		};
+		const wrapper = mount(<SortComponent collection={natural} initialSortParams={sortParams} />);
+		expect(wrapper.find('#mainChild').prop('sortedCollection')).toMatchSnapshot();
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

<img width="393" alt="image" src="https://user-images.githubusercontent.com/26482371/89637438-76f48e00-d8aa-11ea-9f85-8af405e1aaa8.png">
vs.
<img width="343" alt="image" src="https://user-images.githubusercontent.com/26482371/89637456-7c51d880-d8aa-11ea-9954-299ac4b30c87.png">


**What is the chosen solution to this problem?**

Use natural sort order

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
