### PR TITLE
fix(List/ColumnChooser): "Select all" and columns list filter

### DIFF
--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -30,7 +30,7 @@ export default function ColumnChooser({
 }) {
 	const { t } = useTranslation();
 	const {
-		columns, visibleColumns,
+		columns, filteredColumns,
 		onChangeVisibility,
 		onSelectAll, selectAll,
 		setTextFilter, textFilter,
@@ -83,7 +83,7 @@ export default function ColumnChooser({
 	return (
 		<ColumnChooserProvider
 			value={{
-				columns: visibleColumns,
+				columns: filteredColumns,
 				id,
 				onChangeVisibility,
 				onSelectAll,

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useMemo } from 'react';
+import React, { useEffect, useMemo, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { ColumnChooserProvider } from './columnChooser.context';
@@ -31,9 +31,15 @@ export default function ColumnChooser({
 	onSubmit,
 }) {
 	const { t } = useTranslation();
-	const { columns, onChangeVisibility, onSelectAll, selectAll } = useColumnChooserManager(
+	const {
+		columns,
+		onChangeVisibility,
+		onSelectAll, selectAll,
+		setTextFilter, textFilter,
+	} = useColumnChooserManager(
 		columnsFromList,
 		nbLockedLeftItems,
+		initialFilterValue,
 	);
 
 	useEffect(() => {
@@ -48,10 +54,11 @@ export default function ColumnChooser({
 		event.preventDefault();
 		onSubmit(event, mapToColumnsList(columns));
 	};
-	const [filter, setFilter] = useState(initialFilterValue || '');
-	const onFilter = (_, value) => setFilter(value);
-	const resetFilter = () => setFilter('');
-	const filteredColumns = useMemo(() => filterColumns(columns, filter), [columns, filter]);
+
+	// Filter field callbacks
+	const onFilter = useCallback((_, value) => setTextFilter(value), [setTextFilter]);
+	const resetFilter = useCallback(() => setTextFilter(''), [setTextFilter]);
+	const filteredColumns = useMemo(() => filterColumns(columns, textFilter), [columns, textFilter]);
 	const Default = (
 		<React.Fragment>
 			<ColumnChooserHeader />
@@ -67,7 +74,7 @@ export default function ColumnChooser({
 				})}
 				onToggle={resetFilter}
 				onFilter={onFilter}
-				value={filter}
+				value={textFilter}
 			/>
 			<form id={`${id}-form`} className={theme('tc-column-chooser')} onSubmit={onSubmitForm}>
 				<ColumnChooserBody />

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useCallback } from 'react';
+import React, { useEffect, useCallback } from 'react';
 import PropTypes from 'prop-types';
 import { useTranslation } from 'react-i18next';
 import { ColumnChooserProvider } from './columnChooser.context';
@@ -12,8 +12,6 @@ import { getTheme } from '../../../../theme';
 
 const theme = getTheme(cssModule);
 
-const hasColumnLabel = label => column => column.label.toLowerCase().includes(label.toLowerCase());
-const filterColumns = (columns, filter) => columns.filter(hasColumnLabel(filter));
 const changeVisibleToHidden = column => ({
 	hidden: !column.visible,
 	label: column.label,
@@ -32,7 +30,7 @@ export default function ColumnChooser({
 }) {
 	const { t } = useTranslation();
 	const {
-		columns,
+		columns, visibleColumns,
 		onChangeVisibility,
 		onSelectAll, selectAll,
 		setTextFilter, textFilter,
@@ -58,7 +56,7 @@ export default function ColumnChooser({
 	// Filter field callbacks
 	const onFilter = useCallback((_, value) => setTextFilter(value), [setTextFilter]);
 	const resetFilter = useCallback(() => setTextFilter(''), [setTextFilter]);
-	const filteredColumns = useMemo(() => filterColumns(columns, textFilter), [columns, textFilter]);
+
 	const Default = (
 		<React.Fragment>
 			<ColumnChooserHeader />
@@ -85,7 +83,7 @@ export default function ColumnChooser({
 	return (
 		<ColumnChooserProvider
 			value={{
-				columns: filteredColumns,
+				columns: visibleColumns,
 				id,
 				onChangeVisibility,
 				onSelectAll,

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.component.js
@@ -30,15 +30,14 @@ export default function ColumnChooser({
 }) {
 	const { t } = useTranslation();
 	const {
-		columns, filteredColumns,
+		columns,
+		filteredColumns,
 		onChangeVisibility,
-		onSelectAll, selectAll,
-		setTextFilter, textFilter,
-	} = useColumnChooserManager(
-		columnsFromList,
-		nbLockedLeftItems,
-		initialFilterValue,
-	);
+		onSelectAll,
+		selectAll,
+		setTextFilter,
+		textFilter,
+	} = useColumnChooserManager(columnsFromList, nbLockedLeftItems, initialFilterValue);
 
 	useEffect(() => {
 		// eslint-disable-next-line no-console

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -71,7 +71,7 @@ const prepareColumns = (columns, lockedLeftItems) =>
 		),
 	);
 
-export const changeColumnChooserAttribute = key => value => column => {
+const changeColumnChooserAttribute = key => value => column => {
 	if (!column.locked) {
 		return { ...column, [key]: value };
 	}

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useMemo } from 'react';
 import flow from 'lodash/flow';
 import cloneDeep from 'lodash/cloneDeep';
 import { compareOrder } from '../service';
@@ -80,6 +80,10 @@ const changeColumnChooserAttribute = key => value => column => {
 
 const updateVisibilityAttr = changeColumnChooserAttribute('visible');
 
+const hasColumnLabel = label => column => column.label.toLowerCase().includes(label.toLowerCase());
+
+const filterColumns = (columns, filter) => columns.filter(hasColumnLabel(filter));
+
 /** *******************************************************************************
  * HOOK ENTRY POINT
  ******************************************************************************** */
@@ -92,7 +96,15 @@ const updateVisibilityAttr = changeColumnChooserAttribute('visible');
 export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems = 0, initialFilterValue = '') => {
 	const [textFilter, setTextFilter] = useState(initialFilterValue);
 
-	const columns = prepareColumns(initialColumns, nbLockedLeftItems);
+	const columns = useMemo(
+		() => prepareColumns(initialColumns, nbLockedLeftItems),
+		[initialColumns, nbLockedLeftItems]
+	);
+
+	const visibleColumns = useMemo(
+		() => filterColumns(columns, textFilter),
+		[columns, textFilter]
+	);
 
 	const [state, setState] = useState({
 		columns: orderColumns(columns),
@@ -119,6 +131,7 @@ export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems =
 		onChangeVisibility,
 		onSelectAll,
 		columns: cloneDeep(state.columns),
+		visibleColumns,
 		selectAll: state.selectAll,
 		textFilter,
 		setTextFilter,

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -71,19 +71,18 @@ const updateVisibility = (column, visible) => {
  * @param {array} initColumns
  * @param {number} nbLockedLeftItems
  */
-export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems = 0, initialFilterValue = '') => {
-	const [columns, setColumns] = useState(
-		() => prepareColumns(initialColumns, nbLockedLeftItems)
-	);
+export const useColumnChooserManager = (
+	initialColumns = [],
+	nbLockedLeftItems = 0,
+	initialFilterValue = '',
+) => {
+	const [columns, setColumns] = useState(() => prepareColumns(initialColumns, nbLockedLeftItems));
 
 	const [textFilter, setTextFilter] = useState(initialFilterValue);
 
 	const filteredColumns = useMemo(
-		() => columns.filter(
-			column => column.label.toLowerCase().includes(textFilter.toLowerCase()
-			)
-		),
-		[columns, textFilter]
+		() => columns.filter(column => column.label.toLowerCase().includes(textFilter.toLowerCase())),
+		[columns, textFilter],
 	);
 
 	const onChangeVisibility = (value, label) => {

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -89,8 +89,11 @@ const updateVisibilityAttr = changeColumnChooserAttribute('visible');
  * @param {array} initColumns
  * @param {number} nbLockedLeftItems
  */
-export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems = 0) => {
+export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems = 0, initialFilterValue = '') => {
+	const [textFilter, setTextFilter] = useState(initialFilterValue);
+
 	const columns = prepareColumns(initialColumns, nbLockedLeftItems);
+
 	const [state, setState] = useState({
 		columns: orderColumns(columns),
 		selectAll: isEveryItemVisible(columns),
@@ -117,5 +120,7 @@ export const useColumnChooserManager = (initialColumns = [], nbLockedLeftItems =
 		onSelectAll,
 		columns: cloneDeep(state.columns),
 		selectAll: state.selectAll,
+		textFilter,
+		setTextFilter,
 	};
 };

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
@@ -8,7 +8,13 @@ const initialColumns = [
 	{ key: 'name', label: 'Name', order: 2 },
 	{ key: 'author', label: 'Author', order: 3 },
 	{ key: 'created', label: 'Created', order: 6 },
-	{ key: 'modified', label: 'Modified', order: 4, header: 'icon', data: { iconName: 'talend-scheduler' } },
+	{
+		key: 'modified',
+		label: 'Modified',
+		order: 4,
+		header: 'icon',
+		data: { iconName: 'talend-scheduler' },
+	},
 	{ key: 'icon', label: 'Icon', visible: true, order: 5 },
 ];
 

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
@@ -4,41 +4,12 @@ import { act } from 'react-dom/test-utils';
 import { useColumnChooserManager } from './columnChooserManager.hook';
 
 const initialColumns = [
-	{
-		key: 'id',
-		label: 'Id',
-		order: 1,
-	},
-	{
-		key: 'name',
-		label: 'Name',
-		order: 2,
-	},
-	{
-		key: 'author',
-		label: 'Author',
-		order: 3,
-	},
-	{
-		key: 'created',
-		label: 'Created',
-		order: 6,
-	},
-	{
-		key: 'modified',
-		label: 'Modified',
-		order: 4,
-		header: 'icon',
-		data: {
-			iconName: 'talend-scheduler',
-		},
-	},
-	{
-		key: 'icon',
-		label: 'Icon',
-		visible: true,
-		order: 5,
-	},
+	{ key: 'id', label: 'Id', order: 1 },
+	{ key: 'name', label: 'Name', order: 2 },
+	{ key: 'author', label: 'Author', order: 3 },
+	{ key: 'created', label: 'Created', order: 6 },
+	{ key: 'modified', label: 'Modified', order: 4, header: 'icon', data: { iconName: 'talend-scheduler' } },
+	{ key: 'icon', label: 'Icon', visible: true, order: 5 },
 ];
 
 const lockedLeftItems = 2;
@@ -54,11 +25,13 @@ const testHook = hook => {
 
 describe('useColumnChooserManager', () => {
 	let columnChooserHook;
+
 	beforeEach(() =>
 		testHook(() => {
 			columnChooserHook = useColumnChooserManager(initialColumns, lockedLeftItems);
 		}),
 	);
+
 	it('should have no columns defined', () => {
 		// given nothing
 		let hookWithNoValue;
@@ -68,6 +41,7 @@ describe('useColumnChooserManager', () => {
 		});
 		expect(hookWithNoValue.columns).toEqual([]);
 	});
+
 	it('should have some columns with the first two left locked', () => {
 		// given before each
 		// when mounting before each
@@ -81,6 +55,7 @@ describe('useColumnChooserManager', () => {
 			{ key: 'created', label: 'Created', order: 6, visible: true },
 		]);
 	});
+
 	it('should change the visible property of the third column', () => {
 		// given before each
 		// when
@@ -89,6 +64,7 @@ describe('useColumnChooserManager', () => {
 		// then
 		expect(columnChooserHook.columns[2].visible).toBe(false);
 	});
+
 	it('should not change the visible property of the second column which is locked', () => {
 		// given before each
 		// when
@@ -97,6 +73,7 @@ describe('useColumnChooserManager', () => {
 		// then
 		expect(columnChooserHook.columns[1].visible).toBe(true);
 	});
+
 	it('should change the visible value of every column except the locked ones', () => {
 		// given before each
 		// when
@@ -112,5 +89,47 @@ describe('useColumnChooserManager', () => {
 		expect(columnChooserHook.columns[2].visible).toBe(false);
 		expect(columnChooserHook.columns[3].visible).toBe(false);
 		expect(columnChooserHook.columns[4].visible).toBe(false);
+	});
+
+	it('should filter the list of columns', () => {
+		// given before each
+		// when
+		act(() => columnChooserHook.setTextFilter('d'));
+
+		// then
+		expect(columnChooserHook.filteredColumns).toHaveLength(3);
+		expect(columnChooserHook.filteredColumns[0].label).toEqual('Id');
+		expect(columnChooserHook.filteredColumns[1].label).toEqual('Modified');
+		expect(columnChooserHook.filteredColumns[2].label).toEqual('Created');
+	});
+
+	it('should set selectAll value according the shown columns in the chooser', () => {
+		// given before each
+		// Uncheck every column
+		act(() => columnChooserHook.onSelectAll(false));
+		// Check "Modified" and "Created"
+		act(() => columnChooserHook.onChangeVisibility(true, 'Modified'));
+		act(() => columnChooserHook.onChangeVisibility(true, 'Created'));
+		// Filter columns to only have previously checked ones
+		act(() => columnChooserHook.setTextFilter('d'));
+
+		// then
+		expect(columnChooserHook.selectAll).toBe(true);
+	});
+
+	it('should only toggle the filtered items visibilities when using select all', () => {
+		// given before each
+		// when
+		act(() => columnChooserHook.onSelectAll(true));
+		act(() => columnChooserHook.setTextFilter('d'));
+		act(() => columnChooserHook.onSelectAll(false));
+
+		// then
+		expect(columnChooserHook.columns[0].visible).toBe(true);
+		expect(columnChooserHook.columns[1].visible).toBe(true);
+		expect(columnChooserHook.columns[2].visible).toBe(true);
+		expect(columnChooserHook.columns[3].visible).toBe(false);
+		expect(columnChooserHook.columns[4].visible).toBe(true);
+		expect(columnChooserHook.columns[5].visible).toBe(false);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
"Select all" option in the lists' column choser should apply to shown columns (e.g. those shown when the user filters the list of columns)
![image](https://user-images.githubusercontent.com/38908846/100751295-6b901a00-33e7-11eb-89f3-6444398342cb.png)

**What is the chosen solution to this problem?**
Integrate filtering into the column chooser manager and update the manager's behavior accordingly, example :
- Given a list with 3 columns, "_First name_", "_Last name_", "_Login_", all 3 checked (so "_Select all_" is also checked)
- User types in "_name_" in the filter (only "_First name_" and "_Last name_" appear in the list) **→** Unchecks "_Select all_" **→** Apply
- Only "_Login_" column is shown in the list

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
