### PR TITLE
fix(DateTimePickers/TMC-23816): revert import from i18next

### DIFF
--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
@@ -1,7 +1,6 @@
 /*
 * Unexpected issues when importing t directly with named import
 * https://github.com/i18next/i18next/issues/1287
-* (t is not an own property of exported object, it is in it's prototype chain)
 * */
 // eslint-disable-next-line import/no-named-as-default-member
 import i18next from 'i18next';

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
@@ -1,7 +1,7 @@
 /*
-* Unexpected issues when importing t directly with named import
-* https://github.com/i18next/i18next/issues/1287
-* */
+ * Unexpected issues when importing t directly with named import
+ * https://github.com/i18next/i18next/issues/1287
+ * */
 // eslint-disable-next-line import/no-named-as-default-member
 import i18next from 'i18next';
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/error-messages.js
@@ -1,37 +1,43 @@
-import { t } from 'i18next';
+/*
+* Unexpected issues when importing t directly with named import
+* https://github.com/i18next/i18next/issues/1287
+* (t is not an own property of exported object, it is in it's prototype chain)
+* */
+// eslint-disable-next-line import/no-named-as-default-member
+import i18next from 'i18next';
 
 export default function getErrorMessage(key) {
 	switch (key) {
 		case 'INVALID_HOUR_EMPTY':
-			return t('INVALID_HOUR_EMPTY', { defaultValue: 'Hour is required' });
+			return i18next.t('INVALID_HOUR_EMPTY', { defaultValue: 'Hour is required' });
 		case 'INVALID_HOUR_NUMBER':
-			return t('INVALID_HOUR_NUMBER', { defaultValue: 'Hour must be between 00 and 23' });
+			return i18next.t('INVALID_HOUR_NUMBER', { defaultValue: 'Hour must be between 00 and 23' });
 		case 'INVALID_MINUTES_EMPTY':
-			return t('INVALID_MINUTES_EMPTY', { defaultValue: 'Minutes are required' });
+			return i18next.t('INVALID_MINUTES_EMPTY', { defaultValue: 'Minutes are required' });
 		case 'INVALID_MINUTES_NUMBER':
-			return t('INVALID_MINUTES_NUMBER', {
+			return i18next.t('INVALID_MINUTES_NUMBER', {
 				defaultValue: 'Minutes value must be between 00 and 59',
 			});
 		case 'INVALID_SECONDS_EMPTY':
-			return t('INVALID_SECONDS_EMPTY', { defaultValue: 'Seconds are required' });
+			return i18next.t('INVALID_SECONDS_EMPTY', { defaultValue: 'Seconds are required' });
 		case 'INVALID_SECONDS_NUMBER':
-			return t('INVALID_SECONDS_NUMBER', {
+			return i18next.t('INVALID_SECONDS_NUMBER', {
 				defaultValue: 'Seconds value must be between 00 and 59',
 			});
 		case 'INVALID_DATE_FORMAT':
-			return t('INVALID_DATE_FORMAT', { defaultValue: 'Date format is invalid' });
+			return i18next.t('INVALID_DATE_FORMAT', { defaultValue: 'Date format is invalid' });
 		case 'INVALID_MONTH_NUMBER':
-			return t('INVALID_MONTH_NUMBER', { defaultValue: 'Month must be between 01 and 12' });
+			return i18next.t('INVALID_MONTH_NUMBER', { defaultValue: 'Month must be between 01 and 12' });
 		case 'INVALID_DAY_NUMBER':
-			return t('INVALID_DAY_NUMBER', { defaultValue: 'Day is invalid' });
+			return i18next.t('INVALID_DAY_NUMBER', { defaultValue: 'Day is invalid' });
 		case 'INVALID_DAY_OF_MONTH':
-			return t('INVALID_DAY_OF_MONTH', {
+			return i18next.t('INVALID_DAY_OF_MONTH', {
 				defaultValue: "Day value doesn't match an existing day in the month",
 			});
 		case 'TIME_FORMAT_INVALID':
-			return t('TIME_FORMAT_INVALID', { defaultValue: 'Time is invalid' });
+			return i18next.t('TIME_FORMAT_INVALID', { defaultValue: 'Time is invalid' });
 		case 'DATETIME_INVALID_FORMAT':
-			return t('DATETIME_INVALID_FORMAT', { defaultValue: 'Datetime is invalid' });
+			return i18next.t('DATETIME_INVALID_FORMAT', { defaultValue: 'Datetime is invalid' });
 		default:
 			return '';
 	}

--- a/packages/components/src/DateTimePickers/shared/error-messages.js
+++ b/packages/components/src/DateTimePickers/shared/error-messages.js
@@ -1,46 +1,51 @@
-// eslint-disable-next line import/no-named-as-default-member
-import { t } from 'i18next';
+/*
+* Unexpected issues when importing t directly with named import
+* https://github.com/i18next/i18next/issues/1287
+* (t is not an own property of exported object, it is in it's prototype chain)
+* */
+// eslint-disable-next-line import/no-named-as-default-member
+import i18next from 'i18next';
 
 export default function getErrorMessage(key) {
 	switch (key) {
 		case 'INVALID_HOUR_EMPTY':
-			return t('INVALID_HOUR_EMPTY', { defaultValue: 'Hour is required' });
+			return i18next.t('INVALID_HOUR_EMPTY', { defaultValue: 'Hour is required' });
 		case 'INVALID_HOUR_NUMBER':
-			return t('INVALID_HOUR_NUMBER', { defaultValue: 'Hour must be between 00 and 23' });
+			return i18next.t('INVALID_HOUR_NUMBER', { defaultValue: 'Hour must be between 00 and 23' });
 		case 'INVALID_MINUTES_EMPTY':
-			return t('INVALID_MINUTES_EMPTY', { defaultValue: 'Minutes are required' });
+			return i18next.t('INVALID_MINUTES_EMPTY', { defaultValue: 'Minutes are required' });
 		case 'INVALID_MINUTES_NUMBER':
-			return t('INVALID_MINUTES_NUMBER', {
+			return i18next.t('INVALID_MINUTES_NUMBER', {
 				defaultValue: 'Minutes value must be between 00 and 59',
 			});
 		case 'INVALID_SECONDS_EMPTY':
-			return t('INVALID_SECONDS_EMPTY', { defaultValue: 'Seconds are required' });
+			return i18next.t('INVALID_SECONDS_EMPTY', { defaultValue: 'Seconds are required' });
 		case 'INVALID_SECONDS_NUMBER':
-			return t('INVALID_SECONDS_NUMBER', {
+			return i18next.t('INVALID_SECONDS_NUMBER', {
 				defaultValue: 'Seconds value must be between 00 and 59',
 			});
 		case 'INVALID_DATE_FORMAT':
-			return t('INVALID_DATE_FORMAT', { defaultValue: 'Date format is invalid' });
+			return i18next.t('INVALID_DATE_FORMAT', { defaultValue: 'Date format is invalid' });
 		case 'INVALID_DATE_EMPTY':
-			return t('INVALID_DATE_EMPTY', { defaultValue: 'Date is required' });
+			return i18next.t('INVALID_DATE_EMPTY', { defaultValue: 'Date is required' });
 		case 'INVALID_MONTH_NUMBER':
-			return t('INVALID_MONTH_NUMBER', { defaultValue: 'Month must be between 01 and 12' });
+			return i18next.t('INVALID_MONTH_NUMBER', { defaultValue: 'Month must be between 01 and 12' });
 		case 'INVALID_DAY_NUMBER':
-			return t('INVALID_DAY_NUMBER', { defaultValue: 'Day is invalid' });
+			return i18next.t('INVALID_DAY_NUMBER', { defaultValue: 'Day is invalid' });
 		case 'INVALID_DAY_OF_MONTH':
-			return t('INVALID_DAY_OF_MONTH', {
+			return i18next.t('INVALID_DAY_OF_MONTH', {
 				defaultValue: "Day value doesn't match an existing day in the month",
 			});
 		case 'INVALID_TIME_EMPTY':
-			return t('INVALID_TIME_EMPTY', {
+			return i18next.t('INVALID_TIME_EMPTY', {
 				defaultValue: 'Time is required',
 			});
 		case 'TIME_FORMAT_INVALID':
-			return t('TIME_FORMAT_INVALID', { defaultValue: 'Time is invalid' });
+			return i18next.t('TIME_FORMAT_INVALID', { defaultValue: 'Time is invalid' });
 		case 'DATETIME_INVALID_FORMAT':
-			return t('DATETIME_INVALID_FORMAT', { defaultValue: 'Datetime is invalid' });
+			return i18next.t('DATETIME_INVALID_FORMAT', { defaultValue: 'Datetime is invalid' });
 		case 'INVALID_RANGE_START_AFTER_END':
-			return t('INVALID_RANGE_START_AFTER_END', {
+			return i18next.t('INVALID_RANGE_START_AFTER_END', {
 				defaultValue: 'Start date should comes before end date',
 			});
 		default:

--- a/packages/components/src/DateTimePickers/shared/error-messages.js
+++ b/packages/components/src/DateTimePickers/shared/error-messages.js
@@ -1,7 +1,6 @@
 /*
 * Unexpected issues when importing t directly with named import
 * https://github.com/i18next/i18next/issues/1287
-* (t is not an own property of exported object, it is in it's prototype chain)
 * */
 // eslint-disable-next-line import/no-named-as-default-member
 import i18next from 'i18next';

--- a/packages/components/src/DateTimePickers/shared/error-messages.js
+++ b/packages/components/src/DateTimePickers/shared/error-messages.js
@@ -1,7 +1,7 @@
 /*
-* Unexpected issues when importing t directly with named import
-* https://github.com/i18next/i18next/issues/1287
-* */
+ * Unexpected issues when importing t directly with named import
+ * https://github.com/i18next/i18next/issues/1287
+ * */
 // eslint-disable-next-line import/no-named-as-default-member
 import i18next from 'i18next';
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-23816

after importing t directly, there is issue in TMC, t is run not in context of i18n object, so this is not defined
binding context will lead to importing default export anyway

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
