### PR TITLE
fix(IconsProvider): make it work without context 

### DIFF
--- a/packages/components/6.0 - breaking changes.md
+++ b/packages/components/6.0 - breaking changes.md
@@ -174,21 +174,6 @@ And `context` is now attached to `Tile` component.
 +const href = IconsProvider.getIconHREF(iconName);
 ```
 
-The IconsProvider is now a context provider, it must wrap your app
-
-```diff
-function App() {
-   return (
--      <>
--         <IconsProvider />
-+     <IconsProvider>
-         <Home />
--      </>
-+     </IconsProvider>
-   );
-}
-```
-
 ## i18n
 
 1. `I18N_DOMAIN_COMPONENTS` is not exported from index anymore. It is attached to a new `i18n` object.

--- a/packages/components/6.0 - breaking changes.md
+++ b/packages/components/6.0 - breaking changes.md
@@ -164,14 +164,10 @@ And `context` is now attached to `Tile` component.
 
 ## IconsProvider
 
-`getIconHREF` is not exported anymore, but it is attached to `IconsProvider` component.
+`getIconHREF` has been removed.
 
 ```diff
 -import { getIconHREF } from '@talend/react-components/lib/IconsProvider';
-+import IconsProvider from '@talend/react-components/lib/IconsProvider';
-
--const href = getIconHREF(iconName);
-+const href = IconsProvider.getIconHREF(iconName);
 ```
 
 ## i18n

--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -41,8 +41,6 @@ function Icon({ className, name, title, transform, onClick, ...props }) {
 	const imgSrc = name.replace('remote-', '').replace('src-', '');
 	const [content, setContent] = React.useState();
 	const ref = React.useRef();
-	const icons = React.useContext(IconsProvider.reactContext);
-	const isInProvider = ((icons || {}).ids || []).indexOf(name) !== -1;
 	const isRemoteSVG = isRemote && content && content.includes('svg') && !content.includes('script');
 
 	React.useEffect(() => {
@@ -75,10 +73,10 @@ function Icon({ className, name, title, transform, onClick, ...props }) {
 		if (ref.current && isRemoteSVG) {
 			// eslint-disable-next-line no-param-reassign
 			ref.current.innerHTML = content;
-		} else if (ref.current && !isRemote && isInProvider) {
+		} else if (ref.current && !isRemote) {
 			IconsProvider.injectIcon(name, ref.current);
 		}
-	}, [isRemoteSVG, ref, content, name, isRemote, isInProvider]);
+	}, [isRemoteSVG, ref, content, name, isRemote]);
 
 	const accessibility = {
 		focusable: 'false', // IE11

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -18,69 +18,60 @@ const defaultIcons = {
 };
 
 storiesOf('Messaging & Communication/Icon', module)
-	.add('default use svg', () => (
-		<div>
-			<h1>Icon</h1>
-			<IconsProvider>
-				<p>
-					The Icon component use the IconsProvider context. So this Icon is re-render when icons are
-					loaded or updated.
-				</p>
+	.add('default use svg', () => {
+		const [ids, setIds] = React.useState([]);
+		React.useEffect(() => {
+			IconsProvider.getAllIconIds().then(setIds);
+		}, []);
+		return (
+			<div>
+				<h1>Icon</h1>
+				<IconsProvider />
 				<Icon name="talend-apache" />
-				<IconsProvider.reactContext.Consumer>
-					{value => (
-						<>
-							<p>We have {value.ids.length.toString()} svg icons registred:</p>
-							<ul>
-								{value.ids.map((icon, index) => (
-									<li key={index}>
-										<Icon name={icon} /> : <strong>{icon}</strong>
-									</li>
-								))}
-							</ul>
-						</>
-					)}
-				</IconsProvider.reactContext.Consumer>
-			</IconsProvider>
-		</div>
-	))
+				<p>We have {ids.length.toString()} svg icons registered:</p>
+				<ul>
+					{ids.map((icon, index) => (
+						<li key={index}>
+							<Icon name={icon} /> : <strong>{icon}</strong>
+						</li>
+					))}
+				</ul>
+			</div>
+		);
+	})
 	.add('fontawesome', () => (
 		<div>
 			<h1>Icon</h1>
-			<IconsProvider>
-				<p>You can use font awesome icons if you have loaded the stylesheet</p>
-				<ul>
-					<li>
-						<Icon name="fa-bars" /> : <strong>fa-bars</strong>
-					</li>
-				</ul>
-			</IconsProvider>
+			<p>You can use font awesome icons if you have loaded the stylesheet</p>
+			<ul>
+				<li>
+					<Icon name="fa-bars" /> : <strong>fa-bars</strong>
+				</li>
+			</ul>
 		</div>
 	))
 	.add('extends defaults', () => (
 		<div>
 			<h1>Icon</h1>
-			<IconsProvider icons={newIcons}>
-				<p>Here we are adding a new Icon id</p>
-				<ul>
-					<li>
-						<Icon name="test" /> : <strong>test</strong>
-					</li>
-				</ul>
-			</IconsProvider>
+			<IconsProvider icons={newIcons} />
+			<p>Here we are adding a new Icon id</p>
+			<ul>
+				<li>
+					<Icon name="test" /> : <strong>test</strong>
+				</li>
+			</ul>
 		</div>
 	))
 	.add('override defaults', () => (
 		<div>
 			<h1>Icon</h1>
-			<IconsProvider defaultIcons={defaultIcons}>
-				<p>Here we are changing the icon talend-add</p>
-				<ul>
-					<li>
-						<Icon name="talend-add" /> : <strong>talend-add</strong>
-					</li>
-				</ul>
-			</IconsProvider>
+			<IconsProvider defaultIcons={defaultIcons} />
+			<p>Here we are changing the icon talend-add</p>
+			<ul>
+				<li>
+					<Icon name="talend-add" /> : <strong>talend-add</strong>
+				</li>
+			</ul>
 		</div>
 	))
 	.add('remote svg', () => (
@@ -91,44 +82,43 @@ storiesOf('Messaging & Communication/Icon', module)
 	))
 	.add('svg transform', () => (
 		<div>
-			<IconsProvider>
-				<p>Here we are changing the icon talend-apache</p>
-				<ul>
-					<li>
-						<Icon name="talend-apache" />
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="spin" /> : <strong>spin</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-45" /> : <strong>rotate-45</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-90" /> : <strong>rotate-90</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-135" /> : <strong>rotate-135</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-180" /> : <strong>rotate-180</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-225" /> : <strong>rotate-225</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-270" /> : <strong>rotate-270</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="rotate-315" /> : <strong>rotate-315</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="flip-horizontal" /> :{' '}
-						<strong>flip-horizontal</strong>
-					</li>
-					<li>
-						<Icon name="talend-apache" transform="flip-vertical" /> : <strong>flip-vertical</strong>
-					</li>
-				</ul>
-			</IconsProvider>
+			<IconsProvider />
+			<p>Here we are changing the icon talend-apache</p>
+			<ul>
+				<li>
+					<Icon name="talend-apache" />
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="spin" /> : <strong>spin</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-45" /> : <strong>rotate-45</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-90" /> : <strong>rotate-90</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-135" /> : <strong>rotate-135</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-180" /> : <strong>rotate-180</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-225" /> : <strong>rotate-225</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-270" /> : <strong>rotate-270</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="rotate-315" /> : <strong>rotate-315</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="flip-horizontal" /> :{' '}
+					<strong>flip-horizontal</strong>
+				</li>
+				<li>
+					<Icon name="talend-apache" transform="flip-vertical" /> : <strong>flip-vertical</strong>
+				</li>
+			</ul>
 		</div>
 	));

--- a/packages/components/src/IconsProvider/README.md
+++ b/packages/components/src/IconsProvider/README.md
@@ -30,7 +30,6 @@ export function App(props) {
 | bundles      | array    | [ '/all.svg' ]               |
 | defaultIcons | object   | DEPRECATED: all talend icons | the default icons provided                                                  |
 | icons        | object   | DEPRECATED: {}               | use to add icons to the default ones                                        |
-| getIconHref  | function | DEPRECATED: noop             | a function responsible to return a string used as href in svg use attribute |
 
 ## How to customize bundles
 

--- a/packages/components/src/IconsProvider/README.md
+++ b/packages/components/src/IconsProvider/README.md
@@ -16,7 +16,8 @@ import IconsProvider from '@talend/react-components/lib/IconsProvider';
 export function App(props) {
 	return (
 		<React.Fragment>
-			<IconsProvider>{props.children}</IconsProvider>
+			<IconsProvider />
+			{props.children}
 		</React.Fragment>
 	);
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The IconsProvider via context doesn't work in angular apps which has react->ng and ng->react layers. The context is broken.

**What is the chosen solution to this problem?**
Make it work without context
- the iconsProvider share a common list of fetching bundles
- the injectIcon() get the icon is it is already in dom, otherwise it waits for all bundles to be fetched to search again and inject the icon.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
