### PR TITLE
chore(Forms): expose fields in uiForm export

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -24,8 +24,14 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/index.js
+   4:8   error  'Fields' is defined but never used           @typescript-eslint/no-unused-vars
+   4:20  error  Missing file extension for "./fields"        import/extensions
+   4:20  error  Unable to resolve path to module './fields'  import/no-unresolved
+  11:2   error  'Fieldset' is not defined                    no-undef
+
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/index.js
   10:37  error  defaultTitle not found in '../fieldsets/CollapsibleFieldset'  import/named
 
-✖ 10 problems (10 errors, 0 warnings)
+✖ 14 problems (14 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/forms/src/UIForm/fieldsets/index.js
+++ b/packages/forms/src/UIForm/fieldsets/index.js
@@ -1,7 +1,7 @@
 import Array from './Array';
 import CollapsibleFieldset from './CollapsibleFieldset';
 import Columns from './Columns';
-import Fieldset from './Fieldset';
+import Fields from './fields';
 import Tabs from './Tabs';
 
 export default {

--- a/packages/forms/src/UIForm/index.js
+++ b/packages/forms/src/UIForm/index.js
@@ -4,7 +4,7 @@ import Message from './Message';
 import callTrigger from './trigger';
 import utils from './utils';
 import Widget from './Widget';
-import Fields from './fieldsets'
+import Fields from './fieldsets';
 
 import customFormats from './customFormats';
 import lang from './lang';

--- a/packages/forms/src/UIForm/index.js
+++ b/packages/forms/src/UIForm/index.js
@@ -4,6 +4,7 @@ import Message from './Message';
 import callTrigger from './trigger';
 import utils from './utils';
 import Widget from './Widget';
+import Fields from './fieldsets'
 
 import customFormats from './customFormats';
 import lang from './lang';
@@ -17,6 +18,7 @@ export { UIForm, triggers };
 
 UIForm.FormTemplate = FormTemplate;
 UIForm.FieldTemplate = FieldTemplate;
+UIForm.Fields = Fields;
 UIForm.Message = Message;
 UIForm.callTrigger = callTrigger;
 UIForm.utils = utils;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UIForm fields are not accessible without deep imports

**What is the chosen solution to this problem?**
expose fields in UIForm

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
