### PR TITLE
fix(faceted-search): don't reopen the value tooltip for badges with default operator

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,8 @@ Types of changes
 
 ## [unreleased]
 
+- [Fixed](https://github.com/Talend/ui/pull/2972): Don't reopen the value tooltip for badges with default operators
+
 ## [0.12.1]
 
 - [Fixed](https://github.com/Talend/ui/pull/2919): Fallback to default for slider facet

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -76,7 +76,7 @@ const BadgeFaceted = ({
 				{
 					value: badgeValue,
 					operator: badgeOperator,
-					initialOperatorOpened:false,
+					initialOperatorOpened: false,
 					initialValueOpened: false,
 				},
 				{ isInCreation: false },

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -76,6 +76,8 @@ const BadgeFaceted = ({
 				{
 					value: badgeValue,
 					operator: badgeOperator,
+					initialOperatorOpened:false,
+					initialValueOpened: false,
 				},
 				{ isInCreation: false },
 			),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When a badge with a default operator is added (checkbox, text, ...), the value tooltip will pop on each time the faceted search will be mounted.

**What is the chosen solution to this problem?**

Set `initialOperatorOpened` and `initialValueOpened` to `false` when submitting the value.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
