### PR TITLE
fix(IconsProvider): empty container before append icon

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -1,33 +1,6 @@
 
-/home/travis/build/Talend/ui/packages/components/src/AboutDialog/AboutModal.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/ActionBar/ActionBar.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.component.js
   32:66  warning  React Hook useLayoutEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
-
-/home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.stories.js
-  3:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/ActionList/ActionList.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionButton/Button.stories.js
-  7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
-  8:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionFile/File.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
   5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
@@ -35,14 +8,8 @@
 /home/travis/build/Talend/ui/packages/components/src/AppSwitcher/AppSwitcher.component.js
   40:10  error  Elements with the ARIA role "heading" must have the following attributes defined: aria-level  jsx-a11y/role-has-required-aria-props
 
-/home/travis/build/Talend/ui/packages/components/src/Badge/Badge.stories.js
-  8:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
   142:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
-
-/home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Core/Tree/Tree.component.js
   4:1  error  Dependency cycle via ./TreeNode.component:1=>../Tree:4                                             import/no-cycle
@@ -63,9 +30,6 @@
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Core/TreeNodeList/index.js
   1:1  error  Dependency cycle via ../TreeNode:4=>./TreeNode.component:1=>../Tree:4=>./Tree.component:1  import/no-cycle
 
-/home/travis/build/Talend/ui/packages/components/src/DataViewer/DataViewer.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/ModelViewer/Branch/ModelViewerBranch.component.js
   93:6  error  A control must be associated with a text label  jsx-a11y/control-has-associated-label
 
@@ -75,9 +39,6 @@
 
 /home/travis/build/Talend/ui/packages/components/src/Datalist/Datalist.component.js
   42:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/components/src/Datalist/Datalist.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/Manager/Manager.component.js
   31:5  warning  React Hook useEffect has missing dependencies: 'getDateOptions' and 'state.date'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
@@ -97,31 +58,16 @@
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
   26:5  warning  React Hook useEffect has missing dependencies: 'state.endDateTime' and 'state.startDateTime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
    67:6  error  Static HTML elements with event handlers require a role            jsx-a11y/no-static-element-interactions
   108:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
   87:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
-
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
   37:2  warning  The 'showHorizontalAndTest' function makes the dependencies of useEffect Hook (at line 53) change on every render. To fix this, wrap the 'showHorizontalAndTest' definition into its own useCallback() Hook  react-hooks/exhaustive-deps
   57:5  warning  React Hook useEffect has a missing dependency: 'showHorizontalAndTest'. Either include it or remove the dependency array                                                                                     react-hooks/exhaustive-deps
-
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Manager/Manager.component.js
    79:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
@@ -133,9 +79,6 @@
   175:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
   175:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
   175:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
-
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.component.js
    55:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
@@ -176,14 +119,10 @@
   269:43  error  'footerActions' is already declared in the upper scope  no-shadow
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.stories.js
-   10:8   error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-  178:3   error  Empty components are self-closing          react/self-closing-comp
-  179:3   error  Empty components are self-closing          react/self-closing-comp
-  253:33  error  Unary operator '++' used                   no-plusplus
-  305:35  error  Unary operator '++' used                   no-plusplus
-
-/home/travis/build/Talend/ui/packages/components/src/EditableText/EditableText.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
+  177:3   error  Empty components are self-closing  react/self-closing-comp
+  178:3   error  Empty components are self-closing  react/self-closing-comp
+  252:33  error  Unary operator '++' used           no-plusplus
+  304:35  error  Unary operator '++' used           no-plusplus
 
 /home/travis/build/Talend/ui/packages/components/src/EditableText/EditableText.test.js
   12:3  error  Arrow function should not return assignment  no-return-assign
@@ -191,23 +130,14 @@
 /home/travis/build/Talend/ui/packages/components/src/Enumeration/Enumeration.component.js
   227:2  error  defaultProp "t" defined for isRequired propType  react/default-props-match-prop-types
 
-/home/travis/build/Talend/ui/packages/components/src/Enumeration/Enumeration.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/Enumeration/Header/HeaderInput.component.js
   89:5  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
 
 /home/travis/build/Talend/ui/packages/components/src/Enumeration/Items/Item/ItemEdit.component.js
   147:6  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
 
-/home/travis/build/Talend/ui/packages/components/src/FilterBar/Filter.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/FilterBar/FilterBar.component.js
   122:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/components/src/GridLayout/Dashboard.stories.js
-  9:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/GridLayout/Tile/Tile.component.js
   27:4  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
@@ -218,32 +148,14 @@
 /home/travis/build/Talend/ui/packages/components/src/GuidedTour/GuidedTour.stories.js
   102:7  warning  Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger
 
-/home/travis/build/Talend/ui/packages/components/src/HttpError/HttpError.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/InlineMessage/InlineMessage.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/Layout/AppLayout.stories.js
   7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/List/List.stories.js
-  10:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/List/ListComposition.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/ListView/Header/HeaderInput.component.js
   68:5  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
-
-/home/travis/build/Talend/ui/packages/components/src/ListView/ListView.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/MultiSelect/ItemOption.component.js
   39:6  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
@@ -253,9 +165,8 @@
   293:6  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
 
 /home/travis/build/Talend/ui/packages/components/src/MultiSelect/MultiSelect.stories.js
-   5:8  error  'IconsProvider' is defined but never used       @typescript-eslint/no-unused-vars
-  32:7  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
-  44:7  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
+  31:7  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
+  43:7  error  A form label must be associated with a control  jsx-a11y/label-has-associated-control
 
 /home/travis/build/Talend/ui/packages/components/src/Notification/Notification.component.js
   100:3  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener                                                                                                                                                                                                               jsx-a11y/click-events-have-key-events
@@ -263,16 +174,14 @@
   192:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
 
 /home/travis/build/Talend/ui/packages/components/src/Notification/Notification.stories.js
-   6:8   error  'IconsProvider' is defined but never used                     @typescript-eslint/no-unused-vars
-  28:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
-  51:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
-  61:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
-  72:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
-  80:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
+  27:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
+  50:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
+  60:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
+  71:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
+  79:29  error  Use callback in setState when referencing the previous state  react/no-access-state-in-setstate
 
 /home/travis/build/Talend/ui/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
-    9:8  error  'IconsProvider' is defined but never used                                                                                                                                                                                                                                                                                                                         @typescript-eslint/no-unused-vars
-  435:4  error  The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
+  434:4  error  The href attribute requires a valid value to be accessible. Provide a valid, navigable address as the href value. If you cannot provide a valid href, but still need the element to resemble a link, use a button and change it with appropriate styles. Learn more: https://github.com/evcohen/eslint-plugin-jsx-a11y/blob/master/docs/rules/anchor-is-valid.md  jsx-a11y/anchor-is-valid
 
 /home/travis/build/Talend/ui/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
   510:2  error  defaultProp "opened" has no corresponding propTypes declaration  react/default-props-match-prop-types
@@ -336,41 +245,19 @@
   265:20  error    'renderAs' is missing in props validation                                                                                react/prop-types
   265:30  error    'renderAs.name' is missing in props validation                                                                           react/prop-types
 
-/home/travis/build/Talend/ui/packages/components/src/ResourcePicker/ResourcePicker.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/ResourcePicker/index.js
   4:7  error  'TOOLBAR_OPTIONS' is assigned a value but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Rich/Layout/RichLayout.stories.js
-  7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/SidePanel/SidePanel.component.js
    75:5  warning  React Hook useLayoutEffect has missing dependencies: 'large' and 'minimised'. Either include them or remove the dependency array. If 'setWidth' needs the current value of 'large', you can also switch to useReducer instead of useState and read 'large' in the reducer  react-hooks/exhaustive-deps
    83:5  warning  React Hook useEffect has a missing dependency: 'animation'. Either include it or remove the dependency array                                                                                                                                                               react-hooks/exhaustive-deps
   112:3  error    The attribute aria-expanded is not supported by the role navigation                                                                                                                                                                                                        jsx-a11y/role-supports-aria-props
 
-/home/travis/build/Talend/ui/packages/components/src/SidePanel/SidePanel.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Skeleton/Skeleton.stories.js
-  4:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Slider/Slider.stories.js
-  6:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
-/home/travis/build/Talend/ui/packages/components/src/Status/Status.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/Stepper/Stepper.component.js
   170:5  warning  React Hook useEffect has missing dependencies: 'children' and 'transitionState'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/Stepper/Stepper.stories.js
-    5:8   error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-  137:13  error  'children' is missing in props validation  react/prop-types
-
-/home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/SubHeader.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
+  135:13  error  'children' is missing in props validation  react/prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
   129:2  error  defaultProp "t" has no corresponding propTypes declaration  react/default-props-match-prop-types
@@ -382,14 +269,8 @@
   62:5  warning  React Hook useEffect has missing dependencies: 'responsive' and 'showTabBarAndTest'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
   82:5  warning  React Hook useEffect has a missing dependency: 'responsive'. Either include it or remove the dependency array                            react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/TabBar/Tabs.stories.js
-  7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/Toggle/LabelToggle/LabelToggle.component.js
   56:7  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus
-
-/home/travis/build/Talend/ui/packages/components/src/TreeView/FolderTreeView.stories.js
-  7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/TreeView/TreeView.component.js
   104:2  error  defaultProp "id" defined for isRequired propType  react/default-props-match-prop-types
@@ -397,9 +278,6 @@
 /home/travis/build/Talend/ui/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
    98:3  error  defaultProp "level" defined for isRequired propType  react/default-props-match-prop-types
   209:4  error  'item.hidden' is missing in props validation         react/prop-types
-
-/home/travis/build/Talend/ui/packages/components/src/Typeahead/Typeahead.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
   63:2  error  defaultProp "columnData" defined for isRequired propType  react/default-props-match-prop-types
@@ -433,10 +311,9 @@
   70:5  warning  React Hook useEffect has missing dependencies: 'children' and 'setWidths'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/VirtualizedList.stories.js
