### PR TITLE
feat(List/ColumnChoser): Select all non-scrollable

### DIFF
--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
@@ -26,11 +26,14 @@ $tc-height: 4rem;
 	}
 
 	&-body {
-		overflow-y: auto;
 		width: 100%;
 		display: flex;
 		flex-direction: column;
-		max-height: 6 * $tc-height;
+	}
+	
+	&-columns-list {
+		overflow-y: auto;
+		max-height: 5 * $tc-height;
 	}
 
 	&-footer {

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.scss
@@ -30,7 +30,7 @@ $tc-height: 4rem;
 		display: flex;
 		flex-direction: column;
 	}
-	
+
 	&-columns-list {
 		overflow-y: auto;
 		max-height: 5 * $tc-height;

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/ColumnChooserBody.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/ColumnChooserBody.component.js
@@ -16,12 +16,14 @@ const Default = () => {
 	return (
 		<React.Fragment>
 			<SelectAllColumnsCheckbox id={bodyId} onChange={onSelectAll} value={selectAll} t={t} />
-			<ColumnChooserTable
-				id={bodyId}
-				columns={columns}
-				onChangeCheckbox={onChangeVisibility}
-				t={t}
-			/>
+			<div className={theme('tc-column-chooser-columns-list')}>
+				<ColumnChooserTable
+					id={bodyId}
+					columns={columns}
+					onChangeCheckbox={onChangeVisibility}
+					t={t}
+				/>
+			</div>
 		</React.Fragment>
 	);
 };

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/__snapshots__/ColumnChooserBody.component.test.js.snap
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserBody/__snapshots__/ColumnChooserBody.component.test.js.snap
@@ -30,116 +30,118 @@ exports[`ColumnChooserBody should render the columns rows and the column select 
           hide all the columns
         </div>
       </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <svg name="talend-locked"
-             class="theme-tc-svg-icon tc-svg-icon tc-column-chooser-row-locked-icon theme-tc-column-chooser-row-locked-icon"
-             focusable="false"
-             aria-hidden="true"
-        >
-          <use xlink:href="#talend-locked">
-          </use>
-        </svg>
-        <span class="tc-column-chooser-row-label theme-tc-column-chooser-row-label">
-          col1
-        </span>
-      </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <svg name="talend-locked"
-             class="theme-tc-svg-icon tc-svg-icon tc-column-chooser-row-locked-icon theme-tc-column-chooser-row-locked-icon"
-             focusable="false"
-             aria-hidden="true"
-        >
-          <use xlink:href="#talend-locked">
-          </use>
-        </svg>
-        <span class="tc-column-chooser-row-label theme-tc-column-chooser-row-label">
-          col2
-        </span>
-      </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-          <label for="body-context-id-body-checkbox-col3"
-                 data-feature="column-chooser.select.disable"
+      <div class="tc-column-chooser-columns-list theme-tc-column-chooser-columns-list">
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <svg name="talend-locked"
+               class="theme-tc-svg-icon tc-svg-icon tc-column-chooser-row-locked-icon theme-tc-column-chooser-row-locked-icon"
+               focusable="false"
+               aria-hidden="true"
           >
-            <input type="checkbox"
-                   id="body-context-id-body-checkbox-col3"
-                   data-checked="2"
-                   aria-describedby="body-context-id-body-display the column col3"
-                   checked
-            >
-            <span>
-              col3
-            </span>
-          </label>
+            <use xlink:href="#talend-locked">
+            </use>
+          </svg>
+          <span class="tc-column-chooser-row-label theme-tc-column-chooser-row-label">
+            col1
+          </span>
         </div>
-        <div id="body-context-id-body-display the column col3"
-             class="sr-only"
-        >
-          display the column col3
-        </div>
-      </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-          <label for="body-context-id-body-checkbox-col4"
-                 data-feature="column-chooser.select.enable"
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <svg name="talend-locked"
+               class="theme-tc-svg-icon tc-svg-icon tc-column-chooser-row-locked-icon theme-tc-column-chooser-row-locked-icon"
+               focusable="false"
+               aria-hidden="true"
           >
-            <input type="checkbox"
-                   id="body-context-id-body-checkbox-col4"
-                   data-checked="0"
-                   aria-describedby="body-context-id-body-display the column col4"
+            <use xlink:href="#talend-locked">
+            </use>
+          </svg>
+          <span class="tc-column-chooser-row-label theme-tc-column-chooser-row-label">
+            col2
+          </span>
+        </div>
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+            <label for="body-context-id-body-checkbox-col3"
+                   data-feature="column-chooser.select.disable"
             >
-            <span>
-              col4
-            </span>
-          </label>
-        </div>
-        <div id="body-context-id-body-display the column col4"
-             class="sr-only"
-        >
-          display the column col4
-        </div>
-      </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-          <label for="body-context-id-body-checkbox-col5"
-                 data-feature="column-chooser.select.disable"
+              <input type="checkbox"
+                     id="body-context-id-body-checkbox-col3"
+                     data-checked="2"
+                     aria-describedby="body-context-id-body-display the column col3"
+                     checked
+              >
+              <span>
+                col3
+              </span>
+            </label>
+          </div>
+          <div id="body-context-id-body-display the column col3"
+               class="sr-only"
           >
-            <input type="checkbox"
-                   id="body-context-id-body-checkbox-col5"
-                   data-checked="2"
-                   aria-describedby="body-context-id-body-display the column col5"
-                   checked
+            display the column col3
+          </div>
+        </div>
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+            <label for="body-context-id-body-checkbox-col4"
+                   data-feature="column-chooser.select.enable"
             >
-            <span>
-              col5
-            </span>
-          </label>
-        </div>
-        <div id="body-context-id-body-display the column col5"
-             class="sr-only"
-        >
-          display the column col5
-        </div>
-      </div>
-      <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-        <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-          <label for="body-context-id-body-checkbox-col6"
-                 data-feature="column-chooser.select.enable"
+              <input type="checkbox"
+                     id="body-context-id-body-checkbox-col4"
+                     data-checked="0"
+                     aria-describedby="body-context-id-body-display the column col4"
+              >
+              <span>
+                col4
+              </span>
+            </label>
+          </div>
+          <div id="body-context-id-body-display the column col4"
+               class="sr-only"
           >
-            <input type="checkbox"
-                   id="body-context-id-body-checkbox-col6"
-                   data-checked="0"
-                   aria-describedby="body-context-id-body-display the column col6"
-            >
-            <span>
-              col6
-            </span>
-          </label>
+            display the column col4
+          </div>
         </div>
-        <div id="body-context-id-body-display the column col6"
-             class="sr-only"
-        >
-          display the column col6
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+            <label for="body-context-id-body-checkbox-col5"
+                   data-feature="column-chooser.select.disable"
+            >
+              <input type="checkbox"
+                     id="body-context-id-body-checkbox-col5"
+                     data-checked="2"
+                     aria-describedby="body-context-id-body-display the column col5"
+                     checked
+              >
+              <span>
+                col5
+              </span>
+            </label>
+          </div>
+          <div id="body-context-id-body-display the column col5"
+               class="sr-only"
+          >
+            display the column col5
+          </div>
+        </div>
+        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+            <label for="body-context-id-body-checkbox-col6"
+                   data-feature="column-chooser.select.enable"
+            >
+              <input type="checkbox"
+                     id="body-context-id-body-checkbox-col6"
+                     data-checked="0"
+                     aria-describedby="body-context-id-body-display the column col6"
+              >
+              <span>
+                col6
+              </span>
+            </label>
+          </div>
+          <div id="body-context-id-body-display the column col6"
+               class="sr-only"
+          >
+            display the column col6
+          </div>
         </div>
       </div>
     </div>

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/__snapshots__/ColumnChooser.component.test.js.snap
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/__snapshots__/ColumnChooser.component.test.js.snap
@@ -68,135 +68,137 @@ exports[`ColumnChooser should render with default props 1`] = `
             display all the columns
           </div>
         </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Id"
-                   data-feature="column-chooser.select.disable"
-            >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Id"
-                     data-checked="2"
-                     aria-describedby="my-id-body-display the column Id"
-                     checked
+        <div class="tc-column-chooser-columns-list theme-tc-column-chooser-columns-list">
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Id"
+                     data-feature="column-chooser.select.disable"
               >
-              <span>
-                Id
-              </span>
-            </label>
-          </div>
-          <div id="my-id-body-display the column Id"
-               class="sr-only"
-          >
-            display the column Id
-          </div>
-        </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Name"
-                   data-feature="column-chooser.select.disable"
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Id"
+                       data-checked="2"
+                       aria-describedby="my-id-body-display the column Id"
+                       checked
+                >
+                <span>
+                  Id
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Id"
+                 class="sr-only"
             >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Name"
-                     data-checked="2"
-                     aria-describedby="my-id-body-display the column Name"
-                     checked
+              display the column Id
+            </div>
+          </div>
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Name"
+                     data-feature="column-chooser.select.disable"
               >
-              <span>
-                Name
-              </span>
-            </label>
-          </div>
-          <div id="my-id-body-display the column Name"
-               class="sr-only"
-          >
-            display the column Name
-          </div>
-        </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Author"
-                   data-feature="column-chooser.select.disable"
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Name"
+                       data-checked="2"
+                       aria-describedby="my-id-body-display the column Name"
+                       checked
+                >
+                <span>
+                  Name
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Name"
+                 class="sr-only"
             >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Author"
-                     data-checked="2"
-                     aria-describedby="my-id-body-display the column Author"
-                     checked
+              display the column Name
+            </div>
+          </div>
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Author"
+                     data-feature="column-chooser.select.disable"
               >
-              <span>
-                Author
-              </span>
-            </label>
-          </div>
-          <div id="my-id-body-display the column Author"
-               class="sr-only"
-          >
-            display the column Author
-          </div>
-        </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Very-long-name-long-name-long-name-long-name-long-name"
-                   data-feature="column-chooser.select.disable"
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Author"
+                       data-checked="2"
+                       aria-describedby="my-id-body-display the column Author"
+                       checked
+                >
+                <span>
+                  Author
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Author"
+                 class="sr-only"
             >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Very-long-name-long-name-long-name-long-name-long-name"
-                     data-checked="2"
-                     aria-describedby="my-id-body-display the column Very long name long name long name long name long name"
-                     checked
+              display the column Author
+            </div>
+          </div>
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Very-long-name-long-name-long-name-long-name-long-name"
+                     data-feature="column-chooser.select.disable"
               >
-              <span>
-                Very long name long name long name long name long name
-              </span>
-            </label>
-          </div>
-          <div id="my-id-body-display the column Very long name long name long name long name long name"
-               class="sr-only"
-          >
-            display the column Very long name long name long name long name long name
-          </div>
-        </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Icon"
-                   data-feature="column-chooser.select.enable"
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Very-long-name-long-name-long-name-long-name-long-name"
+                       data-checked="2"
+                       aria-describedby="my-id-body-display the column Very long name long name long name long name long name"
+                       checked
+                >
+                <span>
+                  Very long name long name long name long name long name
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Very long name long name long name long name long name"
+                 class="sr-only"
             >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Icon"
-                     data-checked="0"
-                     aria-describedby="my-id-body-display the column Icon"
+              display the column Very long name long name long name long name long name
+            </div>
+          </div>
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Icon"
+                     data-feature="column-chooser.select.enable"
               >
-              <span>
-                Icon
-              </span>
-            </label>
-          </div>
-          <div id="my-id-body-display the column Icon"
-               class="sr-only"
-          >
-            display the column Icon
-          </div>
-        </div>
-        <div class="tc-column-chooser-row theme-tc-column-chooser-row">
-          <div class="checkbox tc-toggle theme-tc-toggle checkbox">
-            <label for="my-id-body-checkbox-Created"
-                   data-feature="column-chooser.select.disable"
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Icon"
+                       data-checked="0"
+                       aria-describedby="my-id-body-display the column Icon"
+                >
+                <span>
+                  Icon
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Icon"
+                 class="sr-only"
             >
-              <input type="checkbox"
-                     id="my-id-body-checkbox-Created"
-                     data-checked="2"
-                     aria-describedby="my-id-body-display the column Created"
-                     checked
-              >
-              <span>
-                Created
-              </span>
-            </label>
+              display the column Icon
+            </div>
           </div>
-          <div id="my-id-body-display the column Created"
-               class="sr-only"
-          >
-            display the column Created
+          <div class="tc-column-chooser-row theme-tc-column-chooser-row">
+            <div class="checkbox tc-toggle theme-tc-toggle checkbox">
+              <label for="my-id-body-checkbox-Created"
+                     data-feature="column-chooser.select.disable"
+              >
+                <input type="checkbox"
+                       id="my-id-body-checkbox-Created"
+                       data-checked="2"
+                       aria-describedby="my-id-body-display the column Created"
+                       checked
+                >
+                <span>
+                  Created
+                </span>
+              </label>
+            </div>
+            <div id="my-id-body-display the column Created"
+                 class="sr-only"
+            >
+              display the column Created
+            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
"Select all" should not be part of the scrollable section of the columns chooser

**What is the chosen solution to this problem?**
Wrap columns in a container with limited height + overflow management

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
