### PR TITLE
feat(cmf): combine reducers in modules

### DIFF
--- a/packages/cmf/__tests__/cmfModule.merge.test.js
+++ b/packages/cmf/__tests__/cmfModule.merge.test.js
@@ -163,13 +163,17 @@ describe('mergeModule', () => {
 	});
 
 	it('should merge reducer', () => {
-		const ob1 = { foo: jest.fn() };
-		const ob2 = { bar: jest.fn() };
+		const ob1 = { foo: jest.fn(), composed: { composed1: jest.fn() } };
+		const ob2 = { bar: jest.fn(), composed: { composed2: jest.fn() } };
 
 		const config = mergeModules({ reducer: ob1 }, { reducer: ob2 });
 		expect(typeof config.reducer).toBe('object');
 		expect(config.reducer.foo).toBe(ob1.foo);
 		expect(config.reducer.bar).toBe(ob2.bar);
+		expect(config.reducer.composed).toEqual({
+			composed1: ob1.composed.composed1,
+			composed2: ob2.composed.composed2,
+		});
 	});
 
 	it('should merge preReducer', () => {

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -41,6 +41,7 @@
     "jsonpath": "^1.0.0",
     "lodash": "^4.17.15",
     "mkdirp": "^1.0.4",
+    "nested-combine-reducers": "^1.2.2",
     "path-to-regexp": "^2.0.0",
     "prop-types": "^15.5.10",
     "react-immutable-proptypes": "^2.1.0",

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { spawn } from 'redux-saga/effects';
-import deepmerge from 'deepmerge';
+import _merge from 'lodash/merge';
 import { assertValueTypeOf } from './assert';
 
 export function deepMerge(obj1, obj2) {
@@ -10,7 +10,7 @@ export function deepMerge(obj1, obj2) {
 	if (!obj1) {
 		return obj2;
 	}
-	return deepmerge.all([obj1, obj2]);
+	return _merge(obj1, obj2);
 }
 
 export function mergeObjects(obj1, obj2) {

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -1,6 +1,11 @@
 import React from 'react';
 import { spawn } from 'redux-saga/effects';
+import deepmerge from 'deepmerge';
 import { assertValueTypeOf } from './assert';
+
+export function deepMerge(obj1, obj2) {
+	return deepmerge.all([obj1, obj2]);
+}
 
 export function mergeObjects(obj1, obj2) {
 	if (!obj2) {
@@ -109,7 +114,7 @@ const MERGE_FNS = {
 	enhancer: mergeFns,
 	middlewares: mergeArrays,
 	storeCallback: mergeFns,
-	reducer: mergeObjects,
+	reducer: deepMerge,
 	preloadedState: getUnique,
 	settingsURL: getUnique,
 	registry: mergeObjects,

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -4,6 +4,12 @@ import deepmerge from 'deepmerge';
 import { assertValueTypeOf } from './assert';
 
 export function deepMerge(obj1, obj2) {
+	if (!obj2) {
+		return obj1;
+	}
+	if (!obj1) {
+		return obj2;
+	}
 	return deepmerge.all([obj1, obj2]);
 }
 

--- a/packages/cmf/src/store.js
+++ b/packages/cmf/src/store.js
@@ -76,7 +76,6 @@ function getReducer(appReducer) {
 	let reducerObject = {};
 	if (appReducer) {
 		if (typeof appReducer === 'object') {
-			// TODO LOOP RECUSIVLY
 			reducerObject = { ...appReducer };
 		} else if (typeof appReducer === 'function') {
 			reducerObject = { app: appReducer };

--- a/packages/cmf/src/store.js
+++ b/packages/cmf/src/store.js
@@ -4,6 +4,7 @@
  */
 import { combineReducers, createStore, applyMiddleware, compose } from 'redux';
 import { enableBatching } from 'redux-batched-actions';
+import { nestedCombineReducers } from 'nested-combine-reducers';
 import thunk from 'redux-thunk';
 import invariant from 'invariant';
 
@@ -75,6 +76,7 @@ function getReducer(appReducer) {
 	let reducerObject = {};
 	if (appReducer) {
 		if (typeof appReducer === 'object') {
+			// TODO LOOP RECUSIVLY
 			reducerObject = { ...appReducer };
 		} else if (typeof appReducer === 'function') {
 			reducerObject = { app: appReducer };
@@ -85,7 +87,8 @@ function getReducer(appReducer) {
 	if (!reducerObject.cmf) {
 		reducerObject.cmf = cmfReducers;
 	}
-	return enableBatching(preApplyReducer(combineReducers(reducerObject)));
+
+	return enableBatching(preApplyReducer(nestedCombineReducers(reducerObject, combineReducers)));
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -7385,7 +7385,14 @@ dot-case@^3.0.3:
     no-case "^3.0.3"
     tslib "^1.10.0"
 
-dot-prop@^4.2.0, dot-prop@^5.1.0, dot-prop@^5.2.0:
+dot-prop@^4.2.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-4.2.1.tgz#45884194a71fc2cda71cbb4bceb3a4dd2f433ba4"
+  integrity sha512-l0p4+mIuJIua0mhxGoh4a+iNL9bmeK5DvnSVQa6T0OhrVmaEa1XScX5Etc673FePCJOArq/4Pa2cLGODUWTPOQ==
+  dependencies:
+    is-obj "^1.0.0"
+
+dot-prop@^5.1.0, dot-prop@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/dot-prop/-/dot-prop-5.3.0.tgz#90ccce708cd9cd82cc4dc8c3ddd9abdd55b20e88"
   integrity sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
@@ -7495,7 +7502,7 @@ element-resize-detector@^1.2.1:
   dependencies:
     batch-processor "1.0.0"
 
-elliptic@^6.5.2, elliptic@^6.5.3:
+elliptic@^6.5.3:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/elliptic/-/elliptic-6.5.3.tgz#cb59eb2efdaf73a0bd78ccd7015a62ad6e0f93d6"
   integrity sha512-IMqzv5wNQf+E6aHeIqATs0tOLeOTwj1QKbRcS3jBbYkl5oLAserA8yJTT7/VyHUYG91PRmPyeQDObKLPpeS4dw==
@@ -10843,6 +10850,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+is-obj@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-1.0.1.tgz#3e4729ac1f5fde025cd7d83a896dab9f4f67db0f"
+  integrity sha1-PkcprB9f3gJc19g6iW2rn09n2w8=
+
 is-obj@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-obj/-/is-obj-2.0.0.tgz#473fb05d973705e3fd9620545018ca8e22ef4982"
@@ -12921,7 +12933,17 @@ minimist-options@^3.0.1:
     arrify "^1.0.1"
     is-plain-obj "^1.1.0"
 
-minimist@0.0.8, minimist@1.1.x, minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
+minimist@0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
+  integrity sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=
+
+minimist@1.1.x:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.1.3.tgz#3bedfd91a92d39016fcfaa1c681e8faa1a1efda8"
+  integrity sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=
+
+minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
   integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
@@ -12993,7 +13015,7 @@ mississippi@^3.0.0:
     stream-each "^1.1.0"
     through2 "^2.0.0"
 
-mixin-deep@^1.2.0, mixin-deep@^1.3.2:
+mixin-deep@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/mixin-deep/-/mixin-deep-1.3.2.tgz#1120b43dc359a785dce65b55b82e257ccf479566"
   integrity sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
@@ -13240,6 +13262,11 @@ neo-async@^2.5.0, neo-async@^2.6.0, neo-async@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
+
+nested-combine-reducers@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/nested-combine-reducers/-/nested-combine-reducers-1.2.2.tgz#376f15fb8bed582db1f78312f8fe6b35105534cb"
+  integrity sha512-PL4SmE7sNRyoxjy0f4HjNcrN2OnLffubem6qNOUOX9Qfv+xi8jvZWk26AH9gWnNVcWVdLdakyr4BOCtNRg87tA==
 
 nested-object-assign@^1.0.3:
   version "1.0.3"
@@ -19526,7 +19553,14 @@ webpack@^4.19.0, webpack@^4.33.0, webpack@^4.38.0, webpack@^4.42.0:
     watchpack "^1.7.4"
     webpack-sources "^1.4.1"
 
-websocket-driver@0.6.5, websocket-driver@>=0.5.1, websocket-driver@^0.7.3:
+websocket-driver@0.6.5:
+  version "0.6.5"
+  resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.6.5.tgz#5cb2556ceb85f4373c6d8238aa691c8454e13a36"
+  integrity sha1-XLJVbOuF9Dc8bYI4qmkchFThOjY=
+  dependencies:
+    websocket-extensions ">=0.1.1"
+
+websocket-driver@>=0.5.1:
   version "0.7.4"
   resolved "https://registry.yarnpkg.com/websocket-driver/-/websocket-driver-0.7.4.tgz#89ad5295bbf64b480abcba31e4953aca706f5760"
   integrity sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can't nest the reducer in the modules, so the shape of the store has every module at root level

**What is the chosen solution to this problem?**
Nest the reducers

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
