### PR TITLE
chore: remove double build and fix some lints

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -165,10 +165,6 @@
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition.stories.js
-  55:49  error  ["resizable"] is better written in dot notation  dot-notation
-  63:49  error  ["resizable"] is better written in dot notation  dot-notation
-
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
   58:36  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '../../VirtualizedList'` instead  import/no-named-as-default-member
@@ -370,9 +366,6 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
   53:35  error  'columnData.tooltipPlacement' is missing in props validation  react/prop-types
 
-/home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
-  55:2  error  'rowData' PropType is defined but prop is never used  react/no-unused-prop-types
-
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   171:3  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
   199:2  error  defaultProp "t" defined for isRequired propType          react/default-props-match-prop-types
@@ -410,5 +403,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 217 problems (196 errors, 21 warnings)
-  17 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 214 problems (193 errors, 21 warnings)
+  15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -166,8 +166,8 @@
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition.stories.js
-  50:49  error  ["resizable"] is better written in dot notation  dot-notation
-  58:49  error  ["resizable"] is better written in dot notation  dot-notation
+  55:49  error  ["resizable"] is better written in dot notation  dot-notation
+  63:49  error  ["resizable"] is better written in dot notation  dot-notation
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
@@ -370,6 +370,9 @@
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
   53:35  error  'columnData.tooltipPlacement' is missing in props validation  react/prop-types
 
+/home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
+  55:2  error  'rowData' PropType is defined but prop is never used  react/no-unused-prop-types
+
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
   171:3  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
   199:2  error  defaultProp "t" defined for isRequired propType          react/default-props-match-prop-types
@@ -407,5 +410,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 216 problems (195 errors, 21 warnings)
+✖ 217 problems (196 errors, 21 warnings)
   17 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -2,4 +2,9 @@
 /home/travis/build/Talend/ui/packages/datagrid/src/components/DefaultCellRenderer/DefaultValueRenderer.component.js
   66:4  error  onMouseOver must be accompanied by onFocus for accessibility  jsx-a11y/mouse-events-have-key-events
 
-✖ 1 problem (1 error, 0 warnings)
+/home/travis/build/Talend/ui/packages/datagrid/src/containers/datagrid.container.stories.js
+  6:22  error  '/home/travis/build/Talend/ui/node_modules/@talend/react-cmf/lib/index.js' imported multiple times  import/no-duplicates
+  8:17  error  '/home/travis/build/Talend/ui/node_modules/@talend/react-cmf/lib/index.js' imported multiple times  import/no-duplicates
+
+✖ 3 problems (3 errors, 0 warnings)
+  1 error and 0 warnings potentially fixable with the `--fix` option.

--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -2,9 +2,4 @@
 /home/travis/build/Talend/ui/packages/datagrid/src/components/DefaultCellRenderer/DefaultValueRenderer.component.js
   66:4  error  onMouseOver must be accompanied by onFocus for accessibility  jsx-a11y/mouse-events-have-key-events
 
-/home/travis/build/Talend/ui/packages/datagrid/src/containers/datagrid.container.stories.js
-  6:22  error  '/home/travis/build/Talend/ui/node_modules/@talend/react-cmf/lib/index.js' imported multiple times  import/no-duplicates
-  8:17  error  '/home/travis/build/Talend/ui/node_modules/@talend/react-cmf/lib/index.js' imported multiple times  import/no-duplicates
-
-✖ 3 problems (3 errors, 0 warnings)
-  1 error and 0 warnings potentially fixable with the `--fix` option.
+✖ 1 problem (1 error, 0 warnings)

--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -4,7 +4,7 @@
   "main": "lib/index.js",
   "mainSrc": "src/index.js",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.test.js
+++ b/packages/cmf-cqrs/src/components/ACKDispatcher/ACKDispatcher.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Map } from 'immutable';
 import { shallow, mount } from 'enzyme';
-import { store } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Container, { DEFAULT_STATE } from './ACKDispatcher.container';
 import Connected, { mapStateToProps } from './ACKDispatcher.connect';
@@ -31,7 +31,7 @@ describe('Container ACKDispatcher', () => {
 		expect(instance.shouldComponentUpdate({ acks: Map({ 123: {} }) })).toBe(true);
 	});
 	it('should render call process acks', () => {
-		const registry = store.registry();
+		const registry = mock.store.registry();
 		const mocked = jest.fn();
 
 		function myActionCreator() {
@@ -58,7 +58,7 @@ describe('Container ACKDispatcher', () => {
 				data: { foo: 'baz' },
 			}),
 		});
-		const registry = store.registry();
+		const registry = mock.store.registry();
 		const mocked = jest.fn();
 
 		function myActionCreator() {
@@ -87,7 +87,7 @@ describe('Container ACKDispatcher', () => {
 			};
 		}
 
-		const registry = store.registry();
+		const registry = mock.store.registry();
 		registry['actionCreator:myActionCreator'] = myActionCreator;
 		const wrapper = shallow(<Container dispatch={dispatch} acks={Map()} />, {
 			context: { registry },
@@ -124,7 +124,7 @@ describe('Container ACKDispatcher', () => {
 				data: { foo: 'baz' },
 			}),
 		});
-		const registry = store.registry();
+		const registry = mock.store.registry();
 		const mocked = jest.fn();
 
 		function myActionCreator() {

--- a/packages/cmf/README.md
+++ b/packages/cmf/README.md
@@ -158,9 +158,11 @@ We want testing experience to be easy so CMF provides some mocks for you.
 ```javascript
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Provider, store as mock } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import MyComponent from './My.component';
+
+const { Provider, store } = mock;
 
 describe('App', () => {
 	it('should render the app container', () => {

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf/src/cmfConnect.md
+++ b/packages/cmf/src/cmfConnect.md
@@ -286,9 +286,11 @@ We want testing experience to be easy so CMF provides some mocks for you.
 ```javascript
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { Provider, store as mock } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import MyComponent from './My.component';
+
+const { Provider, store } = mock;
 
 describe('App', () => {
 	it('should render the app container', () => {

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test",
     "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -52,7 +52,7 @@ function CustomListResizable(props) {
 				dataKey="id"
 				resizable
 				width={400}
-				headerRenderer={List.VList.headerDictionary['resizable']}
+				headerRenderer={List.VList.headerDictionary.resizable}
 			/>
 			<List.VList.Title
 				label="Name"
@@ -60,7 +60,7 @@ function CustomListResizable(props) {
 				columnData={titleProps}
 				resizable
 				width={400}
-				headerRenderer={List.VList.headerDictionary['resizable']}
+				headerRenderer={List.VList.headerDictionary.resizable}
 			/>
 			<List.VList.Badge
 				label="Tag"

--- a/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
+++ b/packages/components/src/VirtualizedList/CellIconText/CellIconText.component.js
@@ -52,7 +52,6 @@ CellIconText.propTypes = {
 		}),
 		PropTypes.string,
 	]),
-	rowData: PropTypes.object,
 	columnData: PropTypes.shape({
 		getIcon: PropTypes.func,
 	}).isRequired,

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -5,7 +5,7 @@ import { withI18next } from 'storybook-addon-i18next';
 import { locales as tuiLocales } from '@talend/locales-tui/locales';
 import createSagaMiddleware from 'redux-saga';
 import withCMF from '@talend/react-storybook-cmf';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import api, { actions, sagas } from '@talend/react-cmf';
 import { List, Map } from 'immutable';
 import { call, put } from 'redux-saga/effects';

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6007",
     "test": "talend-scripts test",

--- a/packages/containers/src/Action/Action.test.js
+++ b/packages/containers/src/Action/Action.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Action, { mapStateToProps, mergeProps } from './Action.connect';
 
 describe('Action', () => {
 	it('should render from name props keeping extra props', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<Action actionId="menu:article" extra="foo" />, { context });
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
@@ -14,7 +14,7 @@ describe('Action', () => {
 
 describe('Action.mapStateToProps', () => {
 	it('should resolve all action props', () => {
-		const state = mock.state();
+		const state = mock.store.state();
 		state.cmf.settings.actions = {
 			'menu:article': {
 				label: 'foo',

--- a/packages/containers/src/ActionBar/ActionBar.test.js
+++ b/packages/containers/src/ActionBar/ActionBar.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Container from './ActionBar.connect';
 
@@ -78,16 +78,11 @@ const actionIds = {
 describe('Container ActionBar', () => {
 	it('should pass the props', () => {
 		const props = { actions };
-		const wrapper = shallow(
-			<Container {...props} />,
-			{ context: mock.context() }
-		);
+		const wrapper = shallow(<Container {...props} />, { context: mock.store.context() });
 		expect(wrapper.props()).toMatchSnapshot();
 	});
 	it('should compute props using CMF with array of string', () => {
-		const wrapper = shallow(
-			<Container actionIds={actionIds} />
-		, { context: mock.context() });
+		const wrapper = shallow(<Container actionIds={actionIds} />, { context: mock.store.context() });
 		expect(wrapper.props()).toMatchSnapshot();
 	});
 });

--- a/packages/containers/src/ActionButton/ActionButton.test.js
+++ b/packages/containers/src/ActionButton/ActionButton.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ActionButton } from '@talend/react-components/lib/Actions';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Connected, {
 	mapStateToProps,
@@ -39,7 +39,7 @@ describe('CMF(Container(ActionButton))', () => {
 			onClick: () => {},
 			label: 'click',
 		};
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<ContainerActionButton {...props} />, {
 			context,
 		});
@@ -62,7 +62,7 @@ describe('CMF(Container(ActionButton))', () => {
 				id: 42,
 			},
 		};
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<ContainerActionButton {...props} />, {
 			context,
 		});
@@ -84,7 +84,7 @@ describe('CMF(Container(ActionButton))', () => {
 			extra: 'foo',
 			actionCreator: 'foo',
 		};
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<ContainerActionButton {...props} />, {
 			context,
 		});

--- a/packages/containers/src/ActionDropdown/ActionDropdown.test.js
+++ b/packages/containers/src/ActionDropdown/ActionDropdown.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import { ActionDropdown } from '@talend/react-components/lib/Actions';
 import Connected, {
 	mapStateToProps,
@@ -66,7 +66,7 @@ describe('Container(ActionDropdown)', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 	it('should render with items', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const actionIds = ['menu:article'];
 		const items = [{ label: 'Foo', actionCreator: 'menu:item' }];
 		const wrapper = shallow(

--- a/packages/containers/src/ActionFile/ActionFile.test.js
+++ b/packages/containers/src/ActionFile/ActionFile.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { ActionFile } from '@talend/react-components/lib/Actions';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Connected, { mapStateToProps, mergeProps, ContainerActionFile } from './ActionFile.connect';
 
@@ -16,7 +16,7 @@ describe('Connected ActionFile', () => {
 		expect(typeof props).toBe('object');
 	});
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<ActionFile id="42" actionId="menu:article" extra="foo" />, {
 			context,
 		});

--- a/packages/containers/src/ActionIconToggle/ActionIconToggle.test.js
+++ b/packages/containers/src/ActionIconToggle/ActionIconToggle.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import { ContainerActionIconToggle, mapStateToProps, mergeProps } from './ActionIconToggle.connect';
 
@@ -27,7 +27,7 @@ const state = {
 describe('Action Icon Toggle', () => {
 	it('should render', () => {
 		// given
-		const context = mock.context();
+		const context = mock.store.context();
 
 		// when
 		const wrapper = shallow(
@@ -49,7 +49,7 @@ describe('Action Icon Toggle', () => {
 
 	it('should dispatch on click', () => {
 		// given
-		const context = mock.context();
+		const context = mock.store.context();
 		const dispatch = jest.fn();
 		const payload = { type: 'TOGGLE-MY-AWESOME-ACTION' };
 

--- a/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.test.js
+++ b/packages/containers/src/ActionSplitDropdown/ActionSplitDropdown.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import Connected, {
 	mapStateToProps,
 	ContainerActionSplitDropdown,
@@ -12,7 +12,7 @@ describe('Connect(CMF(Container(ActionSplitDropdown)))', () => {
 		expect(Connected.WrappedComponent).toBe(ContainerActionSplitDropdown);
 	});
 	it('should map state to props', () => {
-		const state = mock.state();
+		const state = mock.store.state();
 		const actionId = 'menu:article';
 		const actionIds = ['menu:items'];
 		const props = mapStateToProps(state, { actionId, actionIds });
@@ -27,7 +27,7 @@ describe('Connect(CMF(Container(ActionSplitDropdown)))', () => {
 
 describe('Container(ActionSplitDropdown)', () => {
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(
 			<ContainerActionSplitDropdown
 				foo="extra"

--- a/packages/containers/src/Actions/Actions.test.js
+++ b/packages/containers/src/Actions/Actions.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Actions from './Actions.connect';
 
 describe('Actions', () => {
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<Actions actionIds={['menu:demo']} />, { context });
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});

--- a/packages/containers/src/ConfirmDialog/ConfirmDialog.test.js
+++ b/packages/containers/src/ConfirmDialog/ConfirmDialog.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
 import { fromJS, Map } from 'immutable';
-import mock, { store, Provider } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Container from './ConfirmDialog.container';
 import Connected, { mapStateToProps } from './ConfirmDialog.connect';
@@ -33,6 +33,7 @@ describe('Container ConfirmDialog', () => {
 			cancelAction: 'menu:demo',
 			model: { foo: 'bar' },
 		});
+		const { Provider } = mock;
 		const wrapper = renderer
 			.create(
 				<Provider>
@@ -59,7 +60,7 @@ describe('Connected ConfirmDialog', () => {
 			validateAction: 'object:validate',
 			cancelAction: 'object:cancel',
 		});
-		const state = mock.state();
+		const state = mock.store.state();
 		state.cmf.settings.actions['object:validate'] = { name: 'foo' };
 		state.cmf.settings.actions['object:cancel'] = { name: 'foo1' };
 
@@ -71,7 +72,7 @@ describe('Connected ConfirmDialog', () => {
 
 describe('ConfirmDialog.show/hide', () => {
 	it('should change the visibility to true in the state', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({
 			ConfirmDialog: {
 				ConfirmDialog: {
@@ -106,7 +107,7 @@ describe('ConfirmDialog.show/hide', () => {
 	});
 
 	it('should change the visibility to false in the state', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({
 			ConfirmDialog: {
 				ConfirmDialog: {

--- a/packages/containers/src/DeleteResource/DeleteResource.test.js
+++ b/packages/containers/src/DeleteResource/DeleteResource.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import { store } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import Immutable from 'immutable';
 
 import { DeleteResource } from './DeleteResource.container';
 import Connected, { mapStateToProps } from './DeleteResource.connect';
 
-const state = store.state();
+const state = mock.store.state();
 const settings = {};
 state.cmf = {
 	settings,

--- a/packages/containers/src/List/selector.test.js
+++ b/packages/containers/src/List/selector.test.js
@@ -1,5 +1,4 @@
-import { store } from '@talend/react-cmf/lib/mock';
-import cmf from '@talend/react-cmf';
+import cmf, { mock } from '@talend/react-cmf';
 import { fromJS, List } from 'immutable';
 import { mapStateToProps } from './List.connect';
 import { compare, getSortedResults } from './selector';
@@ -19,14 +18,20 @@ const localConfig = {
 		},
 	],
 	list: {
-		columns: [{ key: 'id', name: 'ID' }, { key: 'value', name: 'Value' }],
+		columns: [
+			{ key: 'id', name: 'ID' },
+			{ key: 'value', name: 'Value' },
+		],
 	},
 };
 
-const state = store.state();
+const state = mock.store.state();
 state.cmf.collections = fromJS({
 	default: {
-		columns: [{ key: 'id', name: 'ID' }, { key: 'value', name: 'Value' }],
+		columns: [
+			{ key: 'id', name: 'ID' },
+			{ key: 'value', name: 'Value' },
+		],
 		items: localConfig.items,
 	},
 });

--- a/packages/containers/src/Notification/Notification.test.js
+++ b/packages/containers/src/Notification/Notification.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import renderer from 'react-test-renderer';
-import { store, Provider } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import Immutable, { fromJS } from 'immutable';
 import Container from './Notification.container';
 import Connected, { mergeProps, deleteNotification } from './Notification.connect';
@@ -13,6 +13,7 @@ jest.mock('@talend/react-components/lib/Notification', () => props => (
 
 describe('Container Notification', () => {
 	it('should render', () => {
+		const { Provider } = mock;
 		const wrapper = renderer
 			.create(
 				<Provider>
@@ -58,7 +59,7 @@ describe('Connected Notification', () => {
 
 describe('Notification.pushNotification', () => {
 	it('should add a Notification in the state', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({
 			'Container(Notification)': {
 				Notification: {
@@ -79,7 +80,7 @@ describe('Notification.pushNotification', () => {
 	});
 
 	it('should add a Notification in the state even if the state slot is not yet available', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = new Immutable.Map();
 		const notification = { message: 'hello world' };
 		const newState = pushNotification(state, notification);
@@ -93,7 +94,7 @@ describe('Notification.pushNotification', () => {
 	});
 
 	it('should delete all Notification in the state', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({
 			'Container(Notification)': {
 				Notification: {
@@ -112,7 +113,7 @@ describe('Notification.pushNotification', () => {
 	});
 
 	it('should not change the state if no notification', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({
 			'Container(Notification)': {
 				Notification: {
@@ -125,7 +126,7 @@ describe('Notification.pushNotification', () => {
 	});
 
 	it('should not change the state if notification state is not yet availbale', () => {
-		const state = store.state();
+		const state = mock.store.state();
 		state.cmf.components = fromJS({});
 		const newState = pushNotification(state);
 		expect(newState).toBe(state);

--- a/packages/containers/src/SelectObject/SelectObject.test.js
+++ b/packages/containers/src/SelectObject/SelectObject.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import Immutable from 'immutable';
 
 import Component from './SelectObject.component';
@@ -9,7 +9,7 @@ import Connected, { mapStateToProps } from './SelectObject.connect';
 
 describe('Component SelectObject', () => {
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const item = new Immutable.Map({ id: '1', name: 'foo' });
 		const props = {
 			id: 'my-tree',
@@ -33,17 +33,17 @@ describe('Component SelectObject', () => {
 
 describe('Container SelectObject', () => {
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<Container />, { context });
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 	it('should propagate extra props', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<Container extra="foo" />, { context });
 		expect(wrapper.props().extra).toBe('foo');
 	});
 	it('should default props with Tree map the selectedId and onTreeClick', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const tree = {};
 		const item = new Immutable.Map({ id: '1', name: 'foo' });
 		const sourceData = new Immutable.List([item]);
@@ -67,7 +67,7 @@ describe('Container SelectObject', () => {
 		});
 	});
 	it('should set selectedId props to the only matched item if nothing selected', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const tree = {};
 		const item1 = new Immutable.Map({ id: '1', name: 'foo' });
 		const item2 = new Immutable.Map({ id: '2', name: 'bar' });
@@ -368,7 +368,7 @@ describe('Connected SelectObject', () => {
 		expect(Connected.WrappedComponent).toBe(Container);
 	});
 	it('should map state to props', () => {
-		const state = mock.state();
+		const state = mock.store.state();
 		const data = new Immutable.List([
 			new Immutable.Map({ label: 'foo' }),
 			new Immutable.Map({ label: 'bar' }),

--- a/packages/containers/src/ShortcutManager/ShortcutManager.test.js
+++ b/packages/containers/src/ShortcutManager/ShortcutManager.test.js
@@ -2,7 +2,7 @@ import React from 'react';
 import keycode from 'keycode';
 import { Map } from 'immutable';
 import { shallow, mount } from 'enzyme';
-import { Provider, store as mock } from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import Container from './ShortcutManager.container';
 import Connected from './ShortcutManager.connect';
@@ -21,7 +21,7 @@ describe('Shortcut container', () => {
 });
 
 describe('handles routes', () => {
-	const state = mock.state();
+	const state = mock.store.state();
 	state.cmf.settings.props.shortcuts = {
 		redirectMap: {},
 	};
@@ -33,6 +33,7 @@ describe('handles routes', () => {
 	};
 
 	it('should get the redirectMap', () => {
+		const { Provider } = mock;
 		const wrapper = mount(
 			<Provider state={state}>
 				<Connected view="shortcuts" />

--- a/packages/containers/src/SidePanel/SidePanel.test.js
+++ b/packages/containers/src/SidePanel/SidePanel.test.js
@@ -1,20 +1,20 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import cases from 'jest-in-case';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import SidePanel from './SidePanel.container';
 import { mapStateToProps, mergeProps } from './SidePanel.connect';
 import { ACTION_TYPE_LINK } from './constants';
 
 describe('SidePanel', () => {
 	it('should render', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const sidepanel = shallow(<SidePanel />, { context });
 		expect(sidepanel.getElement()).toMatchSnapshot();
 	});
 	it('should render provided actions as string', () => {
 		const actions = ['menu:article', 'menu:demo'];
-		const context = mock.context();
+		const context = mock.store.context();
 		const sidepanel = shallow(<SidePanel actions={actions} />, { context });
 		expect(sidepanel.getElement()).toMatchSnapshot();
 	});
@@ -23,7 +23,7 @@ describe('SidePanel', () => {
 describe('SidePanel.mapStateToProps', () => {
 	let state;
 	beforeEach(() => {
-		state = mock.state();
+		state = mock.store.state();
 		state.routing = {
 			locationBeforeTransitions: {
 				pathname: '/test',

--- a/packages/containers/src/TreeView/TreeView.test.js
+++ b/packages/containers/src/TreeView/TreeView.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import Immutable from 'immutable';
 import TreeView, {
 	DEFAULT_STATE,
@@ -15,8 +15,8 @@ describe('TreeView', () => {
 	let data;
 
 	beforeEach(() => {
-		context = mock.context();
-		state = mock.state();
+		context = mock.store.context();
+		state = mock.store.state();
 		data = new Immutable.List([
 			new Immutable.Map({ id: 1, name: 'foo', children: [] }),
 			new Immutable.Map({ id: 2, name: 'bar', children: [] }),
@@ -162,7 +162,7 @@ describe('TreeView', () => {
 
 describe('mapStateToProps', () => {
 	it('should return props', () => {
-		const state = mock.state();
+		const state = mock.store.state();
 		const data = new Immutable.Map({
 			foo: new Immutable.Map({
 				bar: new Immutable.List([new Immutable.Map({ foo: 'bar' })]),

--- a/packages/containers/src/actionAPI.test.js
+++ b/packages/containers/src/actionAPI.test.js
@@ -1,4 +1,4 @@
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import { routerAPI } from '@talend/react-cmf-router';
 
 import action, { getActionsProps } from './actionAPI';
@@ -9,7 +9,7 @@ describe('actionAPI.getActionsProps', () => {
 	});
 
 	it('should return props for one action', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const model = { model: true };
 		context.store.dispatch = jest.fn();
 		const props = action.getProps(context, 'menu:demo', model);
@@ -23,7 +23,7 @@ describe('actionAPI.getActionsProps', () => {
 	});
 
 	it('should return props for one action using action creator', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const model = { model: true };
 		context.store.dispatch = jest.fn();
 		context.registry['actionCreator:action-creator'] = jest.fn();
@@ -39,7 +39,7 @@ describe('actionAPI.getActionsProps', () => {
 	});
 
 	it('should return props for multiple actions', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const model = { model: {} };
 		context.store.dispatch = jest.fn();
 		const props = action.getProps(context, ['menu:demo', 'menu:article'], model);
@@ -64,7 +64,7 @@ describe('actionAPI.getActionsProps', () => {
 	});
 
 	it('should return props for multiple object actions', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const model = { model: {} };
 		const a1 = {
 			label: 'A1',

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -43,6 +43,7 @@
     "@storybook/react": "^5.3.1",
     "@talend/icons": "^5.26.0",
     "@talend/locales-tui": "^5.6.0",
+    "@talend/react-cmf": "^5.26.0",
     "@talend/react-components": "^5.26.0",
     "@talend/react-storybook-cmf": "^5.26.0",
     "@talend/scripts-core": "^6.8.2",
@@ -62,9 +63,9 @@
     "style-loader": "^0.23.0"
   },
   "peerDependencies": {
-    "@talend/icons": "^5.0.0",
-    "@talend/react-cmf": "^1.6.0",
-    "@talend/react-components": "^5.0.0",
+    "@talend/icons": "^5.26.0",
+    "@talend/react-cmf": "^5.26.0",
+    "@talend/react-components": "^5.26.0",
     "i18next": "^15.1.3",
     "prop-types": "^15.5.10",
     "react": "^16.8.6",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6010",
     "test": "talend-scripts test --silent",

--- a/packages/datagrid/src/containers/DataGrid/DataGrid.connect.test.js
+++ b/packages/datagrid/src/containers/DataGrid/DataGrid.connect.test.js
@@ -1,12 +1,12 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import ConnectedDataGrid from './DataGrid.connect';
 
 describe('#ConnectedDataGrid', () => {
 	it('should render a connected DataGrid', () => {
-		const context = mock.context();
+		const context = mock.store.context();
 		const wrapper = shallow(<ConnectedDataGrid />, { context });
 		expect(wrapper.getElement().type.displayName).toBe('CMF(Container(DataGrid))');
 	});

--- a/packages/datagrid/src/containers/datagrid.container.stories.js
+++ b/packages/datagrid/src/containers/datagrid.container.stories.js
@@ -3,7 +3,7 @@ import get from 'lodash/get';
 import { storiesOf } from '@storybook/react';
 
 import withCMF from '@talend/react-storybook-cmf';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 import { IconsProvider } from '@talend/react-components';
 import api from '@talend/react-cmf';
 
@@ -85,7 +85,7 @@ sample.data = [
 		})),
 ];
 
-const cmfState = mock.state();
+const cmfState = mock.store.state();
 cmfState.cmf.collections = cmfState.cmf.collections.set('sample', sample);
 cmfState.cmf.collections = cmfState.cmf.collections.set('sampleRenderer', sampleRenderer);
 if (!cmfState.cmf.settings.props) {

--- a/packages/datagrid/src/containers/datagrid.container.stories.js
+++ b/packages/datagrid/src/containers/datagrid.container.stories.js
@@ -3,9 +3,8 @@ import get from 'lodash/get';
 import { storiesOf } from '@storybook/react';
 
 import withCMF from '@talend/react-storybook-cmf';
-import { mock } from '@talend/react-cmf';
 import { IconsProvider } from '@talend/react-components';
-import api from '@talend/react-cmf';
+import api, { mock } from '@talend/react-cmf';
 
 import DataGrid from '.';
 import register from '../register';

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/generator/generators/react-cmf/templates/src/app/components/App/App.container.test.js
+++ b/packages/generator/generators/react-cmf/templates/src/app/components/App/App.container.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import mock from '@talend/react-cmf/lib/mock';
+import { mock } from '@talend/react-cmf';
 
 import App from './App.container';
 
@@ -14,13 +14,11 @@ describe('App container', () => {
 	it('should render', () => {
 		// given
 		// get the CMF state mock and inject your mock in it
-		const context = mock.context();
+		const context = mock.store.context();
 
 		// when
 		// wrap your container with CMF Provider mock, injecting your state mock
-		const wrapper = shallow(
-			<App />
-		, { context });
+		const wrapper = shallow(<App />, { context });
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -17,7 +17,7 @@
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -7,7 +7,7 @@
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "talend-scripts build:lib",
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "start": "echo nothing to start",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -6,7 +6,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib && talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
+    "prepublishOnly": "talend-scripts build:lib:umd --dev && talend-scripts build:lib:umd --prod",
     "prepare": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
     "test:noisy": "cross-env TZ=Europe/Paris talend-scripts test",

--- a/packages/storybook-cmf/src/CMFStory/CMFStory.component.js
+++ b/packages/storybook-cmf/src/CMFStory/CMFStory.component.js
@@ -3,8 +3,7 @@ import React from 'react';
 import { all, fork } from 'redux-saga/effects';
 import PropTypes from 'prop-types';
 import { Provider } from 'react-redux';
-import api, { store, RegistryProvider } from '@talend/react-cmf';
-import mock from '@talend/react-cmf/lib/mock';
+import api, { store, RegistryProvider, mock } from '@talend/react-cmf';
 
 function* initSagaMiddleWare() {
 	yield all([fork(api.sagas.component.handle)]);
@@ -23,7 +22,7 @@ class CMFStory extends React.Component {
 			state = props.state;
 		}
 		if (!state) {
-			state = mock.state();
+			state = mock.store.state();
 		}
 
 		let middlewares = this.props.middleware;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

- There are linter errors from our new talend eslint plugin. It checks if the imports from talend packages are not too deep to support UMDs on CDN.
- npm scripts builds the libs twice on release, because it executes prepare (that compiles with babel) and prepublishOnly (that compiles with babel then builds the UMDs)

**What is the chosen solution to this problem?**

- fix deep imports
- do not compile with babel on prepublishOnly. So the libs are compiled on install and publish (prepare), and the UMDs are built only on publish (prepublishOnly)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
