### PR TITLE
feat(List/ColumnChoser): Max. 5 columns shown

### DIFF
--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
@@ -30,6 +30,7 @@ $tc-height: 4rem;
 		width: 100%;
 		display: flex;
 		flex-direction: column;
+		max-height: 6 * $tc-height;
 	}
 
 	&-footer {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Lists' columns choser should only show 5 columns, and make the columns list scrollable if more need to be shown.

**What is the chosen solution to this problem?**
Set a max-height on the containing element

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
