### PR TITLE
feat(components/typeahead): align to guidelines

### DIFF
--- a/packages/components/src/Datalist/Datalist.scss
+++ b/packages/components/src/Datalist/Datalist.scss
@@ -44,7 +44,6 @@ $tc-datalist-item-height: 4rem !default;
 	> li > div {
 		display: flex;
 		height: $tc-datalist-item-height;
-		padding: 0 $padding-normal;
 		&:hover {
 			background-color: $concrete;
 		}

--- a/packages/components/src/Emphasis/Emphasis.scss
+++ b/packages/components/src/Emphasis/Emphasis.scss
@@ -1,4 +1,4 @@
 .highlight {
-	font-weight: $font-weight-bold;
+	font-weight: $font-weight-semi-bold;
 	font-style: normal;
 }

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -36,7 +36,7 @@ function getItems(items, dataFeature) {
  *
  * <Typeahead {...props} />
  */
-function Typeahead({ onToggle, icon, position, docked, ...rest }) {
+function Typeahead({ onToggle, icon, position, docked, manageNavigation, ...rest }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const inputRef = useRef(null);
 
@@ -127,7 +127,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			onChange: rest.onChange && (event => rest.onChange(event, { value: event.target.value })),
 			onFocus: rest.onFocus,
 			onClick: rest.onClick,
-			onKeyDown: handleKeyDown,
+			onKeyDown: manageNavigation ? handleKeyDown : rest.onKeyDown,
 			placeholder: rest.placeholder,
 			readOnly: rest.readOnly,
 			value: rest.value,
@@ -165,8 +165,8 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...sectionProps,
 		...themeProps,
 		...inputProps,
-		highlightedSectionIndex,
-		highlightedItemIndex,
+		highlightedSectionIndex:  manageNavigation ? highlightedSectionIndex : rest.focusedSectionIndex,
+		highlightedItemIndex: manageNavigation ?  highlightedItemIndex : rest.focusedItemIndex,
 		items: getItems(rest.items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
 			onMouseDown: event => event.preventDefault(),
@@ -248,6 +248,7 @@ Typeahead.propTypes = {
 		]),
 	),
 	children: PropTypes.func, // render props
+	manageNavigation: PropTypes.bool,
 };
 
 export default Typeahead;

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -1,9 +1,10 @@
 import PropTypes from 'prop-types';
-import React, { useRef } from 'react';
+import React, { useRef, useState } from 'react';
 import uuid from 'uuid';
 import classNames from 'classnames';
 import Autowhatever from 'react-autowhatever';
 import { useTranslation } from 'react-i18next';
+import keycode from 'keycode';
 
 import theme from './Typeahead.scss';
 import {
@@ -37,8 +38,10 @@ function getItems(items, dataFeature) {
  */
 function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
-
 	const inputRef = useRef(null);
+
+	const [highlightedSectionIndex, setHighlightedSectionIndex] = useState(0);
+	const [highlightedItemIndex, setHighlightedItemIndex] = useState(0);
 
 	if (docked && onToggle) {
 		return (
@@ -54,6 +57,34 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			/>
 		);
 	}
+
+	const handleKeyDown = (event, data) => {
+		if (rest.onKeyDown) {
+			rest.onKeyDown(event, data);
+		}
+		switch (event.which) {
+			case keycode.codes.down:
+			case keycode.codes.up:
+				event.preventDefault();
+				setHighlightedSectionIndex(data.newHighlightedSectionIndex);
+				setHighlightedItemIndex(data.newHighlightedItemIndex);
+				break;
+			case keycode.codes.enter:
+				event.preventDefault();
+				if (highlightedItemIndex !== null && highlightedItemIndex !== null) {
+					rest.onSelect(event, {
+						sectionIndex: data.highlightedSectionIndex,
+						itemIndex: data.highlightedItemIndex,
+					});
+				}
+				break;
+			case keycode.codes.esc:
+				event.preventDefault();
+				rest.onBlur(event);
+				break;
+			default:
+		}
+	};
 
 	const sectionProps = rest.multiSection
 		? { getSectionItems: section => section.suggestions, renderSectionTitle }
@@ -96,7 +127,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			onChange: rest.onChange && (event => rest.onChange(event, { value: event.target.value })),
 			onFocus: rest.onFocus,
 			onClick: rest.onClick,
-			onKeyDown: rest.onKeyDown,
+			onKeyDown: handleKeyDown,
 			placeholder: rest.placeholder,
 			readOnly: rest.readOnly,
 			value: rest.value,
@@ -127,18 +158,15 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		renderItemData: { value: rest.value, 'data-feature': rest['data-feature'] },
 	};
 
-	const compatibilityProps = {
-		highlightedSectionIndex: rest.focusedSectionIndex,
-		highlightedItemIndex: rest.focusedItemIndex,
-	};
 
 	const autowhateverProps = {
 		...defaultRenderersProps,
 		...rest,
-		...compatibilityProps,
 		...sectionProps,
 		...themeProps,
 		...inputProps,
+		highlightedSectionIndex,
+		highlightedItemIndex,
 		items: getItems(rest.items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
 			onMouseDown: event => event.preventDefault(),

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -36,7 +36,7 @@ function getItems(items, dataFeature) {
  *
  * <Typeahead {...props} />
  */
-function Typeahead({ onToggle, icon, position, docked, manageNavigation, ...rest }) {
+function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const inputRef = useRef(null);
 
@@ -59,9 +59,6 @@ function Typeahead({ onToggle, icon, position, docked, manageNavigation, ...rest
 	}
 
 	const handleKeyDown = (event, data) => {
-		if (rest.onKeyDown) {
-			rest.onKeyDown(event, data);
-		}
 		switch (event.which) {
 			case keycode.codes.down:
 			case keycode.codes.up:
@@ -127,7 +124,7 @@ function Typeahead({ onToggle, icon, position, docked, manageNavigation, ...rest
 			onChange: rest.onChange && (event => rest.onChange(event, { value: event.target.value })),
 			onFocus: rest.onFocus,
 			onClick: rest.onClick,
-			onKeyDown: manageNavigation ? handleKeyDown : rest.onKeyDown,
+			onKeyDown: rest.onKeyDown || handleKeyDown,
 			placeholder: rest.placeholder,
 			readOnly: rest.readOnly,
 			value: rest.value,
@@ -158,15 +155,14 @@ function Typeahead({ onToggle, icon, position, docked, manageNavigation, ...rest
 		renderItemData: { value: rest.value, 'data-feature': rest['data-feature'] },
 	};
 
-
 	const autowhateverProps = {
 		...defaultRenderersProps,
 		...rest,
 		...sectionProps,
 		...themeProps,
 		...inputProps,
-		highlightedSectionIndex:  manageNavigation ? highlightedSectionIndex : rest.focusedSectionIndex,
-		highlightedItemIndex: manageNavigation ?  highlightedItemIndex : rest.focusedItemIndex,
+		highlightedSectionIndex: rest.onKeyDown ? rest.focusedSectionIndex : highlightedSectionIndex,
+		highlightedItemIndex: rest.onKeyDown ? rest.focusedItemIndex : highlightedItemIndex,
 		items: getItems(rest.items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
 			onMouseDown: event => event.preventDefault(),
@@ -248,7 +244,6 @@ Typeahead.propTypes = {
 		]),
 	),
 	children: PropTypes.func, // render props
-	manageNavigation: PropTypes.bool,
 };
 
 export default Typeahead;

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -39,6 +39,12 @@ export function renderInputComponent(props) {
 			<ControlLabel srOnly htmlFor={key}>
 				Search
 			</ControlLabel>
+			{hasIcon && (
+				<div className={classNames(theme['icon-cls'], hasCaret && theme['icon-caret'])}>
+					{icon && <Icon {...icon} />}
+					{hasCaret && <Icon name="talend-caret-down" />}
+				</div>
+			)}
 			{debounceMinLength || debounceTimeout ? (
 				<DebounceInput
 					autoFocus
@@ -63,12 +69,6 @@ export function renderInputComponent(props) {
 					readOnly={readOnly}
 					inputRef={inputRef}
 				/>
-			)}
-			{hasIcon && (
-				<div className={classNames(theme['icon-cls'], hasCaret && theme['icon-caret'])}>
-					{icon && <Icon {...icon} />}
-					{hasCaret && <Icon name="talend-caret-down" />}
-				</div>
 			)}
 		</div>
 	);
@@ -256,6 +256,7 @@ export function renderItem(item, { value, ...rest }) {
 			className={classNames(theme.item, {
 				[theme.disabled]: item.disabled,
 				[theme.selected]: value === title,
+				[theme.multiline]: title && description,
 			})}
 			title={title}
 			data-feature={item['data-feature'] || rest['data-feature']}

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -8,10 +8,13 @@ import DebounceInput from 'react-debounce-input';
 import classNames from 'classnames';
 import { Popper } from 'react-popper';
 
+import { getTheme } from '../theme';
 import Icon from '../Icon';
 import CircularProgress from '../CircularProgress';
 import Emphasis from '../Emphasis';
 import theme from './Typeahead.scss';
+
+const css = getTheme(theme);
 
 export function renderInputComponent(props) {
 	const {
@@ -40,7 +43,7 @@ export function renderInputComponent(props) {
 				Search
 			</ControlLabel>
 			{hasIcon && (
-				<div className={classNames(theme['icon-cls'], hasCaret && theme['icon-caret'])}>
+				<div className={css('icon-cls', { 'icon-caret': hasCaret })}>
 					{icon && <Icon {...icon} />}
 					{hasCaret && <Icon name="talend-caret-down" />}
 				</div>
@@ -138,20 +141,21 @@ export function renderItemsContainerFactory(
 		if (searching) {
 			content = (
 				<div key="searching" className={`${theme['is-searching']} is-searching`}>
-					{searchingText}
 					<CircularProgress />
+					<span>{searchingText}</span>
 				</div>
 			);
 		} else if (noResult && loading) {
 			content = (
 				<div key="loading" className={`${theme['is-loading']} is-loading`}>
-					{loadingText}
+					<span>{loadingText}</span>
 				</div>
 			);
 		} else if (noResult) {
 			content = (
 				<div key="no-result" className={`${theme['no-result']} no-result`}>
-					{noResultText}
+					<Icon name="talend-fieldglass" title={noResultText} />
+					<span>{noResultText}</span>
 				</div>
 			);
 		} else {
@@ -228,14 +232,11 @@ export function renderItemsContainerFactory(
 
 export function renderSectionTitle(section) {
 	if (section && (section.icon || section.title)) {
+		const { hint } = section;
 		return (
-			<div className={classNames(theme['section-header'], 'tc-typeahead-section-header')}>
+			<div className={css('section-header')}>
 				{section.icon && <Icon name={section.icon.name} title={section.icon.title} />}
-				<span
-					className={classNames(theme['section-header-title'], 'tc-typeahead-section-header-title')}
-				>
-					{section.title}
-				</span>
+				<span className={css('section-header-title', { hint })}>{section.title}</span>
 			</div>
 		);
 	}
@@ -263,11 +264,11 @@ export function renderItem(item, { value, ...rest }) {
 		>
 			{get(item, 'icon') && <Icon className={theme['item-icon']} {...item.icon} />}
 			<div className={theme['item-text']}>
-				<span className={classNames(theme['item-title'], 'tc-typeahead-item-title')}>
+				<span className={css('item-title')}>
 					<Emphasis value={value} text={title} />
 				</span>
 				{description && (
-					<p className={classNames(theme['item-description'], 'tc-typeahead-item-description')}>
+					<p className={css('item-description')}>
 						<Emphasis value={value} text={description} />
 					</p>
 				)}

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -30,7 +30,7 @@ export function renderInputComponent(props) {
 	} = props;
 
 	const hasCaret = caret && !disabled && !readOnly;
-	const hasIcon = icon || hasCaret;
+	const hasIcon = icon;
 	const typeaheadContainerIconClasses = classNames(
 		'tc-typeahead-typeahead-input-icon',
 		theme['typeahead-input-container'],
@@ -234,9 +234,9 @@ export function renderSectionTitle(section) {
 	if (section && (section.icon || section.title)) {
 		const { hint } = section;
 		return (
-			<div className={css('section-header')}>
+			<div className={css('section-header', 'tc-typeahead-section-header')}>
 				{section.icon && <Icon name={section.icon.name} title={section.icon.title} />}
-				<span className={css('section-header-title', { hint })}>{section.title}</span>
+				<span className={css('section-header-title', 'tc-typeahead-section-header-title', { hint })}>{section.title}</span>
 			</div>
 		);
 	}
@@ -264,11 +264,11 @@ export function renderItem(item, { value, ...rest }) {
 		>
 			{get(item, 'icon') && <Icon className={theme['item-icon']} {...item.icon} />}
 			<div className={theme['item-text']}>
-				<span className={css('item-title')}>
+				<span className={css('item-title', 'tc-typeahead-item-title')}>
 					<Emphasis value={value} text={title} />
 				</span>
 				{description && (
-					<p className={css('item-description')}>
+					<p className={css('item-description', 'tc-typeahead-item-description')}>
 						<Emphasis value={value} text={description} />
 					</p>
 				)}

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -45,7 +45,6 @@ export function renderInputComponent(props) {
 			{hasIcon && (
 				<div className={css('icon-cls', { 'icon-caret': hasCaret })}>
 					{icon && <Icon {...icon} />}
-					{hasCaret && <Icon name="talend-caret-down" />}
 				</div>
 			)}
 			{debounceMinLength || debounceTimeout ? (
@@ -72,6 +71,11 @@ export function renderInputComponent(props) {
 					readOnly={readOnly}
 					inputRef={inputRef}
 				/>
+			)}
+			{hasCaret && (
+				<div className={css('icon-cls', { 'icon-caret': hasCaret })}>
+					<Icon name="talend-caret-down" />
+				</div>
 			)}
 		</div>
 	);

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -30,11 +30,10 @@ export function renderInputComponent(props) {
 	} = props;
 
 	const hasCaret = caret && !disabled && !readOnly;
-	const hasIcon = icon;
 	const typeaheadContainerIconClasses = classNames(
 		'tc-typeahead-typeahead-input-icon',
 		theme['typeahead-input-container'],
-		hasIcon && theme['typeahead-input-icon'],
+		icon && theme['typeahead-input-icon'],
 		hasCaret && theme['typeahead-input-caret'],
 	);
 	return (
@@ -42,7 +41,7 @@ export function renderInputComponent(props) {
 			<ControlLabel srOnly htmlFor={key}>
 				Search
 			</ControlLabel>
-			{hasIcon && (
+			{icon && (
 				<div className={css('icon-cls', { 'icon-caret': hasCaret })}>
 					{icon && <Icon {...icon} />}
 				</div>

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -6,8 +6,6 @@ $tc-typeahead-input-width: 26rem !default;
 $tc-typeahead-opened-items-container-color: #aaa !default;
 $tc-typeahead-opened-items-container-background-color: #fff !default;
 
-$tc-typeahead-item-description-color: #c0c0c0 !default;
-
 $tc-typeahead-section-border-color: #e0e0e0 !default;
 
 $tc-typeahead-icon-color: $gray !default;
@@ -19,24 +17,28 @@ $tc-typeahead-items-border-radius: $border-radius-base !default;
 $tc-typeahead-items-font-size: 1.5rem !default;
 $tc-typeahead-items-zindex: 1035 !default;
 
+$tc-typeahead-item-height: 3.2rem !default;
+$tc-typeahead-item-description-height: 1.6rem !default;
+
+
 .tc-typeahead-container {
 	position: relative;
 	display: flex;
 	width: auto;
 
-	&.loading {
-		.typeahead-input-container,
-		.items-container {
-			> * {
-				color: inherit;
-				@include heartbeat(object-blink);
-			}
-		}
-	}
+	// &.loading {
+	// 	.typeahead-input-container,
+	// 	.items-container {
+	// 		> * {
+	// 			color: inherit;
+	// 			@include heartbeat(object-blink);
+	// 		}
+	// 	}
+	// }
 
 	.items-container,
 	.items-body {
-		max-height: 70vh;
+		max-height: 32vh;
 	}
 
 	.items-container {
@@ -72,24 +74,29 @@ $tc-typeahead-items-zindex: 1035 !default;
 
 .typeahead-input {
 	min-width: $tc-typeahead-input-width;
+	position: relative;
 
 	&-icon {
-		position: relative;
-		right: 0;
-		display: flex;
-		align-items: center;
-
 		[type='text'].typeahead-input {
-			padding-right: 2.5em;
+			padding-left: 2.5em;
 		}
 
 		.icon-cls {
-			margin: -2em;
+			position: absolute;
 			color: $tc-typeahead-icon-color;
 			pointer-events: none;
+			display: flex;
+			align-items: center;
+			height: 100%;
+			width: 2.5em;
+
+			> * {
+				margin: auto;
+			}
 		}
 	}
 
+	// [NC] fixme :
 	&-caret {
 		[type='text'].typeahead-input {
 			padding-right: 1em;
@@ -113,41 +120,42 @@ $tc-typeahead-items-zindex: 1035 !default;
 	}
 }
 
-.is-loading,
-.is-searching,
-.no-result {
-	padding: $padding-normal;
-	font-size: 1.5rem;
-	font-style: italic;
-	color: $tc-typeahead-item-description-color;
-}
+// .is-loading,
+// .is-searching,
+// .no-result {
+// 	padding: $padding-normal;
+// 	font-size: 1.5rem;
+// 	font-style: italic;
+// 	color: $tc-typeahead-item-description-color;
+// }
 
-.is-searching {
-	display: flex;
-	align-items: center;
+// .is-searching {
+// 	display: flex;
+// 	align-items: center;
 
-	> svg {
-		margin-left: auto;
-	}
-}
+// 	> svg {
+// 		margin-left: auto;
+// 	}
+// }
 
 .items {
 	margin: 0;
 	padding: 0;
 	list-style-type: none;
+	color: $black;
 }
 
 .section-header {
+	color: $black;
 	display: flex;
 	align-items: center;
-	margin-top: -1px;
-	padding: $padding-normal;
-	color: $tc-typeahead-section-header-color;
 	border-top: 1px solid $tc-typeahead-section-border-color;
-	border-bottom: 1px solid $tc-typeahead-section-border-color;
+	height: $tc-typeahead-item-height;
+	padding-left: $padding-small;
+
 
 	&-title {
-		font-size: 1.2rem;
+		font-weight: $font-weight-semi-bold;
 	}
 
 	i + &-title,
@@ -158,21 +166,40 @@ $tc-typeahead-items-zindex: 1035 !default;
 
 .item {
 	margin-bottom: 0;
-	padding: $padding-normal;
 	cursor: pointer;
 	white-space: pre;
 	align-items: center;
 
+	display: flex;
+	align-items: center;
+	padding-left: $padding-small;
+
+	> div {
+		width: 100%;
+	}
+
+	height: $tc-typeahead-item-height;
+	&.multiline {
+		height: $tc-typeahead-item-height + $tc-typeahead-item-description-height;
+	}
+
+	&-title {
+		width: 100%;
+		text-overflow: ellipsis;
+		overflow: hidden;
+	}
+
 	&-description {
+		width: 100%;
+		text-overflow: ellipsis;
 		margin-bottom: 0;
 		font-size: 1.3rem;
-		color: $tc-typeahead-item-description-color;
+		overflow: hidden;
 	}
 
 	&-icon {
 		width: $svg-md-size;
 		height: $svg-md-size;
-		color: $black;
 		margin-right: $padding-normal;
 	}
 
@@ -199,7 +226,7 @@ $tc-typeahead-items-zindex: 1035 !default;
 	}
 }
 
-.highlight-match {
-	font-weight: 600;
-	font-style: normal;
-}
+// .highlight-match {
+// 	font-weight: 600;
+// 	font-style: normal;
+// }

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -193,7 +193,7 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 	}
 
 	&-icon {
-		margin-right: 2.2rem;
+		margin-right: $padding-small;
 	}
 
 	&-title > span,

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -14,27 +14,26 @@ $tc-typeahead-section-header-color: #63aebd !default;
 
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
-$tc-typeahead-items-font-size: 1.5rem !default;
+$tc-typeahead-items-font-size: 1.4rem !default;
 $tc-typeahead-items-zindex: 1035 !default;
 
 $tc-typeahead-item-height: 3.2rem !default;
 $tc-typeahead-item-description-height: 1.6rem !default;
-
 
 .tc-typeahead-container {
 	position: relative;
 	display: flex;
 	width: auto;
 
-	// &.loading {
-	// 	.typeahead-input-container,
-	// 	.items-container {
-	// 		> * {
-	// 			color: inherit;
-	// 			@include heartbeat(object-blink);
-	// 		}
-	// 	}
-	// }
+	&.loading {
+		.typeahead-input-container,
+		.items-container {
+			> * {
+				color: inherit;
+				@include heartbeat(object-blink);
+			}
+		}
+	}
 
 	.items-container,
 	.items-body {
@@ -125,8 +124,7 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 // .no-result {
 // 	padding: $padding-normal;
 // 	font-size: 1.5rem;
-// 	font-style: italic;
-// 	color: $tc-typeahead-item-description-color;
+// 	color: $black
 // }
 
 // .is-searching {
@@ -137,6 +135,19 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 // 		margin-left: auto;
 // 	}
 // }
+
+.is-loading,
+.is-searching,
+.no-result {
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	height: $tc-typeahead-item-height;
+
+	span {
+		margin-left: $padding-smaller;
+	}
+}
 
 .items {
 	margin: 0;
@@ -151,28 +162,44 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 	align-items: center;
 	border-top: 1px solid $tc-typeahead-section-border-color;
 	height: $tc-typeahead-item-height;
-	padding-left: $padding-small;
-
+	padding: {
+		left: $padding-small;
+		right: $padding-small;
+	}
 
 	&-title {
 		font-weight: $font-weight-semi-bold;
+
+		&.hint {
+			font-style: italic;
+			font-weight: normal;
+		}
 	}
 
 	i + &-title,
 	svg + &-title {
-		padding-left: $padding-small;
+		padding-left: $padding-smaller;
+	}
+
+	i,
+	svg {
+		width: $svg-md-size;
+		height: $svg-md-size;
+		color: $dove-gray;
 	}
 }
 
 .item {
-	margin-bottom: 0;
 	cursor: pointer;
 	white-space: pre;
 	align-items: center;
 
 	display: flex;
 	align-items: center;
-	padding-left: $padding-small;
+	padding: {
+		left: $padding-small;
+		right: $padding-small;
+	}
 
 	> div {
 		width: 100%;
@@ -183,32 +210,25 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 		height: $tc-typeahead-item-height + $tc-typeahead-item-description-height;
 	}
 
-	&-title {
+	&-title > span,
+	&-description {
+		display: block;
 		width: 100%;
 		text-overflow: ellipsis;
+		margin: 0;
 		overflow: hidden;
 	}
 
 	&-description {
-		width: 100%;
-		text-overflow: ellipsis;
-		margin-bottom: 0;
-		font-size: 1.3rem;
-		overflow: hidden;
-	}
-
-	&-icon {
-		width: $svg-md-size;
-		height: $svg-md-size;
-		margin-right: $padding-normal;
+		font-size: 1.2rem;
 	}
 
 	&-highlighted,
 	&:hover {
-		background-color: $concrete;
+		background-color: rgba($lochmara, 0.1);
 
 		&.selected {
-			background-color: #ccdce8;
+			background-color: rgba(red, 0.2);
 		}
 	}
 
@@ -222,11 +242,6 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 	}
 
 	&.selected {
-		background-color: rgba($scooter, 0.2);
+		background-color: rgba($lochmara, 0.2);
 	}
 }
-
-// .highlight-match {
-// 	font-weight: 600;
-// 	font-style: normal;
-// }

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -95,13 +95,12 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 		}
 	}
 
-	// [NC] fixme :
 	&-caret {
 		[type='text'].typeahead-input {
 			padding-right: 1em;
 		}
 
-		.icon-caret {
+		.icon-cls {
 			display: flex;
 			align-items: center;
 			justify-content: center;
@@ -118,23 +117,6 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 		}
 	}
 }
-
-// .is-loading,
-// .is-searching,
-// .no-result {
-// 	padding: $padding-normal;
-// 	font-size: 1.5rem;
-// 	color: $black
-// }
-
-// .is-searching {
-// 	display: flex;
-// 	align-items: center;
-
-// 	> svg {
-// 		margin-left: auto;
-// 	}
-// }
 
 .is-loading,
 .is-searching,

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -192,6 +192,10 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 		height: $tc-typeahead-item-height + $tc-typeahead-item-description-height;
 	}
 
+	&-icon {
+		margin-right: 2.2rem;
+	}
+
 	&-title > span,
 	&-description {
 		display: block;

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -228,7 +228,7 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 		background-color: rgba($lochmara, 0.1);
 
 		&.selected {
-			background-color: rgba(red, 0.2);
+			background-color: rgba($lochmara, 0.2);
 		}
 	}
 

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -5,11 +5,23 @@ import Typeahead from './Typeahead.component';
 
 const items = [
 	{
+		title: 'Search in',
+		hint: true,
+		suggestions: [
+			{
+				title: 'First hint example',
+			},
+			{
+				title: 'Second hint example',
+			},
+		],
+	},
+	{
 		title: 'category 1',
-		// icon: {
-		// 	name: 'talend-filter',
-		// 	title: 'icon',
-		// },
+		icon: {
+			name: 'talend-smiley-satisfied',
+			title: 'icon',
+		},
 		suggestions: [
 			{
 				title: 'le title 1',
@@ -18,6 +30,12 @@ const items = [
 			},
 			{
 				title: 'title 2 Les elephants elementaires ont des aile ',
+				disabled: true,
+				description:
+					'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
+			},
+			{
+				title: 'title 3 Les elephants elementaires ont des aile ',
 				description:
 					'description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.',
 			},
@@ -25,10 +43,10 @@ const items = [
 	},
 	{
 		title: 'category 2',
-		// icon: {
-		// 	name: 'fa fa-asterisk',
-		// 	title: 'icon',
-		// },
+		icon: {
+			name: 'talend-smiley-sleep',
+			title: 'icon',
+		},
 		suggestions: [
 			{
 				title: 'title 3',
@@ -117,7 +135,24 @@ storiesOf('Form/Inline form/Typeahead', module)
 			onSelect: action('onSelect'),
 			role: 'searchbox',
 			'data-feature': 'data-feature-typeahead',
+			icon: {
+				name: 'talend-search',
+				title: 'Toggle search input',
+			},
 			// caret: true,
+		};
+		return <Typeahead {...props} />;
+	})
+	.add('with results but loading', () => {
+		const props = {
+			value: 'le',
+			items,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			role: 'searchbox',
+			'data-feature': 'data-feature-typeahead',
+			isLoading: true,
 		};
 		return <Typeahead {...props} />;
 	})

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -57,10 +57,6 @@ const items = [
 	},
 	{
 		title: 'category 3',
-		// icon: {
-		// 	name: 'fa fa-asterisk',
-		// 	title: 'icon',
-		// },
 		suggestions: [
 			{
 				title: 'title 4',
@@ -142,7 +138,7 @@ storiesOf('Form/Inline form/Typeahead', module)
 		};
 		return <Typeahead {...props} />;
 	})
-	.add('with managed navigation', () => {
+	.add('with unmanaged navigation', () => {
 		const props = {
 			value: 'le',
 			items,
@@ -155,6 +151,7 @@ storiesOf('Form/Inline form/Typeahead', module)
 				name: 'talend-search',
 				title: 'Toggle search input',
 			},
+			onKeyDown: action('onKeyDown -> internal nav is bypassed'),
 			manageNavigation: true,
 		};
 		return <Typeahead {...props} />;

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -6,10 +6,10 @@ import Typeahead from './Typeahead.component';
 const items = [
 	{
 		title: 'category 1',
-		icon: {
-			name: 'talend-filter',
-			title: 'icon',
-		},
+		// icon: {
+		// 	name: 'talend-filter',
+		// 	title: 'icon',
+		// },
 		suggestions: [
 			{
 				title: 'le title 1',
@@ -25,10 +25,10 @@ const items = [
 	},
 	{
 		title: 'category 2',
-		icon: {
-			name: 'fa fa-asterisk',
-			title: 'icon',
-		},
+		// icon: {
+		// 	name: 'fa fa-asterisk',
+		// 	title: 'icon',
+		// },
 		suggestions: [
 			{
 				title: 'title 3',
@@ -39,10 +39,10 @@ const items = [
 	},
 	{
 		title: 'category 3',
-		icon: {
-			name: 'fa fa-asterisk',
-			title: 'icon',
-		},
+		// icon: {
+		// 	name: 'fa fa-asterisk',
+		// 	title: 'icon',
+		// },
 		suggestions: [
 			{
 				title: 'title 4',
@@ -117,6 +117,41 @@ storiesOf('Form/Inline form/Typeahead', module)
 			onSelect: action('onSelect'),
 			role: 'searchbox',
 			'data-feature': 'data-feature-typeahead',
+			// caret: true,
+		};
+		return <Typeahead {...props} />;
+	})
+	.add('with results and icon', () => {
+		const props = {
+			value: 'le',
+			items,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			role: 'searchbox',
+			'data-feature': 'data-feature-typeahead',
+			icon: {
+				name: 'talend-search',
+				title: 'Toggle search input',
+			},
+			// caret: true,
+		};
+		return <Typeahead {...props} />;
+	})
+	.add('with results and icon and caret', () => {
+		const props = {
+			value: 'le',
+			items,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			role: 'searchbox',
+			'data-feature': 'data-feature-typeahead',
+			icon: {
+				name: 'talend-search',
+				title: 'Toggle search input',
+			},
+			caret: true,
 		};
 		return <Typeahead {...props} />;
 	})

--- a/packages/components/src/Typeahead/Typeahead.stories.js
+++ b/packages/components/src/Typeahead/Typeahead.stories.js
@@ -139,7 +139,23 @@ storiesOf('Form/Inline form/Typeahead', module)
 				name: 'talend-search',
 				title: 'Toggle search input',
 			},
-			// caret: true,
+		};
+		return <Typeahead {...props} />;
+	})
+	.add('with managed navigation', () => {
+		const props = {
+			value: 'le',
+			items,
+			onBlur: action('onBlur'),
+			onChange: action('onChange'),
+			onSelect: action('onSelect'),
+			role: 'searchbox',
+			'data-feature': 'data-feature-typeahead',
+			icon: {
+				name: 'talend-search',
+				title: 'Toggle search input',
+			},
+			manageNavigation: true,
 		};
 		return <Typeahead {...props} />;
 	})
@@ -169,24 +185,6 @@ storiesOf('Form/Inline form/Typeahead', module)
 				name: 'talend-search',
 				title: 'Toggle search input',
 			},
-			// caret: true,
-		};
-		return <Typeahead {...props} />;
-	})
-	.add('with results and icon and caret', () => {
-		const props = {
-			value: 'le',
-			items,
-			onBlur: action('onBlur'),
-			onChange: action('onChange'),
-			onSelect: action('onSelect'),
-			role: 'searchbox',
-			'data-feature': 'data-feature-typeahead',
-			icon: {
-				name: 'talend-search',
-				title: 'Toggle search input',
-			},
-			caret: true,
 		};
 		return <Typeahead {...props} />;
 	})

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -18,7 +18,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -28,7 +28,6 @@ exports[`Typeahead injection should use render props to inject extra components 
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -89,7 +88,7 @@ exports[`Typeahead injection should use render props to inject extra components 
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     category 1
@@ -113,7 +112,7 @@ exports[`Typeahead injection should use render props to inject extra components 
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     category 2
@@ -150,7 +149,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -160,7 +159,6 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
       value="le"
@@ -195,7 +193,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           style={Object {}}
         >
           <div
-            className="section-header theme-section-header"
+            className="section-header theme-section-header tc-typeahead-section-header theme-tc-typeahead-section-header"
           >
             <i
               aria-hidden="true"
@@ -204,7 +202,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
               title="icon"
             />
             <span
-              className="section-header-title theme-section-header-title"
+              className="section-header-title theme-section-header-title tc-typeahead-section-header-title theme-tc-typeahead-section-header-title"
             >
               category 1
             </span>
@@ -215,11 +213,11 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={true}
-            className="theme-item-highlighted tc-typeahead-item-highlighted"
+            aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
+            style={Object {}}
           >
             <div
               className="theme-item theme-multiline"
@@ -229,7 +227,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     <em
@@ -247,7 +245,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibi
@@ -277,7 +275,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     tit
@@ -313,7 +311,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.
@@ -331,7 +329,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           style={Object {}}
         >
           <div
-            className="section-header theme-section-header"
+            className="section-header theme-section-header tc-typeahead-section-header theme-tc-typeahead-section-header"
           >
             <i
               aria-hidden="true"
@@ -340,7 +338,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
               title="icon"
             />
             <span
-              className="section-header-title theme-section-header-title"
+              className="section-header-title theme-section-header-title tc-typeahead-section-header-title theme-tc-typeahead-section-header-title"
             >
               category 2
             </span>
@@ -365,7 +363,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     tit
@@ -378,7 +376,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium va
@@ -418,7 +416,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -428,7 +426,6 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -485,7 +482,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -495,7 +492,6 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -529,7 +525,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           style={Object {}}
         >
           <div
-            className="section-header theme-section-header"
+            className="section-header theme-section-header tc-typeahead-section-header theme-tc-typeahead-section-header"
           >
             <i
               aria-hidden="true"
@@ -538,7 +534,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
               title="icon"
             />
             <span
-              className="section-header-title theme-section-header-title"
+              className="section-header-title theme-section-header-title tc-typeahead-section-header-title theme-tc-typeahead-section-header-title"
             >
               category 1
             </span>
@@ -549,11 +545,11 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={true}
-            className="theme-item-highlighted tc-typeahead-item-highlighted"
+            aria-selected={false}
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
+            style={Object {}}
           >
             <div
               className="theme-item theme-multiline"
@@ -563,14 +559,14 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     le title 1
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.
@@ -594,14 +590,14 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     title 2 les elephants elementaires ont des aile
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.
@@ -619,7 +615,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           style={Object {}}
         >
           <div
-            className="section-header theme-section-header"
+            className="section-header theme-section-header tc-typeahead-section-header theme-tc-typeahead-section-header"
           >
             <i
               aria-hidden="true"
@@ -628,7 +624,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
               title="icon"
             />
             <span
-              className="section-header-title theme-section-header-title"
+              className="section-header-title theme-section-header-title tc-typeahead-section-header-title theme-tc-typeahead-section-header-title"
             >
               category 2
             </span>
@@ -653,14 +649,14 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
                 className="theme-item-text"
               >
                 <span
-                  className="item-title theme-item-title"
+                  className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
                 >
                   <span>
                     title 3
                   </span>
                 </span>
                 <p
-                  className="item-description theme-item-description"
+                  className="item-description theme-item-description tc-typeahead-item-description theme-tc-typeahead-item-description"
                 >
                   <span>
                     description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.
@@ -694,7 +690,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -704,7 +700,6 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -751,7 +746,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
               className="theme-item-text"
             >
               <span
-                className="item-title theme-item-title"
+                className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
               >
                 <span>
                   category 1
@@ -776,7 +771,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
               className="theme-item-text"
             >
               <span
-                className="item-title theme-item-title"
+                className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
               >
                 <span>
                   category 2
@@ -809,7 +804,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -819,7 +814,6 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -883,7 +877,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -893,7 +887,6 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"
@@ -920,7 +913,7 @@ exports[`Typeahead should pass input extra props 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
+      aria-activedescendant={null}
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       aria-describedby="desc-id"
@@ -932,7 +925,6 @@ exports[`Typeahead should pass input extra props 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
-      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -18,7 +18,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -28,6 +28,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -149,7 +150,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -159,6 +160,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
       value="le"
@@ -213,11 +215,11 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={false}
+            aria-selected={true}
+            className="theme-item-highlighted tc-typeahead-item-highlighted"
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
-            style={Object {}}
           >
             <div
               className="theme-item theme-multiline"
@@ -416,7 +418,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -426,6 +428,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -482,7 +485,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -492,6 +495,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -545,11 +549,11 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={false}
+            aria-selected={true}
+            className="theme-item-highlighted tc-typeahead-item-highlighted"
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
-            style={Object {}}
           >
             <div
               className="theme-item theme-multiline"
@@ -690,7 +694,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -700,6 +704,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -804,7 +809,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -814,6 +819,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -877,7 +883,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -887,6 +893,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"
@@ -913,7 +920,7 @@ exports[`Typeahead should pass input extra props 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       aria-describedby="desc-id"
@@ -925,6 +932,7 @@ exports[`Typeahead should pass input extra props 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -18,7 +18,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -28,6 +28,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -88,7 +89,7 @@ exports[`Typeahead injection should use render props to inject extra components 
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     category 1
@@ -112,7 +113,7 @@ exports[`Typeahead injection should use render props to inject extra components 
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     category 2
@@ -149,7 +150,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -159,6 +160,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
       value="le"
@@ -193,7 +195,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           style={Object {}}
         >
           <div
-            className="theme-section-header tc-typeahead-section-header"
+            className="section-header theme-section-header"
           >
             <i
               aria-hidden="true"
@@ -202,7 +204,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
               title="icon"
             />
             <span
-              className="theme-section-header-title tc-typeahead-section-header-title"
+              className="section-header-title theme-section-header-title"
             >
               category 1
             </span>
@@ -213,21 +215,21 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={false}
+            aria-selected={true}
+            className="theme-item-highlighted tc-typeahead-item-highlighted"
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
-            style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="le title 1"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     <em
@@ -245,7 +247,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibi
@@ -268,14 +270,14 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
             style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="title 2 les elephants elementaires ont des aile"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     tit
@@ -311,7 +313,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.
@@ -329,7 +331,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
           style={Object {}}
         >
           <div
-            className="theme-section-header tc-typeahead-section-header"
+            className="section-header theme-section-header"
           >
             <i
               aria-hidden="true"
@@ -338,7 +340,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
               title="icon"
             />
             <span
-              className="theme-section-header-title tc-typeahead-section-header-title"
+              className="section-header-title theme-section-header-title"
             >
               category 2
             </span>
@@ -356,14 +358,14 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
             style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="title 3"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     tit
@@ -376,7 +378,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium va
@@ -416,7 +418,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -426,6 +428,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -455,7 +458,9 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       <div
         className="theme-is-loading is-loading"
       >
-        Loading...
+        <span>
+          Loading...
+        </span>
       </div>
     </div>
   </div>
@@ -480,7 +485,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -490,6 +495,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -523,7 +529,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           style={Object {}}
         >
           <div
-            className="theme-section-header tc-typeahead-section-header"
+            className="section-header theme-section-header"
           >
             <i
               aria-hidden="true"
@@ -532,7 +538,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
               title="icon"
             />
             <span
-              className="theme-section-header-title tc-typeahead-section-header-title"
+              className="section-header-title theme-section-header-title"
             >
               category 1
             </span>
@@ -543,28 +549,28 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           role="listbox"
         >
           <li
-            aria-selected={false}
+            aria-selected={true}
+            className="theme-item-highlighted tc-typeahead-item-highlighted"
             id="react-autowhatever-my-search-section-0-item-0"
             onMouseDown={[Function]}
             role="option"
-            style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="le title 1"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     le title 1
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: Uxoresque est in pacto est marito est hastam nomine in eos discessura incredibile tempus ardore.
@@ -581,21 +587,21 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
             style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="title 2 les elephants elementaires ont des aile"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     title 2 les elephants elementaires ont des aile
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: Aut aut cum satis inter Epicuri quidem cum erat inquam controversia autem mihi utrumque Attico.
@@ -613,7 +619,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
           style={Object {}}
         >
           <div
-            className="theme-section-header tc-typeahead-section-header"
+            className="section-header theme-section-header"
           >
             <i
               aria-hidden="true"
@@ -622,7 +628,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
               title="icon"
             />
             <span
-              className="theme-section-header-title tc-typeahead-section-header-title"
+              className="section-header-title theme-section-header-title"
             >
               category 2
             </span>
@@ -640,21 +646,21 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
             style={Object {}}
           >
             <div
-              className="theme-item"
+              className="theme-item theme-multiline"
               title="title 3"
             >
               <div
                 className="theme-item-text"
               >
                 <span
-                  className="theme-item-title tc-typeahead-item-title"
+                  className="item-title theme-item-title"
                 >
                   <span>
                     title 3
                   </span>
                 </span>
                 <p
-                  className="theme-item-description tc-typeahead-item-description"
+                  className="item-description theme-item-description"
                 >
                   <span>
                     description: In sanciatur libere audeamus exspectemus amicitia et dum ne audeamus causa monendum honesta studium valeat.
@@ -688,7 +694,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -698,6 +704,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -744,7 +751,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
               className="theme-item-text"
             >
               <span
-                className="theme-item-title tc-typeahead-item-title"
+                className="item-title theme-item-title"
               >
                 <span>
                   category 1
@@ -769,7 +776,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
               className="theme-item-text"
             >
               <span
-                className="theme-item-title tc-typeahead-item-title"
+                className="item-title theme-item-title"
               >
                 <span>
                   category 2
@@ -802,7 +809,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -812,6 +819,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       type="text"
     />
@@ -841,7 +849,16 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       <div
         className="theme-no-result no-result"
       >
-        No result.
+        <svg
+          aria-hidden="true"
+          className="theme-tc-svg-icon tc-svg-icon"
+          focusable="false"
+          name="talend-fieldglass"
+          title="No result."
+        />
+        <span>
+          No result.
+        </span>
       </div>
     </div>
   </div>
@@ -866,7 +883,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       autoComplete="off"
@@ -876,6 +893,7 @@ exports[`Typeahead position should render search bar on the right 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"
@@ -902,7 +920,7 @@ exports[`Typeahead should pass input extra props 1`] = `
       Search
     </label>
     <input
-      aria-activedescendant={null}
+      aria-activedescendant="react-autowhatever-my-search-section-0-item-0"
       aria-autocomplete="list"
       aria-controls="react-autowhatever-my-search"
       aria-describedby="desc-id"
@@ -914,6 +932,7 @@ exports[`Typeahead should pass input extra props 1`] = `
       id="my-search"
       onBlur={[Function]}
       onFocus={[Function]}
+      onKeyDown={[Function]}
       readOnly={false}
       role="searchbox"
       type="text"

--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -94,7 +94,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
             className="theme-item-text"
           >
             <span
-              className="theme-item-title tc-typeahead-item-title"
+              className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
             >
               <span>
                 Bar
@@ -141,10 +141,10 @@ exports[`MultiSelectTagWidget should render section title when items has categor
         style={Object {}}
       >
         <div
-          className="theme-section-header tc-typeahead-section-header"
+          className="section-header theme-section-header tc-typeahead-section-header theme-tc-typeahead-section-header"
         >
           <span
-            className="theme-section-header-title tc-typeahead-section-header-title"
+            className="section-header-title theme-section-header-title tc-typeahead-section-header-title theme-tc-typeahead-section-header-title"
           >
             pet
           </span>
@@ -171,7 +171,7 @@ exports[`MultiSelectTagWidget should render section title when items has categor
               className="theme-item-text"
             >
               <span
-                className="theme-item-title tc-typeahead-item-title"
+                className="item-title theme-item-title tc-typeahead-item-title theme-tc-typeahead-item-title"
               >
                 <span>
                   Puppy
@@ -214,7 +214,16 @@ exports[`MultiSelectTagWidget should take default message when there isnt items 
       className="theme-no-result no-result"
       key="no-result"
     >
-      No result.
+      <svg
+        aria-hidden="true"
+        className="theme-tc-svg-icon tc-svg-icon"
+        focusable="false"
+        name="talend-fieldglass"
+        title="No result."
+      />
+      <span>
+        No result.
+      </span>
     </div>
   </div>
 </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Our Typeahead component is a bit outdated : 
![image](https://user-images.githubusercontent.com/26482371/101636125-2a24ed80-3a2b-11eb-9914-9900c5754855.png)


**What is the chosen solution to this problem?**

Align it to the new guidelines : http://guidelines.talend.com/document/92132#/ui-controls/typeahead

![image](https://user-images.githubusercontent.com/26482371/101636500-b59e7e80-3a2b-11eb-8b48-23063c616cba.png)

- A new `manageNavigation` prop has been added in order to optionally let the component manage the up/down nav (currently, every projects has to reimplement it).
- A new `hint` boolean can be set to `true` in the sections. The section will render has a... hint : 
![image](https://user-images.githubusercontent.com/26482371/101636461-a7e8f900-3a2b-11eb-9e5d-204a8fdc8f77.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
