### PR TITLE
fix(containers): import in storybook initialisation

### DIFF
--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -21,12 +21,14 @@ import { actionsCreators as actionsCreatorsEditableText } from './editabletext.s
 import { registerAllContainers } from '../src/register';
 
 const languages = {};
-Object.keys(tuiLocales).forEach(key => languages[key] = key);
+Object.keys(tuiLocales).forEach(key => (languages[key] = key));
 
-addDecorator(withI18next({
-	i18n,
-	languages,
-}));
+addDecorator(
+	withI18next({
+		i18n,
+		languages,
+	}),
+);
 addDecorator(withCMF);
 addDecorator(withA11y);
 
@@ -198,7 +200,7 @@ api.expression.register('modelHasLabel', context => {
 
 function loadStories() {
 	Object.keys(examples).forEach(example => {
-		const state = mock.state();
+		const state = mock.store.state();
 		state.routing = {
 			locationBeforeTransitions: {
 				pathname: '/storybook',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Containers storybook is ko because of a wrong use of mock import from cmf.

**What is the chosen solution to this problem?**
Fix the mock usage.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
