### PR TITLE
feat(components/HeaderBar): Fix Intercom semantic

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -190,17 +190,12 @@ function AppNotification({ getComponent, hasUnread, t, ...props }) {
 
 function Intercom({ id, config, tooltipPlacement }) {
 	return (
-		<li
-			role="presentation"
-			className={theme('tc-header-bar-intercom', 'tc-header-bar-action', 'separated')}
-		>
-			<ActionIntercom
-				className="btn btn-link"
-				id={id}
-				config={React.useMemo(() => ({ ...config, vertical_padding: 70 }), [config])}
-				tooltipPlacement={tooltipPlacement}
-			/>
-		</li>
+		<ActionIntercom
+			className={theme('tc-header-bar-intercom-default-component', 'btn', 'btn-link')}
+			id={id}
+			config={React.useMemo(() => ({ ...config, vertical_padding: 70 }), [config])}
+			tooltipPlacement={tooltipPlacement}
+		/>
 	);
 }
 
@@ -259,7 +254,14 @@ function HeaderBar(props) {
 						t={props.t}
 					/>
 				)}
-				{intercom}
+				{intercom && (
+					<li
+						role="presentation"
+						className={theme('tc-header-bar-intercom', 'tc-header-bar-action', 'separated')}
+					>
+						{intercom}
+					</li>
+				)}
 				{props.help && (
 					<Components.Help getComponent={props.getComponent} {...props.help} t={props.t} />
 				)}

--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -184,7 +184,7 @@ $background-color-on-hover: shade($brand-primary, 30);
 		}
 	}
 
-	.tc-header-bar-intercom button {
+	.tc-header-bar-intercom-default-component {
 		border-radius: 50%;
 		background: $st-tropaz;
 		min-height: auto;

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -152,7 +152,7 @@ describe('HeaderBar', () => {
 			.dive()
 			.find('withI18nextTranslation(Intercom)');
 		expect(intercomTrigger.length).toBe(1);
-		expect(intercomTrigger.prop('className')).toEqual('btn btn-link');
+		expect(intercomTrigger.prop('className')).toEqual('tc-header-bar-intercom-default-component btn btn-link');
 		expect(intercomTrigger.prop('id')).toEqual('my-intercom');
 		expect(intercomTrigger.prop('config')).toEqual({
 			app_id: 'e19c98d',

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -152,8 +152,8 @@ describe('HeaderBar', () => {
 			.dive()
 			.find('withI18nextTranslation(Intercom)');
 		expect(intercomTrigger.length).toBe(1);
-		expect(intercomTrigger.prop('className')).toEqual(
-			'tc-header-bar-intercom-default-component btn btn-link',
+		expect(intercomTrigger.prop('className')). toContain(
+			'tc-header-bar-intercom-default-component',
 		);
 		expect(intercomTrigger.prop('id')).toEqual('my-intercom');
 		expect(intercomTrigger.prop('config')).toEqual({

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -152,7 +152,9 @@ describe('HeaderBar', () => {
 			.dive()
 			.find('withI18nextTranslation(Intercom)');
 		expect(intercomTrigger.length).toBe(1);
-		expect(intercomTrigger.prop('className')).toEqual('tc-header-bar-intercom-default-component btn btn-link');
+		expect(intercomTrigger.prop('className')).toEqual(
+			'tc-header-bar-intercom-default-component btn btn-link',
+		);
 		expect(intercomTrigger.prop('id')).toEqual('my-intercom');
 		expect(intercomTrigger.prop('config')).toEqual({
 			app_id: 'e19c98d',

--- a/packages/components/src/HeaderBar/HeaderBar.test.js
+++ b/packages/components/src/HeaderBar/HeaderBar.test.js
@@ -152,9 +152,7 @@ describe('HeaderBar', () => {
 			.dive()
 			.find('withI18nextTranslation(Intercom)');
 		expect(intercomTrigger.length).toBe(1);
-		expect(intercomTrigger.prop('className')). toContain(
-			'tc-header-bar-intercom-default-component',
-		);
+		expect(intercomTrigger.prop('className')).toContain('tc-header-bar-intercom-default-component');
 		expect(intercomTrigger.prop('id')).toEqual('my-intercom');
 		expect(intercomTrigger.prop('config')).toEqual({
 			app_id: 'e19c98d',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Intercom component is part of the header bar, which is an unordered list (ul).
When injecting a custom Intercom component, that component must include the proper list element tag (li) in order to not break semantics.

**What is the chosen solution to this problem?**
- Always include list element tag (li) around Intercom component (injected or default)
- Apply default Intercom styles only to default Intercom

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
