### PR TITLE
fix(ListComposition): filter without accents or diacritics

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -159,9 +159,6 @@
   178:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
   271:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
-  27:65  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
-
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
@@ -403,5 +400,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 214 problems (193 errors, 21 warnings)
+✖ 213 problems (193 errors, 20 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -1,12 +1,23 @@
-import { useMemo, useState } from 'react';
+import { useCallback, useState } from 'react';
 import isNil from 'lodash/isNil';
 
+/**
+ * By default, filter is case insensitive and without accents
+ * @param value Raw cell value
+ * @param textFilter User input using for filtering
+ * @returns {boolean} if input matches cell content
+ */
 function defaultFilterFunction(value, textFilter) {
 	const filteredValue = isNil(value) ? '' : value;
-	return filteredValue
-		.toString()
-		.toLowerCase()
-		.includes(textFilter);
+	return (
+		filteredValue
+			.toString()
+			.toLocaleLowerCase()
+			// @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
+			.normalize('NFD')
+			.replace(/[\u0300-\u036f]/g, '')
+			.includes(textFilter)
+	);
 }
 
 export function filter(collection, textFilter, filterFunctions) {
@@ -14,7 +25,7 @@ export function filter(collection, textFilter, filterFunctions) {
 		return collection;
 	}
 
-	const lowerTextFilter = textFilter.toLowerCase();
+	const lowerTextFilter = textFilter.toLocaleLowerCase();
 	return collection.filter(item =>
 		Object.entries(item).find(([key, value]) => {
 			const filterFunction = filterFunctions[key] || defaultFilterFunction;
@@ -24,7 +35,7 @@ export function filter(collection, textFilter, filterFunctions) {
 }
 
 export const filterCollection = (textFilter, filterFunctions = {}) => (collection = []) =>
-	useMemo(() => filter(collection, textFilter, filterFunctions), [
+	useCallback(filter(collection, textFilter, filterFunctions), [
 		collection,
 		textFilter,
 		filterFunctions,

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -1,6 +1,17 @@
 import { useCallback, useState } from 'react';
 import isNil from 'lodash/isNil';
 
+function normalizeInput(text) {
+	return (
+		text
+			.toString()
+			.toLocaleLowerCase()
+			// @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
+			.normalize('NFD')
+			.replace(/[\u0300-\u036f]/g, '')
+	);
+}
+
 /**
  * By default, filter is case insensitive and without accents
  * @param value Raw cell value
@@ -8,16 +19,7 @@ import isNil from 'lodash/isNil';
  * @returns {boolean} if input matches cell content
  */
 function defaultFilterFunction(value, textFilter) {
-	const filteredValue = isNil(value) ? '' : value;
-	return (
-		filteredValue
-			.toString()
-			.toLocaleLowerCase()
-			// @see https://stackoverflow.com/questions/990904/remove-accents-diacritics-in-a-string-in-javascript/37511463#37511463
-			.normalize('NFD')
-			.replace(/[\u0300-\u036f]/g, '')
-			.includes(textFilter)
-	);
+	return !isNil(value) && normalizeInput(value).includes(textFilter);
 }
 
 export function filter(collection, textFilter, filterFunctions) {
@@ -25,11 +27,11 @@ export function filter(collection, textFilter, filterFunctions) {
 		return collection;
 	}
 
-	const lowerTextFilter = textFilter.toLocaleLowerCase();
+	const normalizedTextFilter = normalizeInput(textFilter);
 	return collection.filter(item =>
 		Object.entries(item).find(([key, value]) => {
 			const filterFunction = filterFunctions[key] || defaultFilterFunction;
-			return filterFunction(value, lowerTextFilter);
+			return filterFunction(value, normalizedTextFilter);
 		}),
 	);
 }

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -30,8 +30,10 @@ export function filter(collection, textFilter, filterFunctions) {
 	const normalizedTextFilter = normalizeInput(textFilter);
 	return collection.filter(item =>
 		Object.entries(item).find(([key, value]) => {
-			const filterFunction = filterFunctions[key] || defaultFilterFunction;
-			return filterFunction(value, normalizedTextFilter);
+			if (filterFunctions[key]) {
+				return filterFunctions[key](value, textFilter);
+			}
+			return defaultFilterFunction(value, normalizedTextFilter);
 		}),
 	);
 }

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
@@ -70,6 +70,30 @@ describe('useCollectionFilter', () => {
 		expect(filteredCollection[2].firstName).toEqual('Carly');
 	});
 
+	it('should filter with provided initial text filter using case insensitive and no accents', () => {
+		// when
+		const wrapper = mount(
+			<FilterComponent
+				collection={[
+					{ firstName: 'Léa' },
+					{ firstName: 'Léo' },
+					{ firstName: 'Léon' },
+					{ firstName: 'Lee-Roy' },
+					{ firstName: 'Louis' },
+				]}
+				initialTextFilter="le"
+			/>,
+		);
+
+		// then
+		const filteredCollection = wrapper.find('#mainChild').prop('filteredCollection');
+		expect(filteredCollection).toHaveLength(4);
+		expect(filteredCollection[0].firstName).toEqual('Léa');
+		expect(filteredCollection[1].firstName).toEqual('Léo');
+		expect(filteredCollection[2].firstName).toEqual('Léon');
+		expect(filteredCollection[3].firstName).toEqual('Lee-Roy');
+	});
+
 	it('should filter with new text filter set', () => {
 		// given
 		const wrapper = mount(<FilterComponent collection={collection} />);

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
@@ -94,6 +94,30 @@ describe('useCollectionFilter', () => {
 		expect(filteredCollection[3].firstName).toEqual('Lee-Roy');
 	});
 
+	it('should filter with provided initial text filter using case insensitive and no diacritics', () => {
+		// when
+		const wrapper = mount(
+			<FilterComponent
+				collection={[
+					{ firstName: 'Léa' },
+					{ firstName: 'Léo' },
+					{ firstName: 'Léon' },
+					{ firstName: 'Lee-Roy' },
+					{ firstName: 'Louis' },
+				]}
+				initialTextFilter="lē"
+			/>,
+		);
+
+		// then
+		const filteredCollection = wrapper.find('#mainChild').prop('filteredCollection');
+		expect(filteredCollection).toHaveLength(4);
+		expect(filteredCollection[0].firstName).toEqual('Léa');
+		expect(filteredCollection[1].firstName).toEqual('Léo');
+		expect(filteredCollection[2].firstName).toEqual('Léon');
+		expect(filteredCollection[3].firstName).toEqual('Lee-Roy');
+	});
+
 	it('should filter with new text filter set', () => {
 		// given
 		const wrapper = mount(<FilterComponent collection={collection} />);

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -291,7 +291,7 @@ for (let i = 0; i < 100; i += 1) {
 		tag: 'test',
 		created: 1474495200,
 		modified: 1474495200,
-		description: 'Simple row with icon and actions',
+		description: `Simple row with icon and actions${[' (crème brûlée)', ''][random(1)]}`,
 		author: 'Jean-Pierre DUPONT',
 		icon: 'talend-file-xls-o',
 		display: 'text',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When you try to filter a List with accents or diacritics, you get exact results. 

**What is the chosen solution to this problem?**

Normalize input while filtering

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

https://jira.talendforge.org/browse/TCCUI-201