### PR TITLE
fix(components/OverlayTrigger): import from index

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -24,8 +24,5 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/index.js
-  10:37  error  defaultTitle not found in '../fieldsets/CollapsibleFieldset'  import/named
-
-✖ 10 problems (10 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -286,7 +286,6 @@ export {
 	NavDropdown,
 	NavItem,
 	Overlay,
-	// OverlayTrigger,
 	PageHeader,
 	PageItem,
 	Pager,

--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -56,6 +56,7 @@ import Loader from './Loader';
 import MultiSelect from './MultiSelect';
 import Notification from './Notification';
 import ObjectViewer from './ObjectViewer';
+import OverlayTrigger from './OverlayTrigger';
 import PieChart from './PieChart';
 import Progress from './Progress';
 import QualityBar from './QualityBar';
@@ -128,7 +129,6 @@ const {
 	NavDropdown,
 	NavItem,
 	Overlay,
-	OverlayTrigger,
 	PageHeader,
 	PageItem,
 	Pager,
@@ -211,7 +211,7 @@ export {
 	MultiSelect,
 	Notification,
 	ObjectViewer,
-	// TODO 6.0: export OverlayTrigger here. For now there is already an OverlayTrigger from react-bootstrap
+	OverlayTrigger,
 	PieChart,
 	Progress,
 	QualityBar,
@@ -286,7 +286,7 @@ export {
 	NavDropdown,
 	NavItem,
 	Overlay,
-	OverlayTrigger,
+	// OverlayTrigger,
 	PageHeader,
 	PageItem,
 	Pager,

--- a/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
@@ -45,7 +45,6 @@ exports[`FieldTemplate should render invalid className 1`] = `
 
 exports[`FieldTemplate should render with hint 1`] = `
 <OverlayTrigger
-  defaultOverlayShown={false}
   overlayComponent={
     <span>
       Tooltip content, which helps to understand what is the purpose of this field
@@ -53,12 +52,7 @@ exports[`FieldTemplate should render with hint 1`] = `
   }
   overlayId="myAwesomeField-hint-overlay"
   overlayPlacement="top"
-  trigger={
-    Array [
-      "hover",
-      "focus",
-    ]
-  }
+  preventScrolling={false}
 >
   <Button
     active={false}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We used to import `OverlayTrigger` with its complete path
`@talend/react-components` index exports `OverlayTrigger` of React Bootstrap 

**What is the chosen solution to this problem?**
Since nobody seems to import our OverlayTrigger from the index, let's replace it.
Our component still uses React Bootstrap's OverlayTrigger under the hood!

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
