### PR TITLE
chore(faceted-search): badges without label

### DIFF
--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -26,6 +26,8 @@ Types of changes
 
 ## [unreleased]
 
+- [Added](https://github.com/Talend/ui/pull/2997): Handle badges without labels
+
 ## [0.13.0]
 
 - [Fixed](https://github.com/Talend/ui/pull/2972): Don't reopen the value tooltip for badges with default operators

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -100,19 +100,23 @@ const BadgeFaceted = ({
 
 	return (
 		<Badge id={id} className={theme('tc-badge-faceted')} display={size}>
-			<BadgeComposition.Category category={labelCategory} label={labelCategory} />
-			<BadgeOperatorOverlay
-				id={id}
-				onChangeOverlay={onChangeOperatorOverlay}
-				onHideOverlay={onHideOverlayOperator}
-				operatorLabel={badgeOperator.label}
-				operatorIconName={badgeOperator.iconName}
-				opened={overlayState.operatorOpened}
-				onClick={onChangeOperator}
-				operators={operators}
-				size={size}
-				t={t}
-			/>
+			{labelCategory && (
+				<>
+					<BadgeComposition.Category category={labelCategory} label={labelCategory} />
+					<BadgeOperatorOverlay
+						id={id}
+						onChangeOverlay={onChangeOperatorOverlay}
+						onHideOverlay={onHideOverlayOperator}
+						operatorLabel={badgeOperator.label}
+						operatorIconName={badgeOperator.iconName}
+						opened={overlayState.operatorOpened}
+						onClick={onChangeOperator}
+						operators={operators}
+						size={size}
+						t={t}
+					/>
+				</>
+			)}
 			<BadgeOverlay
 				id={id}
 				className={theme('tc-badge-faceted-overlay')}

--- a/packages/faceted-search/stories/facetedSearch.story.js
+++ b/packages/faceted-search/stories/facetedSearch.story.js
@@ -1,5 +1,7 @@
 import React from 'react';
-import { times } from 'lodash';
+import times from 'lodash/times';
+import set from 'lodash/set';
+import cloneDeep from 'lodash/cloneDeep';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import IconsProvider from '@talend/react-components/lib/IconsProvider';
@@ -23,7 +25,15 @@ import {
 	badgePriceAsCustomAttribute,
 } from './badgesDefinitions.story';
 
-const badgesDefinitions = [badgeName, badgeConnectionType, badgeTags, badgePrice, badgeValid, badgeEmpty, badgeInvalid];
+const badgesDefinitions = [
+	badgeName,
+	badgeConnectionType,
+	badgeTags,
+	badgePrice,
+	badgeValid,
+	badgeEmpty,
+	badgeInvalid,
+];
 const lotsOfBadgesDefinitions = [];
 let i = 0;
 while (i < 50) {
@@ -145,7 +155,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('default', () => (
 		<div>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				{currentFacetedMode =>
 					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.ADVANCED && (
@@ -164,7 +173,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('initialized', () => (
 		<div>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				{currentFacetedMode =>
 					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.ADVANCED && (
@@ -182,9 +190,20 @@ storiesOf('FacetedSearch', module)
 			</FacetedSearch.Faceted>
 		</div>
 	))
+	.add('without label or operator button', () => (
+		<div>
+			<FacetedSearch.Faceted id="my-faceted-search">
+				<FacetedSearch.BasicSearch
+					badgesDefinitions={badgesDefinitions}
+					badgesFaceted={set(cloneDeep(badgesFaceted), 'badges[0].properties.label', '')}
+					onSubmit={action('onSubmit')}
+					callbacks={callbacks}
+				/>
+			</FacetedSearch.Faceted>
+		</div>
+	))
 	.add('basic search with lots of badges definitions', () => (
 		<div style={{ height: '5.5rem' }}>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={lotsOfBadgesDefinitions}
@@ -196,7 +215,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('basic search with badge with very long name', () => (
 		<div style={{ height: '5.5rem' }}>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeWithVeryLongName, badgeConnectionType, badgeName, badgePrice]}
@@ -208,7 +226,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('basic search in a badge with a lot of values', () => (
 		<div style={{ height: '5.5rem' }}>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeEnumWithLotOfValues]}
@@ -220,7 +237,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('basic search with badges categories', () => (
 		<div style={{ height: '5.5rem' }}>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[
@@ -241,7 +257,6 @@ storiesOf('FacetedSearch', module)
 	))
 	.add('basic search with a empty label badge', () => (
 		<div style={{ height: '5.5rem' }}>
-			<IconsProvider />
 			<FacetedSearch.Faceted id="my-faceted-search">
 				<FacetedSearch.BasicSearch
 					badgesDefinitions={[badgeName, badgeEmptyLabel]}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

TDP has badges without  label (= apply to everything)
![image](https://user-images.githubusercontent.com/58977230/95867313-4f69e800-0d69-11eb-8ce5-7d6762d86b87.png)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
