### PR TITLE
fix(HeaderBar): logo color

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.scss
@@ -21,11 +21,11 @@ $background-color-on-hover: shade($brand-primary, 30);
 	z-index: 1030;
 
 	// tmp change Talend logo colors until rebranding is done
-	[name="talend-logo-square"] path {
-		&.ti-foreground {
+	[name='talend-logo-square'] path {
+		&:global(.ti-foreground) {
 			fill: $regal-blue;
 		}
-		&.ti-background {
+		&:global(.ti-background) {
 			fill: $white;
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
#3064 added a scoping for logo svg color, but it turned the global selector into a css module which is not applied anymore.

**What is the chosen solution to this problem?**
Set back the global selector

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
