### PR TITLE
feat(TCCUI-188): add badge type dropdown

### DIFF
--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -13,7 +13,7 @@ const SIZES = {
 	small: 'small',
 };
 
-const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete }) => (
+const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete, dropdown }) => (
 	<React.Fragment>
 		{category && <BadgeLib.Category label={category} />}
 		{category && <BadgeLib.Separator />}
@@ -21,6 +21,7 @@ const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete })
 			{icon && <BadgeLib.Icon name={icon} />}
 		</BadgeLib.Label>
 		{icon && onDelete && <BadgeLib.Separator iconSeparator />}
+        {dropdown && <BadgeLib.Dropdown id={id} props={dropdown} />}
 		{onDelete && <BadgeLib.DeleteAction id={id} onClick={onDelete} disabled={disabled} />}
 	</React.Fragment>
 );
@@ -33,6 +34,7 @@ DefaultBadge.propTypes = {
 	id: PropTypes.string,
 	label: PropTypes.string,
 	onDelete: PropTypes.func,
+    dropdown: PropTypes.object,
 };
 
 const BadgeType = ({ disabled, onSelect, children, ...rest }) => {
@@ -71,6 +73,7 @@ function Badge({
 	selected = false,
 	style,
 	white,
+    dropdown,
 }) {
 	const displayClass =
 		display === SIZES.small ? 'tc-badge-display-small' : 'tc-badge-display-large';
@@ -103,6 +106,7 @@ function Badge({
 						id={id}
 						label={label}
 						onDelete={onDelete}
+                        dropdown={dropdown}
 					/>
 				) : (
 					children
@@ -127,6 +131,7 @@ Badge.propTypes = {
 	selected: PropTypes.bool,
 	style: PropTypes.object,
 	white: PropTypes.bool,
+    dropdown: PropTypes.object,
 };
 
 Badge.SIZES = SIZES;

--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -21,7 +21,7 @@ const DefaultBadge = ({ aslink, category, disabled, icon, id, label, onDelete, d
 			{icon && <BadgeLib.Icon name={icon} />}
 		</BadgeLib.Label>
 		{icon && onDelete && <BadgeLib.Separator iconSeparator />}
-        {dropdown && <BadgeLib.Dropdown id={id} props={dropdown} />}
+		{dropdown && <BadgeLib.Dropdown id={id} props={dropdown} />}
 		{onDelete && <BadgeLib.DeleteAction id={id} onClick={onDelete} disabled={disabled} />}
 	</React.Fragment>
 );
@@ -34,7 +34,7 @@ DefaultBadge.propTypes = {
 	id: PropTypes.string,
 	label: PropTypes.string,
 	onDelete: PropTypes.func,
-    dropdown: PropTypes.object,
+	dropdown: PropTypes.object,
 };
 
 const BadgeType = ({ disabled, onSelect, children, ...rest }) => {
@@ -73,7 +73,7 @@ function Badge({
 	selected = false,
 	style,
 	white,
-    dropdown,
+	dropdown,
 }) {
 	const displayClass =
 		display === SIZES.small ? 'tc-badge-display-small' : 'tc-badge-display-large';
@@ -106,7 +106,7 @@ function Badge({
 						id={id}
 						label={label}
 						onDelete={onDelete}
-                        dropdown={dropdown}
+						dropdown={dropdown}
 					/>
 				) : (
 					children
@@ -131,7 +131,7 @@ Badge.propTypes = {
 	selected: PropTypes.bool,
 	style: PropTypes.object,
 	white: PropTypes.bool,
-    dropdown: PropTypes.object,
+	dropdown: PropTypes.object,
 };
 
 Badge.SIZES = SIZES;

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -114,8 +114,6 @@ $tc-badge-disabled-opacity: 0.62;
 			flex-grow: 0;
 			flex-shrink: 0;
 			padding: 0;
-			background: transparent;
-			box-shadow: none;
 			padding-left: $padding-smaller;
 			text-transform: none;
 			color: black;
@@ -129,7 +127,6 @@ $tc-badge-disabled-opacity: 0.62;
 
 			svg {
 				color: $slate-gray;
-				display: block;
 				margin: $padding-smaller;
 
 				&:hover {

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -108,6 +108,35 @@ $tc-badge-disabled-opacity: 0.62;
 				}
 			}
 		}
+
+		.tc-badge-dropdown {
+			display: flex;
+			flex-grow: 0;
+			flex-shrink: 0;
+			padding: 0;
+			background: transparent;
+			box-shadow: none;
+			padding-left: $padding-smaller;
+			text-transform: none;
+			color: black;
+
+			span {
+				max-width: 16rem;
+				display: block;
+				text-overflow: ellipsis;
+				overflow: hidden;
+			}
+
+			svg {
+				color: $slate-gray;
+				display: block;
+				margin: $padding-smaller;
+
+				&:hover {
+					color: $lochmara;
+				}
+			}
+		}
 	}
 
 	&.tc-badge-display-large {
@@ -149,6 +178,18 @@ $tc-badge-disabled-opacity: 0.62;
 			.tc-badge-delete-icon {
 				height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
 				min-height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
+
+				svg {
+					height: $tc-badge-large-delete-icon-size;
+					width: $tc-badge-large-delete-icon-size;
+				}
+			}
+
+			.tc-badge-dropdown {
+				height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
+				min-height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
+				font-size: $tc-badge-large-label-font-size;
+				font-weight: $tc-badge-large-label-with-categ-font-weight;
 
 				svg {
 					height: $tc-badge-large-delete-icon-size;
@@ -197,6 +238,18 @@ $tc-badge-disabled-opacity: 0.62;
 			.tc-badge-delete-icon {
 				height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
 				min-height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
+
+				svg {
+					height: $tc-badge-small-delete-icon-size;
+					width: $tc-badge-small-delete-icon-size;
+				}
+			}
+
+			.tc-badge-dropdown {
+				height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
+				min-height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
+				font-size: $tc-badge-small-label-font-size;
+				font-weight: $tc-badge-small-label-with-categ-font-weight;
 
 				svg {
 					height: $tc-badge-small-delete-icon-size;

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -677,9 +677,9 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 				<div style={columnStyle}>
 					<span>Edit mode with ellipsis</span>
 				</div>
-                <div style={columnStyle}>
-                    <span>Badge with Dropdown</span>
-                </div>
+				<div style={columnStyle}>
+					<span>Badge with Dropdown</span>
+				</div>
 			</div>
 			<hr />
 			<div style={defaultStyle} id="newVisualWhiteEnabled">
@@ -709,14 +709,9 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onDelete('A')}
 					/>
 				</div>
-                <div style={columnStyle}>
-                    <Badge
-                        display={Badge.SIZES.small}
-                        category="Cat"
-                        dropdown={dropdownProps}
-                        white
-                    />
-                </div>
+				<div style={columnStyle}>
+					<Badge display={Badge.SIZES.small} category="Cat" dropdown={dropdownProps} white />
+				</div>
 			</div>
 			<hr />
 			<div style={defaultStyle} id="newVisualWhiteDisabled">
@@ -755,15 +750,15 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						disabled
 					/>
 				</div>
-                <div style={columnStyle}>
-                    <Badge
-                        display={Badge.SIZES.small}
-                        category="Cat"
-                        dropdown={{ ...dropdownProps, disabled: true }}
-                        disabled
-                        white
-                    />
-                </div>
+				<div style={columnStyle}>
+					<Badge
+						display={Badge.SIZES.small}
+						category="Cat"
+						dropdown={{ ...dropdownProps, disabled: true }}
+						disabled
+						white
+					/>
+				</div>
 			</div>
 			<hr />
 		</section>

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -243,12 +243,12 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 					<Badge
 						display={Badge.SIZES.large}
 						category="Cat"
-						dropdown={{...dropdownProps, label: longStr, tooltipLabel: longStr}}
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
 					/>
 					<Badge
 						display={Badge.SIZES.small}
 						category="Cat"
-						dropdown={{...dropdownProps, label: longStr, tooltipLabel: longStr}}
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
 					/>
 					<span>Read only</span>
 					<Badge label={longStr} display={Badge.SIZES.large} category={longStr} />

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -4,6 +4,8 @@ import { action } from '@storybook/addon-actions';
 import talendIcons from '@talend/icons/dist/react';
 
 import Badge from './Badge.component';
+import FilterBar from '../FilterBar';
+import Action from '../Actions/Action';
 import IconsProvider from '../IconsProvider';
 
 const defaultStyle = {
@@ -24,6 +26,7 @@ const icons = {
 	'talend-cross': talendIcons['talend-cross'],
 	'talend-clock': talendIcons['talend-clock'],
 	'talend-caret-down': talendIcons['talend-caret-down'],
+	'talend-search': talendIcons['talend-search'],
 };
 
 const dropdownProps = {
@@ -46,6 +49,37 @@ const dropdownProps = {
 			onClick: action('document 2 click'),
 		},
 	],
+};
+
+const withComponents = {
+	id: 'context-dropdown-custom-items',
+	label: 'custom items',
+	getComponent: key => {
+		if (key === 'Action') {
+			return Action;
+		} else if (key === 'FilterBar') {
+			return FilterBar;
+		}
+		throw new Error('Component not found');
+	},
+	components: {
+		itemsDropdown: [
+			{
+				component: 'Action',
+				label: 'First item',
+				'data-feature': 'actiondropdown.items',
+			},
+			{
+				divider: true,
+			},
+			{
+				component: 'FilterBar',
+				label: 'Second item',
+				'data-feature': 'actiondropdown.items',
+				onFilter: action('onFilter'),
+			},
+		],
+	},
 };
 
 function onDelete(name) {
@@ -206,6 +240,8 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 					<Badge display={Badge.SIZES.large} category="Cat" dropdown={dropdownProps} />
 					<br />
 					<Badge display={Badge.SIZES.small} category="Cat" dropdown={dropdownProps} />
+					<br />
+					<Badge display={Badge.SIZES.large} category="Cat" dropdown={withComponents} />
 				</div>
 				<div style={columnStyle}>
 					<span>As Link</span>

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -23,6 +23,29 @@ const columnStyle = {
 const icons = {
 	'talend-cross': talendIcons['talend-cross'],
 	'talend-clock': talendIcons['talend-clock'],
+	'talend-caret-down': talendIcons['talend-caret-down'],
+};
+
+const dropdownProps = {
+	id: 'context-dropdown-related-items',
+	label: 'Label',
+	items: [
+		{
+			id: 'context-dropdown-item-document-1',
+			label: 'document 1',
+			'data-feature': 'actiondropdown.items',
+			onClick: action('document 1 click'),
+		},
+		{
+			divider: true,
+		},
+		{
+			id: 'context-dropdown-item-document-2',
+			label: 'document 2',
+			'data-feature': 'actiondropdown.items',
+			onClick: action('document 2 click'),
+		},
+	],
 };
 
 function onDelete(name) {
@@ -170,6 +193,7 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onSelect('B')}
 						{...onDelete('A')}
 					/>
+					<br />
 					<Badge
 						label="Label"
 						display={Badge.SIZES.small}
@@ -178,6 +202,10 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onSelect('B')}
 						{...onDelete('A')}
 					/>
+					<br />
+					<Badge display={Badge.SIZES.large} category="Cat" dropdown={dropdownProps} />
+					<br />
+					<Badge display={Badge.SIZES.small} category="Cat" dropdown={dropdownProps} />
 				</div>
 				<div style={columnStyle}>
 					<span>As Link</span>
@@ -210,6 +238,17 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onSelect('B')}
 						{...onDelete('A')}
 						icon="talend-clock"
+					/>
+					<span>Dropdown</span>
+					<Badge
+						display={Badge.SIZES.large}
+						category="Cat"
+						dropdown={{...dropdownProps, label: longStr, tooltipLabel: longStr}}
+					/>
+					<Badge
+						display={Badge.SIZES.small}
+						category="Cat"
+						dropdown={{...dropdownProps, label: longStr, tooltipLabel: longStr}}
 					/>
 					<span>Read only</span>
 					<Badge label={longStr} display={Badge.SIZES.large} category={longStr} />

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -117,6 +117,9 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 				<div style={columnStyle}>
 					<span>Badge with ellipsis</span>
 				</div>
+				<div style={columnStyle}>
+					<span>Badge with Dropdown</span>
+				</div>
 			</div>
 			<hr />
 			<div style={defaultStyle} id="newVisual">
@@ -236,12 +239,6 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onSelect('B')}
 						{...onDelete('A')}
 					/>
-					<br />
-					<Badge display={Badge.SIZES.large} category="Cat" dropdown={dropdownProps} />
-					<br />
-					<Badge display={Badge.SIZES.small} category="Cat" dropdown={dropdownProps} />
-					<br />
-					<Badge display={Badge.SIZES.large} category="Cat" dropdown={withComponents} />
 				</div>
 				<div style={columnStyle}>
 					<span>As Link</span>
@@ -274,17 +271,6 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onSelect('B')}
 						{...onDelete('A')}
 						icon="talend-clock"
-					/>
-					<span>Dropdown</span>
-					<Badge
-						display={Badge.SIZES.large}
-						category="Cat"
-						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
-					/>
-					<Badge
-						display={Badge.SIZES.small}
-						category="Cat"
-						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
 					/>
 					<span>Read only</span>
 					<Badge label={longStr} display={Badge.SIZES.large} category={longStr} />
@@ -333,6 +319,25 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onDelete('A')}
 					/>
 				</div>
+				<div style={columnStyle}>
+					<Badge display={Badge.SIZES.large} category="Cat" dropdown={dropdownProps} />
+					<br />
+					<Badge display={Badge.SIZES.small} category="Cat" dropdown={dropdownProps} />
+					<br />
+					<Badge display={Badge.SIZES.large} category="Cat" dropdown={withComponents} />
+					<br />
+					<Badge
+						display={Badge.SIZES.large}
+						category="Cat"
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
+					/>
+					<br />
+					<Badge
+						display={Badge.SIZES.small}
+						category="Cat"
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr }}
+					/>
+				</div>
 			</div>
 			<hr />
 		</section>
@@ -355,6 +360,9 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 				</div>
 				<div style={columnStyle}>
 					<span>Badge with ellipsis</span>
+				</div>
+				<div style={columnStyle}>
+					<span>Badge with Dropdown</span>
 				</div>
 			</div>
 			<hr />
@@ -610,6 +618,42 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						disabled
 					/>
 				</div>
+				<div style={columnStyle}>
+					<Badge
+						display={Badge.SIZES.large}
+						category="Cat"
+						dropdown={{ ...dropdownProps, disabled: true }}
+						disabled
+					/>
+					<br />
+					<Badge
+						display={Badge.SIZES.small}
+						category="Cat"
+						dropdown={{ ...dropdownProps, disabled: true }}
+						disabled
+					/>
+					<br />
+					<Badge
+						display={Badge.SIZES.large}
+						category="Cat"
+						dropdown={{ ...withComponents, disabled: true }}
+						disabled
+					/>
+					<br />
+					<Badge
+						display={Badge.SIZES.large}
+						category="Cat"
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr, disabled: true }}
+						disabled
+					/>
+					<br />
+					<Badge
+						display={Badge.SIZES.small}
+						category="Cat"
+						dropdown={{ ...dropdownProps, label: longStr, tooltipLabel: longStr, disabled: true }}
+						disabled
+					/>
+				</div>
 			</div>
 			<hr />
 		</section>
@@ -633,6 +677,9 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 				<div style={columnStyle}>
 					<span>Edit mode with ellipsis</span>
 				</div>
+                <div style={columnStyle}>
+                    <span>Badge with Dropdown</span>
+                </div>
 			</div>
 			<hr />
 			<div style={defaultStyle} id="newVisualWhiteEnabled">
@@ -662,6 +709,14 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						{...onDelete('A')}
 					/>
 				</div>
+                <div style={columnStyle}>
+                    <Badge
+                        display={Badge.SIZES.small}
+                        category="Cat"
+                        dropdown={dropdownProps}
+                        white
+                    />
+                </div>
 			</div>
 			<hr />
 			<div style={defaultStyle} id="newVisualWhiteDisabled">
@@ -700,6 +755,15 @@ storiesOf('Navigation/Badge', module).add('default', () => (
 						disabled
 					/>
 				</div>
+                <div style={columnStyle}>
+                    <Badge
+                        display={Badge.SIZES.small}
+                        category="Cat"
+                        dropdown={{ ...dropdownProps, disabled: true }}
+                        disabled
+                        white
+                    />
+                </div>
 			</div>
 			<hr />
 		</section>

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
@@ -6,12 +6,12 @@ import ActionDropdown from '../../../Actions/ActionDropdown';
 
 const theme = getTheme(badgeCssModule);
 
-const BadgeIcon = ({ props }) => (
+const BadgeDropdown = ({ props }) => (
 	<ActionDropdown className={theme('tc-badge-dropdown')} bsStyle="link" {...props} />
 );
 
-BadgeIcon.propTypes = {
+BadgeDropdown.propTypes = {
 	props: PropTypes.object,
 };
 
-export default BadgeIcon;
+export default BadgeDropdown;

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
@@ -7,11 +7,7 @@ import ActionDropdown from '../../../Actions/ActionDropdown';
 const theme = getTheme(badgeCssModule);
 
 const BadgeIcon = ({ props }) => (
-	<ActionDropdown
-		className={theme('tc-badge-dropdown')}
-		bsStyle="link"
-		{...props}
-	/>
+	<ActionDropdown className={theme('tc-badge-dropdown')} bsStyle="link" {...props} />
 );
 
 BadgeIcon.propTypes = {

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import badgeCssModule from '../../Badge.scss';
+import { getTheme } from '../../../theme';
+import ActionDropdown from '../../../Actions/ActionDropdown';
+
+const theme = getTheme(badgeCssModule);
+
+const BadgeIcon = ({ props }) => (
+	<ActionDropdown
+		className={theme('tc-badge-dropdown')}
+		bsStyle="link"
+		{...props}
+	/>
+);
+
+BadgeIcon.propTypes = {
+	props: PropTypes.object,
+};
+
+export default BadgeIcon;

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.test.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.test.js
@@ -1,0 +1,34 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import BadgeDropdown from './BadgeDropdown.component';
+
+describe('BadgeIcon', () => {
+	it('should default render', () => {
+		// given
+		const dropdownProps = {
+			id: 'context-dropdown-related-items',
+			label: 'Label',
+			items: [
+				{
+					id: 'context-dropdown-item-document-1',
+					label: 'document 1',
+					'data-feature': 'actiondropdown.items',
+					onClick: jest.fn(),
+				},
+				{
+					divider: true,
+				},
+				{
+					id: 'context-dropdown-item-document-2',
+					label: 'document 2',
+					'data-feature': 'actiondropdown.items',
+					onClick: jest.fn(),
+				},
+			],
+		};
+		// when
+		const wrapper = mount(<BadgeDropdown props={dropdownProps} />);
+		// then
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.test.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/BadgeDropdown.component.test.js
@@ -2,8 +2,8 @@ import React from 'react';
 import { mount } from 'enzyme';
 import BadgeDropdown from './BadgeDropdown.component';
 
-describe('BadgeIcon', () => {
-	it('should default render', () => {
+describe('BadgeDropdown', () => {
+	it('should render a dropdown', () => {
 		// given
 		const dropdownProps = {
 			id: 'context-dropdown-related-items',

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/__snapshots__/BadgeDropdown.component.test.js.snap
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/__snapshots__/BadgeDropdown.component.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`BadgeIcon should default render 1`] = `
+exports[`BadgeDropdown should render a dropdown 1`] = `
 <div class="dropdown btn-group btn-group-link">
   <button aria-label="Label"
           id="context-dropdown-related-items"

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/__snapshots__/BadgeDropdown.component.test.js.snap
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/__snapshots__/BadgeDropdown.component.test.js.snap
@@ -1,0 +1,63 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`BadgeIcon should default render 1`] = `
+<div class="dropdown btn-group btn-group-link">
+  <button aria-label="Label"
+          id="context-dropdown-related-items"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          type="button"
+          class="theme-tc-dropdown-button tc-dropdown-button tc-badge-dropdown theme-tc-badge-dropdown dropdown-toggle btn btn-link"
+  >
+    <span class="tc-dropdown-button-title-label">
+      Label
+    </span>
+    <svg name="talend-caret-down"
+         class="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+         focusable="false"
+         aria-hidden="true"
+    >
+      <use xlink:href="#talend-caret-down">
+      </use>
+    </svg>
+  </button>
+  <ul role="menu"
+      class="dropdown-menu"
+      aria-labelledby="context-dropdown-related-items"
+  >
+    <li role="presentation"
+        class="theme-tc-dropdown-item tc-dropdown-item"
+    >
+      <a id="context-dropdown-item-document-1"
+         label="document 1"
+         data-feature="actiondropdown.items"
+         title="document 1"
+         role="menuitem"
+         tabindex="-1"
+         href="#"
+      >
+        document 1
+      </a>
+    </li>
+    <li role="separator"
+        class="divider"
+    >
+    </li>
+    <li role="presentation"
+        class="theme-tc-dropdown-item tc-dropdown-item"
+    >
+      <a id="context-dropdown-item-document-2"
+         label="document 2"
+         data-feature="actiondropdown.items"
+         title="document 2"
+         role="menuitem"
+         tabindex="-1"
+         href="#"
+      >
+        document 2
+      </a>
+    </li>
+  </ul>
+</div>
+`;

--- a/packages/components/src/Badge/BadgeComposition/BadgeDropdown/index.js
+++ b/packages/components/src/Badge/BadgeComposition/BadgeDropdown/index.js
@@ -1,0 +1,3 @@
+import Component from './BadgeDropdown.component';
+
+export default Component;

--- a/packages/components/src/Badge/BadgeComposition/index.js
+++ b/packages/components/src/Badge/BadgeComposition/index.js
@@ -3,6 +3,7 @@ import BadgeDelete from './BadgeDelete';
 import BadgeIcon from './BadgeIcon';
 import BadgeLabel from './BadgeLabel';
 import BadgeSeparator from './BadgeSeparator';
+import BadgeDropdown from './BadgeDropdown';
 
 export default {
 	Category: BadgeCategory,
@@ -10,4 +11,5 @@ export default {
 	Icon: BadgeIcon,
 	Label: BadgeLabel,
 	Separator: BadgeSeparator,
+	Dropdown: BadgeDropdown,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Enhance the Badge component to add support for dropdown
https://jira.talendforge.org/browse/TCCUI-188

**What is the chosen solution to this problem?**
add badge type dropdown
http://2937.talend.surge.sh/components/?path=/story/navigation-badge--default

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
