### PR TITLE
fix(forms): expose arrayitem

### DIFF
--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -145,7 +145,7 @@ Badge.propTypes = {
 	type: PropTypes.oneOf(Object.values(TYPES)),
 	dropdown: PropTypes.object,
 };
-
+Badge.displayName = 'Badge';
 Badge.SIZES = SIZES;
 Badge.TYPES = TYPES;
 export default Badge;

--- a/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
@@ -86,6 +86,7 @@ function DefaultArrayTemplate(props) {
 DefaultArrayTemplate.defaultProps = {
 	isCloseable: false,
 };
+DefaultArrayTemplate.ArrayItem = ArrayItem;
 
 if (process.env.NODE_ENV !== 'production') {
 	DefaultArrayTemplate.propTypes = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We have lots of logs during tests in some project because Badge has no displayName
We can t create a new Array template in forms because we don t have access to the ArrayItem.

**What is the chosen solution to this problem?**

* add displayName to Badge
* expose ArrayItem

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
