### PR TITLE
fix(theme): remove line-height on nav items

### DIFF
--- a/packages/theme/src/theme/_navs.scss
+++ b/packages/theme/src/theme/_navs.scss
@@ -48,6 +48,7 @@ $tc-tabbar-active-color: $lochmara;
 		.btn.btn-link {
 			padding: $padding-large;
 			width: 100%;
+			line-height: 1;
 			text-align: left;
 			text-overflow: ellipsis;
 			overflow: hidden;

--- a/packages/theme/src/theme/_navs.scss
+++ b/packages/theme/src/theme/_navs.scss
@@ -48,7 +48,6 @@ $tc-tabbar-active-color: $lochmara;
 		.btn.btn-link {
 			padding: $padding-large;
 			width: 100%;
-			line-height: 1;
 			text-align: left;
 			text-overflow: ellipsis;
 			overflow: hidden;
@@ -102,7 +101,6 @@ $tc-tabbar-active-color: $lochmara;
 				border: none;
 				border-radius: 0;
 				color: $black;
-				line-height: 1;
 				margin-bottom: 0.5rem;
 				outline: none;
 				padding: $padding-smaller $padding-small;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`line-height` was fixed to 1
![image](https://user-images.githubusercontent.com/18534166/100631305-dc71fc00-332b-11eb-9751-cd220f246903.png)

**What is the chosen solution to this problem?**
No reason to be hard coded, let's remove it.
![image](https://user-images.githubusercontent.com/18534166/100631239-ca905900-332b-11eb-9921-cc3ac0b0e308.png)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
