### PR TITLE
fix(List/ColumnChooser): let's defined its own columns

### DIFF
--- a/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/ListComposition/ColumnChooser/ColumnChooser.component.js
@@ -8,13 +8,13 @@ function ColumnChooser(props) {
 
 	return (
 		<ColumnChooserButton
-			{...props}
 			columns={columns.map(({ dataKey, label }, i) => ({
 				key: dataKey,
 				label,
 				hidden: !visibleColumns?.includes(dataKey),
 				order: i + 1,
 			}))}
+			{...props}
 			onSubmit={(_, changes) => {
 				setVisibleColumns(changes.filter(c => !c.hidden).map(c => c.key));
 				if (props.onSubmit) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
You can't define your own column list definition since #3076 

**What is the chosen solution to this problem?**
Fix this by spreading props after the default column list management in the `ColumnChooser`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
