### PR TITLE
chore(containers): reorganize exports to prepare 6.0

### DIFF
--- a/packages/containers/6.0 - breaking changes.md
+++ b/packages/containers/6.0 - breaking changes.md
@@ -1,0 +1,69 @@
+# 6.0 Breaking changes
+
+## AboutDialog
+
+Constants are now attached to the component.
+
+```diff
+-import AboutDialogConstants from '@talend/react-containers/lib/AboutDialog/AboutDialog.constants'
++import AboutDialog from '@talend/react-containers/lib/AboutDialog';
+
++const AboutDialogConstants = AboutDialog.constants;
+```
+
+## EditableText
+
+Selectors are now attached to the component
+
+```diff
+-import { getEditMode } from '@talend/react-containers/lib/EditableText/EditableText.selectors'
++import EditableText from '@talend/react-containers/lib/EditableText';
+
++const { getEditMode } = EditableText.selectors;
+```
+
+## GuidedTour
+
+Constants are now attached to the component.
+
+```diff
+-import GuidedTourConstants from '@talend/react-containers/lib/GuidedTour/GuidedTour.constants'
++import GuidedTour from '@talend/react-containers/lib/GuidedTour';
+
++const GuidedTourConstants = GuidedTour.constants;
+```
+
+## HeaderBar
+
+Constants and actions are now attached to the component.
+
+```diff
+-import HeaderBarConstants from '@talend/react-containers/lib/HeaderBar/HeaderBar.constants'
+-import HeaderBarActions from '@talend/react-containers/lib/HeaderBar/HeaderBar.actions'
++import HeaderBar from '@talend/react-containers/lib/HeaderBar';
+
++const HeaderBarConstants = HeaderBar.constants;
++const HeaderBarActions = HeaderBar.actions;
+```
+
+## List
+
+Constants and selectors are now attached to the component.
+
+```diff
+-import ListConstants from '@talend/react-containers/lib/List/List.constants'
+-import { getCollectionItems } from '@talend/react-containers/lib/List/selector'
++import List from '@talend/react-containers/lib/List';
+
++const ListConstants = List.constants;
++const { getCollectionItems } = List.selectors;
+```
+
+## registerAllContainers
+
+`registerAllContainers` function is now exported from index
+
+```diff
+-import { registerAllContainers } from '@talend/react-containers/lib/register'
++import { registerAllContainers } from '@talend/react-containers';
+```

