### PR TITLE
feat(components/HeaderBar): Accept custom Intercom component

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -159,7 +159,7 @@
   270:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
 
 /home/travis/build/Talend/ui/packages/components/src/HeaderBar/HeaderBar.stories.js
-  77:32  error  'brand' is missing in props validation  react/prop-types
+  78:32  error  'brand' is missing in props validation  react/prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
   27:65  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -117,8 +117,8 @@ function Information({ getComponent, t, ...props }) {
 			{props.items && props.items.length ? (
 				<Renderers.ActionDropdown pullRight noCaret hideLabel {...global} />
 			) : (
-					<Renderers.Action hideLabel {...global} />
-				)}
+				<Renderers.Action hideLabel {...global} />
+			)}
 		</li>
 	);
 }

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -117,8 +117,8 @@ function Information({ getComponent, t, ...props }) {
 			{props.items && props.items.length ? (
 				<Renderers.ActionDropdown pullRight noCaret hideLabel {...global} />
 			) : (
-				<Renderers.Action hideLabel {...global} />
-			)}
+					<Renderers.Action hideLabel {...global} />
+				)}
 		</li>
 	);
 }
@@ -224,6 +224,14 @@ function HeaderBar(props) {
 	const AppSwitcherComponent =
 		props.AppSwitcher || Inject.get(props.getComponent, 'AppSwitcher', AppSwitcher);
 
+	let intercom;
+	if (props.Intercom) {
+		intercom = props.Intercom;
+	} else if (props.intercom) {
+		console.warn('Deprecated: use @talend/ui-ee/Intercom');
+		intercom = <Components.Intercom getComponent={props.getComponent} {...props.intercom} />;
+	}
+
 	return (
 		<nav className={theme('tc-header-bar', 'navbar')}>
 			<ul className={theme('tc-header-bar-actions', 'navbar-nav')}>
@@ -250,9 +258,7 @@ function HeaderBar(props) {
 						t={props.t}
 					/>
 				)}
-				{props.intercom && (
-					<Components.Intercom getComponent={props.getComponent} {...props.intercom} />
-				)}
+				{intercom}
 				{props.help && (
 					<Components.Help getComponent={props.getComponent} {...props.help} t={props.t} />
 				)}
@@ -358,6 +364,7 @@ if (process.env.NODE_ENV !== 'production') {
 
 	HeaderBar.propTypes = {
 		AppSwitcher: PropTypes.func,
+		Intercom: PropTypes.func,
 		logo: PropTypes.shape(omit(Logo.propTypes, 't')),
 		brand: PropTypes.shape({
 			isSeparated: PropTypes.bool,

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -117,8 +117,8 @@ function Information({ getComponent, t, ...props }) {
 			{props.items && props.items.length ? (
 				<Renderers.ActionDropdown pullRight noCaret hideLabel {...global} />
 			) : (
-				<Renderers.Action hideLabel {...global} />
-			)}
+					<Renderers.Action hideLabel {...global} />
+				)}
 		</li>
 	);
 }
@@ -225,8 +225,9 @@ function HeaderBar(props) {
 		props.AppSwitcher || Inject.get(props.getComponent, 'AppSwitcher', AppSwitcher);
 
 	let intercom;
-	if (props.Intercom) {
-		intercom = props.Intercom;
+	const { Intercom: CustomIntercom } = props;
+	if (CustomIntercom) {
+		intercom = <CustomIntercom />;
 	} else if (props.intercom) {
 		console.warn('Deprecated: use @talend/ui-ee/Intercom');
 		intercom = <Components.Intercom getComponent={props.getComponent} {...props.intercom} />;

--- a/packages/components/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/components/src/HeaderBar/HeaderBar.stories.js
@@ -6,6 +6,7 @@ import { makeDecorator } from '@storybook/addons';
 import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-dependencies
 
 import IconsProvider from '../IconsProvider';
+import Icon from '../Icon';
 import HeaderBar from './HeaderBar.component';
 import AppSwitcher from '../AppSwitcher';
 
@@ -75,6 +76,26 @@ const infoStyle = stylesheet => ({
 
 function AppSwitcherComponent() {
 	return <AppSwitcher {...props.brand} />;
+}
+
+function IntercomComponent() {
+	const style = {
+		color: 'white',
+		margin: '0 10px',
+		width: '3.2rem',
+		height: '3.2rem',
+		borderRadius: '50%',
+		background: 'green',
+		display: 'flex',
+		alignItems: 'center',
+		justifyContent: 'center',
+	};
+
+	return (
+		<div style={style}>
+			<Icon name="talend-bubbles" />
+		</div>
+	);
 }
 
 const withIcons = makeDecorator({
@@ -251,6 +272,9 @@ decoratedStories
 	)
 	.add('barebone', () => <HeaderBar />, { info: { styles: infoStyle } })
 	.add('Custom AppSwitcher', () => <HeaderBar AppSwitcher={AppSwitcherComponent} />, {
+		info: { styles: infoStyle },
+	})
+	.add('Custom Intercom', () => <HeaderBar Intercom={<IntercomComponent />} />, {
 		info: { styles: infoStyle },
 	});
 

--- a/packages/components/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/components/src/HeaderBar/HeaderBar.stories.js
@@ -274,7 +274,7 @@ decoratedStories
 	.add('Custom AppSwitcher', () => <HeaderBar AppSwitcher={AppSwitcherComponent} />, {
 		info: { styles: infoStyle },
 	})
-	.add('Custom Intercom', () => <HeaderBar Intercom={<IntercomComponent />} />, {
+	.add('Custom Intercom', () => <HeaderBar Intercom={IntercomComponent} />, {
 		info: { styles: infoStyle },
 	});
 

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -42,6 +42,16 @@ describe('HeaderBar', () => {
 		expect(element).not.toBeUndefined();
 	});
 
+	it('should render custom Intercom component', () => {
+		function Intercom() {
+			return null;
+		}
+
+		const wrapper = mount(<HeaderBarComponent Intercom={Intercom} />);
+		const element = wrapper.find(Intercom);
+		expect(element).not.toBeUndefined();
+	});
+
 	it('should render search', () => {
 		const search = {
 			id: 'search',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We want to be able to inject a custom Intercom component in the HeaderBar.

**What is the chosen solution to this problem?**
Accept a new prop `Intercom` that receives the rendered Intercom component. This prop has precedence over the `intercom` configuration object.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
