### PR TITLE
feat(component/guidedtour): allow to disable welcome step

### DIFF
--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -25,7 +25,7 @@ function AppGuidedTour({
 	onRequestOpen,
 	onImportDemoContent,
 	onRequestClose,
-	disableWelcomeStep = false,
+	welcomeStepBody = null,
 	...rest
 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
@@ -78,34 +78,36 @@ function AppGuidedTour({
 				setImportDemoContent(false);
 			}}
 			steps={[
-				!disableWelcomeStep && {
+				{
 					content: {
 						header: t('GUIDED_TOUR_WELCOME_STEP_HEADER', {
 							appName,
 							defaultValue: 'Welcome to {{appName}}',
 						}),
-						body: () => (
-							<div>
-								{t('GUIDED_TOUR_WELCOME_STEP_BODY', {
-									defaultValue: `If you're new, you may want to take a quick tour of the tool now.
+						body: () => {
+							return welcomeStepBody || (
+								<div>
+									{t('GUIDED_TOUR_WELCOME_STEP_BODY', {
+										defaultValue: `If you're new, you may want to take a quick tour of the tool now.
 										 If not, you can replay the tour from the user menu.`,
-								})}
-								{demoContentSteps && (
-									<form>
-										<Toggle
-											id="app-guided-tour__import-demo-content-toggle"
-											label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
-												defaultValue: 'Import demo content',
-											})}
-											onChange={event => {
-												setImportDemoContent(event.target.checked);
-											}}
-											checked={importDemoContent}
-										/>
-									</form>
-								)}
-							</div>
-						),
+									})}
+									{demoContentSteps && (
+										<form>
+											<Toggle
+												id="app-guided-tour__import-demo-content-toggle"
+												label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
+													defaultValue: 'Import demo content',
+												})}
+												onChange={event => {
+													setImportDemoContent(event.target.checked);
+												}}
+												checked={importDemoContent}
+											/>
+										</form>
+									)}
+								</div>
+							);
+						},
 					},
 				},
 				importDemoContent && {
@@ -128,7 +130,7 @@ AppGuidedTour.propTypes = {
 	appName: PropTypes.string.isRequired,
 	localStorageKey: PropTypes.string,
 	steps: GuidedTour.propTypes.steps,
-	disableWelcomeStep: PropTypes.bool,
+	welcomeStepBody: PropTypes.node,
 	demoContentSteps: Stepper.propTypes.steps,
 	onRequestOpen: PropTypes.func.isRequired,
 	onImportDemoContent: PropTypes.func,

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -25,6 +25,7 @@ function AppGuidedTour({
 	onRequestOpen,
 	onImportDemoContent,
 	onRequestClose,
+	disableWelcomeStep = false,
 	...rest
 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
@@ -77,7 +78,7 @@ function AppGuidedTour({
 				setImportDemoContent(false);
 			}}
 			steps={[
-				{
+				!disableWelcomeStep && {
 					content: {
 						header: t('GUIDED_TOUR_WELCOME_STEP_HEADER', {
 							appName,
@@ -127,6 +128,7 @@ AppGuidedTour.propTypes = {
 	appName: PropTypes.string.isRequired,
 	localStorageKey: PropTypes.string,
 	steps: GuidedTour.propTypes.steps,
+	disableWelcomeStep: PropTypes.bool,
 	demoContentSteps: Stepper.propTypes.steps,
 	onRequestOpen: PropTypes.func.isRequired,
 	onImportDemoContent: PropTypes.func,

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -85,27 +85,29 @@ function AppGuidedTour({
 							defaultValue: 'Welcome to {{appName}}',
 						}),
 						body: () => {
-							return welcomeStepBody || (
-								<div>
-									{t('GUIDED_TOUR_WELCOME_STEP_BODY', {
-										defaultValue: `If you're new, you may want to take a quick tour of the tool now.
+							return (
+								welcomeStepBody || (
+									<div>
+										{t('GUIDED_TOUR_WELCOME_STEP_BODY', {
+											defaultValue: `If you're new, you may want to take a quick tour of the tool now.
 										 If not, you can replay the tour from the user menu.`,
-									})}
-									{demoContentSteps && (
-										<form>
-											<Toggle
-												id="app-guided-tour__import-demo-content-toggle"
-												label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
-													defaultValue: 'Import demo content',
-												})}
-												onChange={event => {
-													setImportDemoContent(event.target.checked);
-												}}
-												checked={importDemoContent}
-											/>
-										</form>
-									)}
-								</div>
+										})}
+										{demoContentSteps && (
+											<form>
+												<Toggle
+													id="app-guided-tour__import-demo-content-toggle"
+													label={t('GUIDED_TOUR_IMPORT_DEMO_CONTENT', {
+														defaultValue: 'Import demo content',
+													})}
+													onChange={event => {
+														setImportDemoContent(event.target.checked);
+													}}
+													checked={importDemoContent}
+												/>
+											</form>
+										)}
+									</div>
+								)
 							);
 						},
 					},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

the welcome step cannot be disabled

**What is the chosen solution to this problem?**

 allow disabling welcome step by passing `false` to the `disabledWelcomeStep` prop

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
