### PR TITLE
fix(forms/storybook): unwrap IconsProvider

### DIFF
--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -17,14 +17,13 @@ const withFormLayout = (story, options) => {
 	}
 	return (
 		<div className="container-fluid">
-			<IconsProvider>
-				<div
-					className="col-md-offset-1 col-md-10"
-					style={{ marginTop: '20px', marginBottom: '20px' }}
-				>
-					{story()}
-				</div>
-			</IconsProvider>
+			<IconsProvider />
+			<div
+				className="col-md-offset-1 col-md-10"
+				style={{ marginTop: '20px', marginBottom: '20px' }}
+			>
+				{story()}
+			</div>
 		</div>
 	);
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current forms storybook are blank because all stories are wrapped in IconsProvider and we revert this need in #3071 but forgot to fix all storybooks

**What is the chosen solution to this problem?**

Unwrap stories

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
