### PR TITLE
fix(theme): body fonts should be black

### DIFF
--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -34,7 +34,7 @@ $brand-danger: $chestnut-rose !default;
 //** Background color for `<body>`.
 $body-bg: #fff !default;
 //** Global text color on `<body>`.
-$text-color: $gray-dark !default;
+$text-color: $black !default;
 
 //** Global textual link color.
 $link-color: $brand-primary !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Since few years, the body font color of our apps is no longer `$black` : 

![image](https://user-images.githubusercontent.com/26482371/94683580-0e181800-0327-11eb-9aa4-ae9c014305d4.png)

**What is the chosen solution to this problem?**

Set `$text-color` to `$black`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