-    8:8   error  'IconsProvider' is defined but never used        @typescript-eslint/no-unused-vars
-  664:56  error  ["resizable"] is better written in dot notation  dot-notation
-  674:44  error  ["icon"] is better written in dot notation       dot-notation
-  680:56  error  ["resizable"] is better written in dot notation  dot-notation
+  663:56  error  ["resizable"] is better written in dot notation  dot-notation
+  673:44  error  ["icon"] is better written in dot notation       dot-notation
+  679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 195 problems (175 errors, 20 warnings)
+✖ 150 problems (130 errors, 20 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/.storybook/config.js
+++ b/packages/components/.storybook/config.js
@@ -22,6 +22,13 @@ addDecorator(
 );
 addDecorator(withA11y);
 
-addDecorator(storyFn => <><IconsProvider />{storyFn()}</>);
+addDecorator(storyFn => (
+	<>
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
+		{storyFn()}
+	</>
+));
 
 configure([require.context('../src', true, /\.stories\.js$/)], module);

--- a/packages/components/src/AboutDialog/AboutModal.stories.js
+++ b/packages/components/src/AboutDialog/AboutModal.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import AboutDialog from '.';
-import IconsProvider from '../IconsProvider';
 
 const props = {
 	show: true,

--- a/packages/components/src/AboutDialog/AboutModal.stories.js
+++ b/packages/components/src/AboutDialog/AboutModal.stories.js
@@ -48,11 +48,6 @@ const { name, version } = AboutDialog.Table.getColumnHeaders();
 storiesOf('Layout/Modals/AboutModal', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>AboutDialog</h1>
 			{story()}
 		</div>

--- a/packages/components/src/AboutDialog/AboutModal.stories.js
+++ b/packages/components/src/AboutDialog/AboutModal.stories.js
@@ -48,7 +48,11 @@ const { name, version } = AboutDialog.Table.getColumnHeaders();
 storiesOf('Layout/Modals/AboutModal', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>AboutDialog</h1>
 			{story()}
 		</div>

--- a/packages/components/src/AboutDialog/AboutModal.stories.js
+++ b/packages/components/src/AboutDialog/AboutModal.stories.js
@@ -48,7 +48,7 @@ const { name, version } = AboutDialog.Table.getColumnHeaders();
 storiesOf('Layout/Modals/AboutModal', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>AboutDialog</h1>
 			{story()}
 		</div>

--- a/packages/components/src/ActionBar/ActionBar.stories.js
+++ b/packages/components/src/ActionBar/ActionBar.stories.js
@@ -255,11 +255,6 @@ const appMassActions = {
 storiesOf('Form/Controls/ActionBar', module)
 	.add('default', () => (
 		<nav>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<p>No Selected, Layout: Left Space Right</p>
 			<div id="default">
 				<ActionBar {...basicProps} selected={0} />
@@ -293,11 +288,6 @@ storiesOf('Form/Controls/ActionBar', module)
 	))
 	.add('custom', () => (
 		<nav>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<div id="default">
 				<ActionBar>
 					<ActionBar.Content tag="a" left href="#/foo/bar">

--- a/packages/components/src/ActionBar/ActionBar.stories.js
+++ b/packages/components/src/ActionBar/ActionBar.stories.js
@@ -255,7 +255,11 @@ const appMassActions = {
 storiesOf('Form/Controls/ActionBar', module)
 	.add('default', () => (
 		<nav>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<p>No Selected, Layout: Left Space Right</p>
 			<div id="default">
 				<ActionBar {...basicProps} selected={0} />
@@ -289,7 +293,11 @@ storiesOf('Form/Controls/ActionBar', module)
 	))
 	.add('custom', () => (
 		<nav>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<div id="default">
 				<ActionBar>
 					<ActionBar.Content tag="a" left href="#/foo/bar">

--- a/packages/components/src/ActionBar/ActionBar.stories.js
+++ b/packages/components/src/ActionBar/ActionBar.stories.js
@@ -255,7 +255,7 @@ const appMassActions = {
 storiesOf('Form/Controls/ActionBar', module)
 	.add('default', () => (
 		<nav>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<p>No Selected, Layout: Left Space Right</p>
 			<div id="default">
 				<ActionBar {...basicProps} selected={0} />
@@ -289,7 +289,7 @@ storiesOf('Form/Controls/ActionBar', module)
 	))
 	.add('custom', () => (
 		<nav>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<div id="default">
 				<ActionBar>
 					<ActionBar.Content tag="a" left href="#/foo/bar">

--- a/packages/components/src/ActionBar/ActionBar.stories.js
+++ b/packages/components/src/ActionBar/ActionBar.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../IconsProvider';
 import { Action } from '../Actions';
 import ActionBar from './ActionBar.component';
 

--- a/packages/components/src/ActionIntercom/Intercom.stories.js
+++ b/packages/components/src/ActionIntercom/Intercom.stories.js
@@ -7,7 +7,9 @@ const config = { app_id: 'fyq3wodw', email: 'toto@gmail.com' };
 
 storiesOf('Messaging & Communication/Intercom', module).add('default', () => (
 	<React.Fragment>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		<ActionIntercom id="intercom" config={config} />
 	</React.Fragment>
 ));

--- a/packages/components/src/ActionIntercom/Intercom.stories.js
+++ b/packages/components/src/ActionIntercom/Intercom.stories.js
@@ -7,7 +7,7 @@ const config = { app_id: 'fyq3wodw', email: 'toto@gmail.com' };
 
 storiesOf('Messaging & Communication/Intercom', module).add('default', () => (
 	<React.Fragment>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		<ActionIntercom id="intercom" config={config} />
 	</React.Fragment>
 ));

--- a/packages/components/src/ActionIntercom/Intercom.stories.js
+++ b/packages/components/src/ActionIntercom/Intercom.stories.js
@@ -7,9 +7,6 @@ const config = { app_id: 'fyq3wodw', email: 'toto@gmail.com' };
 
 storiesOf('Messaging & Communication/Intercom', module).add('default', () => (
 	<React.Fragment>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
 		<ActionIntercom id="intercom" config={config} />
 	</React.Fragment>
 ));

--- a/packages/components/src/ActionIntercom/Intercom.stories.js
+++ b/packages/components/src/ActionIntercom/Intercom.stories.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
-import IconsProvider from '../IconsProvider';
 import ActionIntercom from './Intercom.component';
 
 const config = { app_id: 'fyq3wodw', email: 'toto@gmail.com' };

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -49,7 +49,11 @@ const stories = storiesOf('Navigation/ActionList', module);
 stories
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -47,16 +47,7 @@ const actions = [
 const stories = storiesOf('Navigation/ActionList', module);
 
 stories
-	.addDecorator(story => (
-		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div>{story()}</div>)
 	.add('default', () => (
 		<div style={{ display: 'inline-table' }}>
 			<ActionList

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -49,7 +49,7 @@ const stories = storiesOf('Navigation/ActionList', module);
 stories
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import ActionList from './ActionList.component';
-import IconsProvider from '../IconsProvider';
 
 const actions = [
 	{
@@ -47,7 +46,6 @@ const actions = [
 const stories = storiesOf('Navigation/ActionList', module);
 
 stories
-	.addDecorator(story => <div>{story()}</div>)
 	.add('default', () => (
 		<div style={{ display: 'inline-table' }}>
 			<ActionList

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -4,7 +4,6 @@ import { action } from '@storybook/addon-actions';
 import withPropsCombinations from 'react-storybook-addon-props-combinations';
 
 import ActionButton from './ActionButton.component';
-import IconsProvider from '../../IconsProvider';
 
 import theme from './Button.stories.scss';
 
@@ -66,11 +65,7 @@ class DisableActionButton extends React.Component {
 
 storiesOf('Buttons/Button', module)
 	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
-	.add('Disable the buttons', () => (
-		<div>
-			<DisableActionButton />
-		</div>
-	))
+	.add('Disable the buttons', () => <DisableActionButton />)
 	.add('default', () => (
 		<div>
 			<h3>By default :</h3>

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -65,16 +65,7 @@ class DisableActionButton extends React.Component {
 }
 
 storiesOf('Buttons/Button', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('Disable the buttons', () => (
 		<div>
 			<DisableActionButton />

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -67,7 +67,7 @@ class DisableActionButton extends React.Component {
 storiesOf('Buttons/Button', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -67,7 +67,11 @@ class DisableActionButton extends React.Component {
 storiesOf('Buttons/Button', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
+++ b/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
@@ -287,8 +287,5 @@ storiesOf('Buttons/Dropdown', module).add('default', () => (
 		<div id="openImmutable">
 			<ActionDropdown {...openWithImmutable} />
 		</div>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
 	</div>
 ));

--- a/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
+++ b/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
@@ -287,6 +287,8 @@ storiesOf('Buttons/Dropdown', module).add('default', () => (
 		<div id="openImmutable">
 			<ActionDropdown {...openWithImmutable} />
 		</div>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 	</div>
 ));

--- a/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
+++ b/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
@@ -287,6 +287,6 @@ storiesOf('Buttons/Dropdown', module).add('default', () => (
 		<div id="openImmutable">
 			<ActionDropdown {...openWithImmutable} />
 		</div>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 	</div>
 ));

--- a/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
+++ b/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ActionDropdown from './ActionDropdown.component';
-import IconsProvider from '../../IconsProvider';
 import FilterBar from '../../FilterBar';
 import Action from '../Action';
 

--- a/packages/components/src/Actions/ActionFile/File.stories.js
+++ b/packages/components/src/Actions/ActionFile/File.stories.js
@@ -16,7 +16,7 @@ const myAction = {
 storiesOf('Buttons/File', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionFile/File.stories.js
+++ b/packages/components/src/Actions/ActionFile/File.stories.js
@@ -16,7 +16,11 @@ const myAction = {
 storiesOf('Buttons/File', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionFile/File.stories.js
+++ b/packages/components/src/Actions/ActionFile/File.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import Action from '../Action';
-import IconsProvider from '../../IconsProvider';
 
 const myAction = {
 	label: 'Click me',

--- a/packages/components/src/Actions/ActionFile/File.stories.js
+++ b/packages/components/src/Actions/ActionFile/File.stories.js
@@ -14,16 +14,7 @@ const myAction = {
 };
 
 storiesOf('Buttons/File', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>

--- a/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
+++ b/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
@@ -66,7 +66,7 @@ class DisableActionIconToggle extends React.Component {
 storiesOf('Buttons/IconToggle', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
+++ b/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ActionIconToggle from './ActionIconToggle.component';
-import IconsProvider from '../../IconsProvider';
 
 const inactiveIconToggle = {
 	icon: 'talend-panel-opener-right',

--- a/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
+++ b/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
@@ -64,16 +64,7 @@ class DisableActionIconToggle extends React.Component {
 }
 
 storiesOf('Buttons/IconToggle', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('disable the buttons', () => (
 		<div>
 			<DisableActionIconToggle />

--- a/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
+++ b/packages/components/src/Actions/ActionIconToggle/IconToggle.stories.js
@@ -66,7 +66,11 @@ class DisableActionIconToggle extends React.Component {
 storiesOf('Buttons/IconToggle', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ActionSplitDropdown from './ActionSplitDropdown.component';
-import IconsProvider from '../../IconsProvider';
 
 const items = [
 	{

--- a/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
@@ -43,11 +43,6 @@ storiesOf('Deprecated/SplitDropdown', module)
 		<div>
 			{story()}
 			<div className="container" style={{ paddingTop: 40 }} />
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</div>
 	))
 	.add('default', () => (

--- a/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
@@ -43,7 +43,11 @@ storiesOf('Deprecated/SplitDropdown', module)
 		<div>
 			{story()}
 			<div className="container" style={{ paddingTop: 40 }} />
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</div>
 	))
 	.add('default', () => (

--- a/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/SplitDropdown.stories.js
@@ -43,7 +43,7 @@ storiesOf('Deprecated/SplitDropdown', module)
 		<div>
 			{story()}
 			<div className="container" style={{ paddingTop: 40 }} />
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</div>
 	))
 	.add('default', () => (

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import AppGuidedTour from './AppGuidedTour.component';
 import Stepper from '../Stepper';
-import IconsProvider from '../IconsProvider';
 
 // eslint-disable-next-line react/prop-types
 function AppGuidedTourContainer({ withDemoContent = false }) {

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -43,15 +43,6 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 }
 
 storiesOf('Messaging & Communication/AppGuidedTour', module)
-	.addDecorator(fn => (
-		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{fn()}
-		</>
-	))
+	.addDecorator(fn => <>{fn()}</>)
 	.add('default', () => <AppGuidedTourContainer withDemoContent />)
 	.add('without demo content', () => <AppGuidedTourContainer />);

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -45,7 +45,11 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 storiesOf('Messaging & Communication/AppGuidedTour', module)
 	.addDecorator(fn => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{fn()}
 		</>
 	))

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -43,6 +43,5 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 }
 
 storiesOf('Messaging & Communication/AppGuidedTour', module)
-	.addDecorator(fn => <>{fn()}</>)
 	.add('default', () => <AppGuidedTourContainer withDemoContent />)
 	.add('without demo content', () => <AppGuidedTourContainer />);

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -45,7 +45,7 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 storiesOf('Messaging & Communication/AppGuidedTour', module)
 	.addDecorator(fn => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{fn()}
 		</>
 	))

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -93,7 +93,11 @@ storiesOf('Navigation/Badge', module)
 		<React.Fragment>
 			<section>
 				<h1>New visual</h1>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<div style={defaultStyle} id="newVisual-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -347,7 +351,11 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>New visual - Disabled</h1>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<div style={defaultStyle} id="newVisualDisabled-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -663,7 +671,11 @@ storiesOf('Navigation/Badge', module)
 
 			<section style={greyBackgroundStyle}>
 				<h1>New visual - white background</h1>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<div style={defaultStyle} id="newVisualWhite-header">
 					<div style={columnStyle}>
 						<span>/</span>
@@ -768,7 +780,11 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>Old Examples</h1>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<div style={defaultStyle} id="oldExample-header">
 					<div style={columnStyle}>
 						<span>Read Only</span>
@@ -886,7 +902,11 @@ storiesOf('Navigation/Badge', module)
 	))
 	.add('colored', () => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{Object.entries(Badge.TYPES).map(([name, value]) => (
 				<div>
 					{name}

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -93,7 +93,7 @@ storiesOf('Navigation/Badge', module)
 		<React.Fragment>
 			<section>
 				<h1>New visual</h1>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<div style={defaultStyle} id="newVisual-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -347,7 +347,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>New visual - Disabled</h1>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<div style={defaultStyle} id="newVisualDisabled-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -663,7 +663,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section style={greyBackgroundStyle}>
 				<h1>New visual - white background</h1>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<div style={defaultStyle} id="newVisualWhite-header">
 					<div style={columnStyle}>
 						<span>/</span>
@@ -768,7 +768,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>Old Examples</h1>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<div style={defaultStyle} id="oldExample-header">
 					<div style={columnStyle}>
 						<span>Read Only</span>
@@ -886,7 +886,7 @@ storiesOf('Navigation/Badge', module)
 	))
 	.add('colored', () => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{Object.entries(Badge.TYPES).map(([name, value]) => (
 				<div>
 					{name}

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -5,7 +5,6 @@ import { action } from '@storybook/addon-actions';
 import Badge from './Badge.component';
 import FilterBar from '../FilterBar';
 import Action from '../Actions/Action';
-import IconsProvider from '../IconsProvider';
 
 const defaultStyle = {
 	display: 'flex',

--- a/packages/components/src/Badge/Badge.stories.js
+++ b/packages/components/src/Badge/Badge.stories.js
@@ -93,11 +93,7 @@ storiesOf('Navigation/Badge', module)
 		<React.Fragment>
 			<section>
 				<h1>New visual</h1>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
+
 				<div style={defaultStyle} id="newVisual-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -351,11 +347,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>New visual - Disabled</h1>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
+
 				<div style={defaultStyle} id="newVisualDisabled-header">
 					<div style={columnStyle}>
 						<span>Tags as links</span>
@@ -671,11 +663,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section style={greyBackgroundStyle}>
 				<h1>New visual - white background</h1>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
+
 				<div style={defaultStyle} id="newVisualWhite-header">
 					<div style={columnStyle}>
 						<span>/</span>
@@ -780,11 +768,7 @@ storiesOf('Navigation/Badge', module)
 
 			<section>
 				<h1>Old Examples</h1>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
+
 				<div style={defaultStyle} id="oldExample-header">
 					<div style={columnStyle}>
 						<span>Read Only</span>
@@ -902,11 +886,6 @@ storiesOf('Navigation/Badge', module)
 	))
 	.add('colored', () => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			{Object.entries(Badge.TYPES).map(([name, value]) => (
 				<div>
 					{name}

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -122,11 +122,6 @@ const descriptiveDetail = {
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-default-1"
@@ -151,11 +146,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Header', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Collapsible Panel Headers</h1>
 			<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 			<CollapsiblePanel
@@ -187,11 +177,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Body', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-content-1"
@@ -212,11 +197,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Theme: descriptive-panel', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Theme : descriptive-panel</h1>
 			<CollapsiblePanel
 				id="panel-textual-1"
@@ -251,11 +231,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Selection', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Selection</h1>
 			<CollapsiblePanel
 				id="panel-selection-1"
@@ -308,11 +283,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Nested', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Nested</h1>
 			<CollapsiblePanel
 				id="panel-nested-1"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -122,7 +122,7 @@ const descriptiveDetail = {
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-default-1"
@@ -147,7 +147,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Header', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Collapsible Panel Headers</h1>
 			<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 			<CollapsiblePanel
@@ -179,7 +179,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Body', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-content-1"
@@ -200,7 +200,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Theme: descriptive-panel', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Theme : descriptive-panel</h1>
 			<CollapsiblePanel
 				id="panel-textual-1"
@@ -235,7 +235,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Selection', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Selection</h1>
 			<CollapsiblePanel
 				id="panel-selection-1"
@@ -288,7 +288,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Nested', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Nested</h1>
 			<CollapsiblePanel
 				id="panel-nested-1"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -122,7 +122,11 @@ const descriptiveDetail = {
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-default-1"
@@ -147,7 +151,11 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Header', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Collapsible Panel Headers</h1>
 			<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 			<CollapsiblePanel
@@ -179,7 +187,11 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Body', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Collapsible Panel</h1>
 			<CollapsiblePanel
 				id="panel-content-1"
@@ -200,7 +212,11 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Theme: descriptive-panel', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Theme : descriptive-panel</h1>
 			<CollapsiblePanel
 				id="panel-textual-1"
@@ -235,7 +251,11 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Selection', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Selection</h1>
 			<CollapsiblePanel
 				id="panel-selection-1"
@@ -288,7 +308,11 @@ storiesOf('Layout/CollapsiblePanel', module)
 	))
 	.add('Nested', () => (
 		<div className="col-lg-offset-1 col-lg-10">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Nested</h1>
 			<CollapsiblePanel
 				id="panel-nested-1"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import CollapsiblePanel from './CollapsiblePanel.component';
-import IconsProvider from '../IconsProvider';
 
 const keyValueContent = [
 	{

--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -34,11 +34,6 @@ const stories = storiesOf('Data/Tree/DataViewer', module);
 stories
 	.addDecorator(story => (
 		<div style={{ backgroundColor: 'white', height: '400px' }} className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -34,7 +34,11 @@ const stories = storiesOf('Data/Tree/DataViewer', module);
 stories
 	.addDecorator(story => (
 		<div style={{ backgroundColor: 'white', height: '400px' }} className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import classNames from 'classnames';
 import get from 'lodash/get';
 import words from 'lodash/words';
-import IconsProvider from '../IconsProvider';
 import ModelViewer from './ModelViewer';
 import RecordsViewer from './RecordsViewer';
 import hierarchicSample from './sample.raw.json';

--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -34,7 +34,7 @@ const stories = storiesOf('Data/Tree/DataViewer', module);
 stories
 	.addDecorator(story => (
 		<div style={{ backgroundColor: 'white', height: '400px' }} className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -67,7 +67,7 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h3>By default</h3>
 				<Datalist {...propsMultiSection} />
 				<h3>default value</h3>
@@ -97,7 +97,7 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h3>By default</h3>
 				<Datalist {...singleSectionProps} />
 				<h3>default value</h3>
@@ -159,7 +159,7 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h3>Disabled</h3>
 				<Datalist {...disabledSectionProps} />
 				<h3>Readonly</h3>

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -67,7 +67,11 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h3>By default</h3>
 				<Datalist {...propsMultiSection} />
 				<h3>default value</h3>
@@ -97,7 +101,11 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h3>By default</h3>
 				<Datalist {...singleSectionProps} />
 				<h3>default value</h3>
@@ -159,7 +167,11 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h3>Disabled</h3>
 				<Datalist {...disabledSectionProps} />
 				<h3>Readonly</h3>

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import Datalist from './Datalist.component';
-import IconsProvider from '../IconsProvider';
 
 const defaultProps = {
 	onChange: action('onChange'),

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -67,11 +67,6 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h3>By default</h3>
 				<Datalist {...propsMultiSection} />
 				<h3>default value</h3>
@@ -101,11 +96,6 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h3>By default</h3>
 				<Datalist {...singleSectionProps} />
 				<h3>default value</h3>
@@ -167,11 +157,6 @@ storiesOf('Form/Controls/Datalist', module)
 		};
 		return (
 			<form className="form">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h3>Disabled</h3>
 				<Datalist {...disabledSectionProps} />
 				<h3>Readonly</h3>

--- a/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
@@ -11,11 +11,6 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
@@ -11,7 +11,7 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputDatePicker from './InputDatePicker.component';
 
@@ -10,17 +9,15 @@ import DatePicker from '../Date/Picker';
 
 storiesOf('Form/Controls/DatePicker/Date', module)
 	.addDecorator(story => (
-		<>
-			<form
-				onSubmit={event => {
-					event.persist();
-					event.preventDefault();
-					action('submit')(event);
-				}}
-			>
-				{story()}
-			</form>
-		</>
+		<form
+			onSubmit={event => {
+				event.persist();
+				event.preventDefault();
+				action('submit')(event);
+			}}
+		>
+			{story()}
+		</form>
 	))
 	.add('Input', () => (
 		<InputDatePicker

--- a/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/DatePicker.stories.js
@@ -11,7 +11,11 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -11,7 +11,7 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -11,7 +11,11 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputDateRangePicker from './InputDateRangePicker.component';
 
@@ -10,17 +9,15 @@ import DatePicker from '../Date/Picker';
 
 storiesOf('Form/Controls/DatePicker/Date Range', module)
 	.addDecorator(story => (
-		<>
-			<form
-				onSubmit={event => {
-					event.persist();
-					event.preventDefault();
-					action('submit')(event);
-				}}
-			>
-				{story()}
-			</form>
-		</>
+		<form
+			onSubmit={event => {
+				event.persist();
+				event.preventDefault();
+				action('submit')(event);
+			}}
+		>
+			{story()}
+		</form>
 	))
 	.add('Input', () => (
 		<InputDateRangePicker

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -11,11 +11,6 @@ import DatePicker from '../Date/Picker';
 storiesOf('Form/Controls/DatePicker/Date Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
@@ -8,7 +8,7 @@ import InputDateTimePicker from './InputDateTimePicker.component';
 storiesOf('Form/Controls/DatePicker/DateTime', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputDateTimePicker from './InputDateTimePicker.component';
 
 storiesOf('Form/Controls/DatePicker/DateTime', module)
 	.addDecorator(story => (
-		<>
-			<form
-				onSubmit={event => {
-					event.persist();
-					event.preventDefault();
-					action('submit')(event);
-				}}
-			>
-				{story()}
-			</form>
-		</>
+		<form
+			onSubmit={event => {
+				event.persist();
+				event.preventDefault();
+				action('submit')(event);
+			}}
+		>
+			{story()}
+		</form>
 	))
 	.add('Input', () => (
 		<InputDateTimePicker

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
@@ -8,7 +8,11 @@ import InputDateTimePicker from './InputDateTimePicker.component';
 storiesOf('Form/Controls/DatePicker/DateTime', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/DateTimePicker.stories.js
@@ -8,11 +8,6 @@ import InputDateTimePicker from './InputDateTimePicker.component';
 storiesOf('Form/Controls/DatePicker/DateTime', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -8,7 +8,11 @@ import InputDateTimeRangePicker from './InputDateTimeRangePicker.component';
 storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputDateTimeRangePicker from './InputDateTimeRangePicker.component';
 
 storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 	.addDecorator(story => (
-		<>
-			<form
-				onSubmit={event => {
-					event.persist();
-					event.preventDefault();
-					action('submit')(event);
-				}}
-			>
-				{story()}
-			</form>
-		</>
+		<form
+			onSubmit={event => {
+				event.persist();
+				event.preventDefault();
+				action('submit')(event);
+			}}
+		>
+			{story()}
+		</form>
 	))
 	.add('Input', () => (
 		<InputDateTimeRangePicker

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -8,11 +8,6 @@ import InputDateTimeRangePicker from './InputDateTimeRangePicker.component';
 storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -8,7 +8,7 @@ import InputDateTimeRangePicker from './InputDateTimeRangePicker.component';
 storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
@@ -1,24 +1,21 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputTimePicker from './InputTimePicker.component';
 import TimePicker from '../pickers/TimePicker';
 
 storiesOf('Form/Controls/DatePicker/Time', module)
 	.addDecorator(story => (
-		<>
-			<form
-				onSubmit={event => {
-					event.persist();
-					event.preventDefault();
-					action('submit')(event);
-				}}
-			>
-				{story()}
-			</form>
-		</>
+		<form
+			onSubmit={event => {
+				event.persist();
+				event.preventDefault();
+				action('submit')(event);
+			}}
+		>
+			{story()}
+		</form>
 	))
 	.add('Input', () => <InputTimePicker onChange={action('onChange')} onBlur={action('onBlur')} />)
 	.add('Picker', () => {

--- a/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
@@ -9,7 +9,11 @@ import TimePicker from '../pickers/TimePicker';
 storiesOf('Form/Controls/DatePicker/Time', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
@@ -9,11 +9,6 @@ import TimePicker from '../pickers/TimePicker';
 storiesOf('Form/Controls/DatePicker/Time', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/TimePicker.stories.js
@@ -9,7 +9,7 @@ import TimePicker from '../pickers/TimePicker';
 storiesOf('Form/Controls/DatePicker/Time', module)
 	.addDecorator(story => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form
 				onSubmit={event => {
 					event.persist();

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
@@ -7,7 +7,9 @@ import InputDateTimePicker from '.';
 
 storiesOf('Deprecated/LegacyDteTimePicker', module).add('Legacy - form mode', () => (
 	<div>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		<div style={{ width: 150 }}>
 			<InputDateTimePicker
 				id="my-date-picker"

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
@@ -7,7 +7,7 @@ import InputDateTimePicker from '.';
 
 storiesOf('Deprecated/LegacyDteTimePicker', module).add('Legacy - form mode', () => (
 	<div>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		<div style={{ width: 150 }}>
 			<InputDateTimePicker
 				id="my-date-picker"

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
@@ -1,23 +1,20 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../IconsProvider';
 
 import InputDateTimePicker from '.';
 
 storiesOf('Deprecated/LegacyDteTimePicker', module).add('Legacy - form mode', () => (
-	<div>
-		<div style={{ width: 150 }}>
-			<InputDateTimePicker
-				id="my-date-picker"
-				name="Datetime"
-				onBlur={action('onBlur')}
-				onChange={action('onChange')}
-				useTime
-				formMode
-				required={false}
-				useSeconds
-			/>
-		</div>
+	<div style={{ width: 150 }}>
+		<InputDateTimePicker
+			id="my-date-picker"
+			name="Datetime"
+			onBlur={action('onBlur')}
+			onChange={action('onChange')}
+			useTime
+			formMode
+			required={false}
+			useSeconds
+		/>
 	</div>
 ));

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/LegacyDateTimePicker.stories.js
@@ -7,9 +7,6 @@ import InputDateTimePicker from '.';
 
 storiesOf('Deprecated/LegacyDteTimePicker', module).add('Legacy - form mode', () => (
 	<div>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
 		<div style={{ width: 150 }}>
 			<InputDateTimePicker
 				id="my-date-picker"

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -258,55 +258,30 @@ storiesOf('Layout/Drawer', module)
 		<Layout header={header} mode="OneColumn" drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</Layout>
 	))
 	.add('Layout 2 columns', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</Layout>
 	))
 	.add('with editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={editableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</Layout>
 	))
 	.add('with long editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={longEditableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</Layout>
 	))
 	.add('Default with no transition', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersNoTransition}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</Layout>
 	))
 	.add('stacked drawers', () => {
@@ -334,11 +309,6 @@ storiesOf('Layout/Drawer', module)
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={stackedDrawers}>
 				<span>zone with drawer</span>
 				{fiftyRows}
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 			</Layout>
 		);
 	})
@@ -354,11 +324,6 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 			</Layout>
 		);
 	})
@@ -387,11 +352,6 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 			</Layout>
 		);
 	})
@@ -446,11 +406,6 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 			</Layout>
 		);
 	})
@@ -480,11 +435,6 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 			</Layout>
 		);
 	});

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -258,35 +258,35 @@ storiesOf('Layout/Drawer', module)
 		<Layout header={header} mode="OneColumn" drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</Layout>
 	))
 	.add('Layout 2 columns', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</Layout>
 	))
 	.add('with editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={editableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</Layout>
 	))
 	.add('with long editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={longEditableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</Layout>
 	))
 	.add('Default with no transition', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersNoTransition}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</Layout>
 	))
 	.add('stacked drawers', () => {
@@ -314,7 +314,7 @@ storiesOf('Layout/Drawer', module)
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={stackedDrawers}>
 				<span>zone with drawer</span>
 				{fiftyRows}
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			</Layout>
 		);
 	})
@@ -330,7 +330,7 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			</Layout>
 		);
 	})
@@ -359,7 +359,7 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			</Layout>
 		);
 	})
@@ -414,7 +414,7 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			</Layout>
 		);
 	})
@@ -444,7 +444,7 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			</Layout>
 		);
 	});

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -7,7 +7,6 @@ import Drawer from './Drawer.component';
 
 import ActionBar from '../ActionBar';
 import HeaderBar from '../HeaderBar';
-import IconsProvider from '../IconsProvider';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
 import { ActionButton } from '../Actions';

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -258,35 +258,55 @@ storiesOf('Layout/Drawer', module)
 		<Layout header={header} mode="OneColumn" drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</Layout>
 	))
 	.add('Layout 2 columns', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</Layout>
 	))
 	.add('with editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={editableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</Layout>
 	))
 	.add('with long editable header', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={longEditableDrawers}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</Layout>
 	))
 	.add('Default with no transition', () => (
 		<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersNoTransition}>
 			<span>zone with drawer</span>
 			{twentyRows}
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</Layout>
 	))
 	.add('stacked drawers', () => {
@@ -314,7 +334,11 @@ storiesOf('Layout/Drawer', module)
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={stackedDrawers}>
 				<span>zone with drawer</span>
 				{fiftyRows}
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 			</Layout>
 		);
 	})
@@ -330,7 +354,11 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 			</Layout>
 		);
 	})
@@ -359,7 +387,11 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={drawersWithTabs}>
 				<span>zone with drawer</span>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 			</Layout>
 		);
 	})
@@ -414,7 +446,11 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 			</Layout>
 		);
 	})
@@ -444,7 +480,11 @@ storiesOf('Layout/Drawer', module)
 		return (
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 			</Layout>
 		);
 	});

--- a/packages/components/src/EditableText/EditableText.stories.js
+++ b/packages/components/src/EditableText/EditableText.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../IconsProvider';
 import EditableText from './EditableText.component';
 
 const props = {

--- a/packages/components/src/EditableText/EditableText.stories.js
+++ b/packages/components/src/EditableText/EditableText.stories.js
@@ -15,7 +15,7 @@ const props = {
 storiesOf('Form/Inline form/EditableText', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>EditableText</h1>
 			{story()}
 		</div>

--- a/packages/components/src/EditableText/EditableText.stories.js
+++ b/packages/components/src/EditableText/EditableText.stories.js
@@ -15,7 +15,11 @@ const props = {
 storiesOf('Form/Inline form/EditableText', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>EditableText</h1>
 			{story()}
 		</div>

--- a/packages/components/src/EditableText/EditableText.stories.js
+++ b/packages/components/src/EditableText/EditableText.stories.js
@@ -15,11 +15,6 @@ const props = {
 storiesOf('Form/Inline form/EditableText', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>EditableText</h1>
 			{story()}
 		</div>

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -320,110 +320,70 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...props} />
 		</div>
 	))
 	.add('default header action disabled', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...headerDisabled} />
 		</div>
 	))
 	.add('default - empty list', () => (
 		<div>
 			<p>Empty list by default:</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...defaultEmptyListProps} />
 		</div>
 	))
 	.add('default with dropdown', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...dropDownActionsProps} />
 		</div>
 	))
 	.add('add', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...addProps} />
 		</div>
 	))
 	.add('edit mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...editItemProps} />
 		</div>
 	))
 	.add('search mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...searchProps} />
 		</div>
 	))
 	.add('search mode - empty list', () => (
 		<div>
 			<p>empty list in search mode :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...searchModeEmptyListProps} />
 		</div>
 	))
 	.add('selected values', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...selectedValuesProps} />
 		</div>
 	))
 	.add('selected values with checkboxes', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<form>
 				<Enumeration {...selectedValuesCheckboxesProps} />
 			</form>
@@ -432,66 +392,42 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('with header error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...headerErrorProps} />
 		</div>
 	))
 	.add('with item in error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...editItemPropsWithError} />
 		</div>
 	))
 	.add('with custom label', () => (
 		<div>
 			<p>Should be 'Users' instead of 'Values'</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...customLabelProps} />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
 			<p>By default: </p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...withIconProps} />
 		</div>
 	))
 	.add('with custom class for row', () => (
 		<div>
 			<p>With custom class on second row: </p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...withClassProps} />
 		</div>
 	))
 	.add('with dynamic height', () => (
 		<div>
 			<p>With dynamic height: </p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<EnumerationDynamicHeight />
 		</div>
 	))
@@ -511,11 +447,7 @@ storiesOf('Form/Controls/Enumeration', module)
 				The function takes a single argument, item data(including index). returns an array of
 				actions.
 			</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<Enumeration {...withCustomActions} />
 		</div>
 	));

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -320,70 +320,70 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...props} />
 		</div>
 	))
 	.add('default header action disabled', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...headerDisabled} />
 		</div>
 	))
 	.add('default - empty list', () => (
 		<div>
 			<p>Empty list by default:</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...defaultEmptyListProps} />
 		</div>
 	))
 	.add('default with dropdown', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...dropDownActionsProps} />
 		</div>
 	))
 	.add('add', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...addProps} />
 		</div>
 	))
 	.add('edit mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...editItemProps} />
 		</div>
 	))
 	.add('search mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...searchProps} />
 		</div>
 	))
 	.add('search mode - empty list', () => (
 		<div>
 			<p>empty list in search mode :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...searchModeEmptyListProps} />
 		</div>
 	))
 	.add('selected values', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...selectedValuesProps} />
 		</div>
 	))
 	.add('selected values with checkboxes', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<form>
 				<Enumeration {...selectedValuesCheckboxesProps} />
 			</form>
@@ -392,42 +392,42 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('with header error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...headerErrorProps} />
 		</div>
 	))
 	.add('with item in error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...editItemPropsWithError} />
 		</div>
 	))
 	.add('with custom label', () => (
 		<div>
 			<p>Should be 'Users' instead of 'Values'</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...customLabelProps} />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
 			<p>By default: </p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...withIconProps} />
 		</div>
 	))
 	.add('with custom class for row', () => (
 		<div>
 			<p>With custom class on second row: </p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...withClassProps} />
 		</div>
 	))
 	.add('with dynamic height', () => (
 		<div>
 			<p>With dynamic height: </p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<EnumerationDynamicHeight />
 		</div>
 	))
