### PR TITLE
fix(TDC-4797/components/radarchart): Increase chart axis label spacing

### DIFF
--- a/packages/components/src/RadarChart/RadarChart.component.js
+++ b/packages/components/src/RadarChart/RadarChart.component.js
@@ -76,14 +76,14 @@ RadarChart.propTypes = {
 };
 
 RadarChart.defaultProps = {
-	cx: 200,
-	cy: 120,
-	height: 240,
+	cx: 210,
+	cy: 140,
+	height: 250,
 	innerRadius: 0,
 	outerRadius: 100,
 	tick: false,
 	tickLine: false,
-	width: 400,
+	width: 420,
 };
 
 /**
@@ -100,7 +100,7 @@ export function LabelWithClick(props) {
 	}
 
 	return (
-		<text {...rest} y={y + 3} data-axis-index={index} role="button" className={selectedClass}>
+		<text {...rest} y={y} data-axis-index={index} role="button" className={selectedClass}>
 			{payload.value}
 		</text>
 	);

--- a/packages/components/src/RadarChart/RadarChart.scss
+++ b/packages/components/src/RadarChart/RadarChart.scss
@@ -1,6 +1,12 @@
 .tc-radar-chart {
-	:global(.recharts-polar-grid-concentric-polygon:not(:last-child)) {
-		display: none;
+	:global {
+		.recharts-polar-grid-concentric-polygon:not(:last-child) {
+			display: none;
+		}
+		.recharts-polar-angle-axis-ticks {
+			transform: scale(1.06);
+			transform-origin: center;
+		}
 	}
 }
 

--- a/packages/components/src/RadarChart/__snapshots__/RadarChart.test.js.snap
+++ b/packages/components/src/RadarChart/__snapshots__/RadarChart.test.js.snap
@@ -2,8 +2,8 @@
 
 exports[`RadarChart should render a RadarChart 1`] = `
 <RadarChart
-  cx={200}
-  cy={120}
+  cx={210}
+  cy={140}
   data={
     Array [
       Object {
@@ -34,12 +34,12 @@ exports[`RadarChart should render a RadarChart 1`] = `
       5,
     ]
   }
-  height={240}
+  height={250}
   innerRadius={0}
   outerRadius={100}
   tick={false}
   tickLine={false}
-  width={400}
+  width={420}
 >
   <PolarAngleAxis
     allowDuplicatedCategory={true}
@@ -83,8 +83,8 @@ exports[`RadarChart should render a RadarChart 1`] = `
 
 exports[`RadarChart should render a chart with custom dots 1`] = `
 <RadarChart
-  cx={200}
-  cy={120}
+  cx={210}
+  cy={140}
   data={
     Array [
       Object {
@@ -115,12 +115,12 @@ exports[`RadarChart should render a chart with custom dots 1`] = `
       5,
     ]
   }
-  height={240}
+  height={250}
   innerRadius={0}
   outerRadius={100}
   tick={false}
   tickLine={false}
-  width={400}
+  width={420}
 >
   <PolarAngleAxis
     allowDuplicatedCategory={true}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Default Recharts axis label positions are too close to the chart under some conditions. We want to increase the default spacing between chart labels and the chart. 

**What is the chosen solution to this problem?**
A bug the Recharts library prevents us from using the expected 'radius' prop to control the draw positions of the axis labels. Instead we use CSS to scale the axis label container and its contents by a small amount, outwards from its centre.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
