### PR TITLE
fix(ComponentForm): export name resolver

### DIFF
--- a/packages/containers/src/ComponentForm/index.js
+++ b/packages/containers/src/ComponentForm/index.js
@@ -4,6 +4,7 @@ import * as ComponentFormSelectors from './ComponentForm.selectors';
 import * as ComponentFormActions from './ComponentForm.actions';
 import kit from './kit';
 import fields from './fields';
+import withNameResolver from './fields/NameResolver';
 
 ComponentForm.sagas = sagas;
 ComponentForm.internalSagas = internalSagas;
@@ -11,5 +12,6 @@ ComponentForm.selectors = ComponentFormSelectors;
 ComponentForm.actions = ComponentFormActions;
 ComponentForm.kit = kit;
 ComponentForm.fields = fields;
+ComponentForm.withNameResolver = withNameResolver;
 
 export default ComponentForm;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

nameresolver is not exposed in ComponetnForm
When you want to create specific widget for tacokit this is needed

**What is the chosen solution to this problem?**

expose it

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