--- a/packages/containers/6.0 - breaking changes.md
+++ b/packages/containers/6.0 - breaking changes.md
@@ -11,6 +11,21 @@ Constants are now attached to the component.
 +const AboutDialogConstants = AboutDialog.constants;
 ```
 
+## ComponentForm
+
+Selectors, actions and the `kit` utility functions are now attached to the component.
+
+```diff
+-import ComponentFormSelectors from '@talend/react-containers/lib/ComponentForm/ComponentForm.selectors'
+-import ComponentFormActions from '@talend/react-containers/lib/ComponentForm/ComponentForm.actions'
+-import createTriggers from '@talend/react-containers/lib/ComponentForm/kit/createTriggers';
++import ComponentForm from '@talend/react-containers/lib/ComponentForm';
+
++const ComponentFormSelectors = ComponentForm.selectors;
++const ComponentFormActions = ComponentForm.actions;
++const { createTriggers } = ComponentForm.kit;
+```
+
 ## EditableText
 
 Selectors are now attached to the component

--- a/packages/containers/src/AboutDialog/index.js
+++ b/packages/containers/src/AboutDialog/index.js
@@ -1,7 +1,7 @@
 import AboutDialog from './AboutDialog.connect';
-
 import AboutDialogSagas from './AboutDialog.sagas';
+import AboutDialogConstants from './AboutDialog.constant';
 
 AboutDialog.sagas = AboutDialogSagas;
-
+AboutDialog.constants = AboutDialogConstants;
 export default AboutDialog;

--- a/packages/containers/src/Action/Action.connect.js
+++ b/packages/containers/src/Action/Action.connect.js
@@ -1,5 +1,5 @@
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import Action from '@talend/react-components/lib/Actions/Action';
+import { Action } from '@talend/react-components/lib/Actions';
 
 export function mapStateToProps(state, ownProps) {
 	if (ownProps.actionId) {

--- a/packages/containers/src/ActionBar/ActionBar.connect.js
+++ b/packages/containers/src/ActionBar/ActionBar.connect.js
@@ -37,7 +37,7 @@ export function mapStateToProps(state, { actionIds }) {
 	return props;
 }
 
-export function mergeProps(stateProps, dispatchProps, ownProps) {
+function mergeProps(stateProps, dispatchProps, ownProps) {
 	const props = { ...ownProps, ...stateProps, ...dispatchProps };
 	delete props.actionIds;
 	return props;

--- a/packages/containers/src/ActionBar/ActionBar.connect.js
+++ b/packages/containers/src/ActionBar/ActionBar.connect.js
@@ -37,7 +37,7 @@ export function mapStateToProps(state, { actionIds }) {
 	return props;
 }
 
-function mergeProps(stateProps, dispatchProps, ownProps) {
+export function mergeProps(stateProps, dispatchProps, ownProps) {
 	const props = { ...ownProps, ...stateProps, ...dispatchProps };
 	delete props.actionIds;
 	return props;

--- a/packages/containers/src/ActionButton/ActionButton.connect.js
+++ b/packages/containers/src/ActionButton/ActionButton.connect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import ActionButton from '@talend/react-components/lib/Actions/ActionButton';
+import { ActionButton } from '@talend/react-components/lib/Actions';
 
 export function mapStateToProps(state, ownProps) {
 	let props = {};

--- a/packages/containers/src/ActionButton/ActionButton.test.js
+++ b/packages/containers/src/ActionButton/ActionButton.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ActionButton from '@talend/react-components/lib/Actions/ActionButton';
+import { ActionButton } from '@talend/react-components/lib/Actions';
 import mock from '@talend/react-cmf/lib/mock';
 
 import Connected, {

--- a/packages/containers/src/ActionDropdown/ActionDropdown.connect.js
+++ b/packages/containers/src/ActionDropdown/ActionDropdown.connect.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import ActionDropdown from '@talend/react-components/lib/Actions/ActionDropdown';
+import { ActionDropdown } from '@talend/react-components/lib/Actions';
 import omit from 'lodash/omit';
 
 import getOnClick from '../actionOnClick';

--- a/packages/containers/src/ActionDropdown/ActionDropdown.test.js
+++ b/packages/containers/src/ActionDropdown/ActionDropdown.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import mock from '@talend/react-cmf/lib/mock';
-import ActionDropdown from '@talend/react-components/lib/Actions/ActionDropdown';
+import { ActionDropdown } from '@talend/react-components/lib/Actions';
 import Connected, {
 	mapStateToProps,
 	ContainerActionDropdown,

--- a/packages/containers/src/ActionFile/ActionFile.connect.js
+++ b/packages/containers/src/ActionFile/ActionFile.connect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import ActionFile from '@talend/react-components/lib/Actions/ActionFile';
+import { ActionFile } from '@talend/react-components/lib/Actions';
 
 export function mapStateToProps(state, ownProps) {
 	if (!ownProps.actionId) {

--- a/packages/containers/src/ActionIconToggle/ActionIconToggle.connect.js
+++ b/packages/containers/src/ActionIconToggle/ActionIconToggle.connect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import ActionIconToggle from '@talend/react-components/lib/Actions/ActionIconToggle';
+import { ActionIconToggle } from '@talend/react-components/lib/Actions';
 
 export function mapStateToProps(state, ownProps) {
 	let props = {};

--- a/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.connect.js
+++ b/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.connect.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import ActionSplitDropdown from '@talend/react-components/lib/Actions/ActionSplitDropdown';
+import { ActionSplitDropdown } from '@talend/react-components/lib/Actions';
 
 import getOnClick from '../actionOnClick';
 

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import cmf, { cmfConnect } from '@talend/react-cmf';
 import Form from '@talend/react-forms';
-import { getValue } from '@talend/react-forms/lib/UIForm/utils/properties';
+import UIForm from '@talend/react-forms/lib/UIForm';
 import omit from 'lodash/omit';
 import get from 'lodash/get';
 import { Map } from 'immutable';
@@ -60,7 +60,7 @@ export function resolveNameForTitleMap({ schema, properties, value }) {
 	const parentKey = schema.key.slice();
 	const key = parentKey.pop();
 	const nameKey = `$${key}_name`;
-	const parentValue = getValue(properties, { key: parentKey });
+	const parentValue = UIForm.utils.properties.getValue(properties, { key: parentKey });
 
 	if (names.some(name => name !== undefined)) {
 		parentValue[nameKey] = valueIsArray ? names : names[0];

--- a/packages/containers/src/ComponentForm/index.js
+++ b/packages/containers/src/ComponentForm/index.js
@@ -1,6 +1,12 @@
 import ComponentForm from './ComponentForm.component';
 import sagas from './ComponentForm.sagas';
+import * as ComponentFormSelectors from './ComponentForm.selectors';
+import * as ComponentFormActions from './ComponentForm.actions';
+import kit from './kit';
 
 ComponentForm.sagas = sagas;
+ComponentForm.selectors = ComponentFormSelectors;
+ComponentForm.actions = ComponentFormActions;
+ComponentForm.kit = kit;
 
 export default ComponentForm;

--- a/packages/containers/src/EditableText/index.js
+++ b/packages/containers/src/EditableText/index.js
@@ -1,3 +1,5 @@
 import EditableText from './EditableText.connect';
+import * as EditableTextSelectors from './EditableText.selectors';
 
+EditableText.selectors = EditableTextSelectors;
 export default EditableText;

--- a/packages/containers/src/FilterBar/index.js
+++ b/packages/containers/src/FilterBar/index.js
@@ -1,9 +1,6 @@
 import FilterBar from './FilterBar.connect';
-import { getComponentState, getQuery } from './FilterBar.selectors';
+import * as FilterBarSelectors from './FilterBar.selectors';
 
-FilterBar.selectors = {
-	getComponentState,
-	getQuery,
-};
+FilterBar.selectors = FilterBarSelectors;
 
 export default FilterBar;

--- a/packages/containers/src/GuidedTour/index.js
+++ b/packages/containers/src/GuidedTour/index.js
@@ -1,7 +1,9 @@
 import GuidedTour from './GuidedTour.connect';
 
 import GuidedTourSagas from './GuidedTour.sagas';
+import GuidedTourConstants from './GuidedTour.constants';
 
 GuidedTour.sagas = GuidedTourSagas;
+GuidedTour.constants = GuidedTourConstants;
 
 export default GuidedTour;

--- a/packages/containers/src/HeaderBar/index.js
+++ b/packages/containers/src/HeaderBar/index.js
@@ -1,7 +1,10 @@
 import HeaderBar from './HeaderBar.connect';
-
 import HeaderBarSagas from './HeaderBar.sagas';
+import * as HeaderBarConstants from './HeaderBar.constant';
+import * as HeaderBarActions from './HeaderBar.actions';
 
 HeaderBar.sagas = HeaderBarSagas;
+HeaderBar.constant = HeaderBarConstants;
+HeaderBar.actions = HeaderBarActions;
 
 export default HeaderBar;

--- a/packages/containers/src/List/index.js
+++ b/packages/containers/src/List/index.js
@@ -1,6 +1,10 @@
 import List from './List.connect';
 import ListSaga from './List.sagas';
+import * as ListConstants from './List.constant';
+import * as ListSelectors from './selector';
 
 List.sagas = ListSaga;
+List.constants = ListConstants;
+List.selectors = ListSelectors;
 
 export default List;

--- a/packages/containers/src/SubHeaderBar/index.js
+++ b/packages/containers/src/SubHeaderBar/index.js
@@ -1,8 +1,5 @@
 import SubHeaderBar from './SubHeaderBar.connect';
-import { getComponentState } from './SubHeaderBar.selectors';
+import * as SubHeaderBarSelectors from './SubHeaderBar.selectors';
 
-SubHeaderBar.selectors = {
-	getComponentState,
-};
-
+SubHeaderBar.selectors = SubHeaderBarSelectors;
 export default SubHeaderBar;

--- a/packages/containers/src/TabBar/index.js
+++ b/packages/containers/src/TabBar/index.js
@@ -1,9 +1,6 @@
 import TabBar from './TabBar.connect';
-import { getSelectedKey, getComponentState } from './TabBar.selectors';
+import * as TabBarSelectors from './TabBar.selectors';
 
-TabBar.selectors = {
-	getSelectedKey,
-	getComponentState,
-};
+TabBar.selectors = TabBarSelectors;
 
 export default TabBar;

--- a/packages/containers/src/cmfModule.js
+++ b/packages/containers/src/cmfModule.js
@@ -1,0 +1,24 @@
+import omit from 'lodash/omit';
+import { cmfConnect } from '@talend/react-cmf';
+import * as allComponents from '@talend/react-components';
+import * as containers from './containers';
+
+const components = Object.keys(allComponents).reduce((acc, key) => {
+	if (!acc[key] && typeof allComponents[key] === 'function') {
+		const options = {};
+		if (['ActionList', 'AppSwitcher', 'Layout', 'RichLayout', 'Dialog'].includes(key)) {
+			options.withComponentRegistry = true;
+		}
+		if (!allComponents[key].displayName) {
+			allComponents[key].displayName = key;
+		}
+		// eslint-disable-next-line no-param-reassign
+		acc[key] = cmfConnect(options)(allComponents[key]);
+	}
+	return acc;
+}, omit(containers, ['actionAPI']));
+
+export default {
+	id: 'containers',
+	components,
+};

--- a/packages/containers/src/index.js
+++ b/packages/containers/src/index.js
@@ -1,25 +1,10 @@
-import omit from 'lodash/omit';
-import * as allComponents from '@talend/react-components';
 import { cmfConnect } from '@talend/react-cmf';
-import * as containers from './containers';
-
-const components = Object.keys(allComponents).reduce((acc, key) => {
-	if (!acc[key] && typeof allComponents[key] === 'function') {
-		const options = {};
-		if (['ActionList', 'AppSwitcher', 'Layout', 'RichLayout', 'Dialog'].includes(key)) {
-			options.withComponentRegistry = true;
-		}
-		if (!allComponents[key].displayName) {
-			allComponents[key].displayName = key;
-		}
-		// eslint-disable-next-line no-param-reassign
-		acc[key] = cmfConnect(options)(allComponents[key]);
-	}
-	return acc;
-}, omit(containers, ['actionAPI']));
+import * as allComponents from '@talend/react-components';
+import cmfModule from './cmfModule';
 
 export * from './containers';
 export { default as actionAPI } from './actionAPI';
+export * from './register';
 
 export const Layout = cmfConnect({
 	omitCMFProps: true,
@@ -42,8 +27,4 @@ export const TooltipTrigger = cmfConnect({
 	omitCMFProps: true,
 })(allComponents.TooltipTrigger);
 
-// cmfModule
-export default {
-	id: 'containers',
-	components,
-};
+export default cmfModule;

--- a/packages/containers/src/register.js
+++ b/packages/containers/src/register.js
@@ -1,7 +1,7 @@
 import cmf from '@talend/react-cmf';
-import containersCMFModule from './index';
+import cmfModule from './cmfModule';
 
 // eslint-disable-next-line import/prefer-default-export
 export function registerAllContainers() {
-	cmf.component.registerMany(containersCMFModule.components);
+	cmf.component.registerMany(cmfModule.components);
 }

--- a/packages/containers/src/register.js
+++ b/packages/containers/src/register.js
@@ -1,7 +1,11 @@
 import cmf from '@talend/react-cmf';
 import cmfModule from './cmfModule';
 
+// TODO 6.0: remove this function
 // eslint-disable-next-line import/prefer-default-export
 export function registerAllContainers() {
+	console.warn(
+		'@talend/react-containers > registerAllContainers() is deprecated. Use the cmf module instead to register the components. This function may be removed in 6.0',
+	);
 	cmf.component.registerMany(cmfModule.components);
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7220,14 +7220,7 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
-  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^5.1.0, dot-prop@^5.2.0:
+dot-prop@^4.2.0, dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -7337,7 +7330,7 @@ element-resize-detector@^1.2.1:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3:
+elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -10678,11 +10671,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -12759,17 +12747,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@1.1.x:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
-  integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
-
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8, minimist@1.1.x, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -12841,7 +12819,7 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
+mixin-deep@^1.2.0, mixin-deep@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
@@ -19403,14 +19381,7 @@ webpack@^4.19.0, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.42.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-websocket-driver@0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
-  integrity sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=
-  dependencies:
-    websocket-extensions ">=0.1.1"
-
-websocket-driver@>=0.5.1:
+websocket-driver@0.6.5, websocket-driver@>=0.5.1, websocket-driver@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Exports will change in 6.0 to support UMD format for CDN.

**What is the chosen solution to this problem?**
Prepare that attaching sagas, constants, actions, selectors to their components.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
