### PR TITLE
feat(components/ColumnChooser): call props.onSubmit if exist

### DIFF
--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -272,7 +272,7 @@ storiesOf('Data/List/List Composition', module)
 					<List.Toolbar>
 						<List.Toolbar.Right>
 							<List.TextFilter id="my-list-textFilter" applyOn={['name', 'description']} />
-							<List.ColumnChooser />
+							<List.ColumnChooser onSubmit={action('onSubmit')} />
 						</List.Toolbar.Right>
 					</List.Toolbar>
 					<CustomList type="TABLE" />

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -1,5 +1,5 @@
 import React from 'react';
-
+import PropTypes from 'prop-types';
 import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
@@ -16,10 +16,17 @@ function ColumnChooser(props) {
 			}))}
 			onSubmit={(_, changes) => {
 				setVisibleColumns(changes.filter(c => !c.hidden).map(c => c.key));
+				if (props.onSubmit) {
+					props.onSubmit(_, changes);
+				}
 			}}
 			{...props}
 		/>
 	);
 }
+
+ColumnChooser.propTypes = {
+	onSubmit: PropTypes.func,
+};
 
 export default ColumnChooser;

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.test.js
@@ -51,4 +51,21 @@ describe('ColumnChooser', () => {
 		// then
 		expect(defaultContext.setVisibleColumns).toBeCalledWith(['bar']);
 	});
+
+	it('should call props.onSubmit if exist', () => {
+		const onSubmit = jest.fn();
+		const wrapper = mount(
+			<ListContext.Provider value={defaultContext}>
+				<ColumnChooser id="myColumnChooser" onSubmit={onSubmit} />
+			</ListContext.Provider>,
+		);
+		const internalOnSubmit = wrapper.find(ColumnChooserButton).prop('onSubmit');
+
+		internalOnSubmit(null, [
+			{ key: 'foo', hidden: true },
+			{ key: 'bar', hidden: false },
+		]);
+
+		expect(onSubmit).toHaveBeenCalled();
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In TMC, we used local storage to keep a record of visible columns, so user don't have to choose columns every time. we would like to have a callback when user submit column changes.
**What is the chosen solution to this problem?**
Call props.onSubmit if exist.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
