### PR TITLE
fix(TabBar): vertical overflow for some-letters

### DIFF
--- a/packages/components/src/TabBar/TabBar.scss
+++ b/packages/components/src/TabBar/TabBar.scss
@@ -46,6 +46,7 @@
 
 		& > button {
 			max-width: initial;
+			line-height: 1.3;
 		}
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Not enough height to display some letters

![image](https://user-images.githubusercontent.com/20522845/100626536-9c604880-332e-11eb-8234-269d8ed611ee.png)

**What is the chosen solution to this problem?**
Increase line height to fix vertical text overflow for tab bar component

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

