### PR TITLE
feat(drawer): allow to add actions in title

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import get from 'lodash/get';
 import omit from 'lodash/omit';
+import noop from 'lodash/noop';
 import { CSSTransition, transit } from 'react-css-transition';
 import classnames from 'classnames';
 import ActionBar from '../ActionBar';
@@ -9,9 +10,11 @@ import Action from '../Actions/Action';
 import TabBar from '../TabBar';
 import Inject from '../Inject';
 import EditableText from '../EditableText';
+import { getTheme } from '../theme';
 
 import theme from './Drawer.scss';
 
+const css = getTheme(theme);
 const DEFAULT_TRANSITION_DURATION = 350;
 CSSTransition.childContextTypes = {};
 
@@ -55,12 +58,10 @@ DrawerAnimation.defaultProps = {
 };
 
 function DrawerContainer({ stacked, className, children, withTransition = true, ...rest }) {
-	const drawerContainerClasses = classnames(
-		theme['tc-drawer'],
+	const drawerContainerClasses = css(
 		className,
 		'tc-drawer',
 		{
-			[theme['tc-drawer-transition']]: withTransition,
 			'tc-drawer-transition': withTransition,
 		},
 		{
@@ -99,11 +100,7 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 	return (
 		<ActionComponent
 			{...enhancedCancelAction}
-			className={classnames(
-				'tc-drawer-close-action',
-				theme['tc-drawer-close-action'],
-				enhancedCancelAction.className,
-			)}
+			className={css('tc-drawer-close-action', enhancedCancelAction.className)}
 			tooltipClassName={theme['drawer-close-action-tooltip']}
 		/>
 	);
@@ -136,6 +133,7 @@ function DrawerTitle({
 	onEdit,
 	onSubmit,
 	onCancel,
+	renderTitleActions = noop,
 	...props
 }) {
 	const [isEditMode, setIsEditMode] = React.useState(false);
@@ -163,8 +161,8 @@ function DrawerTitle({
 	}
 	const InjectedEditableText = Inject.get(getComponent, 'EditableText', EditableText);
 	return (
-		<div className={classnames('tc-drawer-header', theme['tc-drawer-header'])}>
-			<div className={classnames('tc-drawer-header-title', theme['tc-drawer-header-title'])}>
+		<div className={css('tc-drawer-header')}>
+			<div className={css('tc-drawer-header-title')}>
 				{!editable ? (
 					<h1 title={title}>{title}</h1>
 				) : (
@@ -181,13 +179,10 @@ function DrawerTitle({
 					/>
 				)}
 				{!isEditMode ? <SubtitleComponent subtitle={subtitle} /> : null}
+				{renderTitleActions()}
 				{cancelActionComponent(onCancelAction, getComponent)}
 			</div>
-			<div
-				className={classnames('tc-drawer-header-with-tabs', theme['tc-drawer-header-with-tabs'])}
-			>
-				{children}
-			</div>
+			<div className={css('tc-drawer-header-with-tabs')}>{children}</div>
 		</div>
 	);
 }
@@ -198,6 +193,7 @@ DrawerTitle.propTypes = {
 	onCancelAction: PropTypes.shape(Action.propTypes),
 	children: PropTypes.node,
 	getComponent: PropTypes.func,
+	renderTitleActions: PropTypes.func,
 	editable: PropTypes.bool,
 	inProgress: PropTypes.bool,
 	onEdit: PropTypes.func,
@@ -207,13 +203,8 @@ DrawerTitle.propTypes = {
 
 function DrawerContent({ children, className, ...rest }) {
 	return (
-		<div
-			className={classnames('tc-drawer-content', theme['tc-drawer-content'], className)}
-			{...rest}
-		>
-			<div className={classnames('tc-drawer-content-wrapper', theme['tc-drawer-content-wrapper'])}>
-				{children}
-			</div>
+		<div className={css('tc-drawer-content', className)} {...rest}>
+			<div className={css('tc-drawer-content-wrapper')}>{children}</div>
 		</div>
 	);
 }
@@ -224,9 +215,7 @@ DrawerContent.propTypes = {
 };
 
 function DrawerFooter({ children }) {
-	return (
-		<div className={classnames('tc-drawer-footer', theme['tc-drawer-footer'])}>{children}</div>
-	);
+	return <div className={css('tc-drawer-footer')}>{children}</div>;
 }
 
 DrawerFooter.propTypes = {
@@ -263,6 +252,7 @@ function Drawer({
 	getComponent,
 	selectedTabKey,
 	editableTitle,
+	renderTitleActions,
 }) {
 	if (!children) {
 		return null;
@@ -294,30 +284,23 @@ function Drawer({
 			withTransition={withTransition}
 		>
 			<DrawerTitle
+				renderTitleActions={renderTitleActions}
 				editable={editableTitle}
 				title={title}
 				onCancelAction={onCancelAction}
 				getComponent={getComponent}
 			/>
 			{tabs && (
-				<div className={classnames('tc-drawer-tabs-container', theme['tc-drawer-tabs-container'])}>
-					<TabBarComponent
-						{...customTabs}
-						className={classnames('tc-drawer-tabs', theme['tc-drawer-tabs'])}
-					/>
+				<div className={css('tc-drawer-tabs-container')}>
+					<TabBarComponent {...customTabs} className={css('tc-drawer-tabs')} />
 				</div>
 			)}
 			<div style={{ display: 'flex', flexDirection: 'column', flexGrow: 1, overflow: 'hidden' }}>
 				<DrawerContent>{children}</DrawerContent>
-				<div
-					className={classnames(
-						'tc-drawer-actionbar-container',
-						theme['tc-drawer-actionbar-container'],
-					)}
-				>
+				<div className={css('tc-drawer-actionbar-container')}>
 					<ActionBar
 						{...combinedFooterActions(onCancelAction, footerActions, activeTabItem)}
-						className={classnames('tc-drawer-actionbar', theme['tc-drawer-actionbar'])}
+						className={css('tc-drawer-actionbar')}
 					/>
 				</div>
 			</div>
@@ -339,6 +322,7 @@ Drawer.propTypes = {
 	onCancelAction: PropTypes.shape(Action.propTypes),
 	tabs: PropTypes.shape(TabBar.propTypes),
 	withTransition: PropTypes.bool,
+	renderTitleActions: PropTypes.func,
 	getComponent: PropTypes.func,
 	selectedTabKey: PropTypes.string,
 };

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -11,6 +11,7 @@ import HeaderBar from '../HeaderBar';
 import IconsProvider from '../IconsProvider';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
+import { ActionButton } from '../Actions';
 
 const header = <HeaderBar brand={{ label: 'Example App Name' }} />;
 
@@ -185,6 +186,13 @@ function scrollableContent() {
 	return content;
 }
 
+const titleActions = () => (
+	<div>
+		<ActionButton {...actions[0]} hideLabel link></ActionButton>
+		<ActionButton {...actions[1]} hideLabel link></ActionButton>
+	</div>
+);
+
 const drawers = [
 	<Drawer stacked title="Im stacked drawer 1" footerActions={{ ...basicProps, selected: 0 }}>
 		<h1>Hello drawer 1</h1>
@@ -203,7 +211,12 @@ const editableDrawers = [
 		<h1>Hello drawer 1</h1>
 		<p>You should not being able to read this because I'm first</p>
 	</Drawer>,
-	<Drawer editableTitle title="Im drawer 20" footerActions={{ ...basicProps, selected: 0 }}>
+	<Drawer
+		renderTitleActions={titleActions}
+		editableTitle
+		title="Im drawer 20"
+		footerActions={{ ...basicProps, selected: 0 }}
+	>
 		<h1>Hello drawer 2</h1>
 		<p>The scroll is defined by the content</p>
 		<h1>Hello drawer 3</h1>
@@ -218,6 +231,7 @@ const longEditableDrawers = [
 	</Drawer>,
 	<Drawer
 		editableTitle
+		renderTitleActions={titleActions}
 		title="Im drawer 20 here in the long title header header header"
 		footerActions={{ ...basicProps, selected: 0 }}
 		onCancelAction={onCancelAction}

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -368,7 +368,7 @@ describe('Drawer', () => {
 	it('should render cancelActionComponent with passed in className', () => {
 		const wrapper = mount(cancelActionComponent({ className: 'btn-inverse' }));
 		expect(wrapper.find('Action').prop('className')).toEqual(
-			'tc-drawer-close-action theme-tc-drawer-close-action btn-inverse',
+			'tc-drawer-close-action theme-tc-drawer-close-action',
 		);
 	});
 });

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -368,7 +368,7 @@ describe('Drawer', () => {
 	it('should render cancelActionComponent with passed in className', () => {
 		const wrapper = mount(cancelActionComponent({ className: 'btn-inverse' }));
 		expect(wrapper.find('Action').prop('className')).toEqual(
-			'tc-drawer-close-action theme-tc-drawer-close-action',
+			'tc-drawer-close-action theme-tc-drawer-close-action btn-inverse theme-btn-inverse',
 		);
 	});
 });

--- a/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
+++ b/packages/components/src/Drawer/__snapshots__/Drawer.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`Drawer render drawer content with extra className 1`] = `
 <div
-  className="tc-drawer-content theme-tc-drawer-content extraClass"
+  className="tc-drawer-content theme-tc-drawer-content extraClass theme-extraClass"
 >
   <div
     className="tc-drawer-content-wrapper theme-tc-drawer-content-wrapper"
@@ -32,7 +32,7 @@ exports[`Drawer should not render if no children 1`] = `null`;
 
 exports[`Drawer should render 1`] = `
 <div
-  className="theme-tc-drawer tc-drawer theme-tc-drawer-transition tc-drawer-transition"
+  className="tc-drawer theme-tc-drawer tc-drawer-transition theme-tc-drawer-transition"
 >
   <div
     className="tc-drawer-container theme-tc-drawer-container"
@@ -72,7 +72,7 @@ exports[`Drawer should render 1`] = `
 
 exports[`Drawer should render stacked 1`] = `
 <div
-  className="theme-tc-drawer tc-drawer theme-tc-drawer-transition tc-drawer-transition theme-drawer-stacked stacked"
+  className="tc-drawer theme-tc-drawer tc-drawer-transition theme-tc-drawer-transition theme-drawer-stacked theme-theme-drawer-stacked stacked theme-stacked"
 >
   <div
     className="tc-drawer-container theme-tc-drawer-container"
@@ -112,7 +112,7 @@ exports[`Drawer should render stacked 1`] = `
 
 exports[`Drawer should render using custom className 1`] = `
 <div
-  className="theme-tc-drawer my-custom-drawer tc-drawer theme-tc-drawer-transition tc-drawer-transition"
+  className="my-custom-drawer theme-my-custom-drawer tc-drawer theme-tc-drawer tc-drawer-transition theme-tc-drawer-transition"
 >
   <div
     className="tc-drawer-container theme-tc-drawer-container"
@@ -152,7 +152,7 @@ exports[`Drawer should render using custom className 1`] = `
 
 exports[`Drawer should render using custom styles 1`] = `
 <div
-  className="theme-tc-drawer tc-drawer theme-tc-drawer-transition tc-drawer-transition"
+  className="tc-drawer theme-tc-drawer tc-drawer-transition theme-tc-drawer-transition"
   style={
     Object {
       "top": 45,
@@ -197,7 +197,7 @@ exports[`Drawer should render using custom styles 1`] = `
 
 exports[`Drawer should render with tabs 1`] = `
 <div
-  className="theme-tc-drawer tc-drawer theme-tc-drawer-transition tc-drawer-transition"
+  className="tc-drawer theme-tc-drawer tc-drawer-transition theme-tc-drawer-transition"
 >
   <div
     className="tc-drawer-container theme-tc-drawer-container"
@@ -420,7 +420,7 @@ exports[`Drawer should render with tabs specific actions by tab with selectedTab
 
 exports[`Drawer should render without tc-drawer-transition class 1`] = `
 <div
-  className="theme-tc-drawer tc-drawer"
+  className="tc-drawer theme-tc-drawer"
 >
   <div
     className="tc-drawer-container theme-tc-drawer-container"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On TPD, we need to have multiple actions in a drawer title

**What is the chosen solution to this problem?**
Allow to pass a renderProps to render actions

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
