### PR TITLE
chore(theme): flexible icon peer dep

### DIFF
--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -49,7 +49,7 @@
     "webpack-dev-server": "^3.1.11"
   },
   "peerDependencies": {
-    "@talend/icons": "^5.28.0"
+    "@talend/icons": ">=6.3.1"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In a new install, we have a peer dependency issue. Theme v6 requires an icon package v5.

**What is the chosen solution to this problem?**
Make it require icons >=6

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
