### PR TITLE
feat(components/RadarChart): Interactive RadarChart axis dots

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -241,11 +241,10 @@
   348:2  error  defaultProp "display" has no corresponding propTypes declaration            react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/RadarChart/RadarChart.stories.js
-   29:7   error    'activeAxis' is assigned a value but never used  @typescript-eslint/no-unused-vars
-   34:17  warning  Unexpected unnamed function                      func-names
-   36:3   error    Unexpected string concatenation                  prefer-template
-   51:6   error    Value must be omitted for boolean attributes     react/jsx-boolean-value
-  127:5   error    Empty components are self-closing                react/self-closing-comp
+   31:7  error  'activeAxis' is assigned a value but never used  @typescript-eslint/no-unused-vars
+   45:6  error  Value must be omitted for boolean attributes     react/jsx-boolean-value
+  120:5  error  Empty components are self-closing                react/self-closing-comp
+  141:5  error  Empty components are self-closing                react/self-closing-comp
 
 /home/travis/build/Talend/ui/packages/components/src/ResourceList/Resource/Resource.component.js
   52:3   error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
@@ -400,5 +399,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 209 problems (187 errors, 22 warnings)
+✖ 208 problems (187 errors, 21 warnings)
   8 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -243,8 +243,7 @@
 /home/travis/build/Talend/ui/packages/components/src/RadarChart/RadarChart.stories.js
    31:7  error  'activeAxis' is assigned a value but never used  @typescript-eslint/no-unused-vars
    45:6  error  Value must be omitted for boolean attributes     react/jsx-boolean-value
-  120:5  error  Empty components are self-closing                react/self-closing-comp
-  141:5  error  Empty components are self-closing                react/self-closing-comp
+  133:5  error  Empty components are self-closing                react/self-closing-comp
 
 /home/travis/build/Talend/ui/packages/components/src/ResourceList/Resource/Resource.component.js
   52:3   error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
