### PR TITLE
feat(components/radarchart): pass index to the dotwithclick onclick callback

### DIFF
--- a/packages/components/src/RadarChart/RadarChart.component.js
+++ b/packages/components/src/RadarChart/RadarChart.component.js
@@ -155,7 +155,7 @@ export function DotWithClick(props) {
 			{...rest}
 			fill={fill}
 			fillOpacity={1}
-			onClick={onClick}
+			onClick={params => onClick({ ...params, index })}
 			r={activeAxis === index ? STATE.ACTIVE_RADIUS : STATE.DEFAULT_RADIUS}
 			role="button"
 			stroke={fill}

--- a/packages/components/src/RadarChart/RadarChart.test.js
+++ b/packages/components/src/RadarChart/RadarChart.test.js
@@ -71,7 +71,11 @@ describe('RadarChart', () => {
 		wrapper.find('.recharts-polar-angle-axis-tick').at(0).simulate('click');
 
 		// then
-		expect(props.clickMock).toHaveBeenCalled();
+		expect(props.clickMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				index: 0,
+			}), 0, expect.any(Object)
+		);
 	});
 	it('should render a chart with clickable dots', () => {
 		const props = {
@@ -107,7 +111,11 @@ describe('RadarChart', () => {
 		wrapper.find('.recharts-dot').at(0).simulate('click');
 
 		// then
-		expect(props.clickMock).toHaveBeenCalled();
+		expect(props.clickMock).toHaveBeenCalledWith(
+			expect.objectContaining({
+				index: 0,
+			})
+		);
 	});
 	it('should render a chart with custom dots', () => {
 		const props = {

--- a/packages/components/src/RadarChart/RadarChart.test.js
+++ b/packages/components/src/RadarChart/RadarChart.test.js
@@ -74,7 +74,9 @@ describe('RadarChart', () => {
 		expect(props.clickMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				index: 0,
-			}), 0, expect.any(Object)
+			}),
+			0,
+			expect.any(Object),
 		);
 	});
 	it('should render a chart with clickable dots', () => {
@@ -114,7 +116,7 @@ describe('RadarChart', () => {
 		expect(props.clickMock).toHaveBeenCalledWith(
 			expect.objectContaining({
 				index: 0,
-			})
+			}),
 		);
 	});
 	it('should render a chart with custom dots', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`index` is not passed to the `DotWithClick` `onClick` callback

**What is the chosen solution to this problem?**

add it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
