### PR TITLE
fix: datagrid keyboard navigation

### DIFF
--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -285,7 +285,7 @@ export default class DataGrid extends React.Component {
 	}
 
 	handleKeyboard({ nextCellPosition, previousCellPosition }) {
-		if (!nextCellPosition || nextCellPosition < 0) {
+		if (!nextCellPosition || nextCellPosition.rowIndex < 0) {
 			return null;
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
#3007 fix was not correct. To check if we have to handle datagrid keyboard navigation, we need to check if the next row index is positive.

**What is the chosen solution to this problem?**
Fix it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
