### PR TITLE
chore(RHFInput): use required props to display required star

### DIFF
--- a/packages/forms/src/widgets/fields/Input/Input.component.js
+++ b/packages/forms/src/widgets/fields/Input/Input.component.js
@@ -20,6 +20,7 @@ const Input = React.forwardRef((props, ref) => {
 			id={id}
 			label={label}
 			inProgress={inProgress}
+			required={required}
 		>
 			<input
 				{...rest}

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.component.js
@@ -8,6 +8,7 @@ function FieldTemplate(props) {
 	const groupsClassNames = classNames('form-group', {
 		'has-error': props.error,
 		[theme.inProgress]: props.inProgress,
+        required: props.required,
 	});
 
 	return (
@@ -43,6 +44,7 @@ if (process.env.NODE_ENV !== 'production') {
 		id: PropTypes.string,
 		label: PropTypes.string,
 		inProgress: PropTypes.bool,
+		required: PropTypes.bool,
 	};
 }
 

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.component.js
@@ -8,7 +8,7 @@ function FieldTemplate(props) {
 	const groupsClassNames = classNames('form-group', {
 		'has-error': props.error,
 		[theme.inProgress]: props.inProgress,
-        required: props.required,
+		required: props.required,
 	});
 
 	return (

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
@@ -4,10 +4,6 @@
 	@include heartbeat(object-blink);
 }
 
-:global(.form-group.required) {
-	:global {
-		.control-label:after {
-			content: '*';
-		}
-	}
+:global(.form-group.required .control-label):after {
+	content: '*';
 }

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
@@ -3,3 +3,11 @@
 .inProgress {
 	@include heartbeat(object-blink);
 }
+
+:global(.form-group.required) {
+	:global {
+		.control-label:after {
+			content: '*';
+		}
+    }
+}

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.scss
@@ -9,5 +9,5 @@
 		.control-label:after {
 			content: '*';
 		}
-    }
+	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Nothing shows that the value is required in RHF input (fieldtemplate) : 
![image](https://user-images.githubusercontent.com/14272767/97860455-73826e80-1d02-11eb-8446-ffdde71764a7.png)

**What is the chosen solution to this problem?**
adding the "*" to the fieldTemplate: 
![image](https://user-images.githubusercontent.com/14272767/97860575-a7f62a80-1d02-11eb-962e-2dfc5d6e3492.png)


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
