### PR TITLE
fix(TPSVC-15962/AppSwitcher): connect it with component registry

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -238,7 +238,6 @@ function HeaderBar(props) {
 					{...props.brand}
 					{...props.products}
 					isSeparated={!!props.env}
-					getComponent={props.getComponent}
 				/>
 				{props.env && <Components.Environment getComponent={props.getComponent} {...props.env} />}
 			</ul>

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -234,11 +234,7 @@ function HeaderBar(props) {
 				{props.logo && (
 					<Components.Logo getComponent={props.getComponent} {...props.logo} t={props.t} />
 				)}
-				<AppSwitcherComponent
-					{...props.brand}
-					{...props.products}
-					isSeparated={!!props.env}
-				/>
+				<AppSwitcherComponent {...props.brand} {...props.products} isSeparated={!!props.env} />
 				{props.env && <Components.Environment getComponent={props.getComponent} {...props.env} />}
 			</ul>
 			<ul className={theme('tc-header-bar-actions', 'navbar-nav', 'right')}>

--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -6,7 +6,7 @@ import * as containers from './containers';
 const components = Object.keys(allComponents).reduce((acc, key) => {
 	if (!acc[key] && typeof allComponents[key] === 'function') {
 		const options = {};
-		if (['ActionList', 'Layout', 'RichLayout', 'Dialog'].includes(key)) {
+		if (['ActionList', 'AppSwitcher', 'Layout', 'RichLayout', 'Dialog'].includes(key)) {
 			options.withComponentRegistry = true;
 		}
 		if (!allComponents[key].displayName) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

AppSwitcher wait for getComponent to exists in the props. Since #2952 it is cmfConnected so it removes the getComponent props passed by the HeaderBar which is not required now

with UI 5.20
<img width="663" alt="Screenshot 2020-09-30 at 11 45 06" src="https://user-images.githubusercontent.com/19857479/94671600-61349f80-0314-11eb-826f-128afbae6cb0.png">

With UI 5.21 (export reorg)
<img width="583" alt="Screenshot 2020-09-30 at 09 53 04" src="https://user-images.githubusercontent.com/19857479/94671646-6eea2500-0314-11eb-97e5-cd1f897a9efb.png">

#2952 change:
<img width="885" alt="Screenshot 2020-09-30 at 11 47 43" src="https://user-images.githubusercontent.com/19857479/94671738-8b865d00-0314-11eb-96f2-1150ef8c75af.png">


**What is the chosen solution to this problem?**

remove getComponent props from HeaderBar
cmfConnect AppSwitcher withComponentRegistry to true

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
