### PR TITLE
fix(TMC-23400/CollapsiblePanel): warning colors update

### DIFF
--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -105,9 +105,9 @@ $tc-skeleton-background-color: #dfdfdf !default;
 	}
 
 	&.warning {
-		border-left-color: $jaffa;
+		border-left-color: $brand-warning;
 		:global(.tc-status-label) {
-			color: $jaffa;
+			color: $brand-warning;
 		}
 	}
 

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.scss
@@ -105,9 +105,9 @@ $tc-skeleton-background-color: #dfdfdf !default;
 	}
 
 	&.warning {
-		border-left-color: $brand-warning;
+		border-left-color: $jaffa;
 		:global(.tc-status-label) {
-			color: $brand-warning;
+			color: $jaffa;
 		}
 	}
 

--- a/packages/theme/src/theme/_variables.scss
+++ b/packages/theme/src/theme/_variables.scss
@@ -24,7 +24,7 @@ $brand-primary-darker: shade($brand-primary, 25) !default;
 $brand-secondary: $rio-grande !default;
 $brand-success: $rio-grande !default;
 $brand-info: $st-tropaz !default;
-$brand-warning: $lightning-yellow !default;
+$brand-warning: $jaffa !default;
 $brand-danger: $chestnut-rose !default;
 
 //== Scaffolding


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
 According to the guideline, $jaffa -> #EA8330, is the color we should use for any warning text message and component as well 

TMC QAs opened an issue on the Promotion History collapsible panel wrong colors.
**What is the chosen solution to this problem?**

Fixed styles

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
