### PR TITLE
feat(components/list): enrich cellicontext api

### DIFF
--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -24,6 +24,11 @@ function CustomList(props) {
 			<List.VList.Text label="Id" dataKey="id" />
 			<List.VList.Title label="Name" dataKey="name" columnData={titleProps} />
 			<List.VList.IconText label="IconText" dataKey="iconAndText" />
+			<List.VList.IconText
+				label="IconText"
+				columnData={{ getIcon: () => 'talend-tdp-colored' }}
+				dataKey="iconAndTextWithGetter"
+			/>
 			<List.VList.Boolean label="Valid" dataKey="isValid" />
 			<List.VList.Boolean
 				label="ValidWithIcon"

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -285,6 +285,7 @@ for (let i = 0; i < 100; i += 1) {
 			icon: 'talend-list',
 			label: 'list',
 		},
+		iconAndTextWithGetter: 'icon from getter',
 		name: `Title with icon and actions ${i}`,
 		isValid: [true, false, undefined][random(2)],
 		tag: 'test',

--- a/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
+++ b/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
@@ -6,6 +6,21 @@ import theme from './CellIconText.scss';
 
 const css = getTheme(theme);
 
+function getCellIcon({ cellData, rowData, columnData = {} }) {
+	const { getIcon } = columnData;
+	if (getIcon && typeof getIcon === 'function') {
+		return getIcon(rowData);
+	}
+	return cellData.icon;
+}
+
+function getCellLabel({ cellData }) {
+	if (typeof cellData === 'object') {
+		return cellData.label;
+	}
+	return cellData;
+}
+
 /**
  * Cell renderer that displays a boolean
  */
@@ -15,12 +30,13 @@ class CellIconText extends React.Component {
 	}
 
 	render() {
-		const { cellData } = this.props;
+		const icon = getCellIcon(this.props);
+		const label = getCellLabel(this.props);
 
 		return (
 			<div className={css('tc-icon-text')}>
-				{cellData.icon && <Icon name={cellData.icon} />}
-				<span className={theme.label}>{cellData.label}</span>
+				{icon && <Icon name={icon} />}
+				<span className={theme.label}>{label}</span>
 			</div>
 		);
 	}
@@ -29,10 +45,17 @@ class CellIconText extends React.Component {
 CellIconText.displayName = 'VirtualizedList(CellIconText)';
 CellIconText.propTypes = {
 	// The cell value : props.rowData[props.dataKey]
-	cellData: PropTypes.shape({
-		label: PropTypes.string,
-		icon: PropTypes.string,
-	}),
+	cellData: PropTypes.oneOf([
+		PropTypes.shape({
+			label: PropTypes.string,
+			icon: PropTypes.string,
+		}),
+		PropTypes.string,
+	]),
+	rowData: PropTypes.object,
+	columnData: PropTypes.shape({
+		getIcon: PropTypes.func,
+	}).isRequired,
 };
 
 CellIconText.defaultProps = {

--- a/packages/components/src/VirtualizedList/CellIconText/CellIconText.test.js
+++ b/packages/components/src/VirtualizedList/CellIconText/CellIconText.test.js
@@ -3,20 +3,32 @@ import { shallow } from 'enzyme';
 
 import CellIconText from './CellIconText.component';
 
-describe('CellBoolean', () => {
+describe('CellIconText', () => {
 	it('should render an empty cell', () => {
 		const wrapper = shallow(<CellIconText />);
 
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	it('should render an icon cell in a truthy case', () => {
+	it('should render an icon cell with an icon', () => {
 		const wrapper = shallow(
 			<CellIconText
 				cellData={{
 					icon: 'talend-list',
 					label: 'list',
 				}}
+			/>,
+		);
+
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render an icon cell with an icon using the getIcon method', () => {
+		const wrapper = shallow(
+			<CellIconText
+				cellData="List"
+				rowData={{ type: 'list' }}
+				columnData={{ getIcon: ({ type }) => `hihihi-${type}` }}
 			/>,
 		);
 

--- a/packages/components/src/VirtualizedList/CellIconText/__snapshots__/CellIconText.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellIconText/__snapshots__/CellIconText.test.js.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CellBoolean should render an empty cell 1`] = `
+exports[`CellIconText should render an empty cell 1`] = `
 <div
   className="tc-icon-text theme-tc-icon-text"
 >
@@ -10,7 +10,7 @@ exports[`CellBoolean should render an empty cell 1`] = `
 </div>
 `;
 
-exports[`CellBoolean should render an icon cell in a truthy case 1`] = `
+exports[`CellIconText should render an icon cell with an icon 1`] = `
 <div
   className="tc-icon-text theme-tc-icon-text"
 >
@@ -21,6 +21,21 @@ exports[`CellBoolean should render an icon cell in a truthy case 1`] = `
     className="theme-label"
   >
     list
+  </span>
+</div>
+`;
+
+exports[`CellIconText should render an icon cell with an icon using the getIcon method 1`] = `
+<div
+  className="tc-icon-text theme-tc-icon-text"
+>
+  <Icon
+    name="hihihi-list"
+  />
+  <span
+    className="theme-label"
+  >
+    List
   </span>
 </div>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

List cells usually use raw text as `cellData` (especially to keep the default sort working)

**What is the chosen solution to this problem?**

enrich cellicontext api in order to use a `getIcon` function at the `columnData` level

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
