### PR TITLE
fix(forms): remove ie11 support to be umd compliant

### DIFF
--- a/packages/forms/src/rhf/fields/Input/Input.stories.js
+++ b/packages/forms/src/rhf/fields/Input/Input.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
+import { useForm, FormProvider } from 'react-hook-form';
 import { action } from '@storybook/addon-actions';
 import Input from '.';
 

--- a/packages/forms/src/rhf/fields/Input/Input.test.js
+++ b/packages/forms/src/rhf/fields/Input/Input.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
+import { useForm, FormProvider } from 'react-hook-form';
 import Input from './RHFInput.component';
 
 /* eslint-disable-next-line react/prop-types */

--- a/packages/forms/src/rhf/fields/Input/RHFInput.component.js
+++ b/packages/forms/src/rhf/fields/Input/RHFInput.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { useFormContext } from 'react-hook-form';
 import get from 'lodash/get';
 
 import Input from '../../../widgets/fields/Input';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

with UMD build react-hook-form/dist/ie11 is not umd so it is embed in the UMD
on the project side this is the same.

but having rhf embed on both bundle make the provider different.

The side effect of this is useFormContext function call return null like if the context was not provided.

**What is the chosen solution to this problem?**

Remove ie11 dist import to rely on umd so the code is shared.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
