### PR TITLE
fix(ListView): add class to set display: flex only for item with icon

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -24,8 +24,5 @@
 /home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
   57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/utils/index.js
-  10:37  error  defaultTitle not found in '../fieldsets/CollapsibleFieldset'  import/named
-
-✖ 10 problems (10 errors, 0 warnings)
+✖ 9 problems (9 errors, 0 warnings)
   2 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -66,16 +66,20 @@ class Item extends Component {
 					id={itemId}
 					onChange={event => item.onChange(event, item, parentItem)}
 					checked={item.checked}
-					label={searchCriteria ? getSearchedLabel(item.label) : item.label}
+					label={
+						<>
+							{searchCriteria ? getSearchedLabel(item.label) : item.label}
+							{item.icon && <>{(
+								<TooltipTrigger label={item.icon.title} tooltipPlacement="bottom">
+									<span>
+										<Icon {...item.icon} />
+									</span>
+								</TooltipTrigger>
+							)}}
+						</>
+					}
 					aria-label={ariaLabel}
 				/>
-				{item.icon && (
-					<TooltipTrigger label={item.icon.title} tooltipPlacement="bottom">
-						<span>
-							<Icon {...item.icon} />
-						</span>
-					</TooltipTrigger>
-				)}
 				{children && (
 					<div className={classNames('checkbox-nested-expand', { expanded: item.expanded })}>
 						<Action

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -41,6 +41,7 @@ class Item extends Component {
 			'checkbox',
 			{ 'switch-nested': children },
 			{ switch: isSwitchBox },
+			{'with-icon': item.icon},
 		);
 		const ariaLabel = item.checked
 			? t('TC_LISTVIEW_DESELECT', { defaultValue: 'Deselect {{ value }}', value: item.label })

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -41,7 +41,7 @@ class Item extends Component {
 			'checkbox',
 			{ 'switch-nested': children },
 			{ switch: isSwitchBox },
-			{'with-icon': item.icon},
+			{ 'with-icon': item.icon },
 		);
 		const ariaLabel = item.checked
 			? t('TC_LISTVIEW_DESELECT', { defaultValue: 'Deselect {{ value }}', value: item.label })

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -69,13 +69,13 @@ class Item extends Component {
 					label={
 						<>
 							{searchCriteria ? getSearchedLabel(item.label) : item.label}
-							{item.icon && <>{(
+							{item.icon && (
 								<TooltipTrigger label={item.icon.title} tooltipPlacement="bottom">
 									<span>
 										<Icon {...item.icon} />
 									</span>
 								</TooltipTrigger>
-							)}}
+							)}
 						</>
 					}
 					aria-label={ariaLabel}

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -1,6 +1,6 @@
 $tc-listview-height: 40vh !default;
 
-$row-height: 13px;
+$row-height: 12px;
 $row-vertical-margin: $padding-small;
 $row-nested-inner-margin-top: $padding-normal - $padding-small;
 $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
@@ -17,15 +17,14 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 			.checkbox {
 				margin-left: $padding-smaller;
 			}
+
 			.with-icon {
-				display: flex;
-				margin-top: 0;
-				margin-bottom: 0;
+				display: inline-flex;
+				margin: 0;
 
 				.tc-svg-icon {
 					height: $row-height;
 					width: $row-height;
-					margin-top: $padding-small;
 					margin-left: $padding-smaller;
 				}
 			}

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -21,12 +21,13 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 				display: flex;
 				margin-top: 0;
 				margin-bottom: 0;
-			}
-			.tc-svg-icon {
-				height: $row-height;
-				width: $row-height;
-				margin-top: $padding-small;
-				margin-left: $padding-smaller;
+
+				.tc-svg-icon {
+					height: $row-height;
+					width: $row-height;
+					margin-top: $padding-small;
+					margin-left: $padding-smaller;
+				}	
 			}
 
 			.checkbox-nested {

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -27,7 +27,7 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 					width: $row-height;
 					margin-top: $padding-small;
 					margin-left: $padding-smaller;
-				}	
+				}
 			}
 
 			.checkbox-nested {

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -19,6 +19,8 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 			}
 			.with-icon {
 				display: flex;
+				margin-top: 0;
+				margin-bottom: 0;
 			}
 			.tc-svg-icon {
 				height: $row-height;

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -16,6 +16,8 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 		:global {
 			.checkbox {
 				margin-left: $padding-smaller;
+			}
+			.with-icon {
 				display: flex;
 			}
 			.tc-svg-icon {

--- a/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
+++ b/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
@@ -288,7 +288,11 @@ exports[`Items should render 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
-                          label="Lorem ipsum dolor sit amet 0"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 0
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -382,7 +386,11 @@ exports[`Items should render 1`] = `
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
-                          label="Lorem ipsum dolor sit amet 1"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 1
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -474,7 +482,11 @@ exports[`Items should render 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
-                          label="Lorem ipsum dolor sit amet 2"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 2
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -816,7 +828,11 @@ exports[`Items should render with nested items 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor default"
-                          label="Lorem ipsum dolor default"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor default
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -919,7 +935,11 @@ exports[`Items should render with nested items 1`] = `
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor Parent"
                           checked={true}
-                          label="Lorem ipsum dolor Parent"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor Parent
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1329,7 +1349,11 @@ exports[`Items should render with provided id 1`] = `
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
                           id="checkbox-my-widget-1-item"
-                          label="Lorem ipsum dolor sit amet 0"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 0
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1430,7 +1454,11 @@ exports[`Items should render with provided id 1`] = `
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
                           id="checkbox-my-widget-2-item"
-                          label="Lorem ipsum dolor sit amet 1"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 1
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1529,7 +1557,11 @@ exports[`Items should render with provided id 1`] = `
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
                           id="checkbox-my-widget-3-item"
-                          label="Lorem ipsum dolor sit amet 2"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 2
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
@@ -2,25 +2,25 @@
 
 .template:global(.required) {
 	> :global(.checkbox:after) {
-	   position: static;
-	   display: inline;
-	   content: '*';
+		position: static;
+		display: inline;
+		content: '*';
 	}
 	:global {
-	   .control-label:after {
-		  content: '*';
-	   }
-	   .checkbox {
-		  .control-label:after {
-			 content: '';
-		  }
-	   }
-	   // Remove required stars for multi selection
-	   .control-label ~ .checkbox:after {
-		  content: '';
-	   }
+		.control-label:after {
+			content: '*';
+		}
+		.checkbox {
+			.control-label:after {
+				content: '';
+			}
+		}
+		// Remove required stars for multi selection
+		.control-label ~ .checkbox:after {
+			content: '';
+		}
 	}
- }
+}
 
 .updating {
 	@include heartbeat(object-blink);

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
@@ -7,12 +7,6 @@
 		}
 
 		.checkbox {
-			&:after {
-				position: static;
-				display: inline;
-				content: '*';
-			}
-
 			.control-label:after {
 				content: '';
 			}

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
@@ -1,23 +1,26 @@
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 .template:global(.required) {
-	:global {
-		.control-label:after {
-			content: '*';
-		}
-
-		.checkbox {
-			.control-label:after {
-				content: '';
-			}
-		}
-
-		// Remove required stars for multi selection
-		.control-label ~ .checkbox:after {
-			content: '';
-		}
+	> :global(.checkbox:after) {
+	   position: static;
+	   display: inline;
+	   content: '*';
 	}
-}
+	:global {
+	   .control-label:after {
+		  content: '*';
+	   }
+	   .checkbox {
+		  .control-label:after {
+			 content: '';
+		  }
+	   }
+	   // Remove required stars for multi selection
+	   .control-label ~ .checkbox:after {
+		  content: '';
+	   }
+	}
+ }
 
 .updating {
 	@include heartbeat(object-blink);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
listView styles issue
![image](https://user-images.githubusercontent.com/54246061/99251061-5dea6a00-2815-11eb-948c-022c4c3f7c84.png)

**What is the chosen solution to this problem?**
-Add class to set display: flex only for item with an icon

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
