### PR TITLE
fix(forms): remove ie11 support to be umd compliant

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,9 +2,6 @@
 /home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.component.js
   32:66  warning  React Hook useLayoutEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
-  5:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/AppSwitcher/AppSwitcher.component.js
   40:10  error  Elements with the ARIA role "heading" must have the following attributes defined: aria-level  jsx-a11y/role-has-required-aria-props
 
@@ -148,9 +145,6 @@
 /home/travis/build/Talend/ui/packages/components/src/GuidedTour/GuidedTour.stories.js
   102:7  warning  Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger
 
-/home/travis/build/Talend/ui/packages/components/src/Layout/AppLayout.stories.js
-  7:8  error  'IconsProvider' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
   33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
@@ -237,13 +231,12 @@
   51:3  warning  React Hook React.useCallback has a missing dependency: 't'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/ResourceList/ResourceList.stories.js
-    8:8   error    'IconsProvider' is defined but never used                                                                                @typescript-eslint/no-unused-vars
+  253:13  error    'collection' is missing in props validation                                                                              react/prop-types
+  253:24  error    'collection.filter' is missing in props validation                                                                       react/prop-types
   254:13  error    'collection' is missing in props validation                                                                              react/prop-types
-  254:24  error    'collection.filter' is missing in props validation                                                                       react/prop-types
-  255:13  error    'collection' is missing in props validation                                                                              react/prop-types
-  256:3   warning  React Hook React.useMemo has a missing dependency: 'props.collection'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
-  265:20  error    'renderAs' is missing in props validation                                                                                react/prop-types
-  265:30  error    'renderAs.name' is missing in props validation                                                                           react/prop-types
+  255:3   warning  React Hook React.useMemo has a missing dependency: 'props.collection'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+  264:20  error    'renderAs' is missing in props validation                                                                                react/prop-types
+  264:30  error    'renderAs.name' is missing in props validation                                                                           react/prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/ResourcePicker/index.js
   4:7  error  'TOOLBAR_OPTIONS' is assigned a value but never used  @typescript-eslint/no-unused-vars
@@ -315,5 +308,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 150 problems (130 errors, 20 warnings)
+✖ 147 problems (127 errors, 20 warnings)
   15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/forms/src/rhf/fields/Input/Input.stories.js
+++ b/packages/forms/src/rhf/fields/Input/Input.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable import/no-extraneous-dependencies */
 import React from 'react';
-import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
+import { useForm, FormProvider } from 'react-hook-form';
 import { action } from '@storybook/addon-actions';
 import Input from '.';
 

--- a/packages/forms/src/rhf/fields/Input/Input.test.js
+++ b/packages/forms/src/rhf/fields/Input/Input.test.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
-import { useForm, FormProvider } from 'react-hook-form/dist/index.ie11';
+import { useForm, FormProvider } from 'react-hook-form';
 import Input from './RHFInput.component';
 
 /* eslint-disable-next-line react/prop-types */

--- a/packages/forms/src/rhf/fields/Input/RHFInput.component.js
+++ b/packages/forms/src/rhf/fields/Input/RHFInput.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { useFormContext } from 'react-hook-form';
 import get from 'lodash/get';
 
 import Input from '../../../widgets/fields/Input';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

with UMD build react-hook-form/dist/ie11 is not umd so it is embed in the UMD
on the project side this is the same.

but having rhf embed on both bundle make the provider different.

The side effect of this is useFormContext function call return null like if the context was not provided.

**What is the chosen solution to this problem?**

Remove ie11 dist import to rely on umd so the code is shared.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[x] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

```diff
-import { useFormContext } from 'react-hook-form/dist/index.ie11';
+import { useFormContext } from 'react-hook-form';
```

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
