### PR TITLE
fix(components/AboutModal): add optional version

### DIFF
--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -52,15 +52,17 @@ function AboutDialog({
 			<div>
 				<Icon name={icon} className={classNames(theme['about-logo'], 'about-logo')} />
 				<div className={classNames(theme['about-excerpt'], 'about-excerpt')}>
-					<Text
-						text={t('ABOUT_VERSION_NAME', {
-							defaultValue: 'Version: {{version}}',
-							version,
-							interpolation: { escapeValue: false },
-						})}
-						size={Skeleton.SIZES.xlarge}
-						loading={loading}
-					/>
+					{version && (
+						<Text
+							text={t('ABOUT_VERSION_NAME', {
+								defaultValue: 'Version: {{version}}',
+								version,
+								interpolation: { escapeValue: false },
+							})}
+							size={Skeleton.SIZES.xlarge}
+							loading={loading}
+						/>
+					)}
 					<Text
 						text={
 							copyrights ||

--- a/packages/components/src/AboutDialog/AboutModal.stories.js
+++ b/packages/components/src/AboutDialog/AboutModal.stories.js
@@ -54,6 +54,7 @@ storiesOf('Layout/Modals/AboutModal', module)
 		</div>
 	))
 	.add('default', () => <AboutDialog {...props} />)
+	.add('without the version', () => <AboutDialog {...props} version={null} />)
 	.add('loading', () => <AboutDialog loading {...props} />)
 	.add('expanded', () => <AboutDialog expanded {...props} />)
 	.add('expanded with lot of services', () => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We have the version in the cloud product in this modal
**What is the chosen solution to this problem?**
Provide a way to remove it if not setup

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
