### PR TITLE
feat(theme): brand-primary is not customizable anymore

### DIFF
--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -16,7 +16,7 @@ $gray: lighten($gray-base, 33.5%) !default; // #555
 $gray-light: lighten($gray-base, 46.7%) !default; // #777
 $gray-lighter: lighten($gray-base, 85%) !default; // #bfbfbf
 
-$brand-primary: $st-tropaz !default;
+$brand-primary: $regal-blue;
 $brand-primary-lighter: tint($brand-primary, 25) !default;
 $brand-primary-light: tint($brand-primary, 12) !default;
 $brand-primary-dark: shade($brand-primary, 12) !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`$brand-primary` was customizable

**What is the chosen solution to this problem?**
Now, brand-primary is set to `$regal-blue` by default for all.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
http://guidelines.talend.com/document/92132#/design-principles/colors-theme-in-apps

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
