### PR TITLE
fix(tabbar): make tabs take full space

### DIFF
--- a/packages/components/src/TabBar/TabBar.scss
+++ b/packages/components/src/TabBar/TabBar.scss
@@ -19,6 +19,7 @@
 .tc-tab-bar {
 	white-space: nowrap;
 	overflow: hidden;
+	flex: 1;
 
 	& &-item {
 		float: none;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

#3021 has introduce a regression on the tabs rendererd. (5.28 -> 5.29)
Since 5.29 the ul of tabs do not take full width. 

**What is the chosen solution to this problem?**

add flex: 1;

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
