### PR TITLE
chore(router): upgrade cmf dep

### DIFF
--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -51,7 +51,7 @@
     "@talend/icons": "^5.27.0",
     "@talend/locales-tui": "^5.6.0",
     "@talend/react-cmf": "^5.27.0",
-    "@talend/react-cmf-router": "^3.4.0",
+    "@talend/react-cmf-router": "^3.5.0",
     "@talend/react-components": "^5.27.0",
     "@talend/react-forms": "^5.27.0",
     "@talend/react-storybook-cmf": "^5.27.0",
@@ -76,7 +76,7 @@
   "peerDependencies": {
     "@talend/icons": "^5.0.0",
     "@talend/react-cmf": "^5.0.0",
-    "@talend/react-cmf-router": "^3.2.1",
+    "@talend/react-cmf-router": "^3.5.0",
     "@talend/react-components": "^5.0.0",
     "@talend/react-forms": "^5.0.0",
     "i18next": "^15.1.3",

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-cmf-router",
-  "version": "3.4.0",
+  "version": "3.5.0",
   "description": "",
   "main": "lib/index.js",
   "author": "Talend Frontend <frontend@talend.com> (http://www.talend.com)",
@@ -17,7 +17,6 @@
     "lint": "talend-scripts lint:es"
   },
   "dependencies": {
-    "@babel/polyfill": "^7.8.4",
     "lodash": "^4.17.15",
     "path-to-regexp": "^2.0.0",
     "prop-types": "^15.5.10",
@@ -27,12 +26,12 @@
     "redux-saga": "^0.15.4"
   },
   "peerDependencies": {
-    "@talend/react-cmf": ">2.1.0",
+    "@talend/react-cmf": ">=5.27.0",
     "react": "^16.8.6",
     "react-dom": "^16.8.6"
   },
   "devDependencies": {
-    "@talend/react-cmf": "^5.1.1",
+    "@talend/react-cmf": "^5.27.0",
     "@talend/scripts-core": "^6.8.2",
     "@talend/scripts-preset-react-lib": "^6.8.2",
     "enzyme": "^3.11.0",

--- a/packages/router/yarn.lock
+++ b/packages/router/yarn.lock
@@ -807,14 +807,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.8.3"
     "@babel/helper-plugin-utils" "^7.8.3"
 
-"@babel/polyfill@^7.8.4":
-  version "7.8.7"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.8.7.tgz#151ec24c7135481336168c3bd8b8bf0cf91c032f"
-  integrity sha512-LeSfP9bNZH2UOZgcGcZ0PIHUt1ZuHub1L3CVmEyqLxCeDLm4C5Gi8jRH8ZX2PNpDhQCo0z6y/+DIs2JlliXW8w==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@^7.8.7":
   version "7.9.5"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.9.5.tgz#8ddc76039bc45b774b19e2fc548f6807d8a8919f"
@@ -1279,10 +1271,10 @@
     lodash "^4.17.15"
     mkdirp "^0.5.1"
 
-"@talend/react-cmf@^5.1.1":
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-5.1.1.tgz#17092ed7becfc2374cb492456ac1c4bd6c776478"
-  integrity sha512-I28lKETHeVsZzveLt8+dJcyno7Td3thmpVY2vZEbhV+jD7gRqFqRWmvw+1X1VsMVaaqSPl5EE8ps+PYWJSqKkw==
+"@talend/react-cmf@^5.26.0":
+  version "5.26.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-5.26.0.tgz#f16df723e97f20ca7a686f4d09286b864dcc31d8"
+  integrity sha512-iytsfER3nuUjfNEBGMmw4lB6E0vHvvjVLqAV8PU31wpIvLiYJmH2VEj1bsIG5NopwJ93DNKv+J1Vvka3p50bzA==
   dependencies:
     "@sentry/browser" "^5.11.1"
     deepmerge "^1.5.1"
@@ -1290,7 +1282,7 @@
     immutable "^3.8.1"
     invariant "^2.2.2"
     jsonpath "^1.0.0"
-    lodash "^4.17.4"
+    lodash "^4.17.15"
     mkdirp "^1.0.4"
     path-to-regexp "^2.0.0"
     prop-types "^15.5.10"
@@ -1305,12 +1297,12 @@
     redux-storage-decorator-immutablejs "^1.0.4"
     redux-storage-engine-localstorage "^1.1.4"
     redux-thunk "^2.2.0"
-    uuid "^7.0.3"
+    uuid "^3.4.0"
 
-"@talend/react-cmf@^5.26.0":
-  version "5.26.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-5.26.0.tgz#f16df723e97f20ca7a686f4d09286b864dcc31d8"
-  integrity sha512-iytsfER3nuUjfNEBGMmw4lB6E0vHvvjVLqAV8PU31wpIvLiYJmH2VEj1bsIG5NopwJ93DNKv+J1Vvka3p50bzA==
+"@talend/react-cmf@^5.27.0":
+  version "5.27.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-cmf/-/react-cmf-5.27.0.tgz#5d201c1fa7bcd8cfe60224973d7a7c71dd571353"
+  integrity sha512-S1IOOVMUSfMHakj824aoaa/TTNTSfYxSpOpJNh30qAK4DqhX3XQZTaI8Pk5lXb1wu94uakaR2/57opUYWVGcWQ==
   dependencies:
     "@sentry/browser" "^5.11.1"
     deepmerge "^1.5.1"
@@ -3357,7 +3349,7 @@ core-js@^1.0.0:
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
   integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
 
-core-js@^2.4.0, core-js@^2.6.5:
+core-js@^2.4.0:
   version "2.6.5"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.5.tgz#44bc8d249e7fb2ff5d00e0341a7ffb94fbf67895"
   integrity sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==
@@ -7179,7 +7171,7 @@ lodash@^4.0.0, lodash@^4.17.11, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.3
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.20.tgz#b44a9b6297bcb698f1c51a3545a2b3b368d59c52"
   integrity sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
 
-lodash@^4.15.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.15.0, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.2.1:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
@@ -11266,11 +11258,6 @@ uuid@^3.3.2, uuid@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
-uuid@^7.0.3:
-  version "7.0.3"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-7.0.3.tgz#c5c9f2c8cf25dc0a372c4df1441c41f5bd0c680b"
-  integrity sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==
 
 v8-compile-cache@2.0.3:
   version "2.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -855,7 +855,7 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
 
-"@babel/polyfill@^7.8.3", "@babel/polyfill@^7.8.4":
+"@babel/polyfill@^7.8.3":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
   integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
@@ -3029,12 +3029,11 @@
     mkdirp "^1.0.4"
     semver "^7.3.2"
 
-"@talend/react-cmf-router@^3.4.0":
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/@talend/react-cmf-router/-/react-cmf-router-3.4.0.tgz#bd33e55e19bc08c0b4b654e5208e7d98dfd5184f"
-  integrity sha512-8CTIjcisFHaQfcpaeqoT9834pWnZwOH+GWAtckkZrDvjTbZkaRE/iQiQPpOAxWv2cWY54aiUGIb0eb0vpYEg3A==
+"@talend/react-cmf-router@^3.5.0":
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/@talend/react-cmf-router/-/react-cmf-router-3.5.0.tgz#10a6505b42cc798c68591566ee342c9c0ee26f41"
+  integrity sha512-DgdVMuxvRR5cYwEP4TWEbqjxRNrOEjMmoy68uVkrqIJ+znnxBN03JtR7/yAqPJwbXmbRqcHb7zSguwFdwd6vXA==
   dependencies:
-    "@babel/polyfill" "^7.8.4"
     lodash "^4.17.15"
     path-to-regexp "^2.0.0"
     prop-types "^15.5.10"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In router, the version of cmf is outdated and not compatible with cdn build.

**What is the chosen solution to this problem?**
Upgrade

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