@@ -447,7 +447,7 @@ storiesOf('Form/Controls/Enumeration', module)
 				The function takes a single argument, item data(including index). returns an array of
 				actions.
 			</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<Enumeration {...withCustomActions} />
 		</div>
 	));

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -320,70 +320,110 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...props} />
 		</div>
 	))
 	.add('default header action disabled', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...headerDisabled} />
 		</div>
 	))
 	.add('default - empty list', () => (
 		<div>
 			<p>Empty list by default:</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...defaultEmptyListProps} />
 		</div>
 	))
 	.add('default with dropdown', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...dropDownActionsProps} />
 		</div>
 	))
 	.add('add', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...addProps} />
 		</div>
 	))
 	.add('edit mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...editItemProps} />
 		</div>
 	))
 	.add('search mode', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...searchProps} />
 		</div>
 	))
 	.add('search mode - empty list', () => (
 		<div>
 			<p>empty list in search mode :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...searchModeEmptyListProps} />
 		</div>
 	))
 	.add('selected values', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...selectedValuesProps} />
 		</div>
 	))
 	.add('selected values with checkboxes', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<form>
 				<Enumeration {...selectedValuesCheckboxesProps} />
 			</form>
@@ -392,42 +432,66 @@ storiesOf('Form/Controls/Enumeration', module)
 	.add('with header error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...headerErrorProps} />
 		</div>
 	))
 	.add('with item in error', () => (
 		<div>
 			<p>By default :</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...editItemPropsWithError} />
 		</div>
 	))
 	.add('with custom label', () => (
 		<div>
 			<p>Should be 'Users' instead of 'Values'</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...customLabelProps} />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
 			<p>By default: </p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...withIconProps} />
 		</div>
 	))
 	.add('with custom class for row', () => (
 		<div>
 			<p>With custom class on second row: </p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...withClassProps} />
 		</div>
 	))
 	.add('with dynamic height', () => (
 		<div>
 			<p>With dynamic height: </p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<EnumerationDynamicHeight />
 		</div>
 	))
@@ -447,7 +511,11 @@ storiesOf('Form/Controls/Enumeration', module)
 				The function takes a single argument, item data(including index). returns an array of
 				actions.
 			</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<Enumeration {...withCustomActions} />
 		</div>
 	));

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import IconsProvider from '../IconsProvider';
 import Enumeration from './Enumeration.component';
 
 import theme from './Enumeration.stories.scss';

