### PR TITLE
feat(faceted-search): Add colored badge support

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -239,6 +239,16 @@
   347:2  error  defaultProp "minimumPercentage" has no corresponding propTypes declaration  react/default-props-match-prop-types
   348:2  error  defaultProp "display" has no corresponding propTypes declaration            react/default-props-match-prop-types
 
+/home/travis/build/Talend/ui/packages/components/src/QualityBar/QualityBar.stories.js
+  15:6  error  Empty components are self-closing  react/self-closing-comp
+  17:6  error  Empty components are self-closing  react/self-closing-comp
+  19:6  error  Empty components are self-closing  react/self-closing-comp
+  21:6  error  Empty components are self-closing  react/self-closing-comp
+  23:6  error  Empty components are self-closing  react/self-closing-comp
+  25:6  error  Empty components are self-closing  react/self-closing-comp
+  27:6  error  Empty components are self-closing  react/self-closing-comp
+  29:6  error  Empty components are self-closing  react/self-closing-comp
+
 /home/travis/build/Talend/ui/packages/components/src/RadarChart/RadarChart.stories.js
    31:7  error  'activeAxis' is assigned a value but never used  @typescript-eslint/no-unused-vars
    45:6  error  Value must be omitted for boolean attributes     react/jsx-boolean-value
@@ -397,5 +407,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 208 problems (187 errors, 21 warnings)
-  9 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 216 problems (195 errors, 21 warnings)
+  17 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -28,8 +28,17 @@ src/List/Toolbar/Toolbar.scss
   79:6   error  Nesting depth 4 greater than max of 3                    nesting-depth
   92:12  error  Qualifying elements are not allowed for class selectors  no-qualifying-elements
 
+src/QualityBar/QualityRatioBar.scss
+   8:10  error  @extend must be used with a %placeholder  placeholder-in-extend
+  12:10  error  @extend must be used with a %placeholder  placeholder-in-extend
+  16:10  error  @extend must be used with a %placeholder  placeholder-in-extend
+
+src/RatioBar/RatioBar.scss
+  42:11  error  @extend must be used with a %placeholder  placeholder-in-extend
+  47:11  error  @extend must be used with a %placeholder  placeholder-in-extend
+
 src/Typeahead/Typeahead.scss
   32:5  error  Mixins should come before declarations  mixins-before-declarations
 
-✖ 14 problems (13 errors, 1 warning)
+✖ 19 problems (18 errors, 1 warning)
 

