### PR TITLE
feat(components/ListComposition): ColumnChooser

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -162,6 +162,9 @@
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
+/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/VList/VList.component.js
+  25:5  warning  React Hook React.useEffect has missing dependencies: 'children' and 'setColumns'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
+
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
   58:36  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '../../VirtualizedList'` instead  import/no-named-as-default-member
@@ -390,5 +393,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 209 problems (189 errors, 20 warnings)
+✖ 210 problems (189 errors, 21 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -162,9 +162,6 @@
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition/VList/VList.component.js
-  25:5  warning  React Hook React.useEffect has missing dependencies: 'children' and 'setColumns'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
-
 /home/travis/build/Talend/ui/packages/components/src/List/ListToVirtualizedList/ListToVirtualizedList.component.js
   57:34  error  Caution: `VirtualizedList` also has a named export `cellDictionary`. Check if you meant to write `import {cellDictionary} from '../../VirtualizedList'` instead      import/no-named-as-default-member
   58:36  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '../../VirtualizedList'` instead  import/no-named-as-default-member
@@ -393,5 +390,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 210 problems (189 errors, 21 warnings)
+✖ 209 problems (189 errors, 20 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -240,9 +240,10 @@ storiesOf('Data/List/List Composition', module)
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<p>
-				Note that here we manually restrict the filter scope to column with dataKeys equal to{' '}
-				<code>name</code> and <code>description</code>, but it's optional!
+				You can manually restrict the filter scope to specific columns, by passing the dataKey, here it equals to{' '}
+				<code>name</code> and <code>description</code>, but it's optional.
 			</p>
+			<p>Note that the Column Chooser will impact the results, we can filter only on what we see!</p>
 			<pre>
 				{`<List.Manager
  	id="my-list"
@@ -251,6 +252,7 @@ storiesOf('Data/List/List Composition', module)
 	<List.Toolbar>
 		<List.Toolbar.Right>
 			<List.TextFilter id="my-list-textFilter" applyOn={['name', 'description']} />
+			<List.ColumnChooser />
 		</List.Toolbar.Right>
 	</List.Toolbar>
 	<List.VList id="my-vlist" type="TABLE">
@@ -260,10 +262,15 @@ storiesOf('Data/List/List Composition', module)
 `}
 			</pre>
 			<section style={{ height: '50vh' }}>
-				<List.Manager id="my-list" collection={simpleCollection}>
+				<List.Manager
+					id="my-list"
+					collection={simpleCollection}
+					initialVisibleColumns={['id', 'name']}
+				>
 					<List.Toolbar>
 						<List.Toolbar.Right>
 							<List.TextFilter id="my-list-textFilter" applyOn={['name', 'description']} />
+							<List.ColumnChooser />
 						</List.Toolbar.Right>
 					</List.Toolbar>
 					<CustomList type="TABLE" />
@@ -347,10 +354,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -391,10 +395,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 							<List.DisplayMode id="my-list-displayMode" initialDisplayMode="large" />
 						</List.Toolbar.Right>
@@ -435,10 +436,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'name', label: 'Name' },
-									{ key: 'id', label: 'Id' },
-								]}
+								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
 								value={{ sortBy: 'name', isDescending: false }}
 								onChange={action('onSortChange')}
 							/>
@@ -508,10 +506,7 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'id', label: 'Id' },
-									{ key: 'name', label: 'Name' },
-								]}
+								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -562,10 +557,7 @@ storiesOf('Data/List/List Composition', module)
 							<List.TextFilter id="my-list-textFilter" />
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[
-									{ key: 'name', label: 'Name' },
-									{ key: 'id', label: 'Id' },
-								]}
+								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
 								initialValue={{ sortBy: 'id', isDescending: true }}
 							/>
 							<List.DisplayMode id="my-list-displayMode" />

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -240,10 +240,12 @@ storiesOf('Data/List/List Composition', module)
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<p>
-				You can manually restrict the filter scope to specific columns, by passing the dataKey, here it equals to{' '}
-				<code>name</code> and <code>description</code>, but it's optional.
+				You can manually restrict the filter scope to specific columns, by passing the dataKey, here
+				it equals to <code>name</code> and <code>description</code>, but it's optional.
 			</p>
