### PR TITLE
fix(ColumnChooser): do not overwrite onSubmit

### DIFF
--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import pickBy from 'lodash/pickBy';
 import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
@@ -9,6 +8,7 @@ function ColumnChooser(props) {
 
 	return (
 		<ColumnChooserButton
+			{...props}
 			columns={columns.map(({ dataKey, label }, i) => ({
 				key: dataKey,
 				label,
@@ -21,7 +21,6 @@ function ColumnChooser(props) {
 					props.onSubmit(_, changes);
 				}
 			}}
-			{...pickBy(props, (_, key) => key !== 'onSubmit')}
 		/>
 	);
 }

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
+import pickBy from 'lodash/pickBy';
 import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
@@ -21,7 +21,7 @@ function ColumnChooser(props) {
 					props.onSubmit(_, changes);
 				}
 			}}
-			{...omit(props, 'onSubmit')}
+			{...pickBy(props, (_, key) => key !== 'onSubmit')}
 		/>
 	);
 }

--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import omit from 'lodash/omit';
 import { useListContext } from '../context';
 import ColumnChooserButton from '../../Toolbar/ColumnChooserButton';
 
@@ -20,7 +21,7 @@ function ColumnChooser(props) {
 					props.onSubmit(_, changes);
 				}
 			}}
-			{...props}
+			{...omit(props, 'onSubmit')}
 		/>
 	);
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
internal onSubmit will be overwritten by props.onSubmit when spread props to ColumnChooserButton.
**What is the chosen solution to this problem?**
omit onSubmit when spread props.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
