### PR TITLE
chore(forms): break circular dependencies (#3084)

### DIFF
--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,28 +1,7 @@
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.component.js
-  64:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
+/home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/Array.component.test.js
+  479:10  error  'widgets' is already declared in the upper scope  no-shadow
+  497:10  error  'widgets' is already declared in the upper scope  no-shadow
+  515:10  error  'widgets' is already declared in the upper scope  no-shadow
 
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/UIForm.container.js
-  94:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
-  255:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/ListView/ListView.component.js
-  55:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
-  54:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Radios/Radios.component.js
-  47:8  error  The attribute aria-invalid is not supported by the role radio. This role is implicit on the element input  jsx-a11y/role-supports-aria-props
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fields/Text/Text.component.test.js
-  283:8   error  Curly braces are unnecessary here  react/jsx-curly-brace-presence
-  287:11  error  Curly braces are unnecessary here  react/jsx-curly-brace-presence
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
-  57:4  error  The attribute aria-invalid is not supported by the role list. This role is implicit on the element ol  jsx-a11y/role-supports-aria-props
-
-✖ 9 problems (9 errors, 0 warnings)
-  2 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 3 problems (3 errors, 0 warnings)

--- a/packages/forms/src/UIForm/Message/Message.component.test.js
+++ b/packages/forms/src/UIForm/Message/Message.component.test.js
@@ -8,7 +8,8 @@ describe('Message component', () => {
 		// when
 		const wrapper = shallow(
 			<Message
-				id="my-message"
+				descriptionId="my-message-description"
+				errorId="my-message-error"
 				errorMessage="My error message"
 				description="My description"
 				isValid
@@ -23,8 +24,9 @@ describe('Message component', () => {
 		// when
 		const wrapper = shallow(
 			<Message
-				id="my-message"
 				className="has-error"
+				descriptionId="my-message-description"
+				errorId="my-message-error"
 				errorMessage="My error message"
 				description="My description"
 				isValid={false}
@@ -37,7 +39,14 @@ describe('Message component', () => {
 
 	it('should render nothing when field is valid and no description is provided', () => {
 		// when
-		const wrapper = shallow(<Message id="my-message" errorMessage="My error message" isValid />);
+		const wrapper = shallow(
+			<Message
+				descriptionId="my-message-description"
+				errorId="my-message-error"
+				errorMessage="My error message"
+				isValid
+			/>,
+		);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();

--- a/packages/forms/src/UIForm/Message/__snapshots__/Message.component.test.js.snap
+++ b/packages/forms/src/UIForm/Message/__snapshots__/Message.component.test.js.snap
@@ -4,10 +4,12 @@ exports[`Message component should render nothing when field is valid and no desc
 <div>
   <p
     className="help-block"
+    id="my-message-description"
   />
   <p
     aria-live="assertive"
     className="help-block"
+    id="my-message-error"
     role="status"
   >
     
@@ -19,12 +21,14 @@ exports[`Message component should render provided description and no error if th
 <div>
   <p
     className="help-block"
+    id="my-message-description"
   >
     My description
   </p>
   <p
     aria-live="assertive"
     className="help-block"
+    id="my-message-error"
     role="status"
   >
     
@@ -38,12 +42,14 @@ exports[`Message component should render provided error message and no descripti
 >
   <p
     className="help-block"
+    id="my-message-description"
   >
     
   </p>
   <p
     aria-live="assertive"
     className="help-block"
+    id="my-message-error"
     role="status"
   >
     My error message

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -17,6 +17,8 @@ import customFormats from './customFormats';
 import { I18N_DOMAIN_FORMS } from '../constants';
 import '../translate';
 import theme from './UIForm.scss';
+import { WidgetContext } from './context';
+import widgets from './utils/widgets';
 
 export class UIFormComponent extends React.Component {
 	static displayName = 'TalendUIForm';
@@ -61,7 +63,7 @@ export class UIFormComponent extends React.Component {
 	 * @param jsonSchema
 	 * @param uiSchema
 	 */
-	componentWillReceiveProps({ jsonSchema, uiSchema }) {
+	UNSAFE_componentWillReceiveProps({ jsonSchema, uiSchema }) {
 		if (
 			!jsonSchema ||
 			!uiSchema ||
@@ -350,7 +352,9 @@ export class UIFormComponent extends React.Component {
 				target={this.props.target}
 				ref={this.setFormRef}
 			>
-				{formTemplate({ children: this.props.children, widgetsRenderer, buttonsRenderer })}
+				<WidgetContext.Provider value={{ ...widgets, ...this.state.widgets }}>
+					{formTemplate({ children: this.props.children, widgetsRenderer, buttonsRenderer })}
+				</WidgetContext.Provider>
 			</form>
 		);
 	}

--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -91,7 +91,7 @@ export default class UIForm extends React.Component {
 	 * Update live and initialState with the new schema
 	 * @param nextProps
 	 */
-	componentWillReceiveProps(nextProps) {
+	UNSAFE_componentWillReceiveProps(nextProps) {
 		if (nextProps.data !== this.props.data) {
 			this.setState(reinitLiveState(nextProps.data));
 		}

--- a/packages/forms/src/UIForm/UIForm.container.test.js
+++ b/packages/forms/src/UIForm/UIForm.container.test.js
@@ -22,7 +22,7 @@ describe('UIForm container', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
-	describe('#componentWillReceiveProps', () => {
+	describe('#UNSAFE_componentWillReceiveProps', () => {
 		it('should update state if form data structure changed', () => {
 			// given
 			const wrapper = shallow(<UIForm data={data} {...props} />);

--- a/packages/forms/src/UIForm/Widget/Widget.component.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.js
@@ -3,25 +3,12 @@ import React from 'react';
 import { sfPath } from '@talend/json-schema-form-core';
 import TooltipTrigger from '@talend/react-components/lib/TooltipTrigger';
 
-import defaultWidgets from '../utils/widgets';
 import { getError } from '../utils/errors';
 import { getValue } from '../utils/properties';
 import shouldRender from '../utils/condition';
 
 import theme from './Widget.component.scss';
-
-function getWidget(displayMode, widgetId, customWidgets) {
-	// resolve the widget id depending on the display mode
-	const id = displayMode ? `${widgetId}_${displayMode}` : widgetId;
-
-	// Get the widget and fallback to default mode widget if not found
-	let widget = customWidgets[id] || defaultWidgets[id];
-	if (!widget) {
-		widget = customWidgets[widgetId] || defaultWidgets[widgetId];
-	}
-
-	return widget;
-}
+import { useWidget } from '../context';
 
 function isUpdating(updatingKeys = [], key) {
 	if (updatingKeys.length === 0 || !key) {
@@ -46,11 +33,11 @@ export default function Widget(props) {
 	} = props.schema;
 	const widgetId = widget || type;
 
+	const { widgets, WidgetImpl } = useWidget(widgetId, props.displayMode || displayMode);
+
 	if (widgetId === 'hidden' || !shouldRender(condition, props.properties, key)) {
 		return null;
 	}
-
-	const WidgetImpl = getWidget(props.displayMode || displayMode, widgetId, props.widgets);
 
 	if (!WidgetImpl) {
 		return <p className="text-danger">Widget not found {widgetId}</p>;
@@ -68,6 +55,7 @@ export default function Widget(props) {
 		isValid: !error,
 		value: getValue(props.properties, props.schema),
 		valueIsUpdating: isUpdating(props.updating, props.schema.key),
+		widgets,
 	};
 
 	if (tooltip) {
@@ -95,14 +83,7 @@ if (process.env.NODE_ENV !== 'production') {
 		idSeparator: PropTypes.string,
 		properties: PropTypes.object,
 		schema: PropTypes.shape({
-			condition: PropTypes.arrayOf(
-				PropTypes.shape({
-					path: PropTypes.string,
-					values: PropTypes.array,
-					strategy: PropTypes.string,
-					shouldBe: PropTypes.bool,
-				}),
-			),
+			condition: PropTypes.object,
 			displayMode: PropTypes.string,
 			key: PropTypes.array,
 			options: PropTypes.object,
@@ -112,7 +93,7 @@ if (process.env.NODE_ENV !== 'production') {
 			validationMessage: PropTypes.string,
 			widget: PropTypes.string,
 		}).isRequired,
-		updating: PropTypes.arrayOf(PropTypes.shape({ path: PropTypes.string })),
+		updating: PropTypes.arrayOf(PropTypes.string),
 		widgets: PropTypes.object,
 	};
 }

--- a/packages/forms/src/UIForm/Widget/Widget.component.test.js
+++ b/packages/forms/src/UIForm/Widget/Widget.component.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import TooltipTrigger from '@talend/react-components/lib/TooltipTrigger';
+import defaultWidgets from '../utils/widgets';
+import { WidgetContext } from '../context';
 
 import Widget from './Widget.component';
 
@@ -26,55 +28,60 @@ describe('Widget component', () => {
 
 	it('should render widget', () => {
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onFinish={jest.fn('onFinish')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={schema}
-				errors={errors}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={schema}
+					errors={errors}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should wrapper widget into a tooltip trigger', () => {
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onFinish={jest.fn('onFinish')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={{ ...schema, tooltip: 'example tooltip' }}
-				errors={errors}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={{ ...schema, tooltip: 'example tooltip' }}
+					errors={errors}
+				/>
+			</WidgetContext.Provider>,
 		);
-
-		expect(wrapper.getElement().type).toBe(TooltipTrigger);
+		expect(wrapper.find(TooltipTrigger)).toBeDefined();
 	});
 
 	it('should render widget with the specific displayMode', () => {
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onFinish={jest.fn('onFinish')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={schema}
-				errors={errors}
-				displayMode="text"
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={schema}
+					errors={errors}
+					displayMode="text"
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should render nothing if widget does not exist', () => {
@@ -85,12 +92,14 @@ describe('Widget component', () => {
 		};
 
 		// when
-		const wrapper = shallow(
-			<Widget properties={properties} schema={unknownWidgetSchema} errors={errors} />,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget properties={properties} schema={unknownWidgetSchema} errors={errors} />
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should render custom widget', () => {
@@ -101,20 +110,23 @@ describe('Widget component', () => {
 		};
 
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={customWidgetSchema}
-				errors={errors}
-				widgets={customWidgets}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={{ ...defaultWidgets, ...customWidgets }}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={customWidgetSchema}
+					errors={errors}
+					value={customWidgets}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should render custom widget in specific display mode', () => {
@@ -125,21 +137,24 @@ describe('Widget component', () => {
 		};
 
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={customWidgetSchema}
-				errors={errors}
-				widgets={customWidgets}
-				displayMode="text"
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={{ ...defaultWidgets, ...customWidgets }}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={customWidgetSchema}
+					errors={errors}
+					value={customWidgets}
+					displayMode="text"
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toMatchSnapshot();
+		expect(wrapper.html()).toMatchSnapshot();
 	});
 
 	it('should pass validation message from schema over message from errors', () => {
@@ -150,45 +165,55 @@ describe('Widget component', () => {
 		};
 
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={customValidationMessageSchema}
-				errors={errors}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={customValidationMessageSchema}
+					errors={errors}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.props().errorMessage).toBe('My custom validation message');
+		expect(wrapper.find('[role="status"]').text()).toBe('My custom validation message');
 	});
 
 	it('should pass message from errors when there is no validation message in schema', () => {
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={schema}
-				errors={errors}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={schema}
+					errors={errors}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.props().errorMessage).toBe('This is not ok');
+		expect(wrapper.find('[role="status"]').text()).toBe('This is not ok');
 	});
 
 	it("should render null when widgetId is 'hidden'", () => {
 		// when
 		const hidden = { ...schema, widget: 'hidden' };
-		const wrapper = shallow(<Widget schema={hidden} />);
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget schema={hidden} />
+			</WidgetContext.Provider>,
+		);
 
 		// then
-		expect(wrapper.getElement()).toBe(null);
+		expect(wrapper.html()).toBe(null);
 	});
 
 	it('should render widget when conditions are met', () => {
@@ -202,12 +227,21 @@ describe('Widget component', () => {
 				],
 			},
 		};
-		const wrapper = shallow(
-			<Widget schema={withConditions} properties={properties} errors={errors} />,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					schema={withConditions}
+					properties={properties}
+					errors={errors}
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+				/>
+				,
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).not.toBe(null);
+		expect(wrapper.find('input#user_firstname').length).toBe(1);
 	});
 
 	it('should render null when conditions are not met', () => {
@@ -221,31 +255,40 @@ describe('Widget component', () => {
 				],
 			},
 		};
-		const wrapper = shallow(
-			<Widget schema={withConditions} properties={properties} errors={errors} />,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					schema={withConditions}
+					properties={properties}
+					errors={errors}
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.getElement()).toBe(null);
+		expect(wrapper.html()).toBe(null);
 	});
 
 	it('should pass value updating status', () => {
 		// when
-		const wrapper = shallow(
-			<Widget
-				id="myForm"
-				onChange={jest.fn('onChange')}
-				onFinish={jest.fn('onFinish')}
-				onTrigger={jest.fn('onTrigger')}
-				properties={properties}
-				schema={schema}
-				errors={errors}
-				displayMode="text"
-				updating={[schema.key.join('.')]}
-			/>,
+		const wrapper = mount(
+			<WidgetContext.Provider value={defaultWidgets}>
+				<Widget
+					id="myForm"
+					onChange={jest.fn('onChange')}
+					onFinish={jest.fn('onFinish')}
+					onTrigger={jest.fn('onTrigger')}
+					properties={properties}
+					schema={schema}
+					errors={errors}
+					updating={[schema.key.join('.')]}
+				/>
+			</WidgetContext.Provider>,
 		);
 
 		// then
-		expect(wrapper.prop('valueIsUpdating')).toBe(true);
+		expect(wrapper.find('.form-group.theme-updating').length).toBe(1);
 	});
 });

--- a/packages/forms/src/UIForm/Widget/__snapshots__/Widget.component.test.js.snap
+++ b/packages/forms/src/UIForm/Widget/__snapshots__/Widget.component.test.js.snap
@@ -1,168 +1,60 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Widget component should render custom widget 1`] = `
-<customWidget
-  errorMessage="This is not ok"
-  errors={
-    Object {
-      "user,firstname": "This is not ok",
-    }
-  }
-  id="myForm_user_firstname"
-  isValid={false}
-  onChange={[MockFunction]}
-  onTrigger={[MockFunction]}
-  properties={
-    Object {
-      "comment": "",
-      "user": Object {
-        "firstname": "my firstname",
-        "lastname": "my lastname",
-      },
-    }
-  }
-  schema={
-    Object {
-      "key": Array [
-        "user",
-        "firstname",
-      ],
-      "type": "customWidget",
-    }
-  }
-  value="my firstname"
-  valueIsUpdating={false}
-  widgets={
-    Object {
-      "customWidget": [Function],
-      "customWidget_text": [Function],
-    }
-  }
-/>
+<div>
+  my widget
+</div>
 `;
 
 exports[`Widget component should render custom widget in specific display mode 1`] = `
-<customWidget_text
-  displayMode="text"
-  errorMessage="This is not ok"
-  errors={
-    Object {
-      "user,firstname": "This is not ok",
-    }
-  }
-  id="myForm_user_firstname"
-  isValid={false}
-  onChange={[MockFunction]}
-  onTrigger={[MockFunction]}
-  properties={
-    Object {
-      "comment": "",
-      "user": Object {
-        "firstname": "my firstname",
-        "lastname": "my lastname",
-      },
-    }
-  }
-  schema={
-    Object {
-      "key": Array [
-        "user",
-        "firstname",
-      ],
-      "type": "customWidget",
-    }
-  }
-  value="my firstname"
-  valueIsUpdating={false}
-  widgets={
-    Object {
-      "customWidget": [Function],
-      "customWidget_text": [Function],
-    }
-  }
-/>
+<div>
+  my widget in text display mode
+</div>
 `;
 
 exports[`Widget component should render nothing if widget does not exist 1`] = `
-<p
-  className="text-danger"
->
-  Widget not found 
-  unknown
+<p class="text-danger">
+  Widget not found unknown
 </p>
 `;
 
 exports[`Widget component should render widget 1`] = `
-<Text
-  errorMessage="This is not ok"
-  errors={
-    Object {
-      "user,firstname": "This is not ok",
-    }
-  }
-  id="myForm_user_firstname"
-  isValid={false}
-  onChange={[MockFunction]}
-  onFinish={[MockFunction]}
-  onTrigger={[MockFunction]}
-  properties={
-    Object {
-      "comment": "",
-      "user": Object {
-        "firstname": "my firstname",
-        "lastname": "my lastname",
-      },
-    }
-  }
-  schema={
-    Object {
-      "key": Array [
-        "user",
-        "firstname",
-      ],
-      "type": "text",
-    }
-  }
-  value="my firstname"
-  valueIsUpdating={false}
-  widgets={Object {}}
-/>
+<div class="form-group theme-template has-error"
+     aria-busy="false"
+>
+  <input id="myForm_user_firstname"
+         class="form-control"
+         type="text"
+         aria-invalid="true"
+         aria-describedby="myForm_user_firstname-description myForm_user_firstname-error"
+         value="my firstname"
+  >
+  <div>
+    <p class="help-block"
+       id="myForm_user_firstname-description"
+    >
+    </p>
+    <p class="help-block"
+       role="status"
+       aria-live="assertive"
+       id="myForm_user_firstname-error"
+    >
+      This is not ok
+    </p>
+  </div>
+</div>
 `;
 
 exports[`Widget component should render widget with the specific displayMode 1`] = `
-<TextMode
-  displayMode="text"
-  errorMessage="This is not ok"
-  errors={
-    Object {
-      "user,firstname": "This is not ok",
-    }
-  }
-  id="myForm_user_firstname"
-  isValid={false}
-  onChange={[MockFunction]}
-  onFinish={[MockFunction]}
-  onTrigger={[MockFunction]}
-  properties={
-    Object {
-      "comment": "",
-      "user": Object {
-        "firstname": "my firstname",
-        "lastname": "my lastname",
-      },
-    }
-  }
-  schema={
-    Object {
-      "key": Array [
-        "user",
-        "firstname",
-      ],
-      "type": "text",
-    }
-  }
-  value="my firstname"
-  valueIsUpdating={false}
-  widgets={Object {}}
-/>
+<div class="form-group">
+  <dt>
+    <label for="myForm_user_firstname"
+           class="control-label"
+    >
+    </label>
+  </dt>
+  <dd id="myForm_user_firstname">
+    my firstname
+  </dd>
+</div>
 `;

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.component.test.js.snap
@@ -9,119 +9,176 @@ exports[`UIForm component should render form 1`] = `
   onReset={[MockFunction]}
   onSubmit={[Function]}
 >
-  <div
-    className="theme-form-content"
+  <Context.Provider
+    value={
+      Object {
+        "array": [Function],
+        "button": [Function],
+        "button_text": [Function],
+        "buttons": [Function],
+        "buttons_text": [Function],
+        "checkbox": [Function],
+        "checkbox_text": [Function],
+        "checkboxes": [Function],
+        "checkboxes_text": [Function],
+        "code": [Function],
+        "code_text": [Function],
+        "collapsibleFieldset": [Function],
+        "columns": [Function],
+        "comparator": [Function],
+        "comparator_text": [Function],
+        "custom": [Function],
+        "datalist": [Function],
+        "datalist_text": [Function],
+        "date": [Function],
+        "datetime": [Function],
+        "enumeration": [Function],
+        "fieldset": [Function],
+        "fieldset_text": [Function],
+        "file": [Function],
+        "file_text": [Function],
+        "keyValue": [Function],
+        "listView": [Function],
+        "multiSelectTag": [Function],
+        "multiSelectTag_text": [Function],
+        "nestedListView": [Function],
+        "number": [Function],
+        "number_text": [Function],
+        "password": [Function],
+        "password_text": [Function],
+        "radioOrSelect": [Function],
+        "radios": [Function],
+        "radios_text": [Function],
+        "reset": [Function],
+        "resourcePicker": [Function],
+        "select": [Function],
+        "select_text": [Function],
+        "submit": [Function],
+        "tabs": [Function],
+        "text": [Function],
+        "text_text": [Function],
+        "textarea": [Function],
+        "textarea_text": [Function],
+        "time": [Function],
+        "toggle": [Function],
+        "toggle_text": [Function],
+      }
+    }
   >
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "autoFocus": true,
-          "description": "Hint: this is the last name",
-          "key": Array [
-            "lastname",
-          ],
-          "minlength": 10,
-          "ngModelOptions": Object {},
-          "schema": Object {
-            "minLength": 10,
-            "type": "string",
-          },
-          "title": "Last Name (with description)",
-          "type": "text",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "firstname",
-          ],
-          "ngModelOptions": Object {},
-          "placeholder": "Enter your firstname here",
-          "required": true,
-          "schema": Object {
-            "type": "string",
-          },
-          "title": "First Name (with placeholder)",
-          "triggers": Array [
-            "after",
-          ],
-          "type": "text",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "check",
-          ],
-          "title": "Check the thing",
-          "triggers": Array [
-            "after",
-          ],
-          "widget": "button",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-  </div>
-  <div
-    className="theme-form-actions tf-actions-wrapper"
-  >
-    <Buttons
-      className="form-actions"
-      id="myFormId-actions"
-      onClick={[Function]}
-      onTrigger={[Function]}
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "bsStyle": "primary",
-              "label": "Submit",
-              "position": "right",
-              "type": "submit",
-              "widget": "button",
+    <div
+      className="theme-form-content"
+    >
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "autoFocus": true,
+            "description": "Hint: this is the last name",
+            "key": Array [
+              "lastname",
+            ],
+            "minlength": 10,
+            "ngModelOptions": Object {},
+            "schema": Object {
+              "minLength": 10,
+              "type": "string",
             },
-          ],
+            "title": "Last Name (with description)",
+            "type": "text",
+          }
         }
-      }
-    />
-  </div>
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "firstname",
+            ],
+            "ngModelOptions": Object {},
+            "placeholder": "Enter your firstname here",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "title": "First Name (with placeholder)",
+            "triggers": Array [
+              "after",
+            ],
+            "type": "text",
+          }
+        }
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "check",
+            ],
+            "title": "Check the thing",
+            "triggers": Array [
+              "after",
+            ],
+            "widget": "button",
+          }
+        }
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+    </div>
+    <div
+      className="theme-form-actions tf-actions-wrapper"
+    >
+      <Buttons
+        className="form-actions"
+        id="myFormId-actions"
+        onClick={[Function]}
+        onTrigger={[Function]}
+        schema={
+          Object {
+            "items": Array [
+              Object {
+                "bsStyle": "primary",
+                "label": "Submit",
+                "position": "right",
+                "type": "submit",
+                "widget": "button",
+              },
+            ],
+          }
+        }
+      />
+    </div>
+  </Context.Provider>
 </form>
 `;
 
@@ -134,99 +191,156 @@ exports[`UIForm component should render form in text display mode 1`] = `
   onReset={[MockFunction]}
   onSubmit={[Function]}
 >
-  <dl
-    className="theme-form-content"
+  <Context.Provider
+    value={
+      Object {
+        "array": [Function],
+        "button": [Function],
+        "button_text": [Function],
+        "buttons": [Function],
+        "buttons_text": [Function],
+        "checkbox": [Function],
+        "checkbox_text": [Function],
+        "checkboxes": [Function],
+        "checkboxes_text": [Function],
+        "code": [Function],
+        "code_text": [Function],
+        "collapsibleFieldset": [Function],
+        "columns": [Function],
+        "comparator": [Function],
+        "comparator_text": [Function],
+        "custom": [Function],
+        "datalist": [Function],
+        "datalist_text": [Function],
+        "date": [Function],
+        "datetime": [Function],
+        "enumeration": [Function],
+        "fieldset": [Function],
+        "fieldset_text": [Function],
+        "file": [Function],
+        "file_text": [Function],
+        "keyValue": [Function],
+        "listView": [Function],
+        "multiSelectTag": [Function],
+        "multiSelectTag_text": [Function],
+        "nestedListView": [Function],
+        "number": [Function],
+        "number_text": [Function],
+        "password": [Function],
+        "password_text": [Function],
+        "radioOrSelect": [Function],
+        "radios": [Function],
+        "radios_text": [Function],
+        "reset": [Function],
+        "resourcePicker": [Function],
+        "select": [Function],
+        "select_text": [Function],
+        "submit": [Function],
+        "tabs": [Function],
+        "text": [Function],
+        "text_text": [Function],
+        "textarea": [Function],
+        "textarea_text": [Function],
+        "time": [Function],
+        "toggle": [Function],
+        "toggle_text": [Function],
+      }
+    }
   >
-    <Widget
-      displayMode="text"
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "autoFocus": true,
-          "description": "Hint: this is the last name",
-          "key": Array [
-            "lastname",
-          ],
-          "minlength": 10,
-          "ngModelOptions": Object {},
-          "schema": Object {
-            "minLength": 10,
-            "type": "string",
-          },
-          "title": "Last Name (with description)",
-          "type": "text",
+    <dl
+      className="theme-form-content"
+    >
+      <Widget
+        displayMode="text"
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "autoFocus": true,
+            "description": "Hint: this is the last name",
+            "key": Array [
+              "lastname",
+            ],
+            "minlength": 10,
+            "ngModelOptions": Object {},
+            "schema": Object {
+              "minLength": 10,
+              "type": "string",
+            },
+            "title": "Last Name (with description)",
+            "type": "text",
+          }
         }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
+        widgets={
+          Object {
+            "custom": [Function],
+          }
         }
-      }
-    />
-    <Widget
-      displayMode="text"
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "firstname",
-          ],
-          "ngModelOptions": Object {},
-          "placeholder": "Enter your firstname here",
-          "required": true,
-          "schema": Object {
-            "type": "string",
-          },
-          "title": "First Name (with placeholder)",
-          "triggers": Array [
-            "after",
-          ],
-          "type": "text",
+      />
+      <Widget
+        displayMode="text"
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "firstname",
+            ],
+            "ngModelOptions": Object {},
+            "placeholder": "Enter your firstname here",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "title": "First Name (with placeholder)",
+            "triggers": Array [
+              "after",
+            ],
+            "type": "text",
+          }
         }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
+        widgets={
+          Object {
+            "custom": [Function],
+          }
         }
-      }
-    />
-    <Widget
-      displayMode="text"
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "check",
-          ],
-          "title": "Check the thing",
-          "triggers": Array [
-            "after",
-          ],
-          "widget": "button",
+      />
+      <Widget
+        displayMode="text"
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "check",
+            ],
+            "title": "Check the thing",
+            "triggers": Array [
+              "after",
+            ],
+            "widget": "button",
+          }
         }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
+        widgets={
+          Object {
+            "custom": [Function],
+          }
         }
-      }
-    />
-  </dl>
+      />
+    </dl>
+  </Context.Provider>
 </form>
 `;
 
@@ -239,142 +353,199 @@ exports[`UIForm component should render provided actions 1`] = `
   onReset={[MockFunction]}
   onSubmit={[Function]}
 >
-  <div
-    className="theme-form-content"
+  <Context.Provider
+    value={
+      Object {
+        "array": [Function],
+        "button": [Function],
+        "button_text": [Function],
+        "buttons": [Function],
+        "buttons_text": [Function],
+        "checkbox": [Function],
+        "checkbox_text": [Function],
+        "checkboxes": [Function],
+        "checkboxes_text": [Function],
+        "code": [Function],
+        "code_text": [Function],
+        "collapsibleFieldset": [Function],
+        "columns": [Function],
+        "comparator": [Function],
+        "comparator_text": [Function],
+        "custom": [Function],
+        "datalist": [Function],
+        "datalist_text": [Function],
+        "date": [Function],
+        "datetime": [Function],
+        "enumeration": [Function],
+        "fieldset": [Function],
+        "fieldset_text": [Function],
+        "file": [Function],
+        "file_text": [Function],
+        "keyValue": [Function],
+        "listView": [Function],
+        "multiSelectTag": [Function],
+        "multiSelectTag_text": [Function],
+        "nestedListView": [Function],
+        "number": [Function],
+        "number_text": [Function],
+        "password": [Function],
+        "password_text": [Function],
+        "radioOrSelect": [Function],
+        "radios": [Function],
+        "radios_text": [Function],
+        "reset": [Function],
+        "resourcePicker": [Function],
+        "select": [Function],
+        "select_text": [Function],
+        "submit": [Function],
+        "tabs": [Function],
+        "text": [Function],
+        "text_text": [Function],
+        "textarea": [Function],
+        "textarea_text": [Function],
+        "time": [Function],
+        "toggle": [Function],
+        "toggle_text": [Function],
+      }
+    }
   >
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "autoFocus": true,
-          "description": "Hint: this is the last name",
-          "key": Array [
-            "lastname",
-          ],
-          "minlength": 10,
-          "ngModelOptions": Object {},
-          "schema": Object {
-            "minLength": 10,
-            "type": "string",
-          },
-          "title": "Last Name (with description)",
-          "type": "text",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "firstname",
-          ],
-          "ngModelOptions": Object {},
-          "placeholder": "Enter your firstname here",
-          "required": true,
-          "schema": Object {
-            "type": "string",
-          },
-          "title": "First Name (with placeholder)",
-          "triggers": Array [
-            "after",
-          ],
-          "type": "text",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-    <Widget
-      errors={Object {}}
-      id="myFormId"
-      onChange={[Function]}
-      onFinish={[Function]}
-      onTrigger={[Function]}
-      properties={Object {}}
-      schema={
-        Object {
-          "key": Array [
-            "check",
-          ],
-          "title": "Check the thing",
-          "triggers": Array [
-            "after",
-          ],
-          "widget": "button",
-        }
-      }
-      widgets={
-        Object {
-          "custom": [Function],
-        }
-      }
-    />
-  </div>
-  <div
-    className="theme-form-actions tf-actions-wrapper"
-  >
-    <Buttons
-      className="form-actions"
-      id="myFormId-actions"
-      onClick={[Function]}
-      onTrigger={[Function]}
-      schema={
-        Object {
-          "items": Array [
-            Object {
-              "title": "Reset",
-              "type": "reset",
-              "widget": "button",
+    <div
+      className="theme-form-content"
+    >
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "autoFocus": true,
+            "description": "Hint: this is the last name",
+            "key": Array [
+              "lastname",
+            ],
+            "minlength": 10,
+            "ngModelOptions": Object {},
+            "schema": Object {
+              "minLength": 10,
+              "type": "string",
             },
-            Object {
-              "disabled": true,
-              "title": "Disabled",
-              "type": "button",
-              "widget": "button",
-            },
-            Object {
-              "inProgress": true,
-              "title": "In progress",
-              "type": "button",
-              "widget": "button",
-            },
-            Object {
-              "title": "Trigger",
-              "triggers": Array [
-                "test",
-              ],
-              "type": "button",
-              "widget": "button",
-            },
-            Object {
-              "bsStyle": "primary",
-              "title": "Submit",
-              "type": "submit",
-              "widget": "button",
-            },
-          ],
+            "title": "Last Name (with description)",
+            "type": "text",
+          }
         }
-      }
-    />
-  </div>
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "firstname",
+            ],
+            "ngModelOptions": Object {},
+            "placeholder": "Enter your firstname here",
+            "required": true,
+            "schema": Object {
+              "type": "string",
+            },
+            "title": "First Name (with placeholder)",
+            "triggers": Array [
+              "after",
+            ],
+            "type": "text",
+          }
+        }
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+      <Widget
+        errors={Object {}}
+        id="myFormId"
+        onChange={[Function]}
+        onFinish={[Function]}
+        onTrigger={[Function]}
+        properties={Object {}}
+        schema={
+          Object {
+            "key": Array [
+              "check",
+            ],
+            "title": "Check the thing",
+            "triggers": Array [
+              "after",
+            ],
+            "widget": "button",
+          }
+        }
+        widgets={
+          Object {
+            "custom": [Function],
+          }
+        }
+      />
+    </div>
+    <div
+      className="theme-form-actions tf-actions-wrapper"
+    >
+      <Buttons
+        className="form-actions"
+        id="myFormId-actions"
+        onClick={[Function]}
+        onTrigger={[Function]}
+        schema={
+          Object {
+            "items": Array [
+              Object {
+                "title": "Reset",
+                "type": "reset",
+                "widget": "button",
+              },
+              Object {
+                "disabled": true,
+                "title": "Disabled",
+                "type": "button",
+                "widget": "button",
+              },
+              Object {
+                "inProgress": true,
+                "title": "In progress",
+                "type": "button",
+                "widget": "button",
+              },
+              Object {
+                "title": "Trigger",
+                "triggers": Array [
+                  "test",
+                ],
+                "type": "button",
+                "widget": "button",
+              },
+              Object {
+                "bsStyle": "primary",
+                "title": "Submit",
+                "type": "submit",
+                "widget": "button",
+              },
+            ],
+          }
+        }
+      />
+    </div>
+  </Context.Provider>
 </form>
 `;

--- a/packages/forms/src/UIForm/context.js
+++ b/packages/forms/src/UIForm/context.js
@@ -1,0 +1,23 @@
+import React from 'react';
+
+export const WidgetContext = React.createContext();
+
+export function getWidget(widgets, widgetId, displayMode) {
+	if (!widgets) {
+		return undefined;
+	}
+	const id = displayMode ? `${widgetId}_${displayMode}` : widgetId;
+	let widget = widgets[id];
+	if (!widget) {
+		widget = widgets[widgetId];
+	}
+	return widget;
+}
+
+export function useWidget(widgetId, displayMode) {
+	const widgets = React.useContext(WidgetContext);
+	return {
+		widgets,
+		WidgetImpl: getWidget(widgets, widgetId, displayMode),
+	};
+}

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -252,7 +252,7 @@ class EnumerationForm extends React.Component {
 		this.onBlur = this.onBlur.bind(this);
 	}
 
-	componentWillReceiveProps(nextProps) {
+	UNSAFE_componentWillReceiveProps(nextProps) {
 		if (nextProps.value) {
 			this.setState(prevState => ({ ...prevState, items: nextProps.value }));
 		}

--- a/packages/forms/src/UIForm/fields/ListView/ListView.component.js
+++ b/packages/forms/src/UIForm/fields/ListView/ListView.component.js
@@ -52,7 +52,7 @@ class ListViewWidget extends React.Component {
 	 * @param { Object } schema The new mergedSchema
 	 * @param { Array } value The new value
 	 */
-	componentWillReceiveProps({ schema, value }) {
+	UNSAFE_componentWillReceiveProps({ schema, value }) {
 		if (schema !== this.props.schema) {
 			this.setState(oldState =>
 				initItems(schema, value, oldState.searchCriteria, this.onToggleItem.bind(this)),

--- a/packages/forms/src/UIForm/fields/ListView/ListView.component.test.js
+++ b/packages/forms/src/UIForm/fields/ListView/ListView.component.test.js
@@ -82,7 +82,7 @@ describe('ListView field', () => {
 		});
 	});
 
-	describe('componentWillReceiveProps', () => {
+	describe('UNSAFE_componentWillReceiveProps', () => {
 		it('should update items on props.value change', () => {
 			// given
 			const node = document.createElement('div');

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -51,7 +51,7 @@ export default class MultiSelectTag extends React.Component {
 	 * On Tags value change, we update suggestions if they are displayed
 	 * @param { Object } nextProps The new props
 	 */
-	componentWillReceiveProps(nextProps) {
+	UNSAFE_componentWillReceiveProps(nextProps) {
 		if (nextProps.value === this.props.value) {
 			return;
 		}

--- a/packages/forms/src/UIForm/fields/Radios/Radios.component.js
+++ b/packages/forms/src/UIForm/fields/Radios/Radios.component.js
@@ -44,6 +44,7 @@ export default function Radios({
 				schema.titleMap.map((option, index) => (
 					<div className={radioClassNames} key={index}>
 						<label>
+							{/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
 							<input
 								id={`${id}-${index}`}
 								autoFocus={autoFocus}
@@ -54,7 +55,6 @@ export default function Radios({
 								onChange={event => onChange(event, { schema, value: option.value })}
 								type="radio"
 								value={option.value}
-								// eslint-disable-next-line jsx-a11y/aria-proptypes
 								aria-invalid={!isValid}
 								aria-describedby={`${descriptionId} ${errorId}`}
 								{...extractDataAttributes(rest, index)}

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -280,11 +280,11 @@ describe('Text field', () => {
 		// when
 		const wrapper = shallow(
 			<Text
-				id={'myForm'}
+				id="myForm"
 				onChange={jest.fn()}
 				onFinish={jest.fn()}
 				schema={autoCompleteSchema}
-				value={'toto'}
+				value="toto"
 			/>,
 		);
 		expect(wrapper.find('input').prop('autoComplete')).toBe('off');

--- a/packages/forms/src/UIForm/fieldsets/Array/Array.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/Array.component.js
@@ -4,7 +4,6 @@ import { head, get } from 'lodash';
 import Widget from '../../Widget';
 import { shiftArrayErrorsKeys } from '../../utils/validation';
 import defaultTemplates from '../../utils/templates';
-import defaultWidgets from '../../utils/widgets';
 import { getArrayElementSchema } from '../../utils/array';
 
 function getRange(previousIndex, nextIndex) {
@@ -113,7 +112,7 @@ export default class ArrayWidget extends React.Component {
 
 	isCloseable() {
 		const widgetId = this.props.schema.itemWidget;
-		const itemWidget = this.props.widgets[widgetId] || defaultWidgets[widgetId];
+		const itemWidget = this.props.widgets[widgetId];
 		if (!itemWidget) {
 			return false;
 		}

--- a/packages/forms/src/UIForm/fieldsets/Array/Array.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/Array.component.test.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { shallow, mount } from 'enzyme';
 import ArrayWidget from './Array.component';
 import DefaultArrayTemplate from './DefaultArrayTemplate.component';
+import defaultWidgets from '../../utils/widgets';
 
 const schema = {
 	key: ['comments'],
@@ -142,7 +143,7 @@ describe('Array component', () => {
 				onFinish={jest.fn()}
 				schema={{ ...schema, readOnly: true }}
 				value={value}
-				errors={[]}
+				errors={{}}
 			/>,
 		);
 		expect(wrapper.find('Action').length).toBe(0);
@@ -214,6 +215,7 @@ describe('Array component', () => {
 					onFinish={onFinish}
 					schema={{ ...schema, itemWidget: 'collapsibleFieldset' }}
 					value={value}
+					widgets={defaultWidgets}
 				/>,
 			);
 
@@ -422,6 +424,8 @@ describe('Array component', () => {
 					isValid
 					schema={schema}
 					value={value}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
 				/>,
 			);
 
@@ -452,6 +456,8 @@ describe('Array component', () => {
 					isValid
 					schema={deepSchema}
 					value={value}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
 				/>,
 			);
 
@@ -480,6 +486,8 @@ describe('Array component', () => {
 					schema={{ ...schema, itemWidget: 'myCloseableWidget' }}
 					widgets={widgets}
 					value={value}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
 				/>,
 			);
 			expect(wrapper.find(DefaultArrayTemplate).prop('isCloseable')).toEqual(true);
@@ -496,6 +504,8 @@ describe('Array component', () => {
 					schema={{ ...schema, itemWidget: 'someWidget' }}
 					widgets={widgets}
 					value={value}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
 				/>,
 			);
 			expect(wrapper.find(DefaultArrayTemplate).prop('isCloseable')).toEqual(false);
@@ -512,6 +522,8 @@ describe('Array component', () => {
 					schema={{ ...schema, itemWidget: 'someWidget' }}
 					widgets={widgets}
 					value={value}
+					onChange={jest.fn()}
+					onFinish={jest.fn()}
 				/>,
 			);
 			expect(wrapper.find(DefaultArrayTemplate).prop('isCloseable')).toEqual(false);

--- a/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.component.js
@@ -54,6 +54,7 @@ function DefaultArrayTemplate(props) {
 				descriptionId={descriptionId}
 				errorId={errorId}
 			/>
+			{/* eslint-disable-next-line jsx-a11y/role-supports-aria-props */}
 			<ol
 				id={id}
 				className={classNames(theme['tf-array'], 'tf-array')}

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/Array.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/Array.component.test.js.snap
@@ -6,6 +6,8 @@ exports[`Array component #renderItem should render item at given index 1`] = `
   errorMessage="This array is not correct"
   id="talend-array-1"
   isValid={true}
+  onChange={[MockFunction]}
+  onFinish={[MockFunction]}
   schema={
     Object {
       "items": Array [

--- a/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.component.js
@@ -35,6 +35,6 @@ if (process.env.NODE_ENV !== 'production') {
 		id: PropTypes.string,
 		renderItem: PropTypes.func.isRequired,
 		schema: PropTypes.object.isRequired,
-		value: PropTypes.arrayOf(PropTypes.object).isRequired,
+		value: PropTypes.arrayOf(PropTypes.oneOfType([PropTypes.object, PropTypes.string])).isRequired,
 	};
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

This PR is a cherry-pick from TUI 6.

Today in UIForms widgets are rendered by Widget component which recieve custom widgets by props and import default ones.

UIForm import './Widget/Widget.component';
Widget import '../utils/widgets';
utils/widgets import import '../fieldsets/Array';
Array import '../../utils/widgets';

Circular dependencies !

**What is the chosen solution to this problem?**

* Make widgets registry accessible only by context inside UIForm widgets code base.
* update all tests
* fix all lints errors

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
