### PR TITLE
fix(containers/notification): attach actions to Notification

### DIFF
--- a/packages/containers/src/Notification/index.js
+++ b/packages/containers/src/Notification/index.js
@@ -1,13 +1,13 @@
 import Notification from './Notification.connect';
 import pushNotification from './pushNotification';
 import clearNotifications from './clearNotifications';
-import actionCreators from './Notification.actions';
+import * as actions from './Notification.actions';
 import constants from './Notification.constants';
 import sagas from './Notification.sagas';
 
 Notification.push = pushNotification;
 Notification.clear = clearNotifications;
-Notification.actionCreators = actionCreators;
+Notification.actions = actions;
 Notification.constants = constants;
 Notification.sagas = sagas;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We added actions creators to Notification containers to be able to write `Notification.actions`.
But the content is undefined because we default import nothing as they are named exported.



**What is the chosen solution to this problem?**
`import * as actions from './Notification.actions'`

I changed the name from `actionCreators` to `actions` to align the names. It's not a breaking change because it never worked, so I guess never used, so it doesn't break any code.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
