### PR TITLE
feat(ListComposition): filter on limited column list

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -160,10 +160,13 @@
   271:4   error    Emojis should be wrapped in <span>, have role="img", and have an accessible description with aria-label or aria-labelledby  jsx-a11y/accessible-emoji
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
-  27:65  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
+  29:82  warning  React Hook useMemo has unnecessary dependencies: 'filterFunctions' and 'textFilter'. Either exclude them or remove the dependency array. Outer scope values like 'textFilter' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
+
+/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
+  13:5  warning  React Hook React.useEffect has a missing dependency: 'setFilteredColumns'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
@@ -403,5 +406,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 214 problems (193 errors, 21 warnings)
+✖ 215 problems (193 errors, 22 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -165,9 +165,6 @@
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
-  13:5  warning  React Hook React.useEffect has a missing dependency: 'setFilteredColumns'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
-
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
   58:36  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '../../VirtualizedList'` instead  import/no-named-as-default-member
@@ -406,5 +403,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 215 problems (193 errors, 22 warnings)
+✖ 214 problems (193 errors, 21 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -239,6 +239,10 @@ storiesOf('Data/List/List Composition', module)
 			<IconsProvider />
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
+			<p>
+				Note that here we manually restrict the filter scope to column with dataKeys equal to{' '}
+				<code>name</code> and <code>description</code>, but it's optional!
+			</p>
 			<pre>
 				{`<List.Manager
  	id="my-list"
@@ -343,10 +347,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -387,10 +388,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 							<List.DisplayMode id="my-list-displayMode" initialDisplayMode="large" />
 						</List.Toolbar.Right>
@@ -431,10 +429,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'name', label: 'Name' },
-									{ key: 'id', label: 'Id' },
-								]}
+								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
 								value={{ sortBy: 'name', isDescending: false }}
 								onChange={action('onSortChange')}
 							/>
@@ -504,10 +499,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -558,10 +550,7 @@ storiesOf('Data/List/List Composition', module)
 							<List.TextFilter id="my-list-textFilter" />
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'name', label: 'Name' },
-									{ key: 'id', label: 'Id' },
-								]}
+								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
 								initialValue={{ sortBy: 'id', isDescending: true }}
 							/>
 							<List.DisplayMode id="my-list-displayMode" />

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -246,7 +246,7 @@ storiesOf('Data/List/List Composition', module)
 >
 	<List.Toolbar>
 		<List.Toolbar.Right>
-			<List.TextFilter id="my-list-textFilter" />
+			<List.TextFilter id="my-list-textFilter" applyOn={['name', 'description']} />
 		</List.Toolbar.Right>
 	</List.Toolbar>
 	<List.VList id="my-vlist" type="TABLE">
@@ -259,7 +259,7 @@ storiesOf('Data/List/List Composition', module)
 				<List.Manager id="my-list" collection={simpleCollection}>
 					<List.Toolbar>
 						<List.Toolbar.Right>
-							<List.TextFilter id="my-list-textFilter" />
+							<List.TextFilter id="my-list-textFilter" applyOn={['name', 'description']} />
 						</List.Toolbar.Right>
 					</List.Toolbar>
 					<CustomList type="TABLE" />

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -347,7 +347,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -388,7 +391,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 							<List.DisplayMode id="my-list-displayMode" initialDisplayMode="large" />
 						</List.Toolbar.Right>
@@ -429,7 +435,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
+								options={[
+									{ key: 'name', label: 'Name' },
+									{ key: 'id', label: 'Id' },
+								]}
 								value={{ sortBy: 'name', isDescending: false }}
 								onChange={action('onSortChange')}
 							/>
@@ -499,7 +508,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -550,7 +562,10 @@ storiesOf('Data/List/List Composition', module)
 							<List.TextFilter id="my-list-textFilter" />
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
+								options={[
+									{ key: 'name', label: 'Name' },
+									{ key: 'id', label: 'Id' },
+								]}
 								initialValue={{ sortBy: 'id', isDescending: true }}
 							/>
 							<List.DisplayMode id="my-list-displayMode" />

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -9,10 +9,11 @@ import { useCollectionSort } from './hooks/useCollectionSort.hook';
 import { useCollectionFilter } from './hooks/useCollectionFilter.hook';
 import theme from '../List.scss';
 
