### PR TITLE
chore(forms/MultiSelectTag):  adding onBlur callback

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -13,10 +13,6 @@
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
   54:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-  94:3  error  Expected an assignment or function call and instead saw an expression                                                                                                                                                                                                                                        @typescript-eslint/no-unused-expressions
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
-  224:37  error  Expected property shorthand  object-shorthand
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   47:8  error  The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input  jsx-a11y/role-supports-aria-props
@@ -28,5 +24,5 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-✖ 11 problems (11 errors, 0 warnings)
-  3 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 9 problems (9 errors, 0 warnings)
+  2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -12,7 +12,11 @@
   55:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
-  53:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
+  54:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
+  94:3  error  Expected an assignment or function call and instead saw an expression                                                                                                                                                                                                                                        @typescript-eslint/no-unused-expressions
+
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+  224:37  error  Expected property shorthand  object-shorthand
 
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
   47:8  error  The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input  jsx-a11y/role-supports-aria-props
@@ -24,5 +28,5 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-✖ 9 problems (9 errors, 0 warnings)
-  2 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 11 problems (11 errors, 0 warnings)
+  3 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -37,6 +37,7 @@ export default class MultiSelectTag extends React.Component {
 			itemsList: theme.items,
 		};
 
+        this.onBlur = this.onBlur.bind(this);
 		this.onChange = this.onChange.bind(this);
 		this.onFocus = this.onFocus.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);
@@ -87,6 +88,10 @@ export default class MultiSelectTag extends React.Component {
 			default:
 				break;
 		}
+	}
+
+	onBlur(event) {
+		this.props.onBlur && this.props.onBlur(event);
 	}
 
 	/**
@@ -255,6 +260,7 @@ export default class MultiSelectTag extends React.Component {
 							onFocus={this.onFocus}
 							onKeyDown={this.onKeyDown}
 							onSelect={this.onAddTag}
+							onBlur={this.onBlur}
 							placeholder={schema.placeholder}
 							readOnly={schema.readOnly || false}
 							theme={this.theme}
@@ -280,6 +286,7 @@ if (process.env.NODE_ENV !== 'production') {
 		errorMessage: PropTypes.string,
 		errors: PropTypes.object,
 		resolveName: PropTypes.func,
+		onBlur: PropTypes.func,
 		onChange: PropTypes.func.isRequired,
 		onFinish: PropTypes.func.isRequired,
 		onTrigger: PropTypes.func.isRequired,

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -37,7 +37,7 @@ export default class MultiSelectTag extends React.Component {
 			itemsList: theme.items,
 		};
 
-        this.onBlur = this.onBlur.bind(this);
+		this.onBlur = this.onBlur.bind(this);
 		this.onChange = this.onChange.bind(this);
 		this.onFocus = this.onFocus.bind(this);
 		this.onKeyDown = this.onKeyDown.bind(this);

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -91,7 +91,9 @@ export default class MultiSelectTag extends React.Component {
 	}
 
 	onBlur(event) {
-		this.props.onBlur && this.props.onBlur(event);
+	    if (this.props.onBlur) {
+	        this.props.onBlur(event);
+	    }
 	}
 
 	/**

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -91,9 +91,9 @@ export default class MultiSelectTag extends React.Component {
 	}
 
 	onBlur(event) {
-	    if (this.props.onBlur) {
-	        this.props.onBlur(event);
-	    }
+		if (this.props.onBlur) {
+			this.props.onBlur(event);
+		}
 	}
 
 	/**

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
@@ -219,18 +219,15 @@ describe('MultiSelectTag field', () => {
 	});
 
 	it('should call onBlur when blurring the input', () => {
-    		// given
-            const onBlur = jest.fn();
-    		const propsWithBlur = {...props, onBlur: onBlur}
-    		const wrapper = mount(<MultiSelectTag {...propsWithBlur} />);
+		// given
+		const onBlur = jest.fn();
+		const propsWithBlur = { ...props, onBlur: onBlur };
+		const wrapper = mount(<MultiSelectTag {...propsWithBlur} />);
 
-    		// when
-    		wrapper
-    			.find('input')
-    			.at(0)
-    			.simulate('blur');
+		// when
+		wrapper.find('input').at(0).simulate('blur');
 
-    		// then
-    		expect(onBlur).toHaveBeenCalled();
-    	});
+		// then
+		expect(onBlur).toHaveBeenCalled();
+	});
 });

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
@@ -217,4 +217,20 @@ describe('MultiSelectTag field', () => {
 		// then
 		expect(firstLabel).toBe('aze_name');
 	});
+
+	it('should call onBlur when blurring the input', () => {
+    		// given
+            const onBlur = jest.fn();
+    		const propsWithBlur = {...props, onBlur: onBlur}
+    		const wrapper = mount(<MultiSelectTag {...propsWithBlur} />);
+
+    		// when
+    		wrapper
+    			.find('input')
+    			.at(0)
+    			.simulate('blur');
+
+    		// then
+    		expect(onBlur).toHaveBeenCalled();
+    	});
 });

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
@@ -221,7 +221,7 @@ describe('MultiSelectTag field', () => {
 	it('should call onBlur when blurring the input', () => {
 		// given
 		const onBlur = jest.fn();
-		const propsWithBlur = { ...props, onBlur: onBlur };
+		const propsWithBlur = { ...props, onBlur };
 		const wrapper = mount(<MultiSelectTag {...propsWithBlur} />);
 
 		// when

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
@@ -41,6 +41,7 @@ exports[`MultiSelectTag field should render MultiSelectTag 1`] = `
         }
         items={null}
         multiSection={false}
+        onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
         onKeyDown={[Function]}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Not possible to do something on blur

**What is the chosen solution to this problem?**
Adding onBlur to MultiSelectTag props

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
