### PR TITLE
fix: datagrid keyboard regression and VirtualizedList story

### DIFF
--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -419,7 +419,7 @@ function CollapsiblePanels(props) {
 					}}
 					onScroll={action('onScroll')}
 					id="my-list"
-					type={VirtualizedList.listTypes.COLLAPSIBLE_PANEL}
+					type={VirtualizedList.LIST_TYPES.COLLAPSIBLE_PANEL}
 				/>
 			</section>
 		</div>
@@ -735,7 +735,7 @@ storiesOf('Data/List/VirtualizedList', module)
 					collection={collection}
 					id="my-list"
 					rowHeight={135}
-					type={VirtualizedList.listTypes.LARGE}
+					type={VirtualizedList.LIST_TYPES.LARGE}
 				>
 					<VirtualizedList.Text label="Id" dataKey="id" />
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
@@ -772,7 +772,7 @@ storiesOf('Data/List/VirtualizedList', module)
 					onRowDoubleClick={action('doubleClick')}
 					rowHeight={135}
 					selectionToggle={action('selectionToggle')}
-					type={VirtualizedList.listTypes.LARGE}
+					type={VirtualizedList.LIST_TYPES.LARGE}
 				>
 					<VirtualizedList.Text label="Id" dataKey="id" />
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
@@ -808,7 +808,7 @@ storiesOf('Data/List/VirtualizedList', module)
 					isActive={item => item.id === 6}
 					onRowClick={action('onRowClick')}
 					rowHeight={135}
-					type={VirtualizedList.listTypes.LARGE}
+					type={VirtualizedList.LIST_TYPES.LARGE}
 				>
 					<VirtualizedList.Text label="Id" dataKey="id" />
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -285,7 +285,7 @@ export default class DataGrid extends React.Component {
 	}
 
 	handleKeyboard({ nextCellPosition, previousCellPosition }) {
-		if (!nextCellPosition) {
+		if (!nextCellPosition || nextCellPosition < 0) {
 			return null;
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

1. AGGrid has been updated in #2985 and there is a difference of behavior: when on the first row, and user presses up arrow, it goes in the `navigateToNextCell` is executed. Our handler fails in this case
```
this.gridAPI.getDisplayedRowAtIndex(nextCellPosition.rowIndex).setSelected(true, true);

// rowIndex = -1 we end up with Cannot read property 'setSelected' of undefined
```

2. VirtualizedList SB is failing because of wrong path to get constants

**What is the chosen solution to this problem?**

1. check if the index is positive

2. fix the paths

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
