### PR TITLE
chore: change deep imports to non deep to prepare cdn

### DIFF
--- a/output/containers.eslint.txt
+++ b/output/containers.eslint.txt
@@ -1,7 +1,4 @@
 
-/home/travis/build/Talend/ui/packages/containers/src/ActionFile/ActionFile.test.js
-  3:1  error  '@talend/react-components/lib/Actions/ActionFile' import too deep. No more than /lib/Actions  @talend/import-depth
-
 /home/travis/build/Talend/ui/packages/containers/src/AppLoader/AppLoader.saga.js
   55:2   error  iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations  no-restricted-syntax
   55:13  error  'step' is defined but never used                                                                                                                                           @typescript-eslint/no-unused-vars
@@ -9,29 +6,10 @@
 /home/travis/build/Talend/ui/packages/containers/src/ComponentForm/ComponentForm.component.js
   89:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/fields/MultiSelect/MultiSelect.component.js
-  4:1  error  '@talend/react-forms/lib/UIForm/fields/FieldTemplate' import too deep. No more than /lib/UIForm  @talend/import-depth
-  5:1  error  '@talend/react-forms/lib/UIForm/Message/generateId' import too deep. No more than /lib/UIForm    @talend/import-depth
-  9:1  error  '@talend/react-forms/lib/UIForm/trigger' import too deep. No more than /lib/UIForm               @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/fields/MultiSelect/displayMode/TextMode.component.js
-  4:1  error  '@talend/react-forms/lib/UIForm/fields/FieldTemplate' import too deep. No more than /lib/UIForm  @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/fields/NameResolver/NameResolver.component.js
-  3:1  error  '@talend/react-forms/lib/UIForm//utils/properties' import too deep. No more than /lib/UIForm  @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/fields/index.js
-  2:1  error  '@talend/react-forms/lib/UIForm/fields/Datalist' import too deep. No more than /lib/UIForm        @talend/import-depth
-  3:1  error  '@talend/react-forms/lib/UIForm/fields/MultiSelectTag' import too deep. No more than /lib/UIForm  @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/containers/src/ComponentForm/kit/defaultRegistry.js
-  19:1  error  '@talend/react-forms/lib/UIForm/utils/errors' import too deep. No more than /lib/UIForm      @talend/import-depth
-  20:1  error  '@talend/react-forms/lib/UIForm/utils/properties' import too deep. No more than /lib/UIForm  @talend/import-depth
-
 /home/travis/build/Talend/ui/packages/containers/src/List/List.container.js
   124:3  error  defaultProp "state" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/containers/src/Notification/Notification.test.js
   11:57  error  'notifications' is missing in props validation  react/prop-types
 
-✖ 15 problems (15 errors, 0 warnings)
+✖ 5 problems (5 errors, 0 warnings)

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -5,12 +5,6 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.container.js
   94:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Button/SingleButton.component.js
-  3:1  error  '@talend/react-components/lib/Actions/Action' import too deep. No more than /lib/Actions  @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
-  6:1  error  '@talend/react-components/lib/Actions/ActionDropdown' import too deep. No more than /lib/Actions  @talend/import-depth
-
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
   255:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
