### PR TITLE
chore(Enumeration): missing for widgets

### DIFF
--- a/packages/forms/src/UIForm/utils/widgets.js
+++ b/packages/forms/src/UIForm/utils/widgets.js
@@ -9,6 +9,7 @@ import { CheckBox, CheckBoxes, TextModeCheckBox } from '../fields/CheckBox';
 import Code, { CodeTextMode } from '../fields/Code';
 import Datalist, { DatalistTextMode } from '../fields/Datalist';
 import { DateWidget, DateTimeWidget, TimeWidget } from '../fields/Date';
+import Enumeration from '../fields/Enumeration';
 import File from '../fields/File';
 import KeyValue from '../fields/KeyValue';
 import Comparator, { TextModeComparator } from '../fields/Comparator';
@@ -72,6 +73,7 @@ const widgets = {
 	datalist: Datalist,
 	date: DateWidget,
 	datetime: DateTimeWidget,
+	enumeration: Enumeration,
 	time: TimeWidget,
 	keyValue: KeyValue,
 	listView: ListView,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In ui-semantic, Enumeration is imported as a custom widget : 

`<UIForm
     widgets={{enumeration: Enumeration}}
/>`

The import path was quite long : 
import Enumeration from '@talend/react-forms/lib/UIForm/fields/Enumeration/EnumerationWidget';
And lint now enforce that the path are not too long (lib/UiForm at most) which ends in error when the above import is encountered.

**What is the chosen solution to this problem?**

Loading it as a custom was done in order not to load all the widgets, but in fact all the others are imported in widgets.js, so why not this one ? 
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
