### PR TITLE
chore: change RatioBar  composition pattern

### DIFF
--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
-import { RatioBarComposition } from '../RatioBar/RatioBarComposition.component';
+import RatioBar from '../RatioBar';
 import {
 	QualityEmptyLine,
 	QualityInvalidLine,
@@ -50,11 +50,11 @@ export function QualityBar({ invalid, valid, empty, digits = 1 }) {
 	);
 
 	return (
-		<RatioBarComposition>
+		<RatioBar.Composition>
 			<QualityInvalidLine value={invalid} percentage={invalidPercentage} t={t} />
 			<QualityEmptyLine value={empty} percentage={emptyPercentage} t={t} />
 			<QualityValidLine value={valid} percentage={validPercentage} t={t} />
-		</RatioBarComposition>
+		</RatioBar.Composition>
 	);
 }
 

--- a/packages/components/src/QualityBar/QualityRatioBar.component.js
+++ b/packages/components/src/QualityBar/QualityRatioBar.component.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { getTheme } from '../theme';
 import qualityBarTheme from './QualityRatioBar.scss';
-import { RatioBarLine } from '../RatioBar/RatioBarComposition.component';
+import RatioBar from '../RatioBar';
 
 const theme = getTheme(qualityBarTheme);
 
@@ -28,7 +28,7 @@ function formatNumber(value = '') {
 
 export function QualityInvalidLine({ value, percentage, t }) {
 	return (
-		<RatioBarLine
+		<RatioBar.Line
 			percentage={percentage}
 			tooltipLabel={t('INVALID_VALUES', {
 				defaultValue: '{{value}} invalid value ({{percentage}}%)',
@@ -46,7 +46,7 @@ QualityInvalidLine.propTypes = qualityBarLinePropTypes;
 
 export function QualityValidLine({ value, percentage, t }) {
 	return (
-		<RatioBarLine
+		<RatioBar.Line
 			percentage={percentage}
 			tooltipLabel={t('VALID_VALUES', {
 				defaultValue: '{{value}} valid value ({{percentage}}%)',
@@ -64,7 +64,7 @@ QualityValidLine.propTypes = qualityBarLinePropTypes;
 
 export function QualityEmptyLine({ value, percentage, t }) {
 	return (
-		<RatioBarLine
+		<RatioBar.Line
 			percentage={percentage}
 			tooltipLabel={t('EMPTY_VALUES', {
 				defaultValue: '{{value}} empty value ({{percentage}}%)',

--- a/packages/components/src/RatioBar/index.js
+++ b/packages/components/src/RatioBar/index.js
@@ -1,5 +1,7 @@
 import { RatioBar } from './RatioBar.component';
 import { RatioBarComposition, RatioBarLine } from './RatioBarComposition.component';
 
+RatioBar.Composition = RatioBarComposition;
+RatioBar.Line = RatioBarLine;
+
 export default RatioBar;
-export { RatioBarComposition, RatioBarLine };

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -60,7 +60,7 @@ import QualityBar from './QualityBar';
 import RadarChart from './RadarChart';
 import ResourceList from './ResourceList';
 import ResourcePicker from './ResourcePicker';
-import RatioBar, { RatioBarLine, RatioBarComposition } from './RatioBar';
+import RatioBar from './RatioBar';
 import Rich from './RichTooltip';
 import SidePanel from './SidePanel';
 import Skeleton from './Skeleton';
@@ -213,8 +213,6 @@ export {
 	QualityBar,
 	RadarChart,
 	RatioBar,
-	RatioBarLine,
-	RatioBarComposition,
 	ResourceList,
 	ResourcePicker,
 	Rich,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`@talend/react-components` index exports 3 components from RatioBar
- RatioBar
- RatioBarComponent
- RatioBarLine

**What is the chosen solution to this problem?**
To avoid too many exports in index, we try to limit it to 1 component by... component :) 

- export a single RatioBar
- attache composition to the component

```diff
-<RatioBarComposition>
+<RatioBar.Composition>

-<RatioBarLine>
+<RatioBar.Line>
```

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
