### PR TITLE
fix(datagrid): add missing exports needed for integration

### DIFF
--- a/output/datagrid.eslint.txt
+++ b/output/datagrid.eslint.txt
@@ -1,5 +1,5 @@
 
 /home/travis/build/Talend/ui/packages/datagrid/src/components/DefaultCellRenderer/DefaultValueRenderer.component.js
-  66:4  error  onMouseOver must be accompanied by onFocus for accessibility  jsx-a11y/mouse-events-have-key-events
+  68:4  error  onMouseOver must be accompanied by onFocus for accessibility  jsx-a11y/mouse-events-have-key-events
 
 ✖ 1 problem (1 error, 0 warnings)

--- a/packages/datagrid/src/components/DefaultCellRenderer/DefaultCellRenderer.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/DefaultCellRenderer.component.js
@@ -66,4 +66,6 @@ DefaultCellRenderer.propTypes = {
 	getComponent: PropTypes.func,
 };
 
+DefaultCellRenderer.theme = theme;
+
 export default DefaultCellRenderer;

--- a/packages/datagrid/src/components/DefaultCellRenderer/DefaultValueRenderer.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/DefaultValueRenderer.component.js
@@ -22,6 +22,8 @@ export default class DefaultValueRenderer extends React.Component {
 		value: DEFAULT_VALUE_PROP_TYPES,
 	};
 
+	static theme = theme;
+
 	constructor(props) {
 		super(props);
 

--- a/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/FormatValue.component.js
@@ -166,5 +166,6 @@ export function FormatValueComponent(props) {
 FormatValueComponent.propTypes = {
 	value: PropTypes.string,
 };
+FormatValueComponent.theme = theme;
 
 export default FormatValueComponent;

--- a/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/QualityIndicator.component.js
@@ -30,5 +30,6 @@ function QualityIndicator(props) {
 QualityIndicator.propTypes = {
 	qualityIndex: PropTypes.oneOf([QUALITY_INVALID_KEY, QUALITY_EMPTY_KEY, QUALITY_VALID_KEY]),
 };
+QualityIndicator.theme = theme;
 
 export default QualityIndicator;

--- a/packages/datagrid/src/components/DefaultCellRenderer/index.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/index.js
@@ -1,4 +1,7 @@
 import DefaultCellRenderer, { CELL_RENDERER_COMPONENT } from './DefaultCellRenderer.component';
+import QualityIndicator from './QualityIndicator.component';
+import AvroRenderer from './AvroRenderer.component';
+import theme from './DefaultCell.scss';
 
-export { CELL_RENDERER_COMPONENT };
+export { DefaultCellRenderer, CELL_RENDERER_COMPONENT, QualityIndicator, AvroRenderer, theme };
 export default DefaultCellRenderer;

--- a/packages/datagrid/src/components/index.js
+++ b/packages/datagrid/src/components/index.js
@@ -1,3 +1,6 @@
 import DataGrid from './DataGrid/DataGrid.component';
+import DatasetSerializer from './DatasetSerializer';
+import * as DefaultCellRenderer from './DefaultCellRenderer';
 
+export { DataGrid, DatasetSerializer, DefaultCellRenderer };
 export default DataGrid;

--- a/packages/datagrid/src/index.js
+++ b/packages/datagrid/src/index.js
@@ -2,9 +2,11 @@ import DataGrid from './containers';
 import QualityBar from './components/DefaultHeaderRenderer/QualityBar.component';
 import * as constants from './constants';
 import cmfModule from './cmfModule';
+import * as components from './components';
 
 DataGrid.constants = constants;
 DataGrid.QualityBar = QualityBar;
+DataGrid.components = components;
 DataGrid.cmfModule = cmfModule;
 
 export default DataGrid;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The following exports can t be accessed in project using UMD distribution

```javascript
import DATAGRID_PROPTYPES from '@talend/react-datagrid/lib/components/DataGrid/DataGrid.proptypes';
import AvroRenderer from '@talend/react-datagrid/lib/components/DefaultCellRenderer/AvroRenderer.component';

import theme from '@talend/react-datagrid/lib/components/DefaultCellRenderer/DefaultCell.scss';
```

**What is the chosen solution to this problem?**

add them

```javascript
import Datagrid from '@talend/react-datagrid';

const DATAGRID_PROPTYPES = Datagrid.components.DataGrid.propTypes;
const AvroRenderer = Datagrid.components.DefaultCellRenderer.AvroRenderer;
const theme = Datagrid.components.DefaultCellRenderer.theme;
```

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
