### PR TITLE
feat(components/guidedtour): add data-feature to the let me try button

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -150,14 +150,14 @@
   27:4  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
 
 /home/travis/build/Talend/ui/packages/components/src/GuidedTour/GuidedTour.component.js
-  68:2  error  defaultProp "steps" defined for isRequired propType  react/default-props-match-prop-types
+  78:2  error  defaultProp "steps" defined for isRequired propType  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/GuidedTour/GuidedTour.stories.js
    35:6   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
    41:11  error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
-  101:7   warning  Dangerous property 'dangerouslySetInnerHTML' found                                                                          react/no-danger
-  177:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
-  270:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
+  102:7   warning  Dangerous property 'dangerouslySetInnerHTML' found                                                                          react/no-danger
+  178:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
+  271:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
   27:65  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -36,6 +36,7 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 			]}
 			onRequestOpen={() => {}}
 			onRequestClose={() => {}}
+			lastStepNextButtonDataFeature="HEHEEE"
 			{...(withDemoContent ? demoContentProps : {})}
 		/>
 	);

--- a/packages/components/src/GuidedTour/GuidedTour.component.js
+++ b/packages/components/src/GuidedTour/GuidedTour.component.js
@@ -29,7 +29,13 @@ function formatSteps(steps) {
 	});
 }
 
-function GuidedTour({ className, disableAllInteractions, steps, ...rest }) {
+function GuidedTour({
+	className,
+	disableAllInteractions,
+	steps,
+	lastStepNextButtonDataFeature,
+	...rest
+}) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	if (!steps.length) {
 		return null;
@@ -49,7 +55,11 @@ function GuidedTour({ className, disableAllInteractions, steps, ...rest }) {
 			disableInteraction
 			highlightedMaskClassName="tc-guided-tour__highlighted-mask"
 			lastStepNextButton={
-				<Action bsStyle="info" label={t('GUIDEDTOUR_LAST_STEP', { defaultValue: 'Let me try' })} />
+				<Action
+					bsStyle="info"
+					label={t('GUIDEDTOUR_LAST_STEP', { defaultValue: 'Let me try' })}
+					data-feature={lastStepNextButtonDataFeature}
+				/>
 			}
 			maskSpace={10}
 			rounded={4}
@@ -86,6 +96,7 @@ GuidedTour.propTypes = {
 	isOpen: PropTypes.bool,
 	onRequestClose: PropTypes.func,
 	disableAllInteractions: PropTypes.bool,
+	lastStepNextButtonDataFeature: PropTypes.string,
 };
 
 export default GuidedTour;

--- a/packages/components/src/GuidedTour/GuidedTour.stories.js
+++ b/packages/components/src/GuidedTour/GuidedTour.stories.js
@@ -76,6 +76,7 @@ class GuidedTourContainer extends React.Component {
 					hideControls: this.hideControls,
 					t: this.props.t,
 				})}
+				lastStepNextButtonDataFeature="HOHOOO"
 				onRequestClose={this.closeTour}
 				isOpen={isOpen}
 				showCloseButton={controls}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
 
data-feature can't be added to the let me try button

**What is the chosen solution to this problem?**

add a new `lastStepNextButtonDataFeature` property

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
