### PR TITLE
chore(forms): upgrading react hook form to v6

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -40,7 +40,7 @@
     "memoize-one": "^5.0.0",
     "react-autowhatever": "10.2.0",
     "react-bootstrap": "0.32.4",
-    "react-hook-form": "^5.7.0",
+    "react-hook-form": "^6.9.2",
     "react-jsonschema-form": "0.51.0",
     "tv4": "^1.3.0",
     "uuid": "^3.4.0"

--- a/packages/forms/src/rhf/fields/Input/Input.stories.js
+++ b/packages/forms/src/rhf/fields/Input/Input.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import { useForm, FormContext } from 'react-hook-form/dist/react-hook-form.ie11';
+import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
 import { action } from '@storybook/addon-actions';
 import Input from '.';
 
@@ -15,7 +15,7 @@ export default {
 export const States = () => {
 	const rhf = useForm();
 	return (
-		<FormContext {...rhf}>
+		<FormProvider {...rhf}>
 			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
 				<Input id="name" type="text" name="default" label="Default" defaultValue="Jimmy" />
 				<Input
@@ -38,7 +38,7 @@ export const States = () => {
 					Submit
 				</button>
 			</form>
-		</FormContext>
+		</FormProvider>
 	);
 };
 
@@ -46,7 +46,7 @@ export const Types = () => {
 	const rhf = useForm();
 
 	return (
-		<FormContext {...rhf}>
+		<FormProvider {...rhf}>
 			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
 				<Input id="text" type="text" name="text" label="Text" />
 				<Input id="number" type="number" name="number" label="Number" />
@@ -55,7 +55,7 @@ export const Types = () => {
 					Submit
 				</button>
 			</form>
-		</FormContext>
+		</FormProvider>
 	);
 };
 
@@ -63,14 +63,14 @@ export const DefaultValue = () => {
 	const rhf = useForm();
 
 	return (
-		<FormContext {...rhf}>
+		<FormProvider {...rhf}>
 			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
 				<Input id="defaultValue" type="text" name="name" label="Name" defaultValue="Jimmy" />
 				<button type="submit" className="btn btn-primary">
 					Submit
 				</button>
 			</form>
-		</FormContext>
+		</FormProvider>
 	);
 };
 
@@ -78,7 +78,7 @@ export const Description = () => {
 	const rhf = useForm();
 
 	return (
-		<FormContext {...rhf}>
+		<FormProvider {...rhf}>
 			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
 				<Input
 					id="description"
@@ -91,7 +91,7 @@ export const Description = () => {
 					Submit
 				</button>
 			</form>
-		</FormContext>
+		</FormProvider>
 	);
 };
 
@@ -99,7 +99,7 @@ export const Validation = () => {
 	const rhf = useForm({ mode: 'onBlur' });
 
 	return (
-		<FormContext {...rhf}>
+		<FormProvider {...rhf}>
 			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
 				<Input
 					id="required"
@@ -125,6 +125,6 @@ export const Validation = () => {
 					Submit
 				</button>
 			</form>
-		</FormContext>
+		</FormProvider>
 	);
 };

--- a/packages/forms/src/rhf/fields/Input/Input.test.js
+++ b/packages/forms/src/rhf/fields/Input/Input.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import { useForm, FormContext } from 'react-hook-form/dist/react-hook-form.ie11';
+import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
 import Input from './RHFInput.component';
 
 /* eslint-disable-next-line react/prop-types */
@@ -9,10 +9,10 @@ function FormWrapper({ children, onSubmit }) {
 	const rhf = useForm({ mode: 'onChange' });
 	return (
 		<form onSubmit={rhf.handleSubmit(onSubmit)}>
-			<FormContext {...rhf}>
+			<FormProvider {...rhf}>
 				{children}
 				<button type="submit">Submit</button>
-			</FormContext>
+			</FormProvider>
 		</form>
 	);
 }

--- a/packages/forms/src/rhf/fields/Input/RHFInput.component.js
+++ b/packages/forms/src/rhf/fields/Input/RHFInput.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useFormContext } from 'react-hook-form/dist/react-hook-form.ie11';
+import { useFormContext } from 'react-hook-form/dist/index.ie11';
 import get from 'lodash/get';
 
 import Input from '../../../widgets/fields/Input';

--- a/versions/dependencies.json
+++ b/versions/dependencies.json
@@ -31,7 +31,7 @@
   "i18next-parser": "^0.13.0",
   "react-dnd": "^2.5.4",
   "react-draggable": "^3.3.0",
-  "react-hook-form": "^5.7.0",
+  "react-hook-form": "^6.9.2",
   "react-i18next": "^10.11.4",
   "react-popper": "^1.3.7",
   "react-redux": "^5.0.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7220,14 +7220,7 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@^4.2.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
-  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
-  dependencies:
-    is-obj "^1.0.0"
-
-dot-prop@^5.1.0, dot-prop@^5.2.0:
+dot-prop@^4.2.0, dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -7337,7 +7330,7 @@ element-resize-detector@^1.2.1:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.3:
+elliptic@^6.5.2, elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -10678,11 +10671,6 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
-is-obj@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
-  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
-
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -12759,17 +12747,7 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8:
-  version "0.0.8"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
-  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
-
-minimist@1.1.x:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
-  integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
-
-minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8, minimist@1.1.x, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -12841,7 +12819,7 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0:
+mixin-deep@^1.2.0, mixin-deep@^1.3.2:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
@@ -15359,10 +15337,10 @@ react-helmet-async@^1.0.2:
     react-fast-compare "^3.2.0"
     shallowequal "^1.1.0"
 
-react-hook-form@^5.7.0:
-  version "5.7.2"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-5.7.2.tgz#a84e259e5d37dd30949af4f79c4dac31101b79ac"
-  integrity sha512-bJvY348vayIvEUmSK7Fvea/NgqbT2racA2IbnJz/aPlQ3GBtaTeDITH6rtCa6y++obZzG6E3Q8VuoXPir7QYUg==
+react-hook-form@^6.9.2:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.9.2.tgz#9512cd424e62235fda13c8fc1821f88c352e3d23"
+  integrity sha512-vCPEbHVCRvsoqrQARgQ7a3VrXzqbFOO53gHFRdQzLzHMT9kxum3wfcSi8A1b49KPRsomvsqexH4tBUJMneEu+Q==
 
 react-hotkeys@2.0.0:
   version "2.0.0"
@@ -19403,14 +19381,7 @@ webpack@^4.19.0, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.42.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-websocket-driver@0.6.5:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
-  integrity sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=
-  dependencies:
-    websocket-extensions ">=0.1.1"
-
-websocket-driver@>=0.5.1:
+websocket-driver@0.6.5, websocket-driver@>=0.5.1, websocket-driver@^0.7.3:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
some feature available in v6 are needed for schema editor form rewrite

**What is the chosen solution to this problem?**
Here is the guide for migration from v5 to v6 : https://react-hook-form.com/migrate-v5-to-v6/
When migrating my poc to v6, i've encountered some change in how the library manages FieldArray. If you're using this feature, you might need to check that everything's all right.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