-function Manager({ initialDisplayMode, initialSortParams, visibleColumns, children, t, ...rest }) {
+function Manager({ initialDisplayMode, initialSortParams, initialVisibleColumns, children, t, ...rest }) {
 	let collection = rest.collection;
 
 	const [displayMode, setDisplayMode] = useState(initialDisplayMode || displayModesOptions[0]);
+	const [visibleColumns, setVisibleColumns] = useState(initialVisibleColumns);
 
 	// Sort items
 	const { sortedCollection, sortParams, setSortParams } = useCollectionSort(
@@ -39,10 +40,12 @@ function Manager({ initialDisplayMode, initialSortParams, visibleColumns, childr
 	const contextValues = {
 		collection,
 		displayMode,
+		visibleColumns,
 		filteredColumns,
 		setDisplayMode,
 		setSortParams,
 		setTextFilter,
+		setVisibleColumns,
 		setFilteredColumns,
 		sortParams,
 		t,
@@ -60,10 +63,10 @@ Manager.defaultProps = {
 };
 Manager.propTypes = {
 	children: PropTypes.node,
-	visibleColumns: PropTypes.arrayOf(PropTypes.string),
 	collection: PropTypes.array,
 	id: PropTypes.string.isRequired,
 	initialDisplayMode: PropTypes.oneOf(displayModesOptions),
+	initialVisibleColumns: PropTypes.arrayOf(PropTypes.string),
 	initialSortParams: PropTypes.shape({
 		sortBy: PropTypes.string,
 		isDescending: PropTypes.bool,

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -22,15 +22,23 @@ function Manager({ initialDisplayMode, initialSortParams, children, t, ...rest }
 	collection = sortedCollection;
 
 	// Filter by text
-	const { filteredCollection, textFilter, setTextFilter } = useCollectionFilter(collection);
+	const {
+		filteredCollection,
+		textFilter,
+		setTextFilter,
+		filteredColumns,
+		setFilteredColumns,
+	} = useCollectionFilter(collection);
 	collection = filteredCollection;
 
 	const contextValues = {
 		collection,
 		displayMode,
+		filteredColumns,
 		setDisplayMode,
 		setSortParams,
 		setTextFilter,
+		setFilteredColumns,
 		sortParams,
 		t,
 		textFilter,

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -9,7 +9,14 @@ import { useCollectionSort } from './hooks/useCollectionSort.hook';
 import { useCollectionFilter } from './hooks/useCollectionFilter.hook';
 import theme from '../List.scss';
 
-function Manager({ initialDisplayMode, initialSortParams, initialVisibleColumns, children, t, ...rest }) {
+function Manager({
+	initialDisplayMode,
+	initialSortParams,
+	initialVisibleColumns,
+	children,
+	t,
+	...rest
+}) {
 	let collection = rest.collection;
 
 	const [displayMode, setDisplayMode] = useState(initialDisplayMode || displayModesOptions[0]);
@@ -29,12 +36,7 @@ function Manager({ initialDisplayMode, initialSortParams, initialVisibleColumns,
 		setTextFilter,
 		filteredColumns,
 		setFilteredColumns,
-	} = useCollectionFilter(
-		collection,
-		undefined,
-		undefined,
-		visibleColumns,
-	);
+	} = useCollectionFilter(collection, undefined, undefined, visibleColumns);
 	collection = filteredCollection;
 
 	const contextValues = {

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
@@ -67,7 +67,12 @@ describe('List Manager', () => {
 	it('should propagate filter', () => {
 		// given
 		const wrapper = mount(
-			<ListManager collection={[{ id: 0, name: 'toto' }, { id: 1, name: 'tata' }]}>
+			<ListManager
+				collection={[
+					{ id: 0, name: 'toto' },
+					{ id: 1, name: 'tata' },
+				]}
+			>
 				<ContextTestConsumer />
 			</ListManager>,
 		);
@@ -95,7 +100,10 @@ describe('List Manager', () => {
 		// given
 		const wrapper = mount(
 			<ListManager
-				collection={[{ dataKey: 'id', label: 'ID' }, { dataKey: 'name', label: 'Name' }]}
+				collection={[
+					{ dataKey: 'id', label: 'ID' },
+					{ dataKey: 'name', label: 'Name' },
+				]}
 			>
 				<ContextTestConsumer />
 			</ListManager>,
@@ -118,7 +126,12 @@ describe('List Manager', () => {
 	it('should propagate sort', () => {
 		// given
 		const wrapper = mount(
-			<ListManager collection={[{ id: 0, name: 'toto' }, { id: 1, name: 'tata' }]}>
+			<ListManager
+				collection={[
+					{ id: 0, name: 'toto' },
+					{ id: 1, name: 'tata' },
+				]}
+			>
 				<ContextTestConsumer />
 			</ListManager>,
 		);

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
@@ -91,6 +91,30 @@ describe('List Manager', () => {
 		expect(wrapper.find(TestConsumer).prop('collection')).toEqual([{ id: 0, name: 'toto' }]);
 	});
 
+	it('should propagate filtered column list', () => {
+		// given
+		const wrapper = mount(
+			<ListManager
+				collection={[{ dataKey: 'id', label: 'ID' }, { dataKey: 'name', label: 'Name' }]}
+			>
+				<ContextTestConsumer />
+			</ListManager>,
+		);
+		expect(wrapper.find(TestConsumer).prop('filteredColumns')).toBeUndefined();
+
+		const filteredColumns = ['name'];
+
+		// when
+		act(() => {
+			const setFilteredColumns = wrapper.find(TestConsumer).prop('setFilteredColumns');
+			setFilteredColumns(filteredColumns);
+		});
+		wrapper.update();
+
+		// then
+		expect(wrapper.find(TestConsumer).prop('filteredColumns')).toBe(filteredColumns);
+	});
+
 	it('should propagate sort', () => {
 		// given
 		const wrapper = mount(

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -9,7 +9,7 @@ function defaultFilterFunction(value, textFilter) {
 		.includes(textFilter);
 }
 
-export function filter(collection, textFilter, filterFunctions) {
+export function filter(collection, textFilter, filterFunctions, filteredColumns) {
 	if (!textFilter) {
 		return collection;
 	}
@@ -17,25 +17,33 @@ export function filter(collection, textFilter, filterFunctions) {
 	const lowerTextFilter = textFilter.toLowerCase();
 	return collection.filter(item =>
 		Object.entries(item).find(([key, value]) => {
+			if (filteredColumns && Array.isArray(filteredColumns) && !filteredColumns.includes(key)) {
+				return false;
+			}
 			const filterFunction = filterFunctions[key] || defaultFilterFunction;
 			return filterFunction(value, lowerTextFilter);
 		}),
 	);
 }
 
-export const filterCollection = (textFilter, filterFunctions = {}) => (collection = []) =>
-	useMemo(() => filter(collection, textFilter, filterFunctions), [
+export const filterCollection = (textFilter, filterFunctions = {}, filteredColumns) => (
+	collection = [],
+) =>
+	useMemo(() => filter(collection, textFilter, filterFunctions, filteredColumns), [
 		collection,
 		textFilter,
 		filterFunctions,
 	]);
 
-export const useCollectionFilter = (collection = [], initialTextFilter, filterFunctions = {}) => {
+export const useCollectionFilter = (collection = [], initialTextFilter, filterFunctions = {}, initialFilteredColumns) => {
+	const [filteredColumns, setFilteredColumns] = useState(initialFilteredColumns);
 	const [textFilter, setTextFilter] = useState(initialTextFilter);
 
 	return {
-		filteredCollection: filterCollection(textFilter, filterFunctions)(collection),
+		filteredCollection: filterCollection(textFilter, filterFunctions, filteredColumns)(collection),
+		filteredColumns,
 		textFilter,
+		setFilteredColumns,
 		setTextFilter,
 	};
 };

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -44,9 +44,12 @@ export function filter(collection, textFilter, filterFunctions, visibleColumns, 
 	);
 }
 
-export const filterCollection = (textFilter, filterFunctions = {}, visibleColumns, filteredColumns) => (
-	collection = [],
-) =>
+export const filterCollection = (
+	textFilter,
+	filterFunctions = {},
+	visibleColumns,
+	filteredColumns,
+) => (collection = []) =>
 	useCallback(filter(collection, textFilter, filterFunctions, visibleColumns, filteredColumns), [
 		collection,
 		textFilter,
@@ -60,13 +63,18 @@ export const useCollectionFilter = (
 	initialTextFilter,
 	filterFunctions = {},
 	initialVisibleColumns,
-	initialFilteredColumns
+	initialFilteredColumns,
 ) => {
 	const [filteredColumns, setFilteredColumns] = useState(initialFilteredColumns);
 	const [textFilter, setTextFilter] = useState(initialTextFilter);
 
 	return {
-		filteredCollection: filterCollection(textFilter, filterFunctions, initialVisibleColumns, filteredColumns)(collection),
+		filteredCollection: filterCollection(
+			textFilter,
+			filterFunctions,
+			initialVisibleColumns,
+			filteredColumns,
+		)(collection),
 		filteredColumns,
 		textFilter,
 		setFilteredColumns,

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -29,18 +29,18 @@ export function filter(collection, textFilter, filterFunctions, visibleColumns, 
 
 	const normalizedTextFilter = normalizeInput(textFilter);
 	return collection.filter(item =>
-		Object.entries(item).find(([key, value]) => {
-			if (
-				(visibleColumns && Array.isArray(visibleColumns) && !visibleColumns.includes(key)) ||
-				(filteredColumns && Array.isArray(filteredColumns) && !filteredColumns.includes(key))
-			) {
-				return false;
-			}
-			if (filterFunctions[key]) {
-				return filterFunctions[key](value, textFilter);
-			}
-			return defaultFilterFunction(value, normalizedTextFilter);
-		}),
+		Object.entries(item)
+			.filter(([key]) => {
+				if (visibleColumns && Array.isArray(visibleColumns)) return visibleColumns.includes(key);
+				if (filteredColumns && Array.isArray(filteredColumns)) return filteredColumns.includes(key);
+				return true;
+			})
+			.find(([key, value]) => {
+				if (filterFunctions[key]) {
+					return filterFunctions[key](value, textFilter);
+				}
+				return defaultFilterFunction(value, normalizedTextFilter);
+			}),
 	);
 }
 

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.js
@@ -3,10 +3,7 @@ import isNil from 'lodash/isNil';
 
 function defaultFilterFunction(value, textFilter) {
 	const filteredValue = isNil(value) ? '' : value;
-	return filteredValue
-		.toString()
-		.toLowerCase()
-		.includes(textFilter);
+	return filteredValue.toString().toLowerCase().includes(textFilter);
 }
 
 export function filter(collection, textFilter, filterFunctions, filteredColumns) {
@@ -35,7 +32,12 @@ export const filterCollection = (textFilter, filterFunctions = {}, filteredColum
 		filterFunctions,
 	]);
 
-export const useCollectionFilter = (collection = [], initialTextFilter, filterFunctions = {}, initialFilteredColumns) => {
+export const useCollectionFilter = (
+	collection = [],
+	initialTextFilter,
+	filterFunctions = {},
+	initialFilteredColumns,
+) => {
 	const [filteredColumns, setFilteredColumns] = useState(initialFilteredColumns);
 	const [textFilter, setTextFilter] = useState(initialTextFilter);
 

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
@@ -5,8 +5,13 @@ import { mount } from 'enzyme';
 import { useCollectionFilter } from './useCollectionFilter.hook';
 
 const Div = () => <div />;
-function FilterComponent({ collection, initialTextFilter, initialVisibleColumns, filterFunctions,
-							 initialFilteredColumns }) {
+function FilterComponent({
+	collection,
+	initialTextFilter,
+	filterFunctions,
+	initialVisibleColumns,
+	initialFilteredColumns,
+}) {
 	const hookReturn = useCollectionFilter(
 		collection,
 		initialTextFilter,

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionFilter.hook.test.js
@@ -5,14 +5,25 @@ import { mount } from 'enzyme';
 import { useCollectionFilter } from './useCollectionFilter.hook';
 
 const Div = () => <div />;
-function FilterComponent({ collection, initialTextFilter, filterFunctions }) {
-	const hookReturn = useCollectionFilter(collection, initialTextFilter, filterFunctions);
+function FilterComponent({
+	collection,
+	initialTextFilter,
+	filterFunctions,
+	initialFilteredColumns,
+}) {
+	const hookReturn = useCollectionFilter(
+		collection,
+		initialTextFilter,
+		filterFunctions,
+		initialFilteredColumns,
+	);
 	return <Div id="mainChild" {...hookReturn} />;
 }
 FilterComponent.propTypes = {
 	collection: PropTypes.array,
 	initialTextFilter: PropTypes.string,
 	filterFunctions: PropTypes.object,
+	initialFilteredColumns: PropTypes.arrayOf(PropTypes.string),
 };
 
 const collection = [
@@ -89,6 +100,27 @@ describe('useCollectionFilter', () => {
 		expect(filteredCollection[0].firstName).toEqual('Madden');
 		expect(filteredCollection[1].firstName).toEqual('Ferrell');
 		expect(filteredCollection[2].firstName).toEqual('Carly');
+	});
+
+	it('should filter with limited column list', () => {
+		// given
+		const wrapper = mount(
+			<FilterComponent collection={collection} initialFilteredColumns={['lastName']} />,
+		);
+
+		let filteredCollection = wrapper.find('#mainChild').prop('filteredCollection');
+		expect(filteredCollection).toBe(collection);
+
+		// when
+		act(() => {
+			wrapper.find('#mainChild').prop('setTextFilter')('l');
+		});
+		wrapper.update();
+
+		// then
+		filteredCollection = wrapper.find('#mainChild').prop('filteredCollection');
+		expect(filteredCollection).toHaveLength(1);
+		expect(filteredCollection[0].lastName).toEqual('Silva');
 	});
 
 	it('should filter with custom filter function', () => {

--- a/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
+++ b/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
@@ -4,9 +4,13 @@ import { useListContext } from '../context';
 import FilterBar from '../../../FilterBar';
 
 function TextFilter(props) {
-	const { docked, initialDocked, onChange, onToggle, value, ...restProps } = props;
-	const { textFilter, setTextFilter } = useListContext();
+	const { docked, applyOn, initialDocked, onChange, onToggle, value, ...restProps } = props;
+	const { textFilter, setTextFilter, setFilteredColumns } = useListContext();
 	const [dockedState, setDocked] = useState(initialDocked);
+
+	React.useEffect(() => {
+		setFilteredColumns(applyOn);
+	}, [applyOn]);
 
 	const isToggleControlled = onToggle;
 	const isFilterControlled = onChange;
@@ -40,6 +44,7 @@ if (process.env.NODE_ENV !== 'production') {
 	TextFilter.propTypes = {
 		docked: PropTypes.bool,
 		initialDocked: PropTypes.bool,
+		applyOn: PropTypes.arrayOf(PropTypes.string),
 		onChange: PropTypes.func,
 		onToggle: PropTypes.func,
 		value: PropTypes.string,

--- a/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
+++ b/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.js
@@ -10,7 +10,7 @@ function TextFilter(props) {
 
 	React.useEffect(() => {
 		setFilteredColumns(applyOn);
-	}, [applyOn]);
+	}, [applyOn, setFilteredColumns]);
 
 	const isToggleControlled = onToggle;
 	const isFilterControlled = onChange;

--- a/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
+++ b/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
@@ -9,12 +9,16 @@ import { ListContext } from '../context';
 import getDefaultT from '../../../translate';
 
 describe('TextFilter', () => {
-	const defaultContext = {
-		textFilter: '',
-		setTextFilter: jest.fn(),
-		setFilteredColumns: jest.fn(),
-		t: getDefaultT(),
-	};
+	let defaultContext;
+
+	beforeEach(() => {
+		defaultContext = {
+			textFilter: '',
+			setTextFilter: jest.fn(),
+			setFilteredColumns: jest.fn(),
+			t: getDefaultT(),
+		};
+	});
 
 	it('should render text filter component', () => {
 		// when

--- a/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
+++ b/packages/components/src/List/ListComposition/TextFilter/TextFilter.component.test.js
@@ -12,6 +12,7 @@ describe('TextFilter', () => {
 	const defaultContext = {
 		textFilter: '',
 		setTextFilter: jest.fn(),
+		setFilteredColumns: jest.fn(),
 		t: getDefaultT(),
 	};
 
@@ -64,6 +65,18 @@ describe('TextFilter', () => {
 
 		// then
 		expect(context.setTextFilter).toHaveBeenCalledWith('my-filter-value');
+	});
+
+	it('should deal with columns on which apply filter', () => {
+		// when
+		mount(
+			<ListContext.Provider value={defaultContext}>
+				<TextFilter id="myTextFilter" applyOn={['foo']} />
+			</ListContext.Provider>,
+		);
+
+		// then
+		expect(defaultContext.setFilteredColumns).toHaveBeenCalledWith(['foo']);
 	});
 
 	it('should call the toggle callback when they are provided (controlled mode)', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
By default, we perform a filter on each property of the resource we're currently listing

**What is the chosen solution to this problem?**
Be able to precise on which columns we accept to filter using `<TextFilter applyOn={[ 'some', 'columns', 'keys' ]} />`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->

https://jira.talendforge.org/browse/TCCUI-201