### PR TITLE
fix(drawer): spread props to  Transition

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -123,20 +123,17 @@
   7:23  error  Unexpected use of file extension "js" for "./DraggableComponent.js"  import/extensions
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
-  272:43  error  'footerActions' is already declared in the upper scope  no-shadow
+  270:43  error  'footerActions' is already declared in the upper scope  no-shadow
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.stories.js
-   14:1   error  `lodash` import should occur before import of `./Drawer.component`  import/order
-   14:10  error  'remove' is defined but never used                                  @typescript-eslint/no-unused-vars
-  179:3   error  Empty components are self-closing                                   react/self-closing-comp
-  180:3   error  Empty components are self-closing                                   react/self-closing-comp
-  254:33  error  Unary operator '++' used                                            no-plusplus
-  311:35  error  Unary operator '++' used                                            no-plusplus
-  459:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
-  470:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
-  481:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
-  490:12  error  'remove' is already declared in the upper scope                     no-shadow
-  495:7   error  Assignment to property of function parameter 'accu'                 no-param-reassign
+  178:3   error  Empty components are self-closing                    react/self-closing-comp
+  179:3   error  Empty components are self-closing                    react/self-closing-comp
+  253:33  error  Unary operator '++' used                             no-plusplus
+  310:35  error  Unary operator '++' used                             no-plusplus
+  458:55  error  'remove' was used before it was defined              @typescript-eslint/no-use-before-define
+  469:55  error  'remove' was used before it was defined              @typescript-eslint/no-use-before-define
+  480:55  error  'remove' was used before it was defined              @typescript-eslint/no-use-before-define
+  494:7   error  Assignment to property of function parameter 'accu'  no-param-reassign
 
 /home/travis/build/Talend/ui/packages/components/src/EditableText/EditableText.test.js
   12:3  error  Arrow function should not return assignment  no-return-assign
@@ -394,5 +391,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 215 problems (195 errors, 20 warnings)
-  16 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 212 problems (192 errors, 20 warnings)
+  15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -123,13 +123,20 @@
   7:23  error  Unexpected use of file extension "js" for "./DraggableComponent.js"  import/extensions
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
-  273:43  error  'footerActions' is already declared in the upper scope  no-shadow
+  272:43  error  'footerActions' is already declared in the upper scope  no-shadow
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.stories.js
-  178:3   error  Empty components are self-closing  react/self-closing-comp
-  179:3   error  Empty components are self-closing  react/self-closing-comp
-  253:33  error  Unary operator '++' used           no-plusplus
-  310:35  error  Unary operator '++' used           no-plusplus
+   14:1   error  `lodash` import should occur before import of `./Drawer.component`  import/order
+   14:10  error  'remove' is defined but never used                                  @typescript-eslint/no-unused-vars
+  179:3   error  Empty components are self-closing                                   react/self-closing-comp
+  180:3   error  Empty components are self-closing                                   react/self-closing-comp
+  254:33  error  Unary operator '++' used                                            no-plusplus
+  311:35  error  Unary operator '++' used                                            no-plusplus
+  459:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
+  470:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
+  481:55  error  'remove' was used before it was defined                             @typescript-eslint/no-use-before-define
+  490:12  error  'remove' is already declared in the upper scope                     no-shadow
+  495:7   error  Assignment to property of function parameter 'accu'                 no-param-reassign
 
 /home/travis/build/Talend/ui/packages/components/src/EditableText/EditableText.test.js
   12:3  error  Arrow function should not return assignment  no-return-assign
@@ -387,5 +394,5 @@
   703:23  error  Caution: `VirtualizedList` also has a named export `headerDictionary`. Check if you meant to write `import {headerDictionary} from '.'` instead  import/no-named-as-default-member
   703:56  error  ["resizable"] is better written in dot notation                                                                                                  dot-notation
 
-✖ 208 problems (188 errors, 20 warnings)
-  15 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 215 problems (195 errors, 20 warnings)
+  16 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -123,7 +123,7 @@
   7:23  error  Unexpected use of file extension "js" for "./DraggableComponent.js"  import/extensions
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
-  270:43  error  'footerActions' is already declared in the upper scope  no-shadow
+  264:43  error  'footerActions' is already declared in the upper scope  no-shadow
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.stories.js
   178:3   error  Empty components are self-closing                    react/self-closing-comp

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -123,7 +123,7 @@
   7:23  error  Unexpected use of file extension "js" for "./DraggableComponent.js"  import/extensions
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.component.js
-  264:43  error  'footerActions' is already declared in the upper scope  no-shadow
+  273:43  error  'footerActions' is already declared in the upper scope  no-shadow
 
 /home/travis/build/Talend/ui/packages/components/src/Drawer/Drawer.stories.js
   178:3   error  Empty components are self-closing  react/self-closing-comp

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -15,6 +15,7 @@ import { getTheme } from '../theme';
 import theme from './Drawer.scss';
 
 const css = getTheme(theme);
