### PR TITLE
chore: release using GH action

### DIFF
--- a/.github/workflows/release-variables.sh
+++ b/.github/workflows/release-variables.sh
@@ -40,6 +40,6 @@ FORMATTED_CHANGELOG="${FORMATTED_CHANGELOG//$'\n'/'%0A'}"
 FORMATTED_CHANGELOG="${FORMATTED_CHANGELOG//$'\r'/'%0D'}"
 
 # Set env var for create-release action
-echo ::set-env name=CHANGELOG::"$FORMATTED_CHANGELOG"
-echo ::set-env name=TAG::"v$CURRENT_VERSION"
-echo ::set-env name=DEMO_DOMAIN::"$DEMO_DOMAIN"
+echo ::set-output name=CHANGELOG::"$FORMATTED_CHANGELOG"
+echo ::set-output name=TAG::"v$CURRENT_VERSION"
+echo ::set-output name=DEMO_DOMAIN::"$DEMO_DOMAIN"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,14 +42,15 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 14
-      - run: ./.github/workflows/release-variables.sh # this sets env.TAG, env.CHANGELOG and env.DEMO_DOMAIN
+      - id: set-variables
+        run: ./.github/workflows/release-variables.sh # this sets env.TAG, env.CHANGELOG and env.DEMO_DOMAIN
       - uses: actions/create-release@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ env.TAG }}
-          release_name: ${{ env.TAG }}
-          body: ${{ env.CHANGELOG }}
+          tag_name: ${{ steps.set-variables.outputs.TAG }}
+          release_name: ${{ steps.set-variables.outputs.TAG }}
+          body: ${{ steps.set-variables.outputs.CHANGELOG }}
           draft: false
           prerelease: false
-      - run: yarn && yarn build-demo && npx surge --project .static --domain ${{ env.DEMO_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+      - run: yarn && yarn build-demo && npx surge --project .static --domain ${{ steps.set-variables.outputs.DEMO_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
set-env is deprecated using GH Action

**What is the chosen solution to this problem?**
use set-output instead 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
