### PR TITLE
chore: expose List constants and SelectAll

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -24,5 +24,8 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-✖ 9 problems (9 errors, 0 warnings)
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/index.js
+  10:37  error  defaultTitle not found in '../fieldsets/CollapsibleFieldset'  import/named
+
+✖ 10 problems (10 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -8,7 +8,7 @@ import SortBy from './SortBy';
 import TextFilter from './TextFilter';
 import Toolbar from './Toolbar';
 import VList from './VList';
-import SelectAll from '../Toolbar/SelectAll'
+import SelectAll from '../Toolbar/SelectAll';
 import { sortCollection, useCollectionSort } from './Manager/hooks/useCollectionSort.hook';
 import { filterCollection, useCollectionFilter } from './Manager/hooks/useCollectionFilter.hook';
 import useCollectionSelection from './Manager/hooks/useCollectionSelection.hook';

--- a/packages/components/src/List/ListComposition/index.js
+++ b/packages/components/src/List/ListComposition/index.js
@@ -8,20 +8,24 @@ import SortBy from './SortBy';
 import TextFilter from './TextFilter';
 import Toolbar from './Toolbar';
 import VList from './VList';
+import SelectAll from '../Toolbar/SelectAll'
 import { sortCollection, useCollectionSort } from './Manager/hooks/useCollectionSort.hook';
 import { filterCollection, useCollectionFilter } from './Manager/hooks/useCollectionFilter.hook';
 import useCollectionSelection from './Manager/hooks/useCollectionSelection.hook';
 import useCollectionActions from './Manager/hooks/useCollectionActions.hook';
+import * as constants from './constants';
 
 export default {
+	constants,
+	ColumnChooser,
 	DisplayMode,
 	ItemsNumber,
 	LazyLoadingList,
 	InfiniteScrollList: LazyLoadingList,
 	Manager,
+	SelectAll,
 	SortBy,
 	TextFilter,
-	ColumnChooser,
 	Toolbar,
 	VList,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
List constants are not exposed.

**What is the chosen solution to this problem?**
Expose them

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
