### PR TITLE
fix(containers): use same Forms import

### DIFF
--- a/packages/containers/src/Form/Form.container.js
+++ b/packages/containers/src/Form/Form.container.js
@@ -7,9 +7,7 @@ import classnames from 'classnames';
 
 let DefaultArrayFieldTemplate = () => null;
 if (process.env.FORM_MOZ) {
-	// eslint-disable-next-line global-require
-	DefaultArrayFieldTemplate = require('@talend/react-forms').deprecated.templates
-		.ArrayFieldTemplate;
+	DefaultArrayFieldTemplate = BaseForm.deprecated.templates.ArrayFieldTemplate;
 }
 
 export const DEFAULT_STATE = new Immutable.Map({});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Forms related imports are duplicated if we use `MOZ_FORM`

**What is the chosen solution to this problem?**
Use already in-use import

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