--- a/packages/components/src/FilterBar/Filter.stories.js
+++ b/packages/components/src/FilterBar/Filter.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ActionBar from '../ActionBar';
-import IconsProvider from '../IconsProvider';
 import FilterBar from './FilterBar.component';
 
 const propsDockToggle = {

--- a/packages/components/src/FilterBar/Filter.stories.js
+++ b/packages/components/src/FilterBar/Filter.stories.js
@@ -45,7 +45,11 @@ const divStyle = {
 storiesOf('Form/Inline form/FilterBar', module)
 	.add('default-dock and dockable', () => (
 		<div style={divStyle}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<p>When not docked but dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsDockToggle} />
@@ -54,7 +58,11 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('no docked, no dockable and icon visible', () => (
 		<div style={divStyle}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<p>When icon always visible and not docked, no dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsIconAlwaysVisble} />
@@ -63,14 +71,22 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('custom-undock no dockable', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<p>When not docked and no dockable take full width</p>
 			<FilterBar {...propsNoDockToggle} />
 		</div>
 	))
 	.add('disabled input', () => (
 		<div style={divStyle}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<p>With the input filter disable</p>
 			<ActionBar>
 				<FilterBar {...propsDisabled} />

--- a/packages/components/src/FilterBar/Filter.stories.js
+++ b/packages/components/src/FilterBar/Filter.stories.js
@@ -45,11 +45,6 @@ const divStyle = {
 storiesOf('Form/Inline form/FilterBar', module)
 	.add('default-dock and dockable', () => (
 		<div style={divStyle}>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<p>When not docked but dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsDockToggle} />
@@ -58,11 +53,6 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('no docked, no dockable and icon visible', () => (
 		<div style={divStyle}>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<p>When icon always visible and not docked, no dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsIconAlwaysVisble} />
@@ -71,22 +61,12 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('custom-undock no dockable', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<p>When not docked and no dockable take full width</p>
 			<FilterBar {...propsNoDockToggle} />
 		</div>
 	))
 	.add('disabled input', () => (
 		<div style={divStyle}>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<p>With the input filter disable</p>
 			<ActionBar>
 				<FilterBar {...propsDisabled} />

--- a/packages/components/src/FilterBar/Filter.stories.js
+++ b/packages/components/src/FilterBar/Filter.stories.js
@@ -45,7 +45,7 @@ const divStyle = {
 storiesOf('Form/Inline form/FilterBar', module)
 	.add('default-dock and dockable', () => (
 		<div style={divStyle}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<p>When not docked but dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsDockToggle} />
@@ -54,7 +54,7 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('no docked, no dockable and icon visible', () => (
 		<div style={divStyle}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<p>When icon always visible and not docked, no dockable in an ActionBar</p>
 			<ActionBar>
 				<FilterBar {...propsIconAlwaysVisble} />
@@ -63,14 +63,14 @@ storiesOf('Form/Inline form/FilterBar', module)
 	))
 	.add('custom-undock no dockable', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<p>When not docked and no dockable take full width</p>
 			<FilterBar {...propsNoDockToggle} />
 		</div>
 	))
 	.add('disabled input', () => (
 		<div style={divStyle}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<p>With the input filter disable</p>
 			<ActionBar>
 				<FilterBar {...propsDisabled} />

--- a/packages/components/src/GridLayout/Dashboard.stories.js
+++ b/packages/components/src/GridLayout/Dashboard.stories.js
@@ -201,7 +201,7 @@ function GridContainer({ isLoading = false, skeletonConfiguration, isResizable =
 storiesOf('Layout/Dashboard', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/GridLayout/Dashboard.stories.js
+++ b/packages/components/src/GridLayout/Dashboard.stories.js
@@ -199,16 +199,7 @@ function GridContainer({ isLoading = false, skeletonConfiguration, isResizable =
 }
 
 storiesOf('Layout/Dashboard', module)
-	.addDecorator(story => (
-		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div>{story()}</div>)
 	.add('default', () => <GridContainer />)
 	.add('not draggable', () => <GridContainer isDraggable={false} />)
 	.add('not resizable', () => <GridContainer isResizable={false} />)

--- a/packages/components/src/GridLayout/Dashboard.stories.js
+++ b/packages/components/src/GridLayout/Dashboard.stories.js
@@ -6,7 +6,6 @@ import { action } from '@storybook/addon-actions';
 import Action from '../Actions/Action';
 import ActionIconToggle from '../Actions/ActionIconToggle';
 import { InputDateTimePicker } from '../DateTimePickers';
-import IconsProvider from '../IconsProvider';
 import GridLayout from '.';
 
 export const customSkeletonConf = [
@@ -199,7 +198,6 @@ function GridContainer({ isLoading = false, skeletonConfiguration, isResizable =
 }
 
 storiesOf('Layout/Dashboard', module)
-	.addDecorator(story => <div>{story()}</div>)
 	.add('default', () => <GridContainer />)
 	.add('not draggable', () => <GridContainer isDraggable={false} />)
 	.add('not resizable', () => <GridContainer isResizable={false} />)

--- a/packages/components/src/GridLayout/Dashboard.stories.js
+++ b/packages/components/src/GridLayout/Dashboard.stories.js
@@ -201,7 +201,11 @@ function GridContainer({ isLoading = false, skeletonConfiguration, isResizable =
 storiesOf('Layout/Dashboard', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/HttpError/HttpError.stories.js
+++ b/packages/components/src/HttpError/HttpError.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import HttpError from './HttpError.component';
-import IconsProvider from '../IconsProvider';
 
 const commonStyle = {
 	height: '60rem',

--- a/packages/components/src/HttpError/HttpError.stories.js
+++ b/packages/components/src/HttpError/HttpError.stories.js
@@ -66,16 +66,7 @@ const notFoundWithRedirectProps = {
 // Style here is for demonstration purpose, you should use generated className with its status code.
 
 storiesOf('Messaging & Communication/HttpError', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('Forbidden', () => <HttpError style={forbiddenStyle} {...forbiddenProps} />)
 	.add('NotFound', () => <HttpError style={notFoundStyle} {...notFoundProps} />)
 	.add('NotFound with redirect action', () => (

--- a/packages/components/src/HttpError/HttpError.stories.js
+++ b/packages/components/src/HttpError/HttpError.stories.js
@@ -68,7 +68,11 @@ const notFoundWithRedirectProps = {
 storiesOf('Messaging & Communication/HttpError', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/HttpError/HttpError.stories.js
+++ b/packages/components/src/HttpError/HttpError.stories.js
@@ -68,7 +68,7 @@ const notFoundWithRedirectProps = {
 storiesOf('Messaging & Communication/HttpError', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -46,7 +46,6 @@ function Icon({ className, name, title, transform, onClick, ...props }) {
 	React.useEffect(() => {
 		if (isRemote) {
 			fetch(imgSrc, {
-				mode: 'cors',
 				headers: {
 					Accept: 'image/svg+xml',
 				},

--- a/packages/components/src/Icon/Icon.component.js
+++ b/packages/components/src/Icon/Icon.component.js
@@ -46,6 +46,7 @@ function Icon({ className, name, title, transform, onClick, ...props }) {
 	React.useEffect(() => {
 		if (isRemote) {
 			fetch(imgSrc, {
+				mode: 'cors',
 				headers: {
 					Accept: 'image/svg+xml',
 				},

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -27,11 +27,10 @@ storiesOf('Messaging & Communication/Icon', module)
 		setTimeout(() => {
 			setName(ids[ids.indexOf(name) + 1]);
 		}, 1000);
-		const bundles = [`${location.origin}${location.pathname}all.svg`];
 		return (
 			<div>
 				<h1>Icon</h1>
-				<IconsProvider bundles={bundles} />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<p>
 					We have {ids.length.toString()} svg icons registered:{' '}
 					{name && (
@@ -111,7 +110,7 @@ storiesOf('Messaging & Communication/Icon', module)
 		}, 1000);
 		return (
 			<div>
-				<IconsProvider bundles={bundles} />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<p>Here we are changing the icon talend-apache</p>
 				<ul>
 					<li>

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -27,10 +27,11 @@ storiesOf('Messaging & Communication/Icon', module)
 		setTimeout(() => {
 			setName(ids[ids.indexOf(name) + 1]);
 		}, 1000);
+		const bundles = [`${location.origin}${location.pathname}all.svg`];
 		return (
 			<div>
 				<h1>Icon</h1>
-				<IconsProvider />
+				<IconsProvider bundles={bundles} />
 				<p>
 					We have {ids.length.toString()} svg icons registered:{' '}
 					{name && (
@@ -110,7 +111,7 @@ storiesOf('Messaging & Communication/Icon', module)
 		}, 1000);
 		return (
 			<div>
-				<IconsProvider />
+				<IconsProvider bundles={bundles} />
 				<p>Here we are changing the icon talend-apache</p>
 				<ul>
 					<li>

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -30,7 +30,11 @@ storiesOf('Messaging & Communication/Icon', module)
 		return (
 			<div>
 				<h1>Icon</h1>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<p>
 					We have {ids.length.toString()} svg icons registered:{' '}
 					{name && (
@@ -110,7 +114,11 @@ storiesOf('Messaging & Communication/Icon', module)
 		}, 1000);
 		return (
 			<div>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<p>Here we are changing the icon talend-apache</p>
 				<ul>
 					<li>

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -30,11 +30,7 @@ storiesOf('Messaging & Communication/Icon', module)
 		return (
 			<div>
 				<h1>Icon</h1>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
+
 				<p>
 					We have {ids.length.toString()} svg icons registered:{' '}
 					{name && (
@@ -67,7 +63,7 @@ storiesOf('Messaging & Communication/Icon', module)
 	.add('extends defaults', () => (
 		<div>
 			<h1>Icon</h1>
-			<IconsProvider icons={newIcons} />
+			<IconsProvider bundles={[]} icons={newIcons} />
 			<p>Here we are adding a new Icon id</p>
 			<ul>
 				<li>
@@ -79,7 +75,7 @@ storiesOf('Messaging & Communication/Icon', module)
 	.add('override defaults', () => (
 		<div>
 			<h1>Icon</h1>
-			<IconsProvider defaultIcons={defaultIcons} />
+			<IconsProvider bundles={[]} defaultIcons={defaultIcons} />
 			<p>Here we are changing the icon talend-add</p>
 			<ul>
 				<li>
@@ -114,11 +110,6 @@ storiesOf('Messaging & Communication/Icon', module)
 		}, 1000);
 		return (
 			<div>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<p>Here we are changing the icon talend-apache</p>
 				<ul>
 					<li>

--- a/packages/components/src/Icon/Icon.stories.js
+++ b/packages/components/src/Icon/Icon.stories.js
@@ -23,12 +23,22 @@ storiesOf('Messaging & Communication/Icon', module)
 		React.useEffect(() => {
 			IconsProvider.getAllIconIds().then(setIds);
 		}, []);
+		const [name, setName] = React.useState();
+		setTimeout(() => {
+			setName(ids[ids.indexOf(name) + 1]);
+		}, 1000);
 		return (
 			<div>
 				<h1>Icon</h1>
 				<IconsProvider />
-				<Icon name="talend-apache" />
-				<p>We have {ids.length.toString()} svg icons registered:</p>
+				<p>
+					We have {ids.length.toString()} svg icons registered:{' '}
+					{name && (
+						<>
+							<Icon name={name} /> : <strong>{name}</strong>
+						</>
+					)}
+				</p>
 				<ul>
 					{ids.map((icon, index) => (
 						<li key={index}>
@@ -80,45 +90,67 @@ storiesOf('Messaging & Communication/Icon', module)
 			<Icon name="remote-/svg/svg/brands/azure.svg" />
 		</div>
 	))
-	.add('svg transform', () => (
-		<div>
-			<IconsProvider />
-			<p>Here we are changing the icon talend-apache</p>
-			<ul>
-				<li>
-					<Icon name="talend-apache" />
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="spin" /> : <strong>spin</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-45" /> : <strong>rotate-45</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-90" /> : <strong>rotate-90</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-135" /> : <strong>rotate-135</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-180" /> : <strong>rotate-180</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-225" /> : <strong>rotate-225</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-270" /> : <strong>rotate-270</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="rotate-315" /> : <strong>rotate-315</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="flip-horizontal" /> :{' '}
-					<strong>flip-horizontal</strong>
-				</li>
-				<li>
-					<Icon name="talend-apache" transform="flip-vertical" /> : <strong>flip-vertical</strong>
-				</li>
-			</ul>
-		</div>
-	));
+	.add('svg transform', () => {
+		const [transform, setTransform] = React.useState(null);
+		const transforms = [
+			null,
+			'spin',
+			'rotate-45',
+			'rotate-90',
+			'rotate-135',
+			'rotate-180',
+			'rotate-225',
+			'rotate-270',
+			'rotate-315',
+			'flip-horizontal',
+			'flip-vertical',
+		];
+		setTimeout(() => {
+			setTransform(transforms[transforms.indexOf(transform) + 1]);
+		}, 1000);
+		return (
+			<div>
+				<IconsProvider />
+				<p>Here we are changing the icon talend-apache</p>
+				<ul>
+					<li>
+						<Icon name="talend-apache" />
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="spin" /> : <strong>spin</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-45" /> : <strong>rotate-45</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-90" /> : <strong>rotate-90</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-135" /> : <strong>rotate-135</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-180" /> : <strong>rotate-180</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-225" /> : <strong>rotate-225</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-270" /> : <strong>rotate-270</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="rotate-315" /> : <strong>rotate-315</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="flip-horizontal" /> :{' '}
+						<strong>flip-horizontal</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform="flip-vertical" /> : <strong>flip-vertical</strong>
+					</li>
+					<li>
+						<Icon name="talend-apache" transform={transform} />: <strong>{transform}</strong>
+					</li>
+				</ul>
+			</div>
+		);
+	});

--- a/packages/components/src/Icon/Icon.test.js
+++ b/packages/components/src/Icon/Icon.test.js
@@ -73,6 +73,7 @@ describe('Icon', () => {
 		expect(global.fetch).toHaveBeenCalledTimes(1);
 		expect(global.fetch).toHaveBeenCalledWith('/assets/icons/my-icon.svg', {
 			headers: { Accept: 'image/svg+xml' },
+			mode: 'cors',
 		});
 		expect(wrapper.html()).toMatchSnapshot();
 	});

--- a/packages/components/src/Icon/Icon.test.js
+++ b/packages/components/src/Icon/Icon.test.js
@@ -73,7 +73,6 @@ describe('Icon', () => {
 		expect(global.fetch).toHaveBeenCalledTimes(1);
 		expect(global.fetch).toHaveBeenCalledWith('/assets/icons/my-icon.svg', {
 			headers: { Accept: 'image/svg+xml' },
-			mode: 'cors',
 		});
 		expect(wrapper.html()).toMatchSnapshot();
 	});

--- a/packages/components/src/IconsProvider/IconsProvider.component.js
+++ b/packages/components/src/IconsProvider/IconsProvider.component.js
@@ -69,7 +69,7 @@ function addBundle(response) {
 				container.setAttribute('class', 'tc-iconsprovider sr-only');
 				container.setAttribute('focusable', false);
 				container.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
-				container.setAttribute('data-url', new URL(response.url).pathname);
+				container.setAttribute('data-url', response.url);
 				container.innerHTML = content;
 				document.body.appendChild(container);
 			}

--- a/packages/components/src/IconsProvider/IconsProvider.component.js
+++ b/packages/components/src/IconsProvider/IconsProvider.component.js
@@ -49,6 +49,9 @@ function getAllFilterIds() {
 function injectIcon(id, container) {
 	const element = document.querySelector(`.tc-iconsprovider #${id}`);
 	if (element) {
+		while (container.hasChildNodes()) {
+			container.removeChild(container.lastChild);
+		}
 		container.appendChild(element.children[0].cloneNode(true));
 	} else if (Object.keys(FETCHING_BUNDLES).length) {
 		Promise.all(Object.values(FETCHING_BUNDLES)).then(() => injectIcon(id, container));

--- a/packages/components/src/InlineMessage/InlineMessage.stories.js
+++ b/packages/components/src/InlineMessage/InlineMessage.stories.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 
-import IconsProvider from '../IconsProvider';
 import { InlineMessage } from './InlineMessage.component';
 
 const props = {

--- a/packages/components/src/InlineMessage/InlineMessage.stories.js
+++ b/packages/components/src/InlineMessage/InlineMessage.stories.js
@@ -17,11 +17,6 @@ const Wrapper = ({ width, children }) => <div style={{ width }}>{children}</div>
 storiesOf('Messaging & Communication/InlineMessage', module)
 	.add('default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>InlineMessage</h1>
 			<h2>Definition</h2>
 			<p>
@@ -82,11 +77,6 @@ storiesOf('Messaging & Communication/InlineMessage', module)
 	))
 	.add('withBackground', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>InlineMessage</h1>
 			<h2>
 				<code>withBackground</code> prop is passed

--- a/packages/components/src/InlineMessage/InlineMessage.stories.js
+++ b/packages/components/src/InlineMessage/InlineMessage.stories.js
@@ -17,7 +17,11 @@ const Wrapper = ({ width, children }) => <div style={{ width }}>{children}</div>
 storiesOf('Messaging & Communication/InlineMessage', module)
 	.add('default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>InlineMessage</h1>
 			<h2>Definition</h2>
 			<p>
@@ -78,7 +82,11 @@ storiesOf('Messaging & Communication/InlineMessage', module)
 	))
 	.add('withBackground', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>InlineMessage</h1>
 			<h2>
 				<code>withBackground</code> prop is passed

--- a/packages/components/src/InlineMessage/InlineMessage.stories.js
+++ b/packages/components/src/InlineMessage/InlineMessage.stories.js
@@ -17,7 +17,7 @@ const Wrapper = ({ width, children }) => <div style={{ width }}>{children}</div>
 storiesOf('Messaging & Communication/InlineMessage', module)
 	.add('default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>InlineMessage</h1>
 			<h2>Definition</h2>
 			<p>
@@ -78,7 +78,7 @@ storiesOf('Messaging & Communication/InlineMessage', module)
 	))
 	.add('withBackground', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>InlineMessage</h1>
 			<h2>
 				<code>withBackground</code> prop is passed

--- a/packages/components/src/Layout/AppLayout.stories.js
+++ b/packages/components/src/Layout/AppLayout.stories.js
@@ -84,7 +84,7 @@ const tabs = {
 
 const stories = storiesOf('Layout/AppLayout', module).addDecorator(story => (
 	<div>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		{story()}
 	</div>
 ));

--- a/packages/components/src/Layout/AppLayout.stories.js
+++ b/packages/components/src/Layout/AppLayout.stories.js
@@ -82,14 +82,7 @@ const tabs = {
 	selectedKey: '2',
 };
 
-const stories = storiesOf('Layout/AppLayout', module).addDecorator(story => (
-	<div>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
-		{story()}
-	</div>
-));
+const stories = storiesOf('Layout/AppLayout', module).addDecorator(story => <div>{story()}</div>);
 
 const appStyle = require('../../stories/config/themes.scss');
 

--- a/packages/components/src/Layout/AppLayout.stories.js
+++ b/packages/components/src/Layout/AppLayout.stories.js
@@ -84,7 +84,9 @@ const tabs = {
 
 const stories = storiesOf('Layout/AppLayout', module).addDecorator(story => (
 	<div>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		{story()}
 	</div>
 ));

--- a/packages/components/src/Layout/AppLayout.stories.js
+++ b/packages/components/src/Layout/AppLayout.stories.js
@@ -82,7 +82,7 @@ const tabs = {
 	selectedKey: '2',
 };
 
-const stories = storiesOf('Layout/AppLayout', module).addDecorator(story => <div>{story()}</div>);
+const stories = storiesOf('Layout/AppLayout', module);
 
 const appStyle = require('../../stories/config/themes.scss');
 

--- a/packages/components/src/Layout/AppLayout.stories.js
+++ b/packages/components/src/Layout/AppLayout.stories.js
@@ -4,7 +4,6 @@ import { action } from '@storybook/addon-actions';
 
 import Drawer from '../Drawer';
 import HeaderBar from '../HeaderBar';
-import IconsProvider from '../IconsProvider';
 import Layout from '.';
 import SidePanel from '../SidePanel';
 import SubHeaderBar from '../SubHeaderBar';

--- a/packages/components/src/List/List.stories.js
+++ b/packages/components/src/List/List.stories.js
@@ -559,7 +559,7 @@ const itemsForListWithIcons = [
 storiesOf('Data/List/List', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/List/List.stories.js
+++ b/packages/components/src/List/List.stories.js
@@ -559,7 +559,11 @@ const itemsForListWithIcons = [
 storiesOf('Data/List/List', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/List/List.stories.js
+++ b/packages/components/src/List/List.stories.js
@@ -7,7 +7,6 @@ import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-d
 import cloneDeep from 'lodash/cloneDeep';
 
 import List from './List.component';
-import IconsProvider from '../IconsProvider';
 import { columnChooserService } from './Toolbar/ColumnChooserButton';
 
 function MyCustomRow(props) {
@@ -557,7 +556,6 @@ const itemsForListWithIcons = [
 ];
 
 storiesOf('Data/List/List', module)
-	.addDecorator(story => <div>{story()}</div>)
 	.add('Table display', () => (
 		<div style={{ height: '70vh' }} className="virtualized-list">
 			<h1>List</h1>

--- a/packages/components/src/List/List.stories.js
+++ b/packages/components/src/List/List.stories.js
@@ -557,16 +557,7 @@ const itemsForListWithIcons = [
 ];
 
 storiesOf('Data/List/List', module)
-	.addDecorator(story => (
-		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div>{story()}</div>)
 	.add('Table display', () => (
 		<div style={{ height: '70vh' }} className="virtualized-list">
 			<h1>List</h1>

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -91,11 +91,6 @@ function CustomListLazyLoading(props) {
 storiesOf('Data/List/List Composition', module)
 	.add('Default', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Default list</h1>
 			<p>By default List doesn't come with any feature</p>
 			<pre>
@@ -124,11 +119,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with display mode change</h1>
 			<p>You can change display mode by adding the selector in toolbar</p>
 			<pre>
@@ -159,11 +149,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with display mode change</h1>
 			<p>
 				You can control the display mode by
@@ -210,11 +195,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Total Items', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Total items</h1>
 			<p>
 				You can show the total number of elements in the list by adding the ItemsNumber component
@@ -252,11 +232,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<p>
@@ -302,11 +277,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>Text Filter</h1>
 			<p>
 				You can control the filter feature by providing callbacks to
@@ -349,11 +319,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -398,11 +363,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled in large mode', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -447,11 +407,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with sorting feature</h1>
 			<p>
 				You can control the sorting feature by providing both onChange and onOrderChange props
@@ -496,11 +451,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by and resizable column: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with sorting feature and resizing column</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<p>
@@ -571,11 +521,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('lots of actions, layout render: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List with multiple right actions</h1>
 			<p>
 				With multiple actions the Right component will align the actions to the right, and add a
@@ -631,11 +576,6 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Lazy Loading', () => (
 		<div className="virtualized-list">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>List supporting Lazy Loding</h1>
 			<p>
 				The LazyLoadingList list component allows to create lists that supports lazy loading
@@ -728,11 +668,6 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h1>List with selectable items</h1>
 				<p>The list also supports items selection, when using the proper hook.</p>
 
@@ -757,11 +692,6 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h1>List with selectable items + an ActionBar</h1>
 				<pre>
 					{`<List.Manager
@@ -815,11 +745,6 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<h1>List with selectable items + total number of items</h1>
 				<p>The number of selected items is available in the right toolbar</p>
 				<pre>

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -91,7 +91,7 @@ function CustomListLazyLoading(props) {
 storiesOf('Data/List/List Composition', module)
 	.add('Default', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Default list</h1>
 			<p>By default List doesn't come with any feature</p>
 			<pre>
@@ -120,7 +120,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with display mode change</h1>
 			<p>You can change display mode by adding the selector in toolbar</p>
 			<pre>
@@ -151,7 +151,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with display mode change</h1>
 			<p>
 				You can control the display mode by
@@ -198,7 +198,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Total Items', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Total items</h1>
 			<p>
 				You can show the total number of elements in the list by adding the ItemsNumber component
@@ -236,7 +236,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<p>
@@ -282,7 +282,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>Text Filter</h1>
 			<p>
 				You can control the filter feature by providing callbacks to
@@ -325,7 +325,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -370,7 +370,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled in large mode', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -415,7 +415,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with sorting feature</h1>
 			<p>
 				You can control the sorting feature by providing both onChange and onOrderChange props
@@ -460,7 +460,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by and resizable column: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with sorting feature and resizing column</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<p>
@@ -531,7 +531,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('lots of actions, layout render: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List with multiple right actions</h1>
 			<p>
 				With multiple actions the Right component will align the actions to the right, and add a
@@ -587,7 +587,7 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Lazy Loading', () => (
 		<div className="virtualized-list">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>List supporting Lazy Loding</h1>
 			<p>
 				The LazyLoadingList list component allows to create lists that supports lazy loading
@@ -680,7 +680,7 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h1>List with selectable items</h1>
 				<p>The list also supports items selection, when using the proper hook.</p>
 
@@ -705,7 +705,7 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h1>List with selectable items + an ActionBar</h1>
 				<pre>
 					{`<List.Manager
@@ -759,7 +759,7 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<h1>List with selectable items + total number of items</h1>
 				<p>The number of selected items is available in the right toolbar</p>
 				<pre>

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import { simpleCollection } from './ListComposition/collection';
-import IconsProvider from '../IconsProvider';
 import ActionBar from '../ActionBar';
 import List from '.';
 

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -91,7 +91,11 @@ function CustomListLazyLoading(props) {
 storiesOf('Data/List/List Composition', module)
 	.add('Default', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Default list</h1>
 			<p>By default List doesn't come with any feature</p>
 			<pre>
@@ -120,7 +124,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with display mode change</h1>
 			<p>You can change display mode by adding the selector in toolbar</p>
 			<pre>
@@ -151,7 +159,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Display mode: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with display mode change</h1>
 			<p>
 				You can control the display mode by
@@ -198,7 +210,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Total Items', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Total items</h1>
 			<p>
 				You can show the total number of elements in the list by adding the ItemsNumber component
@@ -236,7 +252,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Text Filter</h1>
 			<p>You can filter the dataset with the text by adding the component and let it work itself</p>
 			<p>
@@ -282,7 +302,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Text Filter: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>Text Filter</h1>
 			<p>
 				You can control the filter feature by providing callbacks to
@@ -325,7 +349,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -370,7 +398,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: uncontrolled in large mode', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with sorting feature</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<pre>
@@ -415,7 +447,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by: controlled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with sorting feature</h1>
 			<p>
 				You can control the sorting feature by providing both onChange and onOrderChange props
@@ -460,7 +496,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Sort by and resizable column: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with sorting feature and resizing column</h1>
 			<p>You can change the sorting criteria by adding the component in the toolbar</p>
 			<p>
@@ -531,7 +571,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('lots of actions, layout render: uncontrolled', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List with multiple right actions</h1>
 			<p>
 				With multiple actions the Right component will align the actions to the right, and add a
@@ -587,7 +631,11 @@ storiesOf('Data/List/List Composition', module)
 	))
 	.add('Lazy Loading', () => (
 		<div className="virtualized-list">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>List supporting Lazy Loding</h1>
 			<p>
 				The LazyLoadingList list component allows to create lists that supports lazy loading
@@ -680,7 +728,11 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h1>List with selectable items</h1>
 				<p>The list also supports items selection, when using the proper hook.</p>
 
@@ -705,7 +757,11 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h1>List with selectable items + an ActionBar</h1>
 				<pre>
 					{`<List.Manager
@@ -759,7 +815,11 @@ storiesOf('Data/List/List Composition', module)
 
 		return (
 			<div className="virtualized-list">
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<h1>List with selectable items + total number of items</h1>
 				<p>The number of selected items is available in the right toolbar</p>
 				<pre>

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react'; // eslint-disable-line import/no-extraneous-dependencies
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../../../../IconsProvider';
 import ColumnChooser from './ColumnChooser.component';
 
 const columns = [

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -24,11 +24,7 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>Default mode with minimal props</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<ColumnChooser
 				columnsFromList={columns}
 				nbLockedLeftItems={2}
@@ -41,11 +37,7 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>You can provide and compose some of the column chooser part.</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<ColumnChooser
 				columnsFromList={columns}
 				id="default-column-chooser"

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -24,7 +24,11 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>Default mode with minimal props</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ColumnChooser
 				columnsFromList={columns}
 				nbLockedLeftItems={2}
@@ -37,7 +41,11 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>You can provide and compose some of the column chooser part.</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ColumnChooser
 				columnsFromList={columns}
 				id="default-column-chooser"

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -24,7 +24,7 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>Default mode with minimal props</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ColumnChooser
 				columnsFromList={columns}
 				nbLockedLeftItems={2}
@@ -37,7 +37,7 @@ storiesOf('Data/List/Column Chooser', module)
 		<div>
 			<h1>Column chooser tooltip</h1>
 			<p>You can provide and compose some of the column chooser part.</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ColumnChooser
 				columnsFromList={columns}
 				id="default-column-chooser"

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ListView from '.';
-import IconsProvider from '../IconsProvider';
 
 const filterAction = {
 	label: 'Filter',

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -136,7 +136,11 @@ const withIconProps = {
 storiesOf('Form/Controls/ListView', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<h1>ListView</h1>
 			<form>{story()}</form>
 		</div>

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -136,11 +136,6 @@ const withIconProps = {
 storiesOf('Form/Controls/ListView', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<h1>ListView</h1>
 			<form>{story()}</form>
 		</div>

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -136,7 +136,7 @@ const withIconProps = {
 storiesOf('Form/Controls/ListView', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<h1>ListView</h1>
 			<form>{story()}</form>
 		</div>

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -27,7 +27,11 @@ class Photos extends React.Component {
 	render() {
 		return (
 			<section style={{ margin: 20 }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<form className="form">
 					<div className="form-group">
 						<label className="control-label" htmlFor="storybook">

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 
 import MultiSelect from './MultiSelect.container';
-import IconsProvider from '../IconsProvider';
 
 class Photos extends React.Component {
 	constructor(props) {

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -27,11 +27,6 @@ class Photos extends React.Component {
 	render() {
 		return (
 			<section style={{ margin: 20 }}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<form className="form">
 					<div className="form-group">
 						<label className="control-label" htmlFor="storybook">

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -27,7 +27,7 @@ class Photos extends React.Component {
 	render() {
 		return (
 			<section style={{ margin: 20 }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<form className="form">
 					<div className="form-group">
 						<label className="control-label" htmlFor="storybook">

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import NotificationContainer from './Notification.component';
-import IconsProvider from '../IconsProvider';
 
 class NotificationWrapper extends React.Component {
 	constructor() {

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -91,9 +91,7 @@ class NotificationWrapper extends React.Component {
 storiesOf('Messaging & Communication/Notification', module).add('default', () => (
 	<nav>
 		<h1>Notification</h1>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
+
 		<h2>Definition</h2>
 		<p>The Notification component display notification</p>
 		<ul>

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -91,7 +91,7 @@ class NotificationWrapper extends React.Component {
 storiesOf('Messaging & Communication/Notification', module).add('default', () => (
 	<nav>
 		<h1>Notification</h1>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		<h2>Definition</h2>
 		<p>The Notification component display notification</p>
 		<ul>

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -91,7 +91,9 @@ class NotificationWrapper extends React.Component {
 storiesOf('Messaging & Communication/Notification', module).add('default', () => (
 	<nav>
 		<h1>Notification</h1>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		<h2>Definition</h2>
 		<p>The Notification component display notification</p>
 		<ul>

--- a/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
+++ b/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
@@ -467,21 +467,11 @@ const stories = storiesOf('Data/Tree/DataTreeViewer', module);
 stories
 	.add('tree default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} {...handlerHighlight} />
 		</div>
 	))
 	.add('array tree with datetime', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={dateTimeData}
@@ -492,21 +482,11 @@ stories
 	))
 	.add('primitive array tree', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={primitiveArray} {...rootOpenedTypeHandler} />
 		</div>
 	))
 	.add('tree with hightlighting', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -517,11 +497,6 @@ stories
 	))
 	.add('tree with hightlighting and type', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -533,11 +508,6 @@ stories
 	))
 	.add('tree with labels', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -550,21 +520,11 @@ stories
 	))
 	.add('tree without rootLabel', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} tupleLabel="Record" />
 		</div>
 	))
 	.add('tree with very large root label', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -576,61 +536,31 @@ stories
 	))
 	.add('tree with injected elements', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} {...handlerTags} />
 		</div>
 	))
 	.add('tree with handler', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} {...handler} />
 		</div>
 	))
 	.add('list default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" />
 		</div>
 	))
 	.add('list with handler', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" {...handler} />
 		</div>
 	))
 	.add('table default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="table" title="Table data" />
 		</div>
 	))
 	.add('table with handler', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -647,11 +577,6 @@ stories
 		enhancedData[0].category = repeat(clubCategory, 10);
 		return (
 			<div>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<ObjectViewer
 					id="my-viewer"
 					data={enhancedData}
@@ -664,21 +589,11 @@ stories
 	})
 	.add('flat default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat default with schema', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={{ dataset: data, schema }}
@@ -689,21 +604,11 @@ stories
 	))
 	.add('flat with handler', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={data} {...handler} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat with complex nested data', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={moreComplexDataShape}
@@ -715,11 +620,6 @@ stories
 	))
 	.add('tree with a long field', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<ObjectViewer id="my-viewer" data={longFieldData} {...handlerHighlight} />
 		</div>
 	));

--- a/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
+++ b/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
@@ -467,13 +467,21 @@ const stories = storiesOf('Data/Tree/DataTreeViewer', module);
 stories
 	.add('tree default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} {...handlerHighlight} />
 		</div>
 	))
 	.add('array tree with datetime', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={dateTimeData}
@@ -484,13 +492,21 @@ stories
 	))
 	.add('primitive array tree', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={primitiveArray} {...rootOpenedTypeHandler} />
 		</div>
 	))
 	.add('tree with hightlighting', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -501,7 +517,11 @@ stories
 	))
 	.add('tree with hightlighting and type', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -513,7 +533,11 @@ stories
 	))
 	.add('tree with labels', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -526,13 +550,21 @@ stories
 	))
 	.add('tree without rootLabel', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} tupleLabel="Record" />
 		</div>
 	))
 	.add('tree with very large root label', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -544,37 +576,61 @@ stories
 	))
 	.add('tree with injected elements', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} {...handlerTags} />
 		</div>
 	))
 	.add('tree with handler', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} {...handler} />
 		</div>
 	))
 	.add('list default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" />
 		</div>
 	))
 	.add('list with handler', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" {...handler} />
 		</div>
 	))
 	.add('table default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="table" title="Table data" />
 		</div>
 	))
 	.add('table with handler', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -591,7 +647,11 @@ stories
 		enhancedData[0].category = repeat(clubCategory, 10);
 		return (
 			<div>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<ObjectViewer
 					id="my-viewer"
 					data={enhancedData}
@@ -604,13 +664,21 @@ stories
 	})
 	.add('flat default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat default with schema', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={{ dataset: data, schema }}
@@ -621,13 +689,21 @@ stories
 	))
 	.add('flat with handler', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={data} {...handler} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat with complex nested data', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer
 				id="my-viewer"
 				data={moreComplexDataShape}
@@ -639,7 +715,11 @@ stories
 	))
 	.add('tree with a long field', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<ObjectViewer id="my-viewer" data={longFieldData} {...handlerHighlight} />
 		</div>
 	));

--- a/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
+++ b/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
@@ -6,7 +6,6 @@ import { action } from '@storybook/addon-actions';
 
 import ObjectViewer from './ObjectViewer.component';
 import Icon from '../Icon';
-import IconsProvider from '../IconsProvider';
 import TooltipTrigger from '../TooltipTrigger';
 
 const schema = new Map();

--- a/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
+++ b/packages/components/src/ObjectViewer/DataTreeViewer.stories.js
@@ -467,13 +467,13 @@ const stories = storiesOf('Data/Tree/DataTreeViewer', module);
 stories
 	.add('tree default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} {...handlerHighlight} />
 		</div>
 	))
 	.add('array tree with datetime', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={dateTimeData}
@@ -484,13 +484,13 @@ stories
 	))
 	.add('primitive array tree', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={primitiveArray} {...rootOpenedTypeHandler} />
 		</div>
 	))
 	.add('tree with hightlighting', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -501,7 +501,7 @@ stories
 	))
 	.add('tree with hightlighting and type', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -513,7 +513,7 @@ stories
 	))
 	.add('tree with labels', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -526,13 +526,13 @@ stories
 	))
 	.add('tree without rootLabel', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} tupleLabel="Record" />
 		</div>
 	))
 	.add('tree with very large root label', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -544,37 +544,37 @@ stories
 	))
 	.add('tree with injected elements', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} {...handlerTags} />
 		</div>
 	))
 	.add('tree with handler', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} {...handler} />
 		</div>
 	))
 	.add('list default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" />
 		</div>
 	))
 	.add('list with handler', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} displayMode="list" {...handler} />
 		</div>
 	))
 	.add('table default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} displayMode="table" title="Table data" />
 		</div>
 	))
 	.add('table with handler', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={data}
@@ -591,7 +591,7 @@ stories
 		enhancedData[0].category = repeat(clubCategory, 10);
 		return (
 			<div>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<ObjectViewer
 					id="my-viewer"
 					data={enhancedData}
@@ -604,13 +604,13 @@ stories
 	})
 	.add('flat default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat default with schema', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={{ dataset: data, schema }}
@@ -621,13 +621,13 @@ stories
 	))
 	.add('flat with handler', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={data} {...handler} displayMode="flat" title="Table data" />
 		</div>
 	))
 	.add('flat with complex nested data', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer
 				id="my-viewer"
 				data={moreComplexDataShape}
@@ -639,7 +639,7 @@ stories
 	))
 	.add('tree with a long field', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<ObjectViewer id="my-viewer" data={longFieldData} {...handlerHighlight} />
 		</div>
 	));

--- a/packages/components/src/ResourceList/ResourceList.stories.js
+++ b/packages/components/src/ResourceList/ResourceList.stories.js
@@ -277,7 +277,7 @@ export function FilteredResourceList(props) {
 storiesOf('Data/List/ResourceList', module)
 	.addDecorator(story => (
 		<section>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</section>
 	))

--- a/packages/components/src/ResourceList/ResourceList.stories.js
+++ b/packages/components/src/ResourceList/ResourceList.stories.js
@@ -5,7 +5,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ResourceList from './ResourceList.component';
-import IconsProvider from '../IconsProvider';
 import Icon from '../Icon';
 
 const collection = [

--- a/packages/components/src/ResourceList/ResourceList.stories.js
+++ b/packages/components/src/ResourceList/ResourceList.stories.js
@@ -275,16 +275,7 @@ export function FilteredResourceList(props) {
 }
 
 storiesOf('Data/List/ResourceList', module)
-	.addDecorator(story => (
-		<section>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</section>
-	))
+	.addDecorator(story => <section>{story()}</section>)
 	.add('default', () => <ResourceList {...commonProps} collection={collection} />)
 	.add('simple', () => <ResourceList {...commonProps} collection={simpleCollection} />)
 	.add('preparations', () => (

--- a/packages/components/src/ResourceList/ResourceList.stories.js
+++ b/packages/components/src/ResourceList/ResourceList.stories.js
@@ -275,7 +275,6 @@ export function FilteredResourceList(props) {
 }
 
 storiesOf('Data/List/ResourceList', module)
-	.addDecorator(story => <section>{story()}</section>)
 	.add('default', () => <ResourceList {...commonProps} collection={collection} />)
 	.add('simple', () => <ResourceList {...commonProps} collection={simpleCollection} />)
 	.add('preparations', () => (

--- a/packages/components/src/ResourceList/ResourceList.stories.js
+++ b/packages/components/src/ResourceList/ResourceList.stories.js
@@ -277,7 +277,11 @@ export function FilteredResourceList(props) {
 storiesOf('Data/List/ResourceList', module)
 	.addDecorator(story => (
 		<section>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</section>
 	))

--- a/packages/components/src/ResourcePicker/ResourcePicker.stories.js
+++ b/packages/components/src/ResourcePicker/ResourcePicker.stories.js
@@ -134,16 +134,7 @@ const props = {
 };
 
 storiesOf('Form/Controls/ResourcePicker', module)
-	.addDecorator(story => (
-		<section>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</section>
-	))
+	.addDecorator(story => <section>{story()}</section>)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>

--- a/packages/components/src/ResourcePicker/ResourcePicker.stories.js
+++ b/packages/components/src/ResourcePicker/ResourcePicker.stories.js
@@ -136,7 +136,7 @@ const props = {
 storiesOf('Form/Controls/ResourcePicker', module)
 	.addDecorator(story => (
 		<section>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</section>
 	))

--- a/packages/components/src/ResourcePicker/ResourcePicker.stories.js
+++ b/packages/components/src/ResourcePicker/ResourcePicker.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import ResourcePicker from '.';
-import IconsProvider from '../IconsProvider';
 
 const collection = [
 	{
@@ -134,7 +133,6 @@ const props = {
 };
 
 storiesOf('Form/Controls/ResourcePicker', module)
-	.addDecorator(story => <section>{story()}</section>)
 	.add('default', () => (
 		<div>
 			<p>By default :</p>

--- a/packages/components/src/ResourcePicker/ResourcePicker.stories.js
+++ b/packages/components/src/ResourcePicker/ResourcePicker.stories.js
@@ -136,7 +136,11 @@ const props = {
 storiesOf('Form/Controls/ResourcePicker', module)
 	.addDecorator(story => (
 		<section>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</section>
 	))

--- a/packages/components/src/Rich/Layout/RichLayout.stories.js
+++ b/packages/components/src/Rich/Layout/RichLayout.stories.js
@@ -4,7 +4,6 @@ import { action } from '@storybook/addon-actions';
 
 import { Actions, Action } from '../../Actions';
 import ActionBar from '../../ActionBar';
-import IconsProvider from '../../IconsProvider';
 import CircularProgress from '../../CircularProgress';
 import HeaderTitle from '../HeaderTitle';
 import RichError from '../Error';

--- a/packages/components/src/Rich/Layout/RichLayout.stories.js
+++ b/packages/components/src/Rich/Layout/RichLayout.stories.js
@@ -87,16 +87,7 @@ const footer = (
 const customBody = <div>my custom body rich tolltip</div>;
 
 storiesOf('Layout/RichLayout', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('default', () => (
 		<div>
 			<Action

--- a/packages/components/src/Rich/Layout/RichLayout.stories.js
+++ b/packages/components/src/Rich/Layout/RichLayout.stories.js
@@ -89,7 +89,11 @@ const customBody = <div>my custom body rich tolltip</div>;
 storiesOf('Layout/RichLayout', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Rich/Layout/RichLayout.stories.js
+++ b/packages/components/src/Rich/Layout/RichLayout.stories.js
@@ -89,7 +89,7 @@ const customBody = <div>my custom body rich tolltip</div>;
 storiesOf('Layout/RichLayout', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -100,7 +100,11 @@ const stories = storiesOf('Navigation/SidePanel', module);
 stories
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -98,16 +98,7 @@ const other = [
 const stories = storiesOf('Navigation/SidePanel', module);
 
 stories
-	.addDecorator(story => (
-		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div>{story()}</div>)
 	.add('uncontrolled', () => (
 		<SidePanel
 			id="context"

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -100,7 +100,7 @@ const stories = storiesOf('Navigation/SidePanel', module);
 stories
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -2,7 +2,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '../IconsProvider';
 import Layout from '../Layout';
 import SidePanel from './SidePanel.component';
 
@@ -98,7 +97,6 @@ const other = [
 const stories = storiesOf('Navigation/SidePanel', module);
 
 stories
-	.addDecorator(story => <div>{story()}</div>)
 	.add('uncontrolled', () => (
 		<SidePanel
 			id="context"

--- a/packages/components/src/Skeleton/Skeleton.stories.js
+++ b/packages/components/src/Skeleton/Skeleton.stories.js
@@ -4,16 +4,7 @@ import Skeleton from './Skeleton.component';
 import IconsProvider from '../IconsProvider';
 
 storiesOf('Design Principles/Loading Feedback/Skeleton', module)
-	.addDecorator(story => (
-		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)
 	.add('default', () => (
 		<div>
 			<h4>Circles :</h4>

--- a/packages/components/src/Skeleton/Skeleton.stories.js
+++ b/packages/components/src/Skeleton/Skeleton.stories.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import { storiesOf } from '@storybook/react';
 import Skeleton from './Skeleton.component';
-import IconsProvider from '../IconsProvider';
 
 storiesOf('Design Principles/Loading Feedback/Skeleton', module)
 	.addDecorator(story => <div className="col-lg-offset-2 col-lg-8">{story()}</div>)

--- a/packages/components/src/Skeleton/Skeleton.stories.js
+++ b/packages/components/src/Skeleton/Skeleton.stories.js
@@ -6,7 +6,7 @@ import IconsProvider from '../IconsProvider';
 storiesOf('Design Principles/Loading Feedback/Skeleton', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Skeleton/Skeleton.stories.js
+++ b/packages/components/src/Skeleton/Skeleton.stories.js
@@ -6,7 +6,11 @@ import IconsProvider from '../IconsProvider';
 storiesOf('Design Principles/Loading Feedback/Skeleton', module)
 	.addDecorator(story => (
 		<div className="col-lg-offset-2 col-lg-8">
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -71,7 +71,7 @@ const functionFormatFloor = value => `${Math.floor(value)}`;
 
 storiesOf('Form/Controls/Slider', module).add('default', () => (
 	<section>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		<div style={style}>
 			<div style={delimiterStyle}>
 				<p>By default</p>

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -71,9 +71,6 @@ const functionFormatFloor = value => `${Math.floor(value)}`;
 
 storiesOf('Form/Controls/Slider', module).add('default', () => (
 	<section>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
 		<div style={style}>
 			<div style={delimiterStyle}>
 				<p>By default</p>

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -3,7 +3,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import Slider from './Slider.component';
-import IconsProvider from '../IconsProvider';
 
 const icons = [
 	'talend-activity',

--- a/packages/components/src/Slider/Slider.stories.js
+++ b/packages/components/src/Slider/Slider.stories.js
@@ -71,7 +71,9 @@ const functionFormatFloor = value => `${Math.floor(value)}`;
 
 storiesOf('Form/Controls/Slider', module).add('default', () => (
 	<section>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		<div style={style}>
 			<div style={delimiterStyle}>
 				<p>By default</p>

--- a/packages/components/src/Status/Status.stories.js
+++ b/packages/components/src/Status/Status.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
-import IconsProvider from '../IconsProvider';
 import { Status } from './Status.component';
 
 const cancelAction = {

--- a/packages/components/src/Status/Status.stories.js
+++ b/packages/components/src/Status/Status.stories.js
@@ -28,9 +28,6 @@ const myStatus = {
 
 storiesOf('Messaging & Communication/Status', module).add('default', () => (
 	<div>
-		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
-		/>
 		<h1>Status</h1>
 		<h2>Definition</h2>
 		<p>

--- a/packages/components/src/Status/Status.stories.js
+++ b/packages/components/src/Status/Status.stories.js
@@ -28,7 +28,7 @@ const myStatus = {
 
 storiesOf('Messaging & Communication/Status', module).add('default', () => (
 	<div>
-		<IconsProvider />
+		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		<h1>Status</h1>
 		<h2>Definition</h2>
 		<p>

--- a/packages/components/src/Status/Status.stories.js
+++ b/packages/components/src/Status/Status.stories.js
@@ -28,7 +28,9 @@ const myStatus = {
 
 storiesOf('Messaging & Communication/Status', module).add('default', () => (
 	<div>
-		<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
 		<h1>Status</h1>
 		<h2>Definition</h2>
 		<p>

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -24,7 +24,7 @@ function renderActions(isInError) {
 stories
 	.addDecorator(fn => (
 		<>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{fn()}
 		</>
 	))

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -22,16 +22,7 @@ function renderActions(isInError) {
 }
 
 stories
-	.addDecorator(fn => (
-		<>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{fn()}
-		</>
-	))
+	.addDecorator(fn => <>{fn()}</>)
 	.add('Stepper default', () => {
 		const steps = [
 			{ label: 'Fetch Sample', status: Stepper.LOADING_STEP_STATUSES.SUCCESS },

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -24,7 +24,11 @@ function renderActions(isInError) {
 stories
 	.addDecorator(fn => (
 		<>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{fn()}
 		</>
 	))

--- a/packages/components/src/Stepper/Stepper.stories.js
+++ b/packages/components/src/Stepper/Stepper.stories.js
@@ -2,7 +2,6 @@ import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import Action from '../Actions/Action';
-import IconsProvider from '../IconsProvider';
 import Stepper from './Stepper.component';
 
 const stories = storiesOf('Messaging & Communication/Stepper', module);
@@ -22,7 +21,6 @@ function renderActions(isInError) {
 }
 
 stories
-	.addDecorator(fn => <>{fn()}</>)
 	.add('Stepper default', () => {
 		const steps = [
 			{ label: 'Fetch Sample', status: Stepper.LOADING_STEP_STATUSES.SUCCESS },

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { Label } from 'react-bootstrap';
-import IconsProvider from '../IconsProvider';
 import FilterBar from '../FilterBar';
 import SubHeaderBar from './SubHeaderBar.component';
 

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -73,61 +73,31 @@ const stories = storiesOf('Navigation/SubHeader', module);
 stories
 	.add('with default', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} />
 		</div>
 	))
 	.add('with editable', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} editable />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} iconId="talend-file-csv-o" onGoBack={backAction} />
 		</div>
 	))
 	.add('with subtitle', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} subTitle="mySubTitle" onGoBack={backAction} />
 		</div>
 	))
 	.add('with loading subtitle', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} subTitleLoading onGoBack={backAction} />
 		</div>
 	))
 	.add('with custom subtitle', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar
 				{...viewProps}
 				subTitle="mySubTitle"
@@ -138,21 +108,11 @@ stories
 	))
 	.add('with right components', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight} />
 		</div>
 	))
 	.add('with center components', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} center={[componentAction]}>
 				{center}
 			</SubHeaderBar>
@@ -160,11 +120,6 @@ stories
 	))
 	.add('with center components with tag props', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction}>
 				<SubHeaderBar.Content tag="form" center>
 					<input id="inputTitle" type="text" onChange={action('onChange')} value="" />
@@ -174,11 +129,6 @@ stories
 	))
 	.add('with center && right components', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight}>
 				{center}
 			</SubHeaderBar>
@@ -186,11 +136,6 @@ stories
 	))
 	.add('with all', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -204,11 +149,6 @@ stories
 	))
 	.add('with skeleton', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -222,11 +162,6 @@ stories
 	))
 	.add('with inProgress', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -241,11 +176,6 @@ stories
 	))
 	.add('with right actions loading', () => (
 		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} rightActionsLoading />
 		</div>
 	));

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -73,37 +73,61 @@ const stories = storiesOf('Navigation/SubHeader', module);
 stories
 	.add('with default', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} />
 		</div>
 	))
 	.add('with editable', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} editable />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} iconId="talend-file-csv-o" onGoBack={backAction} />
 		</div>
 	))
 	.add('with subtitle', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} subTitle="mySubTitle" onGoBack={backAction} />
 		</div>
 	))
 	.add('with loading subtitle', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} subTitleLoading onGoBack={backAction} />
 		</div>
 	))
 	.add('with custom subtitle', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar
 				{...viewProps}
 				subTitle="mySubTitle"
@@ -114,13 +138,21 @@ stories
 	))
 	.add('with right components', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight} />
 		</div>
 	))
 	.add('with center components', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} center={[componentAction]}>
 				{center}
 			</SubHeaderBar>
@@ -128,7 +160,11 @@ stories
 	))
 	.add('with center components with tag props', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction}>
 				<SubHeaderBar.Content tag="form" center>
 					<input id="inputTitle" type="text" onChange={action('onChange')} value="" />
@@ -138,7 +174,11 @@ stories
 	))
 	.add('with center && right components', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight}>
 				{center}
 			</SubHeaderBar>
@@ -146,7 +186,11 @@ stories
 	))
 	.add('with all', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -160,7 +204,11 @@ stories
 	))
 	.add('with skeleton', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -174,7 +222,11 @@ stories
 	))
 	.add('with inProgress', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -189,7 +241,11 @@ stories
 	))
 	.add('with right actions loading', () => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<SubHeaderBar {...viewProps} onGoBack={backAction} rightActionsLoading />
 		</div>
 	));

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -73,37 +73,37 @@ const stories = storiesOf('Navigation/SubHeader', module);
 stories
 	.add('with default', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} />
 		</div>
 	))
 	.add('with editable', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} editable />
 		</div>
 	))
 	.add('with icon', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} iconId="talend-file-csv-o" onGoBack={backAction} />
 		</div>
 	))
 	.add('with subtitle', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} subTitle="mySubTitle" onGoBack={backAction} />
 		</div>
 	))
 	.add('with loading subtitle', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} subTitleLoading onGoBack={backAction} />
 		</div>
 	))
 	.add('with custom subtitle', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar
 				{...viewProps}
 				subTitle="mySubTitle"
@@ -114,13 +114,13 @@ stories
 	))
 	.add('with right components', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight} />
 		</div>
 	))
 	.add('with center components', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} center={[componentAction]}>
 				{center}
 			</SubHeaderBar>
@@ -128,7 +128,7 @@ stories
 	))
 	.add('with center components with tag props', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction}>
 				<SubHeaderBar.Content tag="form" center>
 					<input id="inputTitle" type="text" onChange={action('onChange')} value="" />
@@ -138,7 +138,7 @@ stories
 	))
 	.add('with center && right components', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} right={injectedComponentsRight}>
 				{center}
 			</SubHeaderBar>
@@ -146,7 +146,7 @@ stories
 	))
 	.add('with all', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -160,7 +160,7 @@ stories
 	))
 	.add('with skeleton', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -174,7 +174,7 @@ stories
 	))
 	.add('with inProgress', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar
 				{...viewProps}
 				iconId="talend-file-csv-o"
@@ -189,7 +189,7 @@ stories
 	))
 	.add('with right actions loading', () => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<SubHeaderBar {...viewProps} onGoBack={backAction} rightActionsLoading />
 		</div>
 	));

--- a/packages/components/src/TabBar/Tabs.stories.js
+++ b/packages/components/src/TabBar/Tabs.stories.js
@@ -167,7 +167,11 @@ stories
 					{renderContent()}
 				</TabBar>
 			</div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</nav>
 	))
 	.add('custom id generator', () => (
@@ -203,7 +207,11 @@ function generateChildId(key, kind) {
 					I'm the child
 				</TabBar>
 			</div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</nav>
 	))
 	.add('With existing content', () => (
@@ -225,7 +233,11 @@ function generateChildId(key, kind) {
 					I'm the existing content of tab 5
 				</div>
 			</div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</nav>
 	))
 	.add('Fully interactive', () => (
@@ -239,6 +251,10 @@ function generateChildId(key, kind) {
 					I'm the responsive child
 				</InteractiveResponsiveTabs>
 			</div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 		</nav>
 	));

--- a/packages/components/src/TabBar/Tabs.stories.js
+++ b/packages/components/src/TabBar/Tabs.stories.js
@@ -4,7 +4,6 @@ import { action } from '@storybook/addon-actions';
 
 import { ActionButton } from '../Actions';
 import TabBar from './TabBar.component';
-import IconsProvider from '../IconsProvider';
 
 const tabProps = {
 	id: 'my-tabs',

--- a/packages/components/src/TabBar/Tabs.stories.js
+++ b/packages/components/src/TabBar/Tabs.stories.js
@@ -167,7 +167,7 @@ stories
 					{renderContent()}
 				</TabBar>
 			</div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</nav>
 	))
 	.add('custom id generator', () => (
@@ -203,7 +203,7 @@ function generateChildId(key, kind) {
 					I'm the child
 				</TabBar>
 			</div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</nav>
 	))
 	.add('With existing content', () => (
@@ -225,7 +225,7 @@ function generateChildId(key, kind) {
 					I'm the existing content of tab 5
 				</div>
 			</div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</nav>
 	))
 	.add('Fully interactive', () => (
@@ -239,6 +239,6 @@ function generateChildId(key, kind) {
 					I'm the responsive child
 				</InteractiveResponsiveTabs>
 			</div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 		</nav>
 	));

--- a/packages/components/src/TabBar/Tabs.stories.js
+++ b/packages/components/src/TabBar/Tabs.stories.js
@@ -167,11 +167,6 @@ stories
 					{renderContent()}
 				</TabBar>
 			</div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</nav>
 	))
 	.add('custom id generator', () => (
@@ -207,11 +202,6 @@ function generateChildId(key, kind) {
 					I'm the child
 				</TabBar>
 			</div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</nav>
 	))
 	.add('With existing content', () => (
@@ -233,11 +223,6 @@ function generateChildId(key, kind) {
 					I'm the existing content of tab 5
 				</div>
 			</div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</nav>
 	))
 	.add('Fully interactive', () => (
@@ -251,10 +236,5 @@ function generateChildId(key, kind) {
 					I'm the responsive child
 				</InteractiveResponsiveTabs>
 			</div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
 		</nav>
 	));

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -329,7 +329,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with action example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withAddAction} />
 			</div>
 		</div>
@@ -340,7 +340,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<h3>Definition</h3>
 			<p>The icons can be customized, passign the Icon components props</p>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withAddAction} structure={structureWithIcons} />
 			</div>
 		</div>
@@ -352,7 +352,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Custom header and action tooltip property-set example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withHeader} />
 			</div>
 		</div>
@@ -364,7 +364,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without action example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...defaultProps} />
 			</div>
 		</div>
@@ -376,7 +376,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without header example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...defaultProps} noHeader />
 			</div>
 		</div>
@@ -388,7 +388,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withRemoval} />
 			</div>
 		</div>
@@ -400,7 +400,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withActions} />
 			</div>
 		</div>
@@ -412,7 +412,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with deep structure: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withDeepStructure} />
 			</div>
 		</div>
@@ -424,7 +424,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with cornercase: longname </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...cornerCaseLongName} />
 			</div>
 		</div>
@@ -436,7 +436,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without icons: </h3>
 			<div style={style}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<TreeView {...withAddAction} structure={structureWithoutIcons} />
 			</div>
 		</div>

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -329,11 +329,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with action example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withAddAction} />
 			</div>
 		</div>
@@ -344,11 +339,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<h3>Definition</h3>
 			<p>The icons can be customized, passign the Icon components props</p>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withAddAction} structure={structureWithIcons} />
 			</div>
 		</div>
@@ -360,11 +350,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Custom header and action tooltip property-set example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withHeader} />
 			</div>
 		</div>
@@ -376,11 +361,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without action example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...defaultProps} />
 			</div>
 		</div>
@@ -392,11 +372,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without header example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...defaultProps} noHeader />
 			</div>
 		</div>
@@ -408,11 +383,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withRemoval} />
 			</div>
 		</div>
@@ -424,11 +394,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withActions} />
 			</div>
 		</div>
@@ -440,11 +405,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with deep structure: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withDeepStructure} />
 			</div>
 		</div>
@@ -456,11 +416,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with cornercase: longname </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...cornerCaseLongName} />
 			</div>
 		</div>
@@ -472,11 +427,6 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without icons: </h3>
 			<div style={style}>
-				<IconsProvider
-					bundles={[
-						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-					]}
-				/>
 				<TreeView {...withAddAction} structure={structureWithoutIcons} />
 			</div>
 		</div>

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -4,7 +4,6 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import TreeView from './TreeView.component';
-import IconsProvider from '../IconsProvider';
 
 const structure = [
 	{ name: 'hitmonlee', children: [{ name: 'Hitmonchan' }], isOpened: false },

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -329,7 +329,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with action example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withAddAction} />
 			</div>
 		</div>
@@ -340,7 +344,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<h3>Definition</h3>
 			<p>The icons can be customized, passign the Icon components props</p>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withAddAction} structure={structureWithIcons} />
 			</div>
 		</div>
@@ -352,7 +360,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Custom header and action tooltip property-set example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withHeader} />
 			</div>
 		</div>
@@ -364,7 +376,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without action example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...defaultProps} />
 			</div>
 		</div>
@@ -376,7 +392,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without header example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...defaultProps} noHeader />
 			</div>
 		</div>
@@ -388,7 +408,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withRemoval} />
 			</div>
 		</div>
@@ -400,7 +424,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withActions} />
 			</div>
 		</div>
@@ -412,7 +440,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with deep structure: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withDeepStructure} />
 			</div>
 		</div>
@@ -424,7 +456,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set with cornercase: longname </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...cornerCaseLongName} />
 			</div>
 		</div>
@@ -436,7 +472,11 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<p>A view component to display any tree structure, like folders or categories.</p>
 			<h3>Default property-set without icons: </h3>
 			<div style={style}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<TreeView {...withAddAction} structure={structureWithoutIcons} />
 			</div>
 		</div>

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -88,16 +88,7 @@ const noHeaderItems = [
 ];
 
 storiesOf('Form/Inline form/Typeahead', module)
-	.addDecorator(story => (
-		<div>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
-			{story()}
-		</div>
-	))
+	.addDecorator(story => <div>{story()}</div>)
 	.add('default with debounce input', () => {
 		const props = {
 			placeholder: 'Search...',

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import Typeahead from './Typeahead.component';
-import IconsProvider from '../IconsProvider';
 
 const items = [
 	{
@@ -88,7 +87,6 @@ const noHeaderItems = [
 ];
 
 storiesOf('Form/Inline form/Typeahead', module)
-	.addDecorator(story => <div>{story()}</div>)
 	.add('default with debounce input', () => {
 		const props = {
 			placeholder: 'Search...',

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -90,7 +90,7 @@ const noHeaderItems = [
 storiesOf('Form/Inline form/Typeahead', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			{story()}
 		</div>
 	))

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -90,7 +90,11 @@ const noHeaderItems = [
 storiesOf('Form/Inline form/Typeahead', module)
 	.addDecorator(story => (
 		<div>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			{story()}
 		</div>
 	))

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -5,7 +5,6 @@ import { action } from '@storybook/addon-actions'; // eslint-disable-line import
 
 import { SortIndicator } from 'react-virtualized';
 
-import IconsProvider from '../IconsProvider';
 import VirtualizedList from '.';
 
 function MyCustomRow(props) {

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -382,7 +382,11 @@ function CollapsiblePanels(props) {
 	return (
 		<div>
 			<h1>Virtualized List with Collapsible Panels</h1>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '90vh' }}>
 				<VirtualizedList
 					collection={cpCollection}
@@ -430,7 +434,11 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -456,7 +464,11 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with radio button title', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -480,7 +492,11 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with label author', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
@@ -501,7 +517,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				You can enable sort by passing <b>sort</b>, <b>sortBy</b> and <b>sortDirection</b>.<br />
 				To disable sort on a column, add the <b>disableSort</b> props (see Description column).
 			</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -540,7 +560,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -576,7 +600,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -612,7 +640,11 @@ storiesOf('Data/List/VirtualizedList', module)
 			<pre>
 				{'getRowState={row => (row.id === 2 ? { disabled: true, tooltip: "Houlala" } : null)'}
 			</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -646,7 +678,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				<br />
 				Also you have to give the proper header renderer, <b>HeaderResizable</b>.<br />
 			</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" width={40} />
@@ -706,7 +742,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				The row height is by default <b>135px</b> but can be customized by passing a<b>rowHeight</b>{' '}
 				props.
 			</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -740,7 +780,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -777,7 +821,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -822,7 +870,11 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list" disableHeader>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -853,7 +905,11 @@ storiesOf('Data/List/VirtualizedList', module)
 				also the icon name and tooltip label should be provided in list item rowData (in{' '}
 				<b>collection</b> items)
 			</p>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collectionWithTooltupLabel} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -882,7 +938,11 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom noRowsRenderer', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={[]} id="my-list" noRowsRenderer={NoRowsRenderer}>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -905,7 +965,11 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom rowRenderers', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collectionWithTooltupLabel}

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -382,11 +382,7 @@ function CollapsiblePanels(props) {
 	return (
 		<div>
 			<h1>Virtualized List with Collapsible Panels</h1>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '90vh' }}>
 				<VirtualizedList
 					collection={cpCollection}
@@ -434,11 +430,7 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -464,11 +456,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with radio button title', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -492,11 +480,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with label author', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
@@ -517,11 +501,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				You can enable sort by passing <b>sort</b>, <b>sortBy</b> and <b>sortDirection</b>.<br />
 				To disable sort on a column, add the <b>disableSort</b> props (see Description column).
 			</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -560,11 +540,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -600,11 +576,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -640,11 +612,7 @@ storiesOf('Data/List/VirtualizedList', module)
 			<pre>
 				{'getRowState={row => (row.id === 2 ? { disabled: true, tooltip: "Houlala" } : null)'}
 			</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -678,11 +646,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				<br />
 				Also you have to give the proper header renderer, <b>HeaderResizable</b>.<br />
 			</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" width={40} />
@@ -742,11 +706,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				The row height is by default <b>135px</b> but can be customized by passing a<b>rowHeight</b>{' '}
 				props.
 			</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -780,11 +740,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -821,11 +777,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -870,11 +822,7 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list" disableHeader>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -905,11 +853,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				also the icon name and tooltip label should be provided in list item rowData (in{' '}
 				<b>collection</b> items)
 			</p>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collectionWithTooltupLabel} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -938,11 +882,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom noRowsRenderer', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={[]} id="my-list" noRowsRenderer={NoRowsRenderer}>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -965,11 +905,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom rowRenderers', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
-			/>
+
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collectionWithTooltupLabel}

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -382,7 +382,7 @@ function CollapsiblePanels(props) {
 	return (
 		<div>
 			<h1>Virtualized List with Collapsible Panels</h1>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '90vh' }}>
 				<VirtualizedList
 					collection={cpCollection}
@@ -430,7 +430,7 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -456,7 +456,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with radio button title', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -480,7 +480,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > Table with label author', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List with radio button title</h1>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Title label="Name" dataKey="name" columnData={titleProps} />
@@ -501,7 +501,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				You can enable sort by passing <b>sort</b>, <b>sortBy</b> and <b>sortDirection</b>.<br />
 				To disable sort on a column, add the <b>disableSort</b> props (see Description column).
 			</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -540,7 +540,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -576,7 +576,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -612,7 +612,7 @@ storiesOf('Data/List/VirtualizedList', module)
 			<pre>
 				{'getRowState={row => (row.id === 2 ? { disabled: true, tooltip: "Houlala" } : null)'}
 			</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -646,7 +646,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				<br />
 				Also you have to give the proper header renderer, <b>HeaderResizable</b>.<br />
 			</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section>
 				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" width={40} />
@@ -706,7 +706,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				The row height is by default <b>135px</b> but can be customized by passing a<b>rowHeight</b>{' '}
 				props.
 			</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -740,7 +740,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				function that returns if a row is selected.
 			</p>
 			<pre>{'isSelected={item => item.id === 6}'}</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -777,7 +777,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				that returns if a row is active.
 			</p>
 			<pre>{'isActive={item => item.id === 6}'}</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collection}
@@ -822,7 +822,7 @@ storiesOf('Data/List/VirtualizedList', module)
 .virtualized-list div.tc-list-cell-created,
 .virtualized-list div.tc-list-cell-modified { flex: 0 0 90px;}`}
 			</pre>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collection} id="my-list" disableHeader>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -853,7 +853,7 @@ storiesOf('Data/List/VirtualizedList', module)
 				also the icon name and tooltip label should be provided in list item rowData (in{' '}
 				<b>collection</b> items)
 			</p>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={collectionWithTooltupLabel} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -882,7 +882,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom noRowsRenderer', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList collection={[]} id="my-list" noRowsRenderer={NoRowsRenderer}>
 					<VirtualizedList.Text label="Id" dataKey="id" />
@@ -905,7 +905,7 @@ storiesOf('Data/List/VirtualizedList', module)
 	.add('List > custom rowRenderers', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<section style={{ height: '50vh' }}>
 				<VirtualizedList
 					collection={collectionWithTooltupLabel}

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -1,3 +1,4 @@
+import React from 'react';
 import { storiesOf, configure, addDecorator } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { withA11y } from '@storybook/addon-a11y';
@@ -9,6 +10,7 @@ import { mock } from '@talend/react-cmf';
 import api, { actions, sagas } from '@talend/react-cmf';
 import { List, Map } from 'immutable';
 import { call, put } from 'redux-saga/effects';
+import { IconsProvider } from '@talend/react-components';
 import '@talend/bootstrap-theme/src/theme/theme.scss';
 import i18n from './../../../.storybook/i18n';
 import ComponentOverlay from './ComponentOverlay';
@@ -31,6 +33,14 @@ addDecorator(
 );
 addDecorator(withCMF);
 addDecorator(withA11y);
+addDecorator(storyFn => (
+	<>
+		<IconsProvider
+			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+		/>
+		{storyFn()}
+	</>
+));
 
 registerAllContainers();
 const actionLogger = action('dispatch');

--- a/packages/containers/examples/ExampleAboutDialog.js
+++ b/packages/containers/examples/ExampleAboutDialog.js
@@ -1,12 +1,10 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
-import { Action, AboutDialog } from '../src';
 
+import { Action, AboutDialog } from '../src';
 
 export default {
 	default: () => (
 		<div>
-			<IconsProvider />
 			<Action actionId="show:about" />
 			<AboutDialog icon="talend-tdp-colored" />
 		</div>

--- a/packages/containers/examples/ExampleAction.js
+++ b/packages/containers/examples/ExampleAction.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { action as stAction } from '@storybook/addon-actions';
-import { IconsProvider } from '@talend/react-components';
+
 import { Action } from '../src';
 
 const myAction = {
@@ -22,7 +22,6 @@ const eAction = {
 export default function ExampleAction() {
 	return (
 		<div>
-			<IconsProvider />
 			<p>Using actionId</p>
 			<Action actionId="menu:first" />
 			<Action actionId="menu:items" />

--- a/packages/containers/examples/ExampleActionBar.js
+++ b/packages/containers/examples/ExampleActionBar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { action } from '@storybook/addon-actions';
 import { ActionBar } from '../src';
 
@@ -40,7 +40,6 @@ const infos = [
 export default function ExampleActions() {
 	return (
 		<div>
-			<IconsProvider />
 			<p>using action ids</p>
 			<ActionBar actionIds={{ left: ['menu:first', 'menu:second', 'menu:third', 'menu:fourth'] }} />
 			<p>using btn groups</p>

--- a/packages/containers/examples/ExampleActionDropdown.js
+++ b/packages/containers/examples/ExampleActionDropdown.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Immutable from 'immutable';
 import { action } from '@storybook/addon-actions';
-import { IconsProvider } from '@talend/react-components';
 
 import { ActionDropdown } from '../src';
 
@@ -51,10 +50,8 @@ export default function ExampleAction() {
 		]),
 	};
 
-
 	return (
 		<div>
-			<IconsProvider />
 			<p>ActionDropdown with items in the settings</p>
 			<ActionDropdown actionId="menu:items-id" />
 			<p>ActionDropdown with items from an expression</p>

--- a/packages/containers/examples/ExampleActionIconToggle.js
+++ b/packages/containers/examples/ExampleActionIconToggle.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconsProvider, Drawer } from '@talend/react-components';
+import { Drawer } from '@talend/react-components';
 import { cmfConnect } from '@talend/react-cmf';
 
 import { ActionIconToggle } from '../src';
@@ -40,7 +40,6 @@ const MyconnectedDrawer = cmfConnect({ mapStateToProps })(MyDrawer);
 export default function ExampleActionIconToggle() {
 	return (
 		<div>
-			<IconsProvider />
 			<div style={{ padding: '3rem' }}>
 				<p>Click on the icon toggle below</p>
 				<ActionIconToggle actionId="action:icon:toggle" />

--- a/packages/containers/examples/ExampleActionSplitDropdown.js
+++ b/packages/containers/examples/ExampleActionSplitDropdown.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { ActionSplitDropdown } from '../src';
 
 export default function ExampleAction() {
 	return (
 		<div>
-			<IconsProvider />
 			<p>ActionSplitDropdown with items in the settings</p>
 			<ActionSplitDropdown actionId="menu:items-id" />
 			<p>ActionSplitDropdown with items from an expression</p>

--- a/packages/containers/examples/ExampleActions.js
+++ b/packages/containers/examples/ExampleActions.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { action } from '@storybook/addon-actions';
 import { Actions } from '../src';
 
@@ -41,7 +41,6 @@ const infos = [
 export default function ExampleActions() {
 	return (
 		<div>
-			<IconsProvider />
 			<p>using action ids</p>
 			<Actions actionIds={['menu:first', 'menu:second', 'menu:third']} />
 			<p>Using pure component props</p>

--- a/packages/containers/examples/ExampleConfirmDialog.js
+++ b/packages/containers/examples/ExampleConfirmDialog.js
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { IconsProvider } from '@talend/react-components';
 import { Map } from 'immutable';
 import { ConfirmDialog } from '../src';
 
@@ -16,7 +15,6 @@ const initialState = new Map({
 export default function ExampleConfirmDialog() {
 	return (
 		<div>
-			<IconsProvider />
 			<ConfirmDialog initialState={initialState} />
 		</div>
 	);

--- a/packages/containers/examples/ExampleEditableText.js
+++ b/packages/containers/examples/ExampleEditableText.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { EditableText } from '../src';
 
 const props = {
@@ -13,7 +13,6 @@ const props = {
 const ExampleEditableText = {
 	'with-default': () => (
 		<div>
-			<IconsProvider />
 			<EditableText {...props} />
 		</div>
 	),

--- a/packages/containers/examples/ExampleFilterBar.js
+++ b/packages/containers/examples/ExampleFilterBar.js
@@ -1,23 +1,15 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
 
 import { FilterBar } from '../src';
 
 const ExampleFilter = {
 	dockable: () => (
 		<div>
-			<IconsProvider />
-			<FilterBar
-				id="exampleFilterNavbar"
-				placeholder="filter nav bar"
-				dockable
-				navbar
-			/>
+			<FilterBar id="exampleFilterNavbar" placeholder="filter nav bar" dockable navbar />
 		</div>
 	),
 	'not dockable': () => (
 		<div>
-			<IconsProvider />
 			<FilterBar
 				id="exampleFilterNoNavbar"
 				dockable={false}

--- a/packages/containers/examples/ExampleForm.js
+++ b/packages/containers/examples/ExampleForm.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import Form from '../src/Form';
 
 const SCHEMA = `{
@@ -83,13 +83,17 @@ class SchemaInState extends React.Component {
 	render() {
 		return (
 			<div className="container">
-				<IconsProvider />
 				<div className="col-md-6">
 					<Form {...JSON.parse(this.state.schema)} />
 				</div>
 				<div className="col-md-6">
 					<h2>Schema</h2>
-					<textarea rows="20" className="form-control" onChange={this.onChange} value={this.state.schema} />
+					<textarea
+						rows="20"
+						className="form-control"
+						onChange={this.onChange}
+						value={this.state.schema}
+					/>
 				</div>
 			</div>
 		);

--- a/packages/containers/examples/ExampleHomeListView.js
+++ b/packages/containers/examples/ExampleHomeListView.js
@@ -196,15 +196,11 @@ apps.forEach(app => {
 ExampleHomeListView.drawer = () => (
 	<div>
 		<HomeListView header={header} sidepanel={sidepanel} list={listProps}>
-			<Drawer
-				stacked
-				title="Im stacked drawer 1"
-				footerActions={Object.assign({}, basicProps, { selected: 0 })}
-			>
+			<Drawer stacked title="Im stacked drawer 1" footerActions={{ ...basicProps, selected: 0 }}>
 				<h1>Hello drawer 1</h1>
 				<p>You should not being able to read this because I&#39;m first</p>
 			</Drawer>
-			<Drawer title="Im drawer 2" footerActions={Object.assign({}, basicProps, { selected: 0 })}>
+			<Drawer title="Im drawer 2" footerActions={{ ...basicProps, selected: 0 }}>
 				<h1>Hello drawer 2</h1>
 				<p>The content dictate the width</p>
 			</Drawer>
@@ -220,15 +216,12 @@ apps.forEach(app => {
 					<Drawer
 						stacked
 						title="Im stacked drawer 1"
-						footerActions={Object.assign({}, basicProps, { selected: 0 })}
+						footerActions={{ ...basicProps, selected: 0 }}
 					>
 						<h1>Hello drawer 1</h1>
 						<p>You should not being able to read this because I&#39;m first</p>
 					</Drawer>
-					<Drawer
-						title="Im drawer 2"
-						footerActions={Object.assign({}, basicProps, { selected: 0 })}
-					>
+					<Drawer title="Im drawer 2" footerActions={{ ...basicProps, selected: 0 }}>
 						<h1>Hello drawer 2</h1>
 						<p>The content dictate the width</p>
 					</Drawer>

--- a/packages/containers/examples/ExampleHomeListView.js
+++ b/packages/containers/examples/ExampleHomeListView.js
@@ -1,16 +1,12 @@
 import React from 'react';
-import { Drawer, IconsProvider } from '@talend/react-components';
+import { Drawer } from '@talend/react-components';
 import Layout from '@talend/react-components/lib/Layout';
-import talendIcons from '@talend/icons/dist/react';
 import { action } from '@storybook/addon-actions';
 import Immutable from 'immutable';
 
 import { HomeListView } from '../src';
 
-const {
-	TALEND_T7_THEME_APPS: apps,
-	TALEND_T7_THEME_CLASSNAME,
-} = Layout;
+const { TALEND_T7_THEME_APPS: apps, TALEND_T7_THEME_CLASSNAME } = Layout;
 
 const primary = {
 	label: 'Primary',
@@ -67,39 +63,41 @@ const basicProps = {
 	multiSelectActions,
 };
 
-const icons = {
-	'talend-arrow-left': talendIcons['talend-arrow-left'],
-	'talend-badge': talendIcons['talend-badge'],
-	'talend-caret-down': talendIcons['talend-caret-down'],
-	'talend-cross': talendIcons['talend-cross'],
-	'talend-cog': talendIcons['talend-cog'],
-	'talend-dataprep': talendIcons['talend-dataprep'],
-	'talend-expanded': talendIcons['talend-expanded'],
-	'talend-file': talendIcons['talend-file'],
-	'talend-file-json-o': talendIcons['talend-file-json-o'],
-	'talend-file-xls-o': talendIcons['talend-file-xls-o'],
-	'talend-folder': talendIcons['talend-folder'],
-	'talend-icons': talendIcons['talend-icons'],
-	'talend-logo': talendIcons['talend-logo'],
-	'talend-pencil': talendIcons['talend-pencil'],
-	'talend-plus': talendIcons['talend-plus'],
-	'talend-plus-circle': talendIcons['talend-plus-circle'],
-	'talend-search': talendIcons['talend-search'],
-	'talend-star': talendIcons['talend-star'],
-	'talend-streams': talendIcons['talend-streams'],
-	'talend-table': talendIcons['talend-table'],
-	'talend-tiles': talendIcons['talend-tiles'],
-	'talend-trash': talendIcons['talend-trash'],
-	'talend-opener': talendIcons['talend-opener'],
-	'talend-upload': talendIcons['talend-upload'],
-};
-
 const header = {
 	app: 'Example app',
 };
 
 const sidepanel = {
-	actionIds: ['menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third', 'menu:first', 'menu:second', 'menu:third' ],
+	actionIds: [
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+		'menu:first',
+		'menu:second',
+		'menu:third',
+	],
 };
 
 const list = {
@@ -124,7 +122,10 @@ const actions = {
 const toolbar = {
 	sort: {
 		field: 'id',
-		options: [{ id: 'id', name: 'Id' }, { id: 'label', name: 'Name' }],
+		options: [
+			{ id: 'id', name: 'Id' },
+			{ id: 'label', name: 'Name' },
+		],
 	},
 	filter: {
 		placeholder: 'find an object',
@@ -171,7 +172,6 @@ const listProps = {
 const ExampleHomeListView = {
 	default: () => (
 		<div>
-			<IconsProvider defaultIcons={icons} />
 			<HomeListView sidepanel={sidepanel} list={listProps} />
 		</div>
 	),
@@ -183,7 +183,6 @@ apps.forEach(app => {
 	ExampleHomeListView[`🎨 ${app.toUpperCase()} default`] = () => (
 		<div className={appStyle[app]}>
 			<div className={TALEND_T7_THEME_CLASSNAME}>
-				<IconsProvider defaultIcons={icons} />
 				<HomeListView
 					// hasTheme - option must be set if you import one and only one theme
 					sidepanel={sidepanel}
@@ -196,7 +195,6 @@ apps.forEach(app => {
 
 ExampleHomeListView.drawer = () => (
 	<div>
-		<IconsProvider defaultIcons={icons} />
 		<HomeListView header={header} sidepanel={sidepanel} list={listProps}>
 			<Drawer
 				stacked
@@ -218,7 +216,6 @@ apps.forEach(app => {
 	ExampleHomeListView[`🎨 ${app.toUpperCase()} drawer`] = () => (
 		<div className={appStyle[app]}>
 			<div className={TALEND_T7_THEME_CLASSNAME}>
-				<IconsProvider defaultIcons={icons} />
 				<HomeListView header={header} sidepanel={sidepanel} list={listProps}>
 					<Drawer
 						stacked

--- a/packages/containers/examples/ExampleLayout.js
+++ b/packages/containers/examples/ExampleLayout.js
@@ -1,36 +1,7 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
-import talendIcons from '@talend/icons/dist/react';
 
 import { Inject } from '@talend/react-cmf';
 import Immutable from 'immutable';
-
-const icons = {
-	'talend-arrow-left': talendIcons['talend-arrow-left'],
-	'talend-badge': talendIcons['talend-badge'],
-	'talend-caret-down': talendIcons['talend-caret-down'],
-	'talend-cross': talendIcons['talend-cross'],
-	'talend-cog': talendIcons['talend-cog'],
-	'talend-dataprep': talendIcons['talend-dataprep'],
-	'talend-expanded': talendIcons['talend-expanded'],
-	'talend-file': talendIcons['talend-file'],
-	'talend-file-json-o': talendIcons['talend-file-json-o'],
-	'talend-file-xls-o': talendIcons['talend-file-xls-o'],
-	'talend-folder': talendIcons['talend-folder'],
-	'talend-icons': talendIcons['talend-icons'],
-	'talend-logo': talendIcons['talend-logo'],
-	'talend-pencil': talendIcons['talend-pencil'],
-	'talend-plus': talendIcons['talend-plus'],
-	'talend-plus-circle': talendIcons['talend-plus-circle'],
-	'talend-search': talendIcons['talend-search'],
-	'talend-star': talendIcons['talend-star'],
-	'talend-streams': talendIcons['talend-streams'],
-	'talend-table': talendIcons['talend-table'],
-	'talend-tiles': talendIcons['talend-tiles'],
-	'talend-trash': talendIcons['talend-trash'],
-	'talend-opener': talendIcons['talend-opener'],
-	'talend-upload': talendIcons['talend-upload'],
-};
 
 const header = {
 	component: 'HeaderBar',
@@ -41,7 +12,6 @@ const sidepanel = {
 	component: 'SidePanel',
 	actionIds: ['menu:first', 'menu:second', 'menu:third'],
 };
-
 
 const tabs = {
 	component: 'TabBar',
@@ -109,16 +79,18 @@ const list = {
 	]),
 };
 
-const content = [
-	tabs,
-	list,
-];
+const content = [tabs, list];
 
 const ExampleLayout = {
 	default: () => (
 		<div>
-			<IconsProvider defaultIcons={icons} />
-			<Inject component="Layout" mode="TwoColumns" header={header} one={sidepanel} content={content} />
+			<Inject
+				component="Layout"
+				mode="TwoColumns"
+				header={header}
+				one={sidepanel}
+				content={content}
+			/>
 		</div>
 	),
 };

--- a/packages/containers/examples/ExampleList.js
+++ b/packages/containers/examples/ExampleList.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { IconsProvider } from '@talend/react-components';
+
 import api from '@talend/react-cmf';
 import Immutable from 'immutable';
 import cloneDeep from 'lodash/cloneDeep';
@@ -92,7 +92,10 @@ const actionsWithSeparator = {
 const toolbar = {
 	sort: {
 		field: 'id',
-		options: [{ id: 'id', name: 'Id' }, { id: 'label', name: 'Name' }],
+		options: [
+			{ id: 'id', name: 'Id' },
+			{ id: 'label', name: 'Name' },
+		],
 	},
 	display: {
 		displayModes: ['large', 'table'],
@@ -213,7 +216,6 @@ propsTimestampSorted.list.sort = sortUpdatedAsc;
 const ExampleList = {
 	default: () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List {...props} items={items} />
 			</div>
@@ -221,7 +223,6 @@ const ExampleList = {
 	),
 	'with persistent actions': () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List {...props} actions={actionsWithPersistent} items={items} />
 			</div>
@@ -229,7 +230,6 @@ const ExampleList = {
 	),
 	'with separator actions': () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List {...props} actions={actionsWithSeparator} items={items} />
 			</div>
@@ -307,7 +307,6 @@ const ExampleList = {
 		propsPg.toolbar.pagination = {};
 		return (
 			<div>
-				<IconsProvider />
 				<div className="list-container">
 					<List {...propsPg} items={itemsPg} />
 				</div>
@@ -319,7 +318,6 @@ const ExampleList = {
 		props2.list.inProgress = true;
 		return (
 			<div>
-				<IconsProvider />
 				<div className="list-container">
 					<List {...props2} items={items} />
 				</div>
@@ -334,7 +332,6 @@ const ExampleList = {
 		multiSelectionProps.idKey = 'id';
 		return (
 			<div>
-				<IconsProvider />
 				<div className="list-container">
 					<List {...multiSelectionProps} items={items} />
 				</div>
@@ -343,7 +340,6 @@ const ExampleList = {
 	},
 	'no toolbar': () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List list={list} actions={actions} items={items} />
 			</div>
@@ -351,7 +347,6 @@ const ExampleList = {
 	),
 	CustomHeight: () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List {...props} items={items} rowHeight={customHeight} initialState={defaultListState} />
 			</div>
@@ -359,7 +354,6 @@ const ExampleList = {
 	),
 	'sort on timestamps': () => (
 		<div>
-			<IconsProvider />
 			<div className="list-container">
 				<List
 					{...propsTimestampSorted}
@@ -376,7 +370,6 @@ const ExampleList = {
 
 		return (
 			<div>
-				<IconsProvider />
 				<div className="list-container">
 					<List
 						virtualized
@@ -394,7 +387,6 @@ const ExampleList = {
 		};
 		return (
 			<div>
-				<IconsProvider />
 				<div className="list-container">
 					<List
 						virtualized

--- a/packages/containers/examples/ExampleNotification.js
+++ b/packages/containers/examples/ExampleNotification.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { List, Map } from 'immutable';
 import { Notification } from '../src';
 
@@ -12,21 +12,22 @@ const initialState = new Map({
 		{
 			id: 'story-2',
 			type: 'error',
-			message: ['This is a feedback of your operation2', 'This is a feedback of your operation1, This is a feedback of your operation1'],
+			message: [
+				'This is a feedback of your operation2',
+				'This is a feedback of your operation1, This is a feedback of your operation1',
+			],
 		},
 		{
 			id: 'story-3',
 			type: 'warning',
 			message: ['This is a feedback of your operation3', 'details'],
 		},
-
 	]),
 });
 
 export default function ExampleNotification() {
 	return (
 		<div>
-			<IconsProvider />
 			<Notification initialState={initialState} />
 		</div>
 	);

--- a/packages/containers/examples/ExampleObjectViewer.js
+++ b/packages/containers/examples/ExampleObjectViewer.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { ObjectViewer } from '../src';
 
 const veryLongCafeName = "Betty's Cafe witha  veryyyyyyy veryyyyyyyyyy looong name";
@@ -181,49 +181,41 @@ const selectedJsonpath = "$[0]['name']";
 const ExampleObjectViewer = {
 	default: () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} />
 		</div>
 	),
 	'JsonLike with rootLabel': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} rootLabel="Dataset des cafés" />
 		</div>
 	),
 	'JsonLike with hightlight': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} selectedJsonpath={selectedJsonpath} />
 		</div>
 	),
 	'JsonLike with types': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} showType />
 		</div>
 	),
 	'JsonLike with types and tuple name': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} showType tupleLabel="Record" />
 		</div>
 	),
 	'list default': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} displayMode="list" openFirst />
 		</div>
 	),
 	'table default': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} displayMode="table" />
 		</div>
 	),
 	'flat default': () => (
 		<div>
-			<IconsProvider />
 			<ObjectViewer data={data} displayMode="flat" />
 		</div>
 	),

--- a/packages/containers/examples/ExampleSelectObject.js
+++ b/packages/containers/examples/ExampleSelectObject.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { SelectObject } from '../src';
 
 const props = {
@@ -40,19 +40,16 @@ const schema = {
 const ExampleSelectObject = {
 	'default tree': () => (
 		<div>
-			<IconsProvider />
 			<SelectObject {...props} />
 		</div>
 	),
 	'tree with preview': () => (
 		<div>
-			<IconsProvider />
 			<SelectObject {...props} schema={schema} />
 		</div>
 	),
 	'tree with filter mode set to ALL': () => (
 		<div>
-			<IconsProvider />
 			<SelectObject {...props} filterMode={SelectObject.FILTER_MODE.ALL} />
 		</div>
 	),

--- a/packages/containers/examples/ExampleSidePanel.js
+++ b/packages/containers/examples/ExampleSidePanel.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { SidePanel } from '../src';
 
 const actions = [
@@ -20,13 +20,11 @@ const actions = [
 const ExampleSidePanel = {
 	'default settings': () => (
 		<div>
-			<IconsProvider />
 			<SidePanel actions={actions} />
 		</div>
 	),
 	'injected settings': () => (
 		<div>
-			<IconsProvider />
 			<SidePanel
 				actionIds={['menu:first', 'menu:second', 'menu:third']}
 				components={{

--- a/packages/containers/examples/ExampleSlider.js
+++ b/packages/containers/examples/ExampleSlider.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { Map } from 'immutable';
 import Slider from '../src/Slider';
 
@@ -74,7 +74,6 @@ const initialState = new Map({
 const ExampleSlider = {
 	Slider: () => (
 		<div style={{ padding: '0 12px' }}>
-			<IconsProvider />
 			<div style={delimiterStyle}>
 				<p style={paragraphStyle}>default</p>
 				<Slider id="slider1" initialState={initialState} />

--- a/packages/containers/examples/ExampleSubHeaderBar.js
+++ b/packages/containers/examples/ExampleSubHeaderBar.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { SubHeaderBar } from '../src';
 
 const viewSubHeader = {
@@ -43,74 +43,46 @@ const props = {
 const ExampleSubHeaderBar = {
 	'with-default': () => (
 		<div>
-			<IconsProvider />
 			<SubHeaderBar {...props} />
 		</div>
 	),
 	'with-subtitle': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				subTitle="mySubTitle"
-				{...props}
-			/>
+			<SubHeaderBar subTitle="mySubTitle" {...props} />
 		</div>
 	),
 	'with-icon': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				iconId="talend-file-csv-o"
-				{...props}
-			/>
+			<SubHeaderBar iconId="talend-file-csv-o" {...props} />
 		</div>
 	),
 	'with-editable': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				{...props}
-				editable
-			/>
+			<SubHeaderBar {...props} editable />
 		</div>
 	),
 	'with-inProgress': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				{...props}
-				editable
-				inProgress
-			/>
+			<SubHeaderBar {...props} editable inProgress />
 		</div>
 	),
 	'with-loading': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				{...props}
-				loading
-			/>
+			<SubHeaderBar {...props} loading />
 		</div>
 	),
 	'with-right-actions': () => (
 		<div>
-			<IconsProvider />
-			<SubHeaderBar
-				{...props}
-				components={injectedComponentsRight}
-			/>
+			<SubHeaderBar {...props} components={injectedComponentsRight} />
 		</div>
 	),
 	'with-center-actions': () => (
 		<div>
-			<IconsProvider />
 			<SubHeaderBar {...props} components={injectedComponentsCenter} />
 		</div>
 	),
 	'with-all': () => (
 		<div>
-			<IconsProvider />
 			<SubHeaderBar
 				{...props}
 				components={Object.assign({}, injectedComponentsCenter, injectedComponentsRight)}

--- a/packages/containers/examples/ExampleSubHeaderBar.js
+++ b/packages/containers/examples/ExampleSubHeaderBar.js
@@ -41,56 +41,22 @@ const props = {
 };
 
 const ExampleSubHeaderBar = {
-	'with-default': () => (
-		<div>
-			<SubHeaderBar {...props} />
-		</div>
-	),
-	'with-subtitle': () => (
-		<div>
-			<SubHeaderBar subTitle="mySubTitle" {...props} />
-		</div>
-	),
-	'with-icon': () => (
-		<div>
-			<SubHeaderBar iconId="talend-file-csv-o" {...props} />
-		</div>
-	),
-	'with-editable': () => (
-		<div>
-			<SubHeaderBar {...props} editable />
-		</div>
-	),
-	'with-inProgress': () => (
-		<div>
-			<SubHeaderBar {...props} editable inProgress />
-		</div>
-	),
-	'with-loading': () => (
-		<div>
-			<SubHeaderBar {...props} loading />
-		</div>
-	),
-	'with-right-actions': () => (
-		<div>
-			<SubHeaderBar {...props} components={injectedComponentsRight} />
-		</div>
-	),
-	'with-center-actions': () => (
-		<div>
-			<SubHeaderBar {...props} components={injectedComponentsCenter} />
-		</div>
-	),
+	'with-default': () => <SubHeaderBar {...props} />,
+	'with-subtitle': () => <SubHeaderBar subTitle="mySubTitle" {...props} />,
+	'with-icon': () => <SubHeaderBar iconId="talend-file-csv-o" {...props} />,
+	'with-editable': () => <SubHeaderBar {...props} editable />,
+	'with-inProgress': () => <SubHeaderBar {...props} editable inProgress />,
+	'with-loading': () => <SubHeaderBar {...props} loading />,
+	'with-right-actions': () => <SubHeaderBar {...props} components={injectedComponentsRight} />,
+	'with-center-actions': () => <SubHeaderBar {...props} components={injectedComponentsCenter} />,
 	'with-all': () => (
-		<div>
-			<SubHeaderBar
-				{...props}
-				components={Object.assign({}, injectedComponentsCenter, injectedComponentsRight)}
-				iconId="talend-file-csv-o"
-				subTitle="mySubTitle"
-				editable
-			/>
-		</div>
+		<SubHeaderBar
+			{...props}
+			components={{ ...injectedComponentsCenter, ...injectedComponentsRight }}
+			iconId="talend-file-csv-o"
+			subTitle="mySubTitle"
+			editable
+		/>
 	),
 };
 export default ExampleSubHeaderBar;

--- a/packages/containers/examples/ExampleTreeView.js
+++ b/packages/containers/examples/ExampleTreeView.js
@@ -1,11 +1,10 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { TreeView } from '../src';
 
 const ExampleTreeView = {
 	default: () => (
 		<div>
-			<IconsProvider />
 			<TreeView
 				id="my-treeview"
 				collection="with.data"

--- a/packages/containers/examples/ExampleTypeahead.js
+++ b/packages/containers/examples/ExampleTypeahead.js
@@ -77,11 +77,7 @@ const view = {
 };
 
 const ExampleTypeahead = {
-	default: () => (
-		<div>
-			<Typeahead {...view} />
-		</div>
-	),
+	default: () => <Typeahead {...view} />,
 };
 
 export default ExampleTypeahead;

--- a/packages/containers/examples/ExampleTypeahead.js
+++ b/packages/containers/examples/ExampleTypeahead.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { IconsProvider } from '@talend/react-components';
+
 import { Typeahead } from '../src';
 
 const view = {
@@ -19,11 +19,13 @@ const view = {
 			suggestions: [
 				{
 					title: 'le title 1',
-					description: 'description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.',
+					description:
+						'description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.',
 				},
 				{
 					title: 'title 2 Les elephants elementaires ont des aile ',
-					description: 'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
+					description:
+						'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
 				},
 			],
 		},
@@ -36,7 +38,8 @@ const view = {
 			suggestions: [
 				{
 					title: 'title 3',
-					description: 'description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.',
+					description:
+						'description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.',
 				},
 			],
 		},
@@ -49,15 +52,18 @@ const view = {
 			suggestions: [
 				{
 					title: 'title 4',
-					description: 'description: Praesentibus genero ne in Africani mandavi saepius ipsam C in libro et hoc Laeli cum.',
+					description:
+						'description: Praesentibus genero ne in Africani mandavi saepius ipsam C in libro et hoc Laeli cum.',
 				},
 				{
 					title: 'title 5',
-					description: 'description: Feceris unde tot illo tot clientes dederis numerando et indiscretus cum paria et unde ubi.',
+					description:
+						'description: Feceris unde tot illo tot clientes dederis numerando et indiscretus cum paria et unde ubi.',
 				},
 				{
 					title: 'title 6',
-					description: 'description: Gradu quos cedentium sunt appeterent ita ancoralia instar luna sunt etiam ubi incendente nihil observabant.',
+					description:
+						'description: Gradu quos cedentium sunt appeterent ita ancoralia instar luna sunt etiam ubi incendente nihil observabant.',
 				},
 				{
 					title: 'without description',
@@ -73,7 +79,6 @@ const view = {
 const ExampleTypeahead = {
 	default: () => (
 		<div>
-			<IconsProvider />
 			<Typeahead {...view} />
 		</div>
 	),

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -28,7 +28,7 @@ sample.data[2].value.field0.value =
 storiesOf('Data/Datagrid/Datagrid', module)
 	.add('default', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -42,7 +42,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('without subtype', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				columnsConf={{ hideSubType: true }}
 				data={sample}
@@ -57,7 +57,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('datagrid without quality', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				data={sampleWithoutQuality}
 				getComponent={getComponent}
@@ -71,7 +71,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('columns resizables', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -84,7 +84,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('With start index to 1', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -98,7 +98,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('no row specific message', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid
 				data={[]}
 				getComponent={getComponent}
@@ -112,13 +112,13 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('loading datagrid', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid data={sample} loading />
 		</div>
 	))
 	.add('loading cells', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<DataGrid data={sample3} />
 		</div>
 	))
@@ -142,7 +142,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 					<div>
 						<input type="button" value="changestatus" onClick={this.changeState} />
 						Number of fields : {currentSample.schema.fields.length}
-						<IconsProvider />
+						<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 						<div style={{ height: '200px' }}>
 							<DataGrid
 								data={currentSample}
@@ -165,7 +165,7 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	.add('dynamic change data', () => <DynamicDataGrid />)
 	.add('faster datagrid', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider />
+			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 			<FasterDatagrid />
 		</div>
 	))

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -28,7 +28,11 @@ sample.data[2].value.field0.value =
 storiesOf('Data/Datagrid/Datagrid', module)
 	.add('default', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -42,7 +46,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('without subtype', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				columnsConf={{ hideSubType: true }}
 				data={sample}
@@ -57,7 +65,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('datagrid without quality', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				data={sampleWithoutQuality}
 				getComponent={getComponent}
@@ -71,7 +83,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('columns resizables', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -84,7 +100,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('With start index to 1', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				data={sample}
 				getComponent={getComponent}
@@ -98,7 +118,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('no row specific message', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid
 				data={[]}
 				getComponent={getComponent}
@@ -112,13 +136,21 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	))
 	.add('loading datagrid', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid data={sample} loading />
 		</div>
 	))
 	.add('loading cells', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<DataGrid data={sample3} />
 		</div>
 	))
@@ -142,7 +174,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 					<div>
 						<input type="button" value="changestatus" onClick={this.changeState} />
 						Number of fields : {currentSample.schema.fields.length}
-						<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+						<IconsProvider
+							bundles={[
+								'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+							]}
+						/>
 						<div style={{ height: '200px' }}>
 							<DataGrid
 								data={currentSample}
@@ -165,7 +201,11 @@ storiesOf('Data/Datagrid/Datagrid', module)
 	.add('dynamic change data', () => <DynamicDataGrid />)
 	.add('faster datagrid', () => (
 		<div style={{ height: '100vh' }}>
-			<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
 			<FasterDatagrid />
 		</div>
 	))

--- a/packages/datagrid/src/containers/datagrid.container.stories.js
+++ b/packages/datagrid/src/containers/datagrid.container.stories.js
@@ -219,7 +219,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'default',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid />
 			</div>
 		),
@@ -229,7 +229,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'loading',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid componentId="ProgressDatagrid" />
 			</div>
 		),
@@ -239,7 +239,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with custom renderers',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid componentId="CustomizedDatagrid" />
 			</div>
 		),
@@ -249,7 +249,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with custom avro renderers',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid componentId="CustomizedAvroDatagrid" />
 			</div>
 		),
@@ -259,7 +259,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with selected rows',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid componentId="HightLightRows" className={theme['td-grid-focus-row']} />
 			</div>
 		),
@@ -269,7 +269,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'multiple grid',
 		() => (
 			<div>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<div style={{ height: '50vh' }}>
 					<DataGrid componentId="HightLightRows" />
 				</div>
@@ -284,7 +284,7 @@ storiesOf('Data/Datagrid/Containers', module)
 		'type renderer',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider />
+				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
 				<DataGrid componentId="TypeRenderer" data={sampleRenderer} />
 			</div>
 		),

--- a/packages/datagrid/src/containers/datagrid.container.stories.js
+++ b/packages/datagrid/src/containers/datagrid.container.stories.js
@@ -219,7 +219,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'default',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid />
 			</div>
 		),
@@ -229,7 +233,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'loading',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid componentId="ProgressDatagrid" />
 			</div>
 		),
@@ -239,7 +247,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with custom renderers',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid componentId="CustomizedDatagrid" />
 			</div>
 		),
@@ -249,7 +261,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with custom avro renderers',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid componentId="CustomizedAvroDatagrid" />
 			</div>
 		),
@@ -259,7 +275,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'with selected rows',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid componentId="HightLightRows" className={theme['td-grid-focus-row']} />
 			</div>
 		),
@@ -269,7 +289,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'multiple grid',
 		() => (
 			<div>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<div style={{ height: '50vh' }}>
 					<DataGrid componentId="HightLightRows" />
 				</div>
@@ -284,7 +308,11 @@ storiesOf('Data/Datagrid/Containers', module)
 		'type renderer',
 		() => (
 			<div style={{ height: '100vh' }}>
-				<IconsProvider bundles={[`${location.origin}${location.pathname}all.svg`]} />
+				<IconsProvider
+					bundles={[
+						'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+					]}
+				/>
 				<DataGrid componentId="TypeRenderer" data={sampleRenderer} />
 			</div>
 		),

--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -11,13 +11,25 @@ import i18n from '../../../.storybook/i18n';
 const languages = {};
 Object.keys(tuiLocales).forEach(key => (languages[key] = key));
 
+function withIconsProvider(story) {
+	return (
+		<>
+			<IconsProvider
+				bundles={[
+					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
+				]}
+			/>
+			{story()}
+		</>
+	);
+}
+
 const withFormLayout = (story, options) => {
 	if (options.kind === 'Layout') {
 		return story();
 	}
 	return (
 		<div className="container-fluid">
-			<IconsProvider />
 			<div
 				className="col-md-offset-1 col-md-10"
 				style={{ marginTop: '20px', marginBottom: '20px' }}
@@ -34,6 +46,7 @@ addDecorator(
 		languages,
 	}),
 );
+addDecorator(withIconsProvider);
 addDecorator(withA11y);
 addDecorator(withFormLayout);
 configure(

--- a/packages/forms/src/deprecated/templates/ArrayFieldTemplate.js
+++ b/packages/forms/src/deprecated/templates/ArrayFieldTemplate.js
@@ -66,7 +66,6 @@ function ArrayFieldTemplate(props) {
 	return (
 		<fieldset className={`${theme.ArrayFieldTemplate} ArrayFieldTemplate`} data-content={title}>
 			{title && <legend>{title}</legend>}
-			<IconsProvider />
 			{canAdd && (
 				<button
 					className={addBtnClass}

--- a/packages/forms/src/deprecated/templates/ArrayFieldTemplate.js
+++ b/packages/forms/src/deprecated/templates/ArrayFieldTemplate.js
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 
 import Icon from '@talend/react-components/lib/Icon';
-import IconsProvider from '@talend/react-components/lib/IconsProvider';
 import { withTranslation } from 'react-i18next';
 
 import { I18N_DOMAIN_FORMS } from '../../constants';

--- a/packages/forms/stories-core/customDisplayMode.js
+++ b/packages/forms/stories-core/customDisplayMode.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import IconsProvider from '@talend/react-components/lib/IconsProvider';
 import { action } from '@storybook/addon-actions';
 import { UIForm } from '../src/UIForm';
 
@@ -216,7 +215,6 @@ const schema = {
 function story() {
 	return (
 		<div>
-			<IconsProvider />
 			<h2>displayMode="text"</h2>
 			<p>Form can be used to display data in read only</p>
 			<UIForm

--- a/packages/forms/stories-core/customErrors.js
+++ b/packages/forms/stories-core/customErrors.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import IconsProvider from '@talend/react-components/lib/IconsProvider';
 import { action } from '@storybook/addon-actions';
 import { UIForm } from '../src/UIForm';
 
@@ -201,7 +200,6 @@ const errors = schema.uiSchema.reduce(
 function story() {
 	return (
 		<div>
-			<IconsProvider />
 			<h2>Updating status</h2>
 			<p>
 				Form can disable and add an animation feedback on the widgets. To do so, you need to pass a

--- a/packages/forms/stories-core/customTemplateStory.js
+++ b/packages/forms/stories-core/customTemplateStory.js
@@ -106,7 +106,6 @@ function story() {
 	};
 	return (
 		<div>
-			/>
 			<UIForm
 				templates={templates}
 				data={schema}

--- a/packages/forms/stories-core/customTemplateStory.js
+++ b/packages/forms/stories-core/customTemplateStory.js
@@ -1,20 +1,11 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { action } from '@storybook/addon-actions';
-import { IconsProvider, Actions } from '@talend/react-components';
+import { Actions } from '@talend/react-components';
 import { UIForm } from '../src/UIForm';
 
 function CustomArrayTemplate(props) {
-	const {
-		canReorder,
-		id,
-		onAdd,
-		onRemove,
-		onReorder,
-		renderItem,
-		schema,
-		value,
-	} = props;
+	const { canReorder, id, onAdd, onRemove, onReorder, renderItem, schema, value } = props;
 
 	return (
 		<div>
@@ -47,19 +38,21 @@ function CustomArrayTemplate(props) {
 								label: 'Move Up',
 								icon: 'talend-caret-down',
 								className: 'icon-up',
-								onClick: event => onReorder(event, {
-									previousIndex: index,
-									nextIndex: index - 1,
-								}),
+								onClick: event =>
+									onReorder(event, {
+										previousIndex: index,
+										nextIndex: index - 1,
+									}),
 							},
 							{
 								label: 'Move Down',
 								icon: 'talend-caret-down',
-								onClick: event => onReorder(event, {
-									previousIndex: index,
-									nextIndex: index + 1,
-								}),
-							}
+								onClick: event =>
+									onReorder(event, {
+										previousIndex: index,
+										nextIndex: index + 1,
+									}),
+							},
 						);
 					}
 
@@ -113,7 +106,7 @@ function story() {
 	};
 	return (
 		<div>
-			<IconsProvider />
+			/>
 			<UIForm
 				templates={templates}
 				data={schema}

--- a/packages/forms/stories-core/customUpdating.js
+++ b/packages/forms/stories-core/customUpdating.js
@@ -189,7 +189,6 @@ const updating = schema.uiSchema.map(w => w.key);
 function story() {
 	return (
 		<div>
-			/>
 			<h2>Updating status</h2>
 			<p>
 				Form can disable and add an animation feedback on the widgets. To do so, you need to pass a

--- a/packages/forms/stories-core/customUpdating.js
+++ b/packages/forms/stories-core/customUpdating.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import IconsProvider from '@talend/react-components/lib/IconsProvider';
 import { action } from '@storybook/addon-actions';
 import { UIForm } from '../src/UIForm';
 
@@ -190,7 +189,7 @@ const updating = schema.uiSchema.map(w => w.key);
 function story() {
 	return (
 		<div>
-			<IconsProvider />
+			/>
 			<h2>Updating status</h2>
 			<p>
 				Form can disable and add an animation feedback on the widgets. To do so, you need to pass a

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -2,7 +2,6 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import uuid from 'uuid';
 import { action } from '@storybook/addon-actions';
-import IconsProvider from '@talend/react-components/lib/IconsProvider';
 import { UIForm } from '../src/UIForm';
 import Enumeration from '../src/UIForm/fields/Enumeration';
 import { PRESIGNED_URL_TRIGGER_ACTION } from '../src/UIForm/fields/File/File.component';
@@ -213,7 +212,6 @@ class DisplayModeForm extends React.Component {
 	render() {
 		return (
 			<section>
-				<IconsProvider />
 				{this.props.doc && (
 					<a
 						href={`https://github.com/Talend/ui/tree/master/packages/forms/src/UIForm/${this.props.category}/${this.props.doc}`}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current if Icon props change the icon is appended so we have a second icon

**What is the chosen solution to this problem?**

* add story for that
* fix the bug

![Screen-Recording-2020-11-19-at-1](https://user-images.githubusercontent.com/19857479/99699118-e37a4e00-2a91-11eb-8ccf-4a7cda6bbf03.gif)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