+const DEFAULT_TRANSITION_DURATION = 350;
 
 const STYLES = {
 	entering: { transform: 'translateX(100%)' },
@@ -25,6 +26,7 @@ const STYLES = {
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
+	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
 
 	return (
 		<Transition
@@ -39,7 +41,7 @@ function DrawerAnimation(props) {
 		>
 			{transitionState => {
 				const style = {
-					transition: 'transform 350ms ease-in-out',
+					transition: `transform ${timeout}ms ease-in-out`,
 					...STYLES[transitionState],
 				};
 				return React.cloneElement(children, { style });

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -20,23 +20,32 @@ const DEFAULT_TRANSITION_DURATION = 350;
 const STYLES = {
 	entering: { transform: 'translateX(100%)' },
 	entered: { transform: 'translateX(0%)' },
-	exiting: { transform: 'translateX(0%)' },
+	exiting: { transform: 'translateX(100%)' },
 	exited: { transform: 'translateX(100%)' },
 };
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
 	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
-	const defaultStyle = {
-		transition: `transform ${timeout}ms ease-in-out`,
-		transform: 'translateX(100%)',
-	};
 
 	return (
-		<Transition in appear timeout={timeout}>
+		<Transition
+			in
+			appear
+			exit
+			timeout={{
+				appear: 0,
+				enter: 0,
+				exit: 500,
+			}}
+			{...rest}
+		>
 			{transitionState => {
-				const style = { ...defaultStyle, ...STYLES[transitionState] };
-				return React.cloneElement(children, { ...rest, style });
+				const style = {
+					transition: `transform ${timeout}ms ease-in-out`,
+					...STYLES[transitionState],
+				};
+				return React.cloneElement(children, { style });
 			}}
 		</Transition>
 	);

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -32,7 +32,6 @@ function DrawerAnimation(props) {
 		<Transition
 			in
 			appear
-			exit
 			timeout={{
 				appear: 0,
 				enter: 0,

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -18,7 +18,7 @@ const css = getTheme(theme);
 const DEFAULT_TRANSITION_DURATION = 350;
 
 const STYLES = {
-	entering: { transform: 'translateX(100%)' },
+	entering: { transform: 'translateX(0%)' },
 	entered: { transform: 'translateX(0%)' },
 	exiting: { transform: 'translateX(100%)' },
 	exited: { transform: 'translateX(100%)' },
@@ -29,19 +29,11 @@ function DrawerAnimation(props) {
 	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
 
 	return (
-		<Transition
-			in
-			appear
-			timeout={{
-				appear: 0,
-				enter: 0,
-				exit: withTransition ? 500 : 0,
-			}}
-			{...rest}
-		>
+		<Transition in appear timeout={withTransition ? 500 : 0} {...rest}>
 			{transitionState => {
 				const style = {
 					transition: `transform ${timeout}ms ease-in-out`,
+					transform: 'translateX(100%)',
 					...STYLES[transitionState],
 				};
 				return React.cloneElement(children, { style });

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -15,7 +15,6 @@ import { getTheme } from '../theme';
 import theme from './Drawer.scss';
 
 const css = getTheme(theme);
-const DEFAULT_TRANSITION_DURATION = 350;
 
 const STYLES = {
 	entering: { transform: 'translateX(100%)' },
@@ -26,7 +25,6 @@ const STYLES = {
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
-	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
 
 	return (
 		<Transition
@@ -35,13 +33,13 @@ function DrawerAnimation(props) {
 			timeout={{
 				appear: 0,
 				enter: 0,
-				exit: 500,
+				exit: withTransition ? 500 : 0,
 			}}
 			{...rest}
 		>
 			{transitionState => {
 				const style = {
-					transition: `transform ${timeout}ms ease-in-out`,
+					transition: 'transform 350ms ease-in-out',
 					...STYLES[transitionState],
 				};
 				return React.cloneElement(children, { style });

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -11,7 +11,6 @@ import IconsProvider from '../IconsProvider';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
 import { ActionButton } from '../Actions';
-import { remove } from 'lodash';
 
 const header = <HeaderBar brand={{ label: 'Example App Name' }} />;
 

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -476,11 +476,11 @@ storiesOf('Layout/Drawer', module)
 			),
 			third: (
 				<Drawer
-					withTransition
+					withTransition={false}
 					title="Im drawer 3"
 					onCancelAction={{ label: 'Close', onClick: () => remove('third') }}
 				>
-					<h1>Hello drawer 3</h1>
+					<h1>No transition on this one</h1>
 					Coucou
 				</Drawer>
 			),

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -11,6 +11,7 @@ import IconsProvider from '../IconsProvider';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
 import { ActionButton } from '../Actions';
+import { remove } from 'lodash';
 
 const header = <HeaderBar brand={{ label: 'Example App Name' }} />;
 
@@ -445,6 +446,65 @@ storiesOf('Layout/Drawer', module)
 			<Layout header={header} mode="TwoColumns" one={sidePanel} drawers={[<CustomDrawer />]}>
 				<span>zone with drawer</span>
 				<IconsProvider />
+			</Layout>
+		);
+	})
+	.add('Interactive', () => {
+		const allDrawers = {
+			first: (
+				<Drawer
+					withTransition
+					stacked
+					title="Im stacked drawer 1"
+					onCancelAction={{ label: 'Close', onClick: () => remove('first') }}
+				>
+					<h1>Hello drawer 1</h1>
+					<p>You should not being able to read this because I'm first</p>
+				</Drawer>
+			),
+			second: (
+				<Drawer
+					withTransition
+					stacked
+					title="Im drawer 2"
+					onCancelAction={{ label: 'Close', onClick: () => remove('second') }}
+				>
+					<h1>Hello drawer 2</h1>
+					<p>The scroll is defined by the content</p>
+					{scrollableContent()}
+				</Drawer>
+			),
+			third: (
+				<Drawer
+					withTransition
+					title="Im drawer 3"
+					onCancelAction={{ label: 'Close', onClick: () => remove('third') }}
+				>
+					<h1>Hello drawer 3</h1>
+					Coucou
+				</Drawer>
+			),
+		};
+		const [displayedDrawers, setDisplayedDrawers] = React.useState(allDrawers);
+
+		function remove(id) {
+			setDisplayedDrawers(oldDrawers =>
+				Object.entries(oldDrawers)
+					.filter(([key]) => key !== id)
+					.reduce((accu, [key, value]) => {
+						accu[key] = value;
+						return accu;
+					}, {}),
+			);
+		}
+
+		return (
+			<Layout header={header} mode="OneColumn" drawers={Object.values(displayedDrawers)}>
+				<div style={{ padding: '1.5rem' }}>
+					<button className="btn btn-primary" onClick={() => setDisplayedDrawers(allDrawers)}>
+						Set back the drawers
+					</button>
+				</div>
 			</Layout>
 		);
 	});

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -24,23 +24,26 @@ body > div {
  <Layout mode="TwoColumns" one={one} two={two}></Layout>
  */
 function WithDrawer({ drawers, children }) {
+	const hasDrawer = drawers && drawers.length > 0;
 	return (
 		<div className={theme['tc-with-drawer']}>
 			{children}
-			<TransitionGroup appear className={theme['tc-with-drawer-container']}>
-				{drawers &&
-					drawers.map((drawer, key) => (
-						<Drawer.Animation
-							withTransition={
-								get(drawer, 'props.withTransition', true) &&
-								get(drawer, 'props.route.state.withTransition')
-							}
-							key={get(drawer, 'props.route.path', key)}
-						>
-							<div className="tc-with-drawer-wrapper">{drawer}</div>
-						</Drawer.Animation>
-					))}
-			</TransitionGroup>
+			{hasDrawer && (
+				<TransitionGroup className={theme['tc-with-drawer-container']}>
+					{drawers &&
+						drawers.map((drawer, key) => (
+							<Drawer.Animation
+								withTransition={
+									get(drawer, 'props.withTransition', true) &&
+									get(drawer, 'props.route.state.withTransition')
+								}
+								key={get(drawer, 'props.route.path', key)}
+							>
+								<div className="tc-with-drawer-wrapper">{drawer}</div>
+							</Drawer.Animation>
+						))}
+				</TransitionGroup>
+			)}
 		</div>
 	);
 }

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -24,26 +24,23 @@ body > div {
  <Layout mode="TwoColumns" one={one} two={two}></Layout>
  */
 function WithDrawer({ drawers, children }) {
-	const hasDrawer = drawers && drawers.length > 0;
 	return (
 		<div className={theme['tc-with-drawer']}>
 			{children}
-			{hasDrawer && (
-				<TransitionGroup className={theme['tc-with-drawer-container']}>
-					{drawers &&
-						drawers.map((drawer, key) => (
-							<Drawer.Animation
-								withTransition={
-									get(drawer, 'props.withTransition', true) &&
-									get(drawer, 'props.route.state.withTransition')
-								}
-								key={get(drawer, 'props.route.path', key)}
-							>
-								<div className="tc-with-drawer-wrapper">{drawer}</div>
-							</Drawer.Animation>
-						))}
-				</TransitionGroup>
-			)}
+			<TransitionGroup className={theme['tc-with-drawer-container']}>
+				{drawers &&
+					drawers.map((drawer, key) => (
+						<Drawer.Animation
+							withTransition={
+								get(drawer, 'props.withTransition', true) &&
+								get(drawer, 'props.route.state.withTransition')
+							}
+							key={get(drawer, 'props.route.path', key)}
+						>
+							<div className="tc-with-drawer-wrapper">{drawer}</div>
+						</Drawer.Animation>
+					))}
+			</TransitionGroup>
 		</div>
 	);
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Since #2958 we have a regression on unmounted Drawer components which stay there.

**What is the chosen solution to this problem?**

* Spread the props from TransitionGroup to Transition has mentionned in the documentation
* Add story so we can play with it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