--- a/packages/faceted-search/CHANGELOG.md
+++ b/packages/faceted-search/CHANGELOG.md
@@ -29,6 +29,7 @@ Types of changes
 - [Added](https://github.com/Talend/ui/pull/2994): Read only support
 - [Added](https://github.com/Talend/ui/pull/2997): Handle badges without labels
 - [Added](https://github.com/Talend/ui/pull/3000): Added complies/wordComplies pattern operators support
+- [Added](https://github.com/Talend/ui/pull/3013): Added colored badge support
 
 ## [0.13.0]
 

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -46,8 +46,8 @@
     "@storybook/addon-actions": "^5.3.1",
     "@storybook/addons": "^5.3.1",
     "@storybook/react": "^5.3.1",
-    "@talend/icons": "^5.24.0",
-    "@talend/react-components": "^5.24.0",
+    "@talend/icons": "^5.25.0",
+    "@talend/react-components": "^5.25.0",
     "@talend/scripts-core": "^6.7.0",
     "@talend/scripts-preset-react-lib": "^6.7.0",
     "cross-env": "^5.2.0",
@@ -65,9 +65,8 @@
     "style-loader": "^0.23.0"
   },
   "peerDependencies": {
-    "@talend/icons": ">= 5.24.0",
-    "@talend/react-cmf": ">= 5.24.0",
-    "@talend/react-components": ">= 5.24.0",
+    "@talend/icons": ">= 5.25.0",
+    "@talend/react-components": ">= 5.25.0",
     "i18next": "^15.1.3",
     "prop-types": "^15.5.10",
     "react": "^16.8.6",

--- a/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
@@ -37,6 +37,7 @@ export const BadgeCheckboxes = ({
 	value,
 	category,
 	values,
+	displayType,
 	t,
 }) => {
 	const currentOperators = useMemo(() => operators, [operators]);
@@ -46,6 +47,7 @@ export const BadgeCheckboxes = ({
 	return (
 		<BadgeFaceted
 			badgeId={id}
+			displayType={displayType}
 			id={badgeCheckboxesId}
 			initialOperatorOpened={initialOperatorOpened}
 			initialValueOpened={initialValueOpened}
@@ -97,4 +99,5 @@ BadgeCheckboxes.propTypes = {
 	removable: PropTypes.bool,
 	values: PropTypes.array,
 	t: PropTypes.func.isRequired,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
 };

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -21,6 +21,7 @@ const findOperatorByName = name => operator => name === operator.name;
 
 const BadgeFaceted = ({
 	badgeId,
+  displayType,
 	children,
 	id,
 	labelCategory,
@@ -100,7 +101,7 @@ const BadgeFaceted = ({
 	};
 
 	return (
-		<Badge id={id} className={theme('tc-badge-faceted')} display={size}>
+		<Badge id={id} className={theme('tc-badge-faceted')} display={size} type={displayType}>
 			{labelCategory && (
 				<>
 					<Badge.Category category={labelCategory} label={labelCategory} />
@@ -147,7 +148,8 @@ const BadgeFaceted = ({
 
 BadgeFaceted.propTypes = {
 	badgeId: PropTypes.string.isRequired,
-	labelCategory: PropTypes.string.isRequired,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
+  labelCategory: PropTypes.string.isRequired,
 	children: PropTypes.func.isRequired,
 	id: PropTypes.string.isRequired,
 	initialOperatorOpened: PropTypes.bool,

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -21,7 +21,7 @@ const findOperatorByName = name => operator => name === operator.name;
 
 const BadgeFaceted = ({
 	badgeId,
-  displayType,
+	displayType,
 	children,
 	id,
 	labelCategory,
@@ -149,7 +149,7 @@ const BadgeFaceted = ({
 BadgeFaceted.propTypes = {
 	badgeId: PropTypes.string.isRequired,
 	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
-  labelCategory: PropTypes.string.isRequired,
+	labelCategory: PropTypes.string.isRequired,
 	children: PropTypes.func.isRequired,
 	id: PropTypes.string.isRequired,
 	initialOperatorOpened: PropTypes.bool,

--- a/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumber.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumber.component.js
@@ -52,6 +52,7 @@ const BadgeNumber = ({
 	category,
 	readOnly,
 	removable,
+	displayType,
 }) => {
 	const currentOperators = useMemo(() => operators || createDefaultOperators(t), [operators, t]);
 	const currentOperator = operator || currentOperators[0];
@@ -59,6 +60,7 @@ const BadgeNumber = ({
 	return (
 		<BadgeFaceted
 			badgeId={id}
+			displayType={displayType}
 			id={badgeTextId}
 			initialOperatorOpened={initialOperatorOpened}
 			initialValueOpened={initialValueOpened}
@@ -99,6 +101,7 @@ BadgeNumber.propTypes = {
 	category: PropTypes.string,
 	readOnly: PropTypes.bool,
 	removable: PropTypes.bool,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
@@ -11,7 +11,7 @@ $circle-size-small: 1.8rem !default;
 		height: $circle-size-large;
 	}
 	align-items: center;
-	background: white;
+	background: rgba(255,255,255,0.5);
 	border-radius: 10rem;
 	display: inline-flex;
 	justify-content: center;

--- a/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.scss
@@ -11,7 +11,7 @@ $circle-size-small: 1.8rem !default;
 		height: $circle-size-large;
 	}
 	align-items: center;
-	background: rgba(255,255,255,0.5);
+	background: rgba(255, 255, 255, 0.5);
 	border-radius: 10rem;
 	display: inline-flex;
 	justify-content: center;

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.component.js
@@ -37,6 +37,7 @@ const BadgeSlider = ({
 	category,
 	defaultValue = 0,
 	unit = '',
+	displayType,
 	...rest
 }) => {
 	const currentOperators = useMemo(() => operators || createDefaultOperators(t), [operators, t]);
@@ -48,6 +49,7 @@ const BadgeSlider = ({
 	return (
 		<BadgeFaceted
 			badgeId={id}
+			displayType={displayType}
 			id={badgeTextId}
 			initialOperatorOpened={initialOperatorOpened}
 			initialValueOpened={initialValueOpened}
@@ -90,6 +92,7 @@ BadgeSlider.propTypes = {
 	category: PropTypes.string,
 	defaultValue: PropTypes.number,
 	unit: PropTypes.string,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -40,6 +40,7 @@ export const BadgeTags = ({
 	callbacks,
 	readOnly,
 	removable,
+	displayType,
 	t,
 }) => {
 	const [tagsValues, setTagsValues] = useState([]);
@@ -69,6 +70,7 @@ export const BadgeTags = ({
 	return (
 		<BadgeFaceted
 			badgeId={id}
+			displayType={displayType}
 			id={badgeTagsId}
 			initialOperatorOpened={initialOperatorOpened}
 			initialValueOpened={initialValueOpened}
@@ -121,4 +123,5 @@ BadgeTags.propTypes = {
 	t: PropTypes.func.isRequired,
 	readOnly: PropTypes.bool,
 	removable: PropTypes.bool,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
 };

--- a/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.component.js
@@ -37,6 +37,7 @@ const BadgeText = ({
 	category,
 	readOnly,
 	removable,
+	displayType,
 }) => {
 	const currentOperators = useMemo(() => operators || createDefaultOperators(t), [operators, t]);
 	const currentOperator = operator || currentOperators[0];
@@ -44,6 +45,7 @@ const BadgeText = ({
 	return (
 		<BadgeFaceted
 			badgeId={id}
+			displayType={displayType}
 			id={badgeTextId}
 			initialOperatorOpened={initialOperatorOpened}
 			initialValueOpened={initialValueOpened}
@@ -84,6 +86,7 @@ BadgeText.propTypes = {
 	category: PropTypes.string,
 	readOnly: PropTypes.bool,
 	removable: PropTypes.bool,
+	displayType: PropTypes.oneOf(Object.values(Badge.TYPES)),
 };
 
 // eslint-disable-next-line import/prefer-default-export

--- a/packages/faceted-search/src/dictionary/badge.dictionary.js
+++ b/packages/faceted-search/src/dictionary/badge.dictionary.js
@@ -34,4 +34,4 @@ const createBadgesDict = badges => {
 
 const getBadgesFromDict = (badges, badgeKey) => badges[badgeKey];
 
-export { createBadgesDict, getBadgesFromDict };
+export { createBadgesDict, getBadgesFromDict, standardBadgeTypeNames };

--- a/packages/faceted-search/src/hooks/facetedBadges.hook.js
+++ b/packages/faceted-search/src/hooks/facetedBadges.hook.js
@@ -1,7 +1,7 @@
 import { useEffect, useReducer } from 'react';
 import { closeInitOpenedBadge, createBadge, deleteBadge, updateBadge } from '../CRUDBadges';
 
-const BADGES_ACTIONS_KEYS = {
+export const BADGES_ACTIONS_KEYS = {
 	ADD_BADGE: 'ADD_BADGE',
 	UPDATE_BADGE: 'UPDATE_BADGE',
 	DELETE_BADGE: 'DELETE_BADGE',

--- a/packages/faceted-search/stories/facetedSearch.story.js
+++ b/packages/faceted-search/stories/facetedSearch.story.js
@@ -6,6 +6,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { useTranslation } from 'react-i18next';
 import IconsProvider from '@talend/react-components/lib/IconsProvider';
+import Badge from '@talend/react-components/lib/Badge';
 import FacetedSearch from '../src';
 import { FacetedSearchIcon } from '../src/components/FacetedSearchIcon';
 import { BadgeFacetedProvider } from '../src/components/context/badgeFaceted.context';
@@ -186,6 +187,25 @@ storiesOf('FacetedSearch', module)
 						<FacetedSearch.BasicSearch
 							badgesDefinitions={badgesDefinitions}
 							badgesFaceted={badgesFaceted}
+							onSubmit={action('onSubmit')}
+							callbacks={callbacks}
+						/>
+					))
+				}
+			</FacetedSearch.Faceted>
+		</div>
+	))
+	.add('colored', () => (
+		<div>
+			<FacetedSearch.Faceted id="my-faceted-search">
+				{currentFacetedMode =>
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.ADVANCED && (
+						<FacetedSearch.AdvancedSearch onSubmit={action('onSubmit')} />
+					)) ||
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.BASIC && (
+						<FacetedSearch.BasicSearch
+							badgesDefinitions={badgesDefinitions}
+							badgesFaceted={set(cloneDeep(badgesFaceted), 'badges[0].properties.displayType', Badge.TYPES.VALUE)}
 							onSubmit={action('onSubmit')}
 							callbacks={callbacks}
 						/>

--- a/packages/faceted-search/yarn.lock
+++ b/packages/faceted-search/yarn.lock
@@ -1901,10 +1901,10 @@
   resolved "https://registry.yarnpkg.com/@talend/html-webpack-plugin/-/html-webpack-plugin-1.1.0.tgz#7665ca9140c81277ded25b8328fd3508f758b9ce"
   integrity sha512-iVXGta9LexjQWOOaLsgYpDZeBAUmR6Jjplujrw/FIpl2FyDXBduATQdqqPAz1lueU2Hj4wBNSWLEKIprDapPrg==
 
-"@talend/icons@^5.24.0":
-  version "5.24.0"
-  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-5.24.0.tgz#49dc4b2ee1d322379413dfb62af5455cebf78190"
-  integrity sha512-YEh8WQH3E6poSRkhwLBEMK+Q+5mslFlwjgmTmFychlpKg14EfJjzZjg+SAF2k0NVxd5yVrEXZXZvvjwqPn529g==
+"@talend/icons@^5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@talend/icons/-/icons-5.25.0.tgz#eba19c68ab03d08bd5c9cf479bc1d43f12f8d048"
+  integrity sha512-BbPQu0NK9bcZ/dVP2TDz560giuLGe8iOVvdSC9N6A809obsC5ric7+9EP7oehc1MPalqjllvAu/cBYO2Y9kIaw==
 
 "@talend/react-cmf-webpack-plugin@>=3.4.0":
   version "5.13.0"
@@ -1945,10 +1945,10 @@
     redux-thunk "^2.2.0"
     uuid "^7.0.3"
 
-"@talend/react-components@^5.24.0":
-  version "5.24.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-5.24.0.tgz#10cfb6d782e7da03653172a9e254c24e51d82813"
-  integrity sha512-bg+MFMewI+XWPM3hYDFbQcW77x2GvPHH6pncW/9CkytkqQ0bSramxuKxd0e4hV3BMbRne4Xj/hUvsaD30fyFgw==
+"@talend/react-components@^5.25.0":
+  version "5.25.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-components/-/react-components-5.25.0.tgz#9f07e20145b4394165f0c88df7c2f168350c365a"
+  integrity sha512-2rBkJ0Tj7HaA9HAk5wFp8f1/o7hurI0/yBfQZ8qp1YFni/NXaoEjwEsO/bx74Zkzy/I728IvNCf3tu8iViMUGw==
   dependencies:
     ally.js "^1.4.1"
     classnames "^2.2.5"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

TDP & TDS need colored badges for their filter bars.
Color support is already implemented in the `Badge` component through the `type` props

**What is the chosen solution to this problem?**

A `displayType` property is added on the badge definition and forwarded to the `Badge` component

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
