### PR TITLE
feat(TCCUI-188) - show border on focus

### DIFF
--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -84,6 +84,7 @@ function Badge({
 		'tc-badge-readonly': !onDelete,
 		'tc-badge-aslink': aslink,
 		'tc-badge-edit': onDelete && onSelect,
+		'tc-badge-dropdown': dropdown,
 	});
 	const badgeClasses = theme('tc-badge-button', {
 		'tc-badge-white': white,

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -353,7 +353,7 @@ $tc-badge-disabled-opacity: 0.62;
 		.tc-badge-button {
 			&:not(.tc-badge-disabled) {
 				&:global(.ally-focus-within) {
-					border-color: rgba($lochmara, 1);
+					border-color: $lochmara;
 				}
 			}
 		}

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -1,7 +1,6 @@
 $tc-badge-large-label-font-size: 1.4rem !default;
 $tc-badge-large-label-font-weight: normal !default;
-$tc-badge-large-label-with-categ-font-weight: $font-weight-bold !default;
-$tc-badge-large-label-dropdown-font-weight: $font-weight-semi-bold !default;
+$tc-badge-large-label-with-categ-font-weight: $font-weight-semi-bold !default;
 $tc-badge-large-height: 2.4rem !default;
 $tc-badge-large-vertical-padding: ($tc-badge-large-height - $tc-badge-large-label-font-size * $line-height-base) / 2 !default;
 $tc-badge-large-margin: $padding-smaller !default;
@@ -11,8 +10,7 @@ $tc-badge-large-padding: $padding-small;
 
 $tc-badge-small-label-font-size: 1.2rem !default;
 $tc-badge-small-label-font-weight: normal !default;
-$tc-badge-small-label-with-categ-font-weight: $font-weight-bold !default;
-$tc-badge-small-label-dropdown-font-weight: $font-weight-semi-bold !default;
+$tc-badge-small-label-with-categ-font-weight: $font-weight-semi-bold !default;
 $tc-badge-small-height: 2rem !default;
 $tc-badge-small-vertical-padding: ($tc-badge-small-height - $tc-badge-small-label-font-size * $line-height-base) / 2 !default;
 $tc-badge-small-margin: $padding-smaller !default;
@@ -209,7 +207,7 @@ $tc-badge-disabled-opacity: 0.62;
 				height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
 				min-height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
 				font-size: $tc-badge-large-label-font-size;
-				font-weight: $tc-badge-large-label-dropdown-font-weight;
+				font-weight: $tc-badge-large-label-with-categ-font-weight;
 
 				svg {
 					height: $tc-badge-large-delete-icon-size;
@@ -269,7 +267,7 @@ $tc-badge-disabled-opacity: 0.62;
 				height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
 				min-height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
 				font-size: $tc-badge-small-label-font-size;
-				font-weight: $tc-badge-small-label-dropdown-font-weight;
+				font-weight: $tc-badge-small-label-with-categ-font-weight;
 
 				svg {
 					height: $tc-badge-small-delete-icon-size;

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -135,11 +135,11 @@ $tc-badge-disabled-opacity: 0.62;
 					color: $lochmara;
 				}
 			}
-            &:hover,
-            &:focus,
-            &:global(.ally-focus-within) {
-              outline: none;
-            }
+			&:hover,
+			&:focus,
+			&:global(.ally-focus-within) {
+				outline: none;
+			}
 		}
 	}
 

--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -1,6 +1,7 @@
 $tc-badge-large-label-font-size: 1.4rem !default;
 $tc-badge-large-label-font-weight: normal !default;
 $tc-badge-large-label-with-categ-font-weight: $font-weight-bold !default;
+$tc-badge-large-label-dropdown-font-weight: $font-weight-semi-bold !default;
 $tc-badge-large-height: 2.4rem !default;
 $tc-badge-large-vertical-padding: ($tc-badge-large-height - $tc-badge-large-label-font-size * $line-height-base) / 2 !default;
 $tc-badge-large-margin: $padding-smaller !default;
@@ -11,6 +12,7 @@ $tc-badge-large-padding: $padding-small;
 $tc-badge-small-label-font-size: 1.2rem !default;
 $tc-badge-small-label-font-weight: normal !default;
 $tc-badge-small-label-with-categ-font-weight: $font-weight-bold !default;
+$tc-badge-small-label-dropdown-font-weight: $font-weight-semi-bold !default;
 $tc-badge-small-height: 2rem !default;
 $tc-badge-small-vertical-padding: ($tc-badge-small-height - $tc-badge-small-label-font-size * $line-height-base) / 2 !default;
 $tc-badge-small-margin: $padding-smaller !default;
@@ -133,6 +135,11 @@ $tc-badge-disabled-opacity: 0.62;
 					color: $lochmara;
 				}
 			}
+            &:hover,
+            &:focus,
+            &:global(.ally-focus-within) {
+              outline: none;
+            }
 		}
 	}
 
@@ -186,7 +193,7 @@ $tc-badge-disabled-opacity: 0.62;
 				height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
 				min-height: $tc-badge-large-height - 2 * $tc-badge-large-vertical-padding;
 				font-size: $tc-badge-large-label-font-size;
-				font-weight: $tc-badge-large-label-with-categ-font-weight;
+				font-weight: $tc-badge-large-label-dropdown-font-weight;
 
 				svg {
 					height: $tc-badge-large-delete-icon-size;
@@ -246,7 +253,7 @@ $tc-badge-disabled-opacity: 0.62;
 				height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
 				min-height: $tc-badge-small-height - 2 * $tc-badge-small-vertical-padding;
 				font-size: $tc-badge-small-label-font-size;
-				font-weight: $tc-badge-small-label-with-categ-font-weight;
+				font-weight: $tc-badge-small-label-dropdown-font-weight;
 
 				svg {
 					height: $tc-badge-small-delete-icon-size;
@@ -305,6 +312,16 @@ $tc-badge-disabled-opacity: 0.62;
 	&-disabled {
 		.tc-badge-button {
 			opacity: $tc-badge-disabled-opacity;
+		}
+	}
+
+	&-dropdown {
+		.tc-badge-button {
+			&:not(.tc-badge-disabled) {
+				&:global(.ally-focus-within) {
+					border-color: rgba($lochmara, 1);
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The focus state border on Badge with dropdown needs to be improved to show the border on the whole Badge
https://jira.talendforge.org/browse/TCCUI-188

**What is the chosen solution to this problem?**
Add border on the whole badge and remove the outline from the dropdown element
http://2946.talend.surge.sh/components/?path=/story/navigation-badge--default

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
