### PR TITLE
fix(components/ListView): Cherry-pick fix from #3073 for 6.x

### DIFF
--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -41,6 +41,7 @@ class Item extends Component {
 			'checkbox',
 			{ 'switch-nested': children },
 			{ switch: isSwitchBox },
+			{ 'with-icon': item.icon },
 		);
 		const ariaLabel = item.checked
 			? t('TC_LISTVIEW_DESELECT', { defaultValue: 'Deselect {{ value }}', value: item.label })
@@ -65,16 +66,20 @@ class Item extends Component {
 					id={itemId}
 					onChange={event => item.onChange(event, item, parentItem)}
 					checked={item.checked}
-					label={searchCriteria ? getSearchedLabel(item.label) : item.label}
+					label={
+						<>
+							{searchCriteria ? getSearchedLabel(item.label) : item.label}
+							{item.icon && (
+								<TooltipTrigger label={item.icon.title} tooltipPlacement="bottom">
+									<span>
+										<Icon {...item.icon} />
+									</span>
+								</TooltipTrigger>
+							)}
+						</>
+					}
 					aria-label={ariaLabel}
 				/>
-				{item.icon && (
-					<TooltipTrigger label={item.icon.title} tooltipPlacement="bottom">
-						<span>
-							<Icon {...item.icon} />
-						</span>
-					</TooltipTrigger>
-				)}
 				{children && (
 					<div className={classNames('checkbox-nested-expand', { expanded: item.expanded })}>
 						<Action

--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -1,6 +1,6 @@
 $tc-listview-height: 40vh !default;
 
-$row-height: 13px;
+$row-height: 12px;
 $row-vertical-margin: $padding-small;
 $row-nested-inner-margin-top: $padding-normal - $padding-small;
 $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
@@ -16,13 +16,17 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 		:global {
 			.checkbox {
 				margin-left: $padding-smaller;
-				display: flex;
 			}
-			.tc-svg-icon {
-				height: $row-height;
-				width: $row-height;
-				margin-top: $padding-small;
-				margin-left: $padding-smaller;
+
+			.with-icon {
+				display: inline-flex;
+				margin: 0;
+
+				.tc-svg-icon {
+					height: $row-height;
+					width: $row-height;
+					margin-left: $padding-smaller;
+				}
 			}
 
 			.checkbox-nested {

--- a/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
+++ b/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
@@ -288,7 +288,11 @@ exports[`Items should render 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
-                          label="Lorem ipsum dolor sit amet 0"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 0
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -382,7 +386,11 @@ exports[`Items should render 1`] = `
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
-                          label="Lorem ipsum dolor sit amet 1"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 1
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -474,7 +482,11 @@ exports[`Items should render 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
-                          label="Lorem ipsum dolor sit amet 2"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 2
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -816,7 +828,11 @@ exports[`Items should render with nested items 1`] = `
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor default"
-                          label="Lorem ipsum dolor default"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor default
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -919,7 +935,11 @@ exports[`Items should render with nested items 1`] = `
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor Parent"
                           checked={true}
-                          label="Lorem ipsum dolor Parent"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor Parent
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1325,7 +1345,11 @@ exports[`Items should render with provided id 1`] = `
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
                           id="checkbox-my-widget-1-item"
-                          label="Lorem ipsum dolor sit amet 0"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 0
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1426,7 +1450,11 @@ exports[`Items should render with provided id 1`] = `
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
                           id="checkbox-my-widget-2-item"
-                          label="Lorem ipsum dolor sit amet 1"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 1
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div
@@ -1525,7 +1553,11 @@ exports[`Items should render with provided id 1`] = `
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
                           id="checkbox-my-widget-3-item"
-                          label="Lorem ipsum dolor sit amet 2"
+                          label={
+                            <React.Fragment>
+                              Lorem ipsum dolor sit amet 2
+                            </React.Fragment>
+                          }
                           onChange={[Function]}
                         >
                           <div

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.scss
@@ -1,23 +1,20 @@
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 .template:global(.required) {
+	> :global(.checkbox:after) {
+		position: static;
+		display: inline;
+		content: '*';
+	}
 	:global {
 		.control-label:after {
 			content: '*';
 		}
-
 		.checkbox {
-			&:after {
-				position: static;
-				display: inline;
-				content: '*';
-			}
-
 			.control-label:after {
 				content: '';
 			}
 		}
-
 		// Remove required stars for multi selection
 		.control-label ~ .checkbox:after {
 			content: '';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There's a bug on nested ListView component that has been fixed on 5.x (master) branch, but is missing from the 6.x branch

**What is the chosen solution to this problem?**
Cherry-pick changes

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