@@ -30,5 +24,5 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-✖ 11 problems (11 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/containers/src/ActionFile/ActionFile.test.js
+++ b/packages/containers/src/ActionFile/ActionFile.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import ActionFile from '@talend/react-components/lib/Actions/ActionFile';
+import { ActionFile } from '@talend/react-components/lib/Actions';
 import mock from '@talend/react-cmf/lib/mock';
 
 import Connected, { mapStateToProps, mergeProps, ContainerActionFile } from './ActionFile.connect';

--- a/packages/containers/src/ComponentForm/fields/MultiSelect/MultiSelect.component.js
+++ b/packages/containers/src/ComponentForm/fields/MultiSelect/MultiSelect.component.js
@@ -1,12 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import MultiSelect from '@talend/react-components/lib/MultiSelect';
-import FieldTemplate from '@talend/react-forms/lib/UIForm/fields/FieldTemplate';
-import {
-	generateDescriptionId,
-	generateErrorId,
-} from '@talend/react-forms/lib/UIForm/Message/generateId';
-import callTrigger from '@talend/react-forms/lib/UIForm/trigger';
+import Form from '@talend/react-forms';
 
 export default class MultiSelectField extends React.Component {
 	constructor(props) {
@@ -23,7 +18,7 @@ export default class MultiSelectField extends React.Component {
 	}
 
 	onTrigger(event) {
-		callTrigger(event, {
+		Form.UIForm.callTrigger(event, {
 			eventNames: [event.type],
 			triggersDefinitions: this.props.schema.triggers,
 			onTrigger: this.onTriggerResult,
@@ -82,11 +77,13 @@ export default class MultiSelectField extends React.Component {
 	}
 
 	render() {
+		const { generateDescriptionId, generateErrorId } = Form.UIForm.Message.utils;
 		const { id, isValid, errorMessage, schema } = this.props;
 		const descriptionId = generateDescriptionId(id);
 		const errorId = generateErrorId(id);
 		const errorMsg = errorMessage || this.getChildrenErrorMessage();
 		const isDeepValid = isValid && !errorMsg;
+		const FieldTemplate = Form.UIForm.FieldTemplate.DefaultModeTemplate;
 
 		return (
 			<FieldTemplate

--- a/packages/containers/src/ComponentForm/fields/MultiSelect/displayMode/TextMode.component.js
+++ b/packages/containers/src/ComponentForm/fields/MultiSelect/displayMode/TextMode.component.js
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import Badge from '@talend/react-components/lib/Badge';
-import { TextMode as FieldTemplate } from '@talend/react-forms/lib/UIForm/fields/FieldTemplate';
+import Form from '@talend/react-forms';
 import VirtualizedList from '@talend/react-components/lib/VirtualizedList';
 
 function renderItem(props) {
@@ -21,6 +21,8 @@ export default function MultiSelectTextMode(props) {
 		name: names[index],
 		value: nextVal,
 	}));
+	const FieldTemplate = Form.UIForm.FieldTemplate.TextModeTemplate;
+
 	return (
 		<FieldTemplate id={props.id} label={props.schema.title}>
 			<div style={{ height: 300 }}>

--- a/packages/containers/src/ComponentForm/fields/NameResolver/NameResolver.component.js
+++ b/packages/containers/src/ComponentForm/fields/NameResolver/NameResolver.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { getValue } from '@talend/react-forms/lib/UIForm//utils/properties';
+import Form from '@talend/react-forms';
 
 export default function withNameResolver(WrappedComponent) {
 	function NameResolver(props) {
@@ -10,6 +10,7 @@ export default function withNameResolver(WrappedComponent) {
 			key[key.length - 1] = `$${key[key.length - 1]}_name`;
 
 			const nameSchema = { ...props.schema, key };
+			const { getValue } = Form.UIForm.utils.properties;
 			return getValue(props.properties, nameSchema) || value;
 		}
 

--- a/packages/containers/src/ComponentForm/fields/index.js
+++ b/packages/containers/src/ComponentForm/fields/index.js
@@ -1,8 +1,12 @@
 /* eslint-disable import/prefer-default-export */
-import DatalistWidget from '@talend/react-forms/lib/UIForm/fields/Datalist';
-import MultiSelectTagWidget from '@talend/react-forms/lib/UIForm/fields/MultiSelectTag';
+import Form from '@talend/react-forms';
 import MultiSelect, { MultiSelectTextMode } from './MultiSelect';
 import withNameResolver from './NameResolver';
+
+const {
+	multiSelectTag: MultiSelectTagWidget,
+	datalist: DatalistWidget,
+} = Form.UIForm.utils.widgets;
 
 export default {
 	datalist: withNameResolver(DatalistWidget),

--- a/packages/containers/src/ComponentForm/kit/defaultRegistry.js
+++ b/packages/containers/src/ComponentForm/kit/defaultRegistry.js
@@ -16,9 +16,10 @@
 
 import clonedeep from 'lodash/cloneDeep';
 import get from 'lodash/get';
-import { removeError, addError, getError } from '@talend/react-forms/lib/UIForm/utils/errors';
-import { mutateValue } from '@talend/react-forms/lib/UIForm/utils/properties';
+import Form from '@talend/react-forms';
 
+const { removeError, addError, getError } = Form.UIForm.utils.errors;
+const { mutateValue } = Form.UIForm.utils.properties;
 /**
  * Change errors on the target input
  * Add the error if trigger results in an error

--- a/packages/forms/src/UIForm/Message/index.js
+++ b/packages/forms/src/UIForm/Message/index.js
@@ -1,5 +1,7 @@
 import Message from './Message.component';
+import * as utils from './generateId';
 
 export * from './generateId';
 
+Message.utils = utils;
 export default Message;

--- a/packages/forms/src/UIForm/fields/Button/SingleButton.component.js
+++ b/packages/forms/src/UIForm/fields/Button/SingleButton.component.js
@@ -1,6 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import Action from '@talend/react-components/lib/Actions/Action';
+import { Action } from '@talend/react-components/lib/Actions';
 import Inject from '@talend/react-components/lib/Inject';
 import classNames from 'classnames';
 

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.component.js
@@ -3,7 +3,7 @@ import React from 'react';
 import last from 'lodash/last';
 import classNames from 'classnames';
 
-import ActionDropdown from '@talend/react-components/lib/Actions/ActionDropdown';
+import { ActionDropdown } from '@talend/react-components/lib/Actions';
 
 import Text from '../Text';
 import Widget from '../../Widget';

--- a/packages/forms/src/UIForm/fields/FieldTemplate/index.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/index.js
@@ -1,5 +1,6 @@
 import FieldTemplate from './FieldTemplate.component';
 import TextMode from './displayMode/TextMode.component';
 
+export { FieldTemplate as DefaultModeTemplate, TextMode as TextModeTemplate };
 export { TextMode };
 export default FieldTemplate;

--- a/packages/forms/src/UIForm/index.js
+++ b/packages/forms/src/UIForm/index.js
@@ -1,4 +1,5 @@
 import * as FormTemplate from './FormTemplate';
+import * as FieldTemplate from './fields/FieldTemplate';
 import Message from './Message';
 import callTrigger from './trigger';
 import utils from './utils';
@@ -15,6 +16,7 @@ import * as triggers from './utils/triggers';
 export { UIForm, triggers };
 
 UIForm.FormTemplate = FormTemplate;
+UIForm.FieldTemplate = FieldTemplate;
 UIForm.Message = Message;
 UIForm.callTrigger = callTrigger;
 UIForm.utils = utils;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There are some deep imports from modules to modules (ex: `@talend/react-components/lib/MyComponent/utils`).  
But to prepare libraries to CDN we need to import from index.  
A babel plugin allows us to write /lib/MyComponent and it transform it to import from index. But when it's too deep, the plugin doesn't work.

For forms library each part are exposed from a single Form object.

**What is the chosen solution to this problem?**
Fix the imports

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