@@ -399,5 +398,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 208 problems (187 errors, 21 warnings)
-  8 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 207 problems (186 errors, 21 warnings)
+  7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/RadarChart/RadarChart.component.js
+++ b/packages/components/src/RadarChart/RadarChart.component.js
@@ -142,26 +142,26 @@ Dot.propTypes = {
  */
 // TODO 6.0: remove this export
 export function DotWithClick(props) {
-	const { activeAxis, fill, index, ...rest } = props;
-	let radius = 2;
-	let strokeRadius = 12;
-
-	if (activeAxis === index) {
-		radius = 4;
-		strokeRadius = 8;
-	}
+	const { activeAxis, fill, index, onClick, ...rest } = props;
+	const STATE = {
+		DEFAULT_RADIUS: 2,
+		DEFAULT_STROKE_WIDTH: 12,
+		ACTIVE_RADIUS: 4,
+		ACTIVE_STROKE_WIDTH: 8,
+	};
 
 	return (
 		<RechartsDot
 			{...rest}
 			fill={fill}
 			fillOpacity={1}
-			r={radius}
+			onClick={onClick}
+			r={activeAxis === index ? STATE.ACTIVE_RADIUS : STATE.DEFAULT_RADIUS}
 			role="button"
-			tabIndex={0}
 			stroke={fill}
 			strokeOpacity={0}
-			strokeWidth={strokeRadius}
+			strokeWidth={activeAxis === index ? STATE.ACTIVE_STROKE_WIDTH : STATE.DEFAULT_STROKE_WIDTH}
+			tabIndex={0}
 		/>
 	);
 }
@@ -170,6 +170,7 @@ DotWithClick.propTypes = {
 	activeAxis: PropTypes.number,
 	fill: PropTypes.string,
 	index: PropTypes.number,
+	onClick: PropTypes.func,
 };
 
 // TODO 6.0: remove those exports

--- a/packages/components/src/RadarChart/RadarChart.component.js
+++ b/packages/components/src/RadarChart/RadarChart.component.js
@@ -136,10 +136,47 @@ Dot.propTypes = {
 	index: PropTypes.number,
 };
 
+/**
+ * This function provides a clickable axis dot element
+ * @param {Object} props the current props of the Radar
+ */
+// TODO 6.0: remove this export
+export function DotWithClick(props) {
+	const { activeAxis, fill, index, ...rest } = props;
+	let radius = 2;
+	let strokeRadius = 12;
+
+	if (activeAxis === index) {
+		radius = 4;
+		strokeRadius = 8;
+	}
+
+	return (
+		<RechartsDot
+			{...rest}
+			fill={fill}
+			fillOpacity={1}
+			r={radius}
+			role="button"
+			tabIndex="0"
+			stroke={fill}
+			strokeOpacity={0}
+			strokeWidth={strokeRadius}
+		/>
+	);
+}
+DotWithClick.displayName = 'DotWithClick';
+DotWithClick.propTypes = {
+	activeAxis: PropTypes.number,
+	fill: PropTypes.string,
+	index: PropTypes.number,
+};
+
 // TODO 6.0: remove those exports
 export { Radar, PolarAngleAxis };
 
 RadarChart.LabelWithClick = LabelWithClick;
 RadarChart.Dot = Dot;
+RadarChart.DotWithClick = DotWithClick;
 RadarChart.Radar = Radar;
 RadarChart.PolarAngleAxis = PolarAngleAxis;

--- a/packages/components/src/RadarChart/RadarChart.component.js
+++ b/packages/components/src/RadarChart/RadarChart.component.js
@@ -158,7 +158,7 @@ export function DotWithClick(props) {
 			fillOpacity={1}
 			r={radius}
 			role="button"
-			tabIndex="0"
+			tabIndex={0}
 			stroke={fill}
 			strokeOpacity={0}
 			strokeWidth={strokeRadius}

--- a/packages/components/src/RadarChart/RadarChart.stories.js
+++ b/packages/components/src/RadarChart/RadarChart.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 import RadarChart from '.';
 
 const ExampleDataSingle = [
@@ -28,18 +29,6 @@ const ExampleDataClickable = [
 
 const chartDomain = [0, 5];
 const activeAxis = 2;
-
-/**
- * Click functions provided by the host app
- */
-const onClick = function () {
-	document.getElementById('clickMessage').innerHTML =
-		'Good job! You clicked ' + event.target.innerHTML + '.';
-};
-const onClickDot = function () {
-	document.getElementById('clickMessage').innerHTML =
-		'Good job! You clicked an axis dot.';
-};
 
 const stories = storiesOf('Data/Dataviz/RadarChart', module);
 stories
@@ -94,7 +83,7 @@ stories
 				<RadarChart.PolarAngleAxis
 					dataKey="axis"
 					tick={<RadarChart.LabelWithClick activeAxis={2} />}
-					onClick={onClick}
+					onClick={action('Axis label was clicked')}
 				/>
 				<RadarChart.Radar
 					dataKey="A"
@@ -119,7 +108,7 @@ stories
 				<RadarChart.PolarAngleAxis dataKey="axis" />
 				<RadarChart.Radar
 					dataKey="A"
-					dot={<RadarChart.DotWithClick activeAxis={2} onClick={onClickDot} />}
+					dot={<RadarChart.DotWithClick activeAxis={2} onClick={action('Axis dot was clicked')} />}
 					fill="#19426c"
 					fillOpacity={0.1}
 					name="Trust score"

--- a/packages/components/src/RadarChart/RadarChart.stories.js
+++ b/packages/components/src/RadarChart/RadarChart.stories.js
@@ -94,10 +94,6 @@ stories
 					stroke="#19426c"
 				/>
 			</RadarChart>
-
-			<div>
-				<p id="clickMessage">You haven't clicked anything yet.</p>
-			</div>
 		</div>
 	))
 	.add('Radar Chart Clickable Dot', () => (
@@ -115,10 +111,6 @@ stories
 					stroke="#19426c"
 				/>
 			</RadarChart>
-
-			<div>
-				<p id="clickMessage"></p>
-			</div>
 		</div>
 	))
 	.add('Radar Chart Custom Dot', () => (

--- a/packages/components/src/RadarChart/RadarChart.stories.js
+++ b/packages/components/src/RadarChart/RadarChart.stories.js
@@ -7,7 +7,7 @@ const ExampleDataSingle = [
 	{ axis: 'Popularity', A: 3 },
 	{ axis: 'Completeness', A: 2 },
 	{ axis: 'Discoverability', A: 1 },
-	{ axis: 'other', A: 1 },
+	{ axis: 'Usage', A: 1 },
 ];
 
 const ExampleDataMultiple = [
@@ -15,7 +15,7 @@ const ExampleDataMultiple = [
 	{ axis: 'Popularity', A: 3, B: 5 },
 	{ axis: 'Completeness', A: 2, B: 1 },
 	{ axis: 'Discoverability', A: 1, B: 3 },
-	{ axis: 'other', A: 1, B: 3 },
+	{ axis: 'Usage', A: 1, B: 3 },
 ];
 
 const ExampleDataClickable = [
@@ -23,6 +23,7 @@ const ExampleDataClickable = [
 	{ axis: 'Popularity', A: 3 },
 	{ axis: 'Completeness', A: 2 },
 	{ axis: 'Discoverability', A: 1 },
+	{ axis: 'Usage', A: 1 },
 ];
 
 const chartDomain = [0, 5];
@@ -34,6 +35,10 @@ const activeAxis = 2;
 const onClick = function () {
 	document.getElementById('clickMessage').innerHTML =
 		'Good job! You clicked ' + event.target.innerHTML + '.';
+};
+const onClickDot = function () {
+	document.getElementById('clickMessage').innerHTML =
+		'Good job! You clicked an axis dot.';
 };
 
 const stories = storiesOf('Data/Dataviz/RadarChart', module);
@@ -81,7 +86,7 @@ stories
 			</RadarChart>
 		</div>
 	))
-	.add('Radar Chart Clickable', () => (
+	.add('Radar Chart Clickable Label', () => (
 		<div>
 			<h2>Clickable labels</h2>
 			<p>A radar chart with clickable axis labels</p>
@@ -92,17 +97,38 @@ stories
 					onClick={onClick}
 				/>
 				<RadarChart.Radar
-					name="Trust score"
 					dataKey="A"
 					dot={false}
-					stroke="#19426c"
 					fill="#19426c"
 					fillOpacity={0.1}
+					name="Trust score"
+					stroke="#19426c"
 				/>
 			</RadarChart>
 
 			<div>
 				<p id="clickMessage">You haven't clicked anything yet.</p>
+			</div>
+		</div>
+	))
+	.add('Radar Chart Clickable Dot', () => (
+		<div>
+			<h2>Clickable dot</h2>
+			<p>A radar chart with clickable dots</p>
+			<RadarChart data={ExampleDataClickable} domain={chartDomain}>
+				<RadarChart.PolarAngleAxis dataKey="axis" />
+				<RadarChart.Radar
+					dataKey="A"
+					dot={<RadarChart.DotWithClick activeAxis={2} onClick={onClickDot} />}
+					fill="#19426c"
+					fillOpacity={0.1}
+					name="Trust score"
+					stroke="#19426c"
+				/>
+			</RadarChart>
+
+			<div>
+				<p id="clickMessage"></p>
 			</div>
 		</div>
 	))
@@ -117,7 +143,6 @@ stories
 					dot={<RadarChart.Dot activeAxis={2} />}
 					fill="#19426c"
 					fillOpacity={0.1}
-					isAnimationActive={false}
 					name="Trust score"
 					stroke="#19426c"
 				/>

--- a/packages/components/src/RadarChart/RadarChart.test.js
+++ b/packages/components/src/RadarChart/RadarChart.test.js
@@ -68,7 +68,49 @@ describe('RadarChart', () => {
 		);
 
 		// when
-		wrapper.find('.recharts-polar-angle-axis-tick').at(0).simulate('click');
+		wrapper
+			.find('.recharts-polar-angle-axis-tick')
+			.at(0)
+			.simulate('click');
+
+		// then
+		expect(props.clickMock).toHaveBeenCalled();
+	});
+	it('should render a chart with clickable dots', () => {
+		const props = {
+			data: [
+				{ axis: 'Validity', A: 4 },
+				{ axis: 'Social curation', A: 3 },
+				{ axis: 'Completeness', A: 2 },
+				{ axis: 'Discoverability', A: 1 },
+				{ axis: 'Usage', A: 1 },
+			],
+			domain: [0, 5],
+			dataKey: 'axis',
+			activeAxis: 2,
+			clickMock: jest.fn(),
+		};
+
+		// when
+		const wrapper = mount(
+			<RadarChart data={props.data} domain={props.domain}>
+				<RadarChart.PolarAngleAxis dataKey={props.dataKey} />
+				<RadarChart.Radar
+					dataKey="A"
+					dot={<RadarChart.DotWithClick activeAxis={2} onClick={props.clickMock} />}
+					fill="#19426c"
+					fillOpacity={0.1}
+					name="Trust score"
+					stroke="#19426c"
+				/>
+			</RadarChart>,
+		);
+
+		// when
+		wrapper
+			.find('.recharts-dot')
+			.at(0)
+			.simulate('click');
 
 		// then
 		expect(props.clickMock).toHaveBeenCalled();

--- a/packages/components/src/RadarChart/RadarChart.test.js
+++ b/packages/components/src/RadarChart/RadarChart.test.js
@@ -68,10 +68,7 @@ describe('RadarChart', () => {
 		);
 
 		// when
-		wrapper
-			.find('.recharts-polar-angle-axis-tick')
-			.at(0)
-			.simulate('click');
+		wrapper.find('.recharts-polar-angle-axis-tick').at(0).simulate('click');
 
 		// then
 		expect(props.clickMock).toHaveBeenCalled();
@@ -107,10 +104,7 @@ describe('RadarChart', () => {
 		);
 
 		// when
-		wrapper
-			.find('.recharts-dot')
-			.at(0)
-			.simulate('click');
+		wrapper.find('.recharts-dot').at(0).simulate('click');
 
 		// then
 		expect(props.clickMock).toHaveBeenCalled();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Evidence suggests that when interacting with a radar chart, users are likely to attempt to click on the individual axis dots. At present only interactive axis labels are supported by the RadarChart component. This requirement is tracked in [TDC-4796](https://jira.talendforge.org/browse/TDC-4796). 

**What is the chosen solution to this problem?**
Add a new functional component to the RadarChart which will render a clickable axis dot. The dot should be configured in the same way as the existing label component, to meet the contextual needs of an interactive element.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
