### PR TITLE
fix(TDC-3764/File): Support base64 encoded file names with multi-byte characters

### DIFF
--- a/packages/forms/src/UIForm/fields/File/File.component.js
+++ b/packages/forms/src/UIForm/fields/File/File.component.js
@@ -18,6 +18,22 @@ const BASE64_NAME = ';name=';
 const BASE64_PREFIX = ';base64,';
 
 /**
+ * Decode the base64 file name with wide character support
+ * @param {string} filename The base64 value of the file name
+ * @returns {string} The decoded file name
+ */
+function base64Decode(filename) {
+	return decodeURIComponent(
+		atob(filename)
+			.split('')
+			.map(c => {
+				return `%${`00${c.charCodeAt(0).toString(16)}`.slice(-2)}`;
+			})
+			.join(''),
+	);
+}
+
+/**
  * Extract the file name from the value
  * @param {string} value The base64 value of the file.
  * Looks like `data:text/xml;name=test.xml;base64,PD94bWwgdmVyc2l...`
@@ -36,7 +52,7 @@ function getFileName(value, schema) {
 			trigger => trigger.action === PRESIGNED_URL_TRIGGER_ACTION,
 		);
 		if (uploadTrigger) {
-			return atob(value.split('.')[1]);
+			return base64Decode(value.split('.')[1]);
 		}
 	}
 	return value;

--- a/packages/forms/src/UIForm/fields/File/File.component.js
+++ b/packages/forms/src/UIForm/fields/File/File.component.js
@@ -247,6 +247,6 @@ FileWidget.defaultProps = {
 	schema: {},
 };
 
-export { FileWidget };
+export { FileWidget, base64Decode };
 
 export default withTranslation(I18N_DOMAIN_FORMS)(FileWidget);

--- a/packages/forms/src/UIForm/fields/File/File.component.js
+++ b/packages/forms/src/UIForm/fields/File/File.component.js
@@ -18,7 +18,7 @@ const BASE64_NAME = ';name=';
 const BASE64_PREFIX = ';base64,';
 
 /**
- * Decode the base64 file name with wide character support
+ * Decode the base64 file name with multi-byte character support
  * @param {string} filename The base64 value of the file name
  * @returns {string} The decoded file name
  */

--- a/packages/forms/src/UIForm/fields/File/File.component.test.js
+++ b/packages/forms/src/UIForm/fields/File/File.component.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { shallow } from 'enzyme';
-import File, { FileWidget } from './File.component';
+import File, { FileWidget, base64Decode } from './File.component';
 
 describe('File field', () => {
 	const schema = {
@@ -242,5 +242,11 @@ describe('File field', () => {
 		expect(wrapper.state('fileName')).toBe('');
 		const textInputUpdated = wrapper.find('input[type="text"]');
 		expect(textInputUpdated.props().value).toBe('');
+	});
+
+	it('should base64 encode single and multi-byte strings', () => {
+		expect(base64Decode('Y3LDqG1lLnhsc3g=')).toBe('crème.xlsx');
+		expect(base64Decode('Y3JlYW0ueGxzeA==')).toBe('cream.xlsx');
+		expect(base64Decode('Y3JlYW0tYW5kLXN1Z2FyLnhsc3g=')).toBe('cream-and-sugar.xlsx');
 	});
 });

--- a/packages/forms/stories-core/jsonStories.js
+++ b/packages/forms/stories-core/jsonStories.js
@@ -18,6 +18,14 @@ function capitalizeFirstLetter(string) {
 	return string.charAt(0).toUpperCase() + string.slice(1);
 }
 
+function stringToB64(string) {
+	return window.btoa(
+		encodeURIComponent(string).replace(/%([0-9A-F]{2})/g, (match, p1) => {
+			return String.fromCharCode(`0x${p1}`);
+		}),
+	);
+}
+
 function getFilteredCollection({ name, selection, certified, favorites, selected, orders }) {
 	const methods = {
 		asc: (a, b) => (a > b ? -1 : 1),
@@ -179,7 +187,7 @@ function createCommonProps(tab) {
 							resolve({
 								properties: properties => ({
 									...properties,
-									[key]: `${uuid.v4()}.${btoa(name)}`,
+									[key]: `${uuid.v4()}.${stringToB64(name)}`,
 								}),
 							}),
 						3000,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The current atob() method used to decode base64 file names for the file upload component does not support multi-byte characters (e.g. `ć, è`). This results in parsing errors when the file name is displayed in the input value (e.g. `cÌ.xlsx`).

**What is the chosen solution to this problem?**
The decoding function is improved based on the SO discussion linked below. This solution includes additional decoding steps to reduce the content to a byte stream and re-encode it to produce the original string. Initial tests indicate that this approach is flexible enough to service multiple base64 encoding approaches and as such should not result in a breaking change if the components is provided a string encoded using simply `window.btoa()`.

In addition, the story for this component has been enhanced to utilise an encoding approach that supports multi-byte characters.

[JIRA issue](https://jira.talendforge.org/browse/TDC-3674)
[SO Discussion](https://stackoverflow.com/questions/30106476)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

**[ ] This PR introduces a breaking change**
