### PR TITLE
fix(components/list composition): wrong position for the order icon with resizable column

### DIFF
--- a/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.scss
+++ b/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.scss
@@ -23,8 +23,8 @@ $drag-element-width: $padding-smaller;
 		align-self: center;
 		overflow: hidden;
 		text-overflow: ellipsis;
-        white-space: nowrap;
-        display: inline-flex;
+		white-space: nowrap;
+		display: inline-flex;
 	}
 
 	&-drag-button {

--- a/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.scss
+++ b/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.scss
@@ -23,7 +23,8 @@ $drag-element-width: $padding-smaller;
 		align-self: center;
 		overflow: hidden;
 		text-overflow: ellipsis;
-		white-space: nowrap;
+        white-space: nowrap;
+        display: inline-flex;
 	}
 
 	&-drag-button {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Wrong position for the order icon with the resizable column

![image](https://user-images.githubusercontent.com/32456736/101501329-e4efb580-396f-11eb-8511-a4c21d795b65.png)

**What is the chosen solution to this problem?**
align text and icon
![image](https://user-images.githubusercontent.com/32456736/101501550-2bddab00-3970-11eb-82b0-b39828a7eb84.png)


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
