### PR TITLE
fix(TimePicker): default width should be slightly bigger

### DIFF
--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.scss
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.scss
@@ -1,4 +1,4 @@
-$tc-timepicker-width: 7rem !default;
+$tc-timepicker-width: 8rem !default;
 $tc-timepicker-height: 17rem !default;
 $tc-timepicker-box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2) !default;
 $tc-timepicker-z-index: $zindex-dropdown !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
default value makes timepicker with seconds not nice : 
![image](https://user-images.githubusercontent.com/14272767/100271380-b3cbba00-2f59-11eb-8a25-a84b86a9243d.png)

**What is the chosen solution to this problem?**
making it a little bit bigger by default 
![image](https://user-images.githubusercontent.com/14272767/100272300-2be6af80-2f5b-11eb-8520-b8d09a8453f4.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
