### PR TITLE
chore: update eslint libraries

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -13,10 +13,10 @@
   },
   "license": "Apache-2.0",
   "dependencies": {
-    "babel-eslint": "8.2.3",
-    "eslint": "4.19.1",
-    "eslint-config-airbnb": "16.1.0",
-    "eslint-plugin-import": "2.12.0",
+    "babel-eslint": "10.1.0",
+    "eslint": "7.12.1",
+    "eslint-config-airbnb": "18.2.0",
+    "eslint-plugin-import": "2.22.1",
     "eslint-plugin-jsx-a11y": "6.0.3",
     "eslint-plugin-react-hooks": "^1.3.0",
     "eslint-plugin-react": "7.9.1"


### PR DESCRIPTION
* update babel-eslint to 10.1.0
* update eslint to 7.12.1
* update eslint-config-airbnb to 18.2.0
* update eslint-plugin-import to 2.22.1

**What is the problem this PR is trying to solve?**
We want to use new syntaxes in Javascript such as [optional chaining](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Op%C3%A9rateurs/Optional_chaining) and the previous version of `babel-eslint` doesn't allow those syntaxes.

**What is the chosen solution to this problem?**
I updated babel-eslint to the latest version.
I also updated other npm packages that we use in the API Team products: `eslint`, `eslint-config-airbnb`, and `eslint-plugin-import`.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
