### PR TITLE
fix(http): Return full error in http handle request

### DIFF
--- a/packages/http/src/http.common.js
+++ b/packages/http/src/http.common.js
@@ -66,7 +66,9 @@ export async function handleBody(response) {
  */
 export async function handleHttpResponse(response) {
 	if (!testHTTPCode.isSuccess(response.status)) {
-		throw new Error(response);
+		const error = new Error(response.status);
+		error.response = response;
+		throw error;
 	}
 	if (response.status === HTTP_STATUS.NO_CONTENT) {
 		return {

--- a/packages/http/src/http.common.test.js
+++ b/packages/http/src/http.common.test.js
@@ -117,6 +117,31 @@ describe('#handleHttpResponse', () => {
 			done();
 		});
 	});
+
+	it('should handle the response with an error http code', async () => {
+		await expect(
+			handleHttpResponse(
+				new Response('', {
+					status: HTTP_STATUS.INTERNAL_SERVER_ERROR,
+				}),
+			),
+		).rejects.toThrow(`${HTTP_STATUS.INTERNAL_SERVER_ERROR}`);
+	});
+
+	it('should return response in error from handle request', async () => {
+		expect.assertions(2);
+
+		try {
+			await handleHttpResponse(
+				new Response('', {
+					status: HTTP_STATUS.INTERNAL_SERVER_ERROR,
+				}),
+			);
+		} catch (e) {
+			expect(e.response instanceof Response).toBe(true);
+			expect(e.response.status).toEqual(500);
+		}
+	});
 });
 
 describe('#encodePayload', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an issue in `@talend/http` here: https://github.com/Talend/ui/blob/master/packages/http/src/http.common.js#L69
Xe can’t pass the response to Error, because it only take a string message as param. Behind, we can’t exploit this response (to get status for example).

In current CMF http sagas it works because it’s a promise, so we can pass anything: https://github.com/Talend/ui/blob/master/packages/cmf/src/sagas/http.js#L90

**What is the chosen solution to this problem?**
To fix this, we simply instance an error with the request status, and the complete response in a custom property and only throw the error after that.

I add some tests to cover the fix.

Thanks @jmfrancois for the help on this 👍

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
