### PR TITLE
fix(components/HeaderBar): Talend logo color

### DIFF
--- a/packages/components/.storybook/config.js
+++ b/packages/components/.storybook/config.js
@@ -10,6 +10,7 @@ import { locales as tuiLocales } from '@talend/locales-tui/locales';
 import 'focus-outline-manager';
 import '../../../.storybook/sortStories';
 import i18n from './../../../.storybook/i18n';
+import { IconsProvider } from '../src';
 
 const languages = {};
 Object.keys(tuiLocales).forEach(key => (languages[key] = key));
@@ -20,5 +21,7 @@ addDecorator(
 	}),
 );
 addDecorator(withA11y);
+
+addDecorator(storyFn => <IconsProvider>{storyFn()}</IconsProvider>);
 
 configure([require.context('../src', true, /\.stories\.js$/)], module);

--- a/packages/components/.storybook/config.js
+++ b/packages/components/.storybook/config.js
@@ -22,6 +22,6 @@ addDecorator(
 );
 addDecorator(withA11y);
 
-addDecorator(storyFn => <IconsProvider>{storyFn()}</IconsProvider>);
+addDecorator(storyFn => <><IconsProvider />{storyFn()}</>);
 
 configure([require.context('../src', true, /\.stories\.js$/)], module);

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -154,12 +154,6 @@ $tc-skeleton-background-color: #dfdfdf !default;
 		}
 	}
 
-	&.open {
-		:global(.tc-icon-toggle) svg {
-			transform: rotate(180deg);
-		}
-	}
-
 	.group {
 		display: flex;
 	}

--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -12,18 +12,6 @@ $background-color-on-hover: shade($brand-primary, 30);
 	}
 }
 
-// tmp change Talend logo colors until rebranding is done
-:global {
-	#talend-logo-square path {
-		&.ti-foreground {
-			fill: $regal-blue;
-		}
-		&.ti-background {
-			fill: $white;
-		}
-	}
-}
-
 .tc-header-bar {
 	background-color: $brand-primary-darker;
 	display: flex;
@@ -31,6 +19,16 @@ $background-color-on-hover: shade($brand-primary, 30);
 	top: 0;
 	width: 100%;
 	z-index: 1030;
+
+	// tmp change Talend logo colors until rebranding is done
+	[name="talend-logo-square"] path {
+		&.ti-foreground {
+			fill: $regal-blue;
+		}
+		&.ti-background {
+			fill: $white;
+		}
+	}
 
 	svg {
 		margin: 0;

--- a/packages/components/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/components/src/HeaderBar/HeaderBar.stories.js
@@ -5,7 +5,6 @@ import { makeDecorator } from '@storybook/addons';
 
 import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-dependencies
 
-import IconsProvider from '../IconsProvider';
 import Icon from '../Icon';
 import HeaderBar from './HeaderBar.component';
 import AppSwitcher from '../AppSwitcher';
@@ -103,7 +102,6 @@ const withIcons = makeDecorator({
 		const story = getStory(context);
 		return (
 			<div>
-				<IconsProvider />
 				{story}
 				<div className="container" style={{ paddingTop: 40 }} />
 			</div>

--- a/packages/components/src/Icon/Icon.scss
+++ b/packages/components/src/Icon/Icon.scss
@@ -9,6 +9,7 @@ $tc-icon-size: $svg-md-size !default;
 	width: $tc-icon-size;
 	height: $tc-icon-size;
 	fill: currentColor;
+	transform-origin: center;
 
 	use {
 		pointer-events: none;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
IconsProvider has changed and CSS selectors must change too

**What is the chosen solution to this problem?**
Adapt CSS selector for the HeaderBar related logo to preserve colors

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
