### PR TITLE
fix(ListView): add margin-left to item with icon

### DIFF
--- a/packages/components/src/ListView/Items/Items.scss
+++ b/packages/components/src/ListView/Items/Items.scss
@@ -21,6 +21,7 @@ $row-nested-inner-margin-bottom: $padding-larger - $padding-small;
 			.with-icon {
 				display: inline-flex;
 				margin: 0;
+				margin-left: $padding-smaller;
 
 				.tc-svg-icon {
 					height: $row-height;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
![image](https://user-images.githubusercontent.com/54246061/100427177-baae1600-309a-11eb-88b5-0f8f6a0db277.png)


**What is the chosen solution to this problem?**
Add margin-left to item with an icon

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
