### PR TITLE
fix(cmf): Avoid infinite rerender on error page

### DIFF
--- a/packages/cmf/src/components/ErrorPanel/ErrorPanel.component.js
+++ b/packages/cmf/src/components/ErrorPanel/ErrorPanel.component.js
@@ -12,11 +12,12 @@ function reload() {
 function ErrorPanel({ error = {} }) {
 	const [url, setURL] = React.useState();
 	useEffect(() => {
-		setURL(onError.createObjectURL(error));
+		const newUrl = onError.createObjectURL(error);
+		setURL(newUrl);
 		return () => {
-			onError.revokeObjectURL(url);
+			onError.revokeObjectURL(newUrl);
 		};
-	}, [error, url]);
+	}, [error]);
 	const HAS_REPORT = onError.hasReportFeature();
 	return (
 		<div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
CMF apps fall in an infinite render loop when encountering an error.

**What is the chosen solution to this problem?**
Break the infinite loop between the `useState` and the `useEffect`.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
