### PR TITLE
fix(forms): rhf from peer to dependencies

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -41,6 +41,7 @@
     "react-autowhatever": "10.2.0",
     "react-bootstrap": "0.32.4",
     "react-jsonschema-form": "0.51.0",
+    "react-hook-form": "^5.7.0",
     "tv4": "^1.3.0",
     "uuid": "^3.4.0"
   },
@@ -68,7 +69,6 @@
     "react": "^16.13.1",
     "react-ace": "6.2.0",
     "react-dom": "^16.13.1",
-    "react-hook-form": "^5.7.0",
     "react-i18next": "^10.11.4",
     "react-test-renderer": "^16.13.1",
     "sass-lint": "^1.13.1",
@@ -82,7 +82,6 @@
     "react": "^16.8.6",
     "react-ace": "6.2.0",
     "react-dom": "^16.8.6",
-    "react-hook-form": "^5.7.0",
     "react-i18next": "^10.11.4"
   },
   "publishConfig": {

--- a/versions/dependencies.json
+++ b/versions/dependencies.json
@@ -31,6 +31,7 @@
   "i18next-parser": "^0.13.0",
   "react-dnd": "^2.5.4",
   "react-draggable": "^3.3.0",
+  "react-hook-form": "^5.7.0",
   "react-i18next": "^10.11.4",
   "react-popper": "^1.3.7",
   "react-redux": "^5.0.7",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a breaking change in 5.22, the code of forms RHF wrappers are now exported in forms package index.
So any import from index makes the project execute the RHF wrappers code now.

But RHF is in peer dependencies, so projects that don't use RHF don't install it locally.

**What is the chosen solution to this problem?**
Move RHF from peer to dependency.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
