### PR TITLE
chore(travis): remove test against react 16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,14 @@ before_install:
 matrix:
   fast_finish: true
   include:
-    - language: node_js
-      env: NAME=test_react_16 REACT_VERSION="^16.0.0"
-      node_js:
-        - '14'
-      script:
-        - yarn test
-        - yarn test:extra
+    # to use with the next major release of react
+    # - language: node_js
+    #   env: NAME=test_react_16 REACT_VERSION="^16.0.0"
+    #   node_js:
+    #     - '14'
+    #   script:
+    #     - yarn test
+    #     - yarn test:extra
 
     - language: node_js
       node_js:


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we test all UI against react 16 twice.

**What is the chosen solution to this problem?**

comment this line to keep for the next major release of react (17)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