-			<p>Note that the Column Chooser will impact the results, we can filter only on what we see!</p>
+			<p>
+				Note that the Column Chooser will impact the results, we can filter only on what we see!
+			</p>
 			<pre>
 				{`<List.Manager
  	id="my-list"
@@ -354,7 +356,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -395,7 +400,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 							<List.DisplayMode id="my-list-displayMode" initialDisplayMode="large" />
 						</List.Toolbar.Right>
@@ -436,7 +444,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
+								options={[
+									{ key: 'name', label: 'Name' },
+									{ key: 'id', label: 'Id' },
+								]}
 								value={{ sortBy: 'name', isDescending: false }}
 								onChange={action('onSortChange')}
 							/>
@@ -506,7 +517,10 @@ storiesOf('Data/List/List Composition', module)
 						<List.Toolbar.Right>
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'id', label: 'Id' }, { key: 'name', label: 'Name' }]}
+								options={[
+									{ key: 'id', label: 'Id' },
+									{ key: 'name', label: 'Name' },
+								]}
 							/>
 						</List.Toolbar.Right>
 					</List.Toolbar>
@@ -557,7 +571,10 @@ storiesOf('Data/List/List Composition', module)
 							<List.TextFilter id="my-list-textFilter" />
 							<List.SortBy
 								id="my-list-sortBy"
-								options={[{ key: 'name', label: 'Name' }, { key: 'id', label: 'Id' }]}
+								options={[
+									{ key: 'name', label: 'Name' },
+									{ key: 'id', label: 'Id' },
+								]}
 								initialValue={{ sortBy: 'id', isDescending: true }}
 							/>
 							<List.DisplayMode id="my-list-displayMode" />

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -4,7 +4,7 @@ import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
 function ColumnChooser(props) {
-	const { columns = [], visibleColumns, setVisibleColumns } = useListContext();
+	const { columns, visibleColumns, setVisibleColumns } = useListContext();
 
 	return (
 		<ColumnChooserButton

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -4,22 +4,22 @@ import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
 function ColumnChooser(props) {
-    const { columns = [], visibleColumns, setVisibleColumns } = useListContext();
+	const { columns = [], visibleColumns, setVisibleColumns } = useListContext();
 
-    return (
-        <ColumnChooserButton
-            columns={columns.map(({ dataKey, label }, i) => ({
-                key: dataKey,
-                label,
-                hidden: !visibleColumns?.includes(dataKey),
-                order: i + 1,
-            }))}
-            onSubmit={(_, changes) => {
-                setVisibleColumns(changes.filter(c => !c.hidden).map(c => c.key));
-            }}
-            {...props}
-        />
-    );
+	return (
+		<ColumnChooserButton
+			columns={columns.map(({ dataKey, label }, i) => ({
+				key: dataKey,
+				label,
+				hidden: !visibleColumns?.includes(dataKey),
+				order: i + 1,
+			}))}
+			onSubmit={(_, changes) => {
+				setVisibleColumns(changes.filter(c => !c.hidden).map(c => c.key));
+			}}
+			{...props}
+		/>
+	);
 }
 
 export default ColumnChooser;

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { useListContext } from '../context';
+import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
+
+function ColumnChooser(props) {
+    const { columns = [], visibleColumns, setVisibleColumns } = useListContext();
+
+    return (
+        <ColumnChooserButton
+            columns={columns.map(({ dataKey, label }, i) => ({
+                key: dataKey,
+                label,
+                hidden: !visibleColumns?.includes(dataKey),
+                order: i + 1,
+            }))}
+            onSubmit={(_, changes) => {
+                setVisibleColumns(changes.filter(c => !c.hidden).map(c => c.key));
+            }}
+            {...props}
+        />
+    );
+}
+
+export default ColumnChooser;

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
@@ -12,7 +12,10 @@ describe('ColumnChooser', () => {
 
 	beforeEach(() => {
 		defaultContext = {
-			columns: [{ dataKey: 'foo', label: 'Foo' }, { dataKey: 'bar', label: 'Bar' }],
+			columns: [
+				{ dataKey: 'foo', label: 'Foo' },
+				{ dataKey: 'bar', label: 'Bar' },
+			],
 			setVisibleColumns: jest.fn(),
 			t: getDefaultT(),
 		};
@@ -40,7 +43,10 @@ describe('ColumnChooser', () => {
 		const onSubmit = wrapper.find(ColumnChooserButton).prop('onSubmit');
 
 		// when
-		onSubmit(null, [{ key: 'foo', hidden: true }, { key: 'bar', hidden: false }]);
+		onSubmit(null, [
+			{ key: 'foo', hidden: true },
+			{ key: 'bar', hidden: false },
+		]);
 
 		// then
 		expect(defaultContext.setVisibleColumns).toBeCalledWith(['bar']);

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
@@ -1,0 +1,48 @@
+/* eslint-disable react/prop-types */
+import React from 'react';
+import { mount } from 'enzyme';
+
+import ColumnChooser from '.';
+import { ListContext } from '../context';
+import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
+import getDefaultT from '../../../translate';
+
+describe('ColumnChooser', () => {
+	let defaultContext;
+
+	beforeEach(() => {
+		defaultContext = {
+			columns: [{ dataKey: 'foo', label: 'Foo' }, { dataKey: 'bar', label: 'Bar' }],
+			setVisibleColumns: jest.fn(),
+			t: getDefaultT(),
+		};
+	});
+
+	it('should render column chooser component', () => {
+		// when
+		const wrapper = mount(
+			<ListContext.Provider value={defaultContext}>
+				<ColumnChooser id="myColumnChooser" />
+			</ListContext.Provider>,
+		);
+
+		// then
+		expect(wrapper.find(ColumnChooserButton)).toBeDefined();
+	});
+
+	it('should update columns', () => {
+		// given
+		const wrapper = mount(
+			<ListContext.Provider value={defaultContext}>
+				<ColumnChooser id="myColumnChooser" />
+			</ListContext.Provider>,
+		);
+		const onSubmit = wrapper.find(ColumnChooserButton).prop('onSubmit');
+
+		// when
+		onSubmit(null, [{ key: 'foo', hidden: true }, { key: 'bar', hidden: false }]);
+
+		// then
+		expect(defaultContext.setVisibleColumns).toBeCalledWith(['bar']);
+	});
+});

--- a/packages/components/src/List/ListComposition/ColumnChooser/index.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/index.js
@@ -1,0 +1,3 @@
+import ColumnChooser from './ColumnChooser.component';
+
+export default ColumnChooser;

--- a/packages/components/src/List/ListComposition/LazyLoadingList/LazyLoadingList.component.test.js
+++ b/packages/components/src/List/ListComposition/LazyLoadingList/LazyLoadingList.component.test.js
@@ -7,7 +7,7 @@ import LazyLoadingList from './LazyLoadingList.component';
 import { ListContext } from '../context';
 
 describe('LazyLoadingList', () => {
-	const defaultContext = { collection: [] };
+	const defaultContext = { collection: [], setColumns: jest.fn() };
 
 	it('should render lazy loading list component', () => {
 		// when

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -20,6 +20,7 @@ function Manager({
 	let collection = rest.collection;
 
 	const [displayMode, setDisplayMode] = useState(initialDisplayMode || displayModesOptions[0]);
+	const [columns, setColumns] = useState();
 	const [visibleColumns, setVisibleColumns] = useState(initialVisibleColumns);
 
 	// Sort items
@@ -42,11 +43,13 @@ function Manager({
 	const contextValues = {
 		collection,
 		displayMode,
+		columns,
 		visibleColumns,
 		filteredColumns,
 		setDisplayMode,
 		setSortParams,
 		setTextFilter,
+		setColumns,
 		setVisibleColumns,
 		setFilteredColumns,
 		sortParams,

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.js
@@ -20,7 +20,7 @@ function Manager({
 	let collection = rest.collection;
 
 	const [displayMode, setDisplayMode] = useState(initialDisplayMode || displayModesOptions[0]);
-	const [columns, setColumns] = useState();
+	const [columns, setColumns] = useState([]);
 	const [visibleColumns, setVisibleColumns] = useState(initialVisibleColumns);
 
 	// Sort items

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
@@ -96,6 +96,33 @@ describe('List Manager', () => {
 		expect(wrapper.find(TestConsumer).prop('collection')).toEqual([{ id: 0, name: 'toto' }]);
 	});
 
+	it('should propagate column list', () => {
+		// given
+		const wrapper = mount(
+			<ListManager
+				collection={[
+					{ dataKey: 'id', label: 'ID' },
+					{ dataKey: 'name', label: 'Name' },
+				]}
+			>
+				<ContextTestConsumer />
+			</ListManager>,
+		);
+		expect(wrapper.find(TestConsumer).prop('columns')).toBeUndefined();
+
+		const columns = ['id', 'name'];
+
+		// when
+		act(() => {
+			const setColumns = wrapper.find(TestConsumer).prop('setColumns');
+			setColumns(columns);
+		});
+		wrapper.update();
+
+		// then
+		expect(wrapper.find(TestConsumer).prop('columns')).toBe(columns);
+	});
+
 	it('should propagate filtered column list', () => {
 		// given
 		const wrapper = mount(

--- a/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
+++ b/packages/components/src/List/ListComposition/Manager/ListManager.component.test.js
@@ -108,7 +108,7 @@ describe('List Manager', () => {
 				<ContextTestConsumer />
 			</ListManager>,
 		);
-		expect(wrapper.find(TestConsumer).prop('columns')).toBeUndefined();
+		expect(wrapper.find(TestConsumer).prop('columns')).toEqual([]);
 
 		const columns = ['id', 'name'];
 
@@ -120,7 +120,7 @@ describe('List Manager', () => {
 		wrapper.update();
 
 		// then
-		expect(wrapper.find(TestConsumer).prop('columns')).toBe(columns);
+		expect(wrapper.find(TestConsumer).prop('columns')).toEqual(columns);
 	});
 
 	it('should propagate filtered column list', () => {

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -20,9 +20,7 @@ function VList({ children, ...rest }) {
 
 	React.useEffect(() => {
 		if (Array.isArray(children)) {
-			setColumns([
-				...new Set(children.filter(column => column.props?.dataKey).map(column => column.props)),
-			]);
+			setColumns(children.filter(column => column.props?.dataKey).map(column => column.props));
 		}
 	}, [children, setColumns]);
 

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -22,7 +22,7 @@ function VList({ children, ...rest }) {
 		if (Array.isArray(children)) {
 			setColumns(children.filter(column => column.props?.dataKey).map(column => column.props));
 		}
-	}, []);
+	});
 
 	return (
 		<div className={theme.vlist}>

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import get from 'lodash/get';
 
 import { useListContext } from '../context';
@@ -7,13 +8,22 @@ import { DISPLAY_MODE, SORT } from '../constants';
 
 import theme from '../List.scss';
 
-function VList(props) {
+function VList({ children, ...rest }) {
 	const {
 		displayMode = DISPLAY_MODE.TABLE,
 		collection,
+		visibleColumns,
 		setSortParams,
 		sortParams,
+		setColumns,
 	} = useListContext();
+
+	React.useEffect(() => {
+		if (Array.isArray(children)) {
+			setColumns(children.filter(column => column.props?.dataKey).map(column => column.props));
+		}
+	}, []);
+
 	return (
 		<div className={theme.vlist}>
 			<VirtualizedList
@@ -24,11 +34,19 @@ function VList(props) {
 				sort={({ sortBy, sortDirection }) =>
 					setSortParams({ sortBy, isDescending: sortDirection === SORT.DESC })
 				}
-				{...props}
-			/>
+				{...rest}
+			>
+				{visibleColumns
+					? children.filter(column => visibleColumns?.includes(column.props?.dataKey))
+					: children}
+			</VirtualizedList>
 		</div>
 	);
 }
+
+VList.propTypes = {
+	children: PropTypes.arrayOf(PropTypes.node),
+};
 
 // we port the VirtualizedList columns to VList to allow VList.Title/Badge/...
 Object.entries(VirtualizedList).forEach(([key, value]) => {

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -20,7 +20,9 @@ function VList({ children, ...rest }) {
 
 	React.useEffect(() => {
 		if (Array.isArray(children)) {
-			setColumns(children.filter(column => column.props?.dataKey).map(column => column.props));
+			setColumns([
+				...new Set(children.filter(column => column.props?.dataKey).map(column => column.props)),
+			]);
 		}
 	}, [children, setColumns]);
 

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -22,7 +22,7 @@ function VList({ children, ...rest }) {
 		if (Array.isArray(children)) {
 			setColumns(children.filter(column => column.props?.dataKey).map(column => column.props));
 		}
-	});
+	}, [children, setColumns]);
 
 	return (
 		<div className={theme.vlist}>

--- a/packages/components/src/List/ListComposition/VList/VList.component.test.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.test.js
@@ -8,7 +8,7 @@ import { ListContext } from '../context';
 describe('List VList', () => {
 	it('should pass collection', () => {
 		// given
-		const contextValue = { collection: [{ id: 0 }, { id: 1 }] };
+		const contextValue = { collection: [{ id: 0 }, { id: 1 }], setColumns: jest.fn()  };
 
 		// when
 		const wrapper = mount(
@@ -23,7 +23,7 @@ describe('List VList', () => {
 
 	it('should pass displayMode from context in uncontrolled mode', () => {
 		// given
-		const contextValue = { displayMode: 'large', collection: [] };
+		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn()  };
 
 		// when
 		const wrapper = mount(
@@ -38,7 +38,7 @@ describe('List VList', () => {
 
 	it('should pass displayMode from props in controlled mode', () => {
 		// given
-		const contextValue = { displayMode: 'large', collection: [] };
+		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn()  };
 
 		// when
 		const wrapper = mount(

--- a/packages/components/src/List/ListComposition/VList/VList.component.test.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.test.js
@@ -8,7 +8,7 @@ import { ListContext } from '../context';
 describe('List VList', () => {
 	it('should pass collection', () => {
 		// given
-		const contextValue = { collection: [{ id: 0 }, { id: 1 }], setColumns: jest.fn()  };
+		const contextValue = { collection: [{ id: 0 }, { id: 1 }], setColumns: jest.fn() };
 
 		// when
 		const wrapper = mount(
@@ -23,7 +23,7 @@ describe('List VList', () => {
 
 	it('should pass displayMode from context in uncontrolled mode', () => {
 		// given
-		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn()  };
+		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn() };
 
 		// when
 		const wrapper = mount(
@@ -38,7 +38,7 @@ describe('List VList', () => {
 
 	it('should pass displayMode from props in controlled mode', () => {
 		// given
-		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn()  };
+		const contextValue = { displayMode: 'large', collection: [], setColumns: jest.fn() };
 
 		// when
 		const wrapper = mount(

--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -1,5 +1,6 @@
 import useLocalStorage from 'react-use/lib/useLocalStorage';
 import DisplayMode from './DisplayMode';
+import ColumnChooser from './ColumnChooser';
 import ItemsNumber from './ItemsNumber';
 import LazyLoadingList from './LazyLoadingList';
 import Manager from './Manager';
@@ -20,6 +21,7 @@ export default {
 	Manager,
 	SortBy,
 	TextFilter,
+	ColumnChooser,
 	Toolbar,
 	VList,
 };

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserTable/ColumnChooserTable.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserTable/ColumnChooserTable.component.js
@@ -5,10 +5,10 @@ import { columnsPropTypes } from '../../columnChooser.propTypes';
 
 const ColumnChooserTable = ({ columns = [], id, onChangeCheckbox, t }) =>
 	columns.map(column => (
-		<ColumnChooserRow key={column.label}>
+		<ColumnChooserRow key={column.key}>
 			<ColumnChooserRow.Checkbox
 				checked={column.visible}
-				id={id}
+				id={id || column.key}
 				dataFeature="column-chooser.select"
 				description={t('CHECKBOX_DISPLAY_COLUMN_DESCRIPTION', {
 					defaultValue: 'display the column {{label}}',

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserTable/ColumnChooserTable.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserTable/ColumnChooserTable.component.js
@@ -8,7 +8,7 @@ const ColumnChooserTable = ({ columns = [], id, onChangeCheckbox, t }) =>
 		<ColumnChooserRow key={column.key}>
 			<ColumnChooserRow.Checkbox
 				checked={column.visible}
-				id={id || column.key}
+				id={id}
 				dataFeature="column-chooser.select"
 				description={t('CHECKBOX_DISPLAY_COLUMN_DESCRIPTION', {
 					defaultValue: 'display the column {{label}}',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Try to implement ColumnChooser in a list can be a _pain in the ass_

**What is the chosen solution to this problem?**
Be able to simply use `<List.ColumnChooser />` in the toolbar to get it for free

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
