### PR TITLE
feat(forms): Add Select widget in React Hook Form

### DIFF
--- a/packages/forms/src/rhf/fields/Select/RHFSelect.component.js
+++ b/packages/forms/src/rhf/fields/Select/RHFSelect.component.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { useFormContext } from 'react-hook-form';
+import get from 'lodash/get';
+
+import Select from '../../../widgets/fields/Select';
+
+function RHFSelect(props) {
+	const { rules = {}, ...rest } = props;
+	const { errors, register } = useFormContext();
+	const error = get(errors, rest.name)?.message;
+	return <Select {...rest} ref={register(rules)} error={error} />;
+}
+
+if (process.env.NODE_ENV !== 'production') {
+	RHFSelect.propTypes = {
+		rules: PropTypes.object,
+	};
+}
+
+export default RHFSelect;

--- a/packages/forms/src/rhf/fields/Select/Select.stories.js
+++ b/packages/forms/src/rhf/fields/Select/Select.stories.js
@@ -1,0 +1,113 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import React from 'react';
+import { useForm, FormProvider } from 'react-hook-form';
+import { action } from '@storybook/addon-actions';
+import Select from '.';
+
+export default {
+	title: 'RHF/Select',
+
+	parameters: {
+		component: Select,
+	},
+};
+
+export const States = () => {
+	const rhf = useForm();
+	return (
+		<FormProvider {...rhf}>
+			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
+				<Select
+					id="name"
+					name="default"
+					label="Default"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+				/>
+				<Select
+					id="disabled"
+					name="disabled"
+					label="Disabled"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					disabled
+				/>
+				<button type="submit" className="btn btn-primary">
+					Submit
+				</button>
+			</form>
+		</FormProvider>
+	);
+};
+
+export const Description = () => {
+	const rhf = useForm();
+
+	return (
+		<FormProvider {...rhf}>
+			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
+				<Select
+					id="name"
+					type="text"
+					name="default"
+					label="Default"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					description="This field has a description"
+				/>
+				<button type="submit" className="btn btn-primary">
+					Submit
+				</button>
+			</form>
+		</FormProvider>
+	);
+};
+
+export const Validation = () => {
+	const rhf = useForm({ mode: 'onBlur' });
+
+	return (
+		<FormProvider {...rhf}>
+			<form onSubmit={rhf.handleSubmit(action('submit'))} noValidate>
+				<Select
+					id="required"
+					name="required"
+					label="Required"
+					placeholder="Choose an option"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					rules={{ required: 'This is required' }}
+					required
+				/>
+
+				<Select
+					id="notBlue"
+					name="notBlue"
+					label="Not blue"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					rules={{
+						validate(value) {
+							return value === 'blue' ? 'This should not be blue' : null;
+						},
+					}}
+					required
+				/>
+
+				<button type="submit" className="btn btn-primary">
+					Submit
+				</button>
+			</form>
+		</FormProvider>
+	);
+};

--- a/packages/forms/src/rhf/fields/Select/Select.test.js
+++ b/packages/forms/src/rhf/fields/Select/Select.test.js
@@ -1,0 +1,90 @@
+import React from 'react';
+import { act } from 'react-dom/test-utils';
+import { mount } from 'enzyme';
+import { useForm, FormProvider } from 'react-hook-form';
+import Select from './RHFSelect.component';
+
+/* eslint-disable-next-line react/prop-types */
+function FormWrapper({ children, onSubmit }) {
+	const rhf = useForm({ mode: 'onChange' });
+	return (
+		<form onSubmit={rhf.handleSubmit(onSubmit)}>
+			<FormProvider {...rhf}>
+				{children}
+				<button type="submit">Submit</button>
+			</FormProvider>
+		</form>
+	);
+}
+
+describe('Input RHF widget', () => {
+	it('should integrate with RHF', async () => {
+		// given
+		const onSubmit = jest.fn();
+		// when
+		const wrapper = mount(
+			<FormWrapper onSubmit={onSubmit}>
+				<Select
+					id="name"
+					name="name"
+					label="name"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					required
+					rules={{
+						required: 'This should not be empty',
+					}}
+				/>{' '}
+			</FormWrapper>,
+		);
+		// then
+		await act(async () => {
+			wrapper.find('form').simulate('submit');
+		});
+		expect(onSubmit.mock.calls[0][0]).toEqual({ name: 'blue' });
+
+		await act(async () => {
+			const select = wrapper.find('select').at(0);
+			select.getDOMNode().value = 'red';
+			select.getDOMNode().dispatchEvent(new Event('change'));
+			wrapper.find('form').simulate('submit');
+		});
+
+		expect(onSubmit.mock.calls[1][0]).toEqual({ name: 'red' });
+	});
+
+	it('should render RHF error', async () => {
+		// given
+		const onSubmit = jest.fn();
+		// when
+		const wrapper = mount(
+			<FormWrapper onSubmit={onSubmit}>
+				<Select
+					id="name"
+					name="name"
+					label="name"
+					options={[
+						{ value: 'blue', name: 'Blue color' },
+						{ value: 'red', name: 'Red color' },
+					]}
+					required
+					rules={{
+						required: 'This should not be empty',
+					}}
+				/>
+			</FormWrapper>,
+		);
+		// then
+		expect(wrapper.find('p[id="name-error"]').text()).toBe('');
+
+		await act(async () => {
+			const select = wrapper.find('select').at(0);
+			select.getDOMNode().value = '';
+			select.getDOMNode().dispatchEvent(new Event('change'));
+		});
+
+		expect(wrapper.find('p[id="name-error"]').text()).toBe('This should not be empty');
+	});
+});

--- a/packages/forms/src/rhf/fields/Select/index.js
+++ b/packages/forms/src/rhf/fields/Select/index.js
@@ -1,0 +1,3 @@
+import RHFSelect from './RHFSelect.component';
+
+export default RHFSelect;

--- a/packages/forms/src/rhf/index.js
+++ b/packages/forms/src/rhf/index.js
@@ -1,5 +1,7 @@
 import Input from './fields/Input';
+import Select from './fields/Select';
 
 export default {
 	Input,
+	Select,
 };

--- a/packages/forms/src/widgets/fields/Select/Select.component.js
+++ b/packages/forms/src/widgets/fields/Select/Select.component.js
@@ -1,0 +1,65 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import classnames from 'classnames';
+import FieldTemplate from '../../templates/FieldTemplate';
+import { generateDescriptionId, generateErrorId } from '../../templates/utils';
+
+const Select = React.forwardRef((props, ref) => {
+	const { className, description, error, label, inProgress, placeholder, ...rest } = props;
+	const { id, required, options } = rest;
+
+	const descriptionId = generateDescriptionId(id);
+	const errorId = generateErrorId(id);
+
+	return (
+		<FieldTemplate
+			description={description}
+			descriptionId={descriptionId}
+			error={error}
+			errorId={errorId}
+			id={id}
+			label={label}
+			inProgress={inProgress}
+			required={required}
+		>
+			<select
+				{...rest}
+				ref={ref}
+				className={classnames('form-control', className)}
+				// eslint-disable-next-line jsx-a11y/aria-proptypes
+				aria-invalid={!!error}
+				aria-required={required}
+				aria-describedby={`${descriptionId} ${errorId}`}
+			>
+				{placeholder ? (
+					<option disabled value="">
+						{placeholder}
+					</option>
+				) : null}
+				{options &&
+					options.map(option => {
+						const optionProps = {
+							key: option.value,
+							value: option.value,
+						};
+						return <option {...optionProps}>{option.name}</option>;
+					})}
+			</select>
+		</FieldTemplate>
+	);
+});
+
+if (process.env.NODE_ENV !== 'production') {
+	Select.propTypes = {
+		id: PropTypes.string.isRequired,
+		className: PropTypes.string,
+		description: PropTypes.string,
+		error: PropTypes.string,
+		label: PropTypes.string.isRequired,
+		inProgress: PropTypes.bool,
+		rules: PropTypes.object,
+		placeholder: PropTypes.string,
+	};
+}
+
+export default Select;

--- a/packages/forms/src/widgets/fields/Select/Select.test.js
+++ b/packages/forms/src/widgets/fields/Select/Select.test.js
@@ -1,0 +1,69 @@
+import React from 'react';
+import { shallow, mount } from 'enzyme';
+import Select from './Select.component';
+
+describe('Select agnostic widget', () => {
+	it('should use the common field template', () => {
+		// given
+		const props = {
+			id: 'test',
+			label: 'Test',
+			className: 'myCustomClass',
+			options: [
+				{ value: 'blue', name: 'Blue color' },
+				{ value: 'red', name: 'Red color' },
+			],
+		};
+		// when
+		const wrapper = shallow(<Select {...props} />);
+		// then
+		const fieldTemplateProps = wrapper.find('FieldTemplate').props();
+		expect(fieldTemplateProps.id).toEqual('test');
+		expect(fieldTemplateProps.label).toEqual('Test');
+		expect(fieldTemplateProps.error).toBeUndefined();
+	});
+
+	it('should render a select', () => {
+		// given
+		const props = {
+			id: 'test',
+			name: 'test-name',
+			label: 'Test',
+			className: 'myCustomClass',
+			options: [
+				{ value: 'blue', name: 'Blue color' },
+				{ value: 'red', name: 'Red color' },
+			],
+		};
+		// when
+		const wrapper = mount(<Select {...props} />);
+		// then
+		const select = wrapper.find('select').getDOMNode();
+		expect(select.getAttribute('class')).toEqual('form-control myCustomClass');
+		expect(select.getAttribute('name')).toEqual('test-name');
+	});
+
+	it('should ensure a11y', () => {
+		// given
+		const props = {
+			id: 'test',
+			name: 'test-name',
+			label: 'Test',
+			className: 'myCustomClass',
+			description: 'this is an error',
+			error: 'error label',
+			required: true,
+			options: [
+				{ value: 'blue', name: 'Blue color' },
+				{ value: 'red', name: 'Red color' },
+			],
+		};
+		// when
+		const wrapper = mount(<Select {...props} />);
+		// then
+		const select = wrapper.find('select').getDOMNode();
+		expect(select.getAttribute('aria-invalid')).toBeTruthy();
+		expect(select.getAttribute('aria-required')).toBeTruthy();
+		expect(select.getAttribute('aria-describedby')).toBe('test-description test-error');
+	});
+});

--- a/packages/forms/src/widgets/fields/Select/index.js
+++ b/packages/forms/src/widgets/fields/Select/index.js
@@ -1,0 +1,3 @@
+import Select from './Select.component';
+
+export default Select;

--- a/packages/forms/src/widgets/fields/index.js
+++ b/packages/forms/src/widgets/fields/index.js
@@ -1,5 +1,7 @@
 import Input from './Input';
+import Select from './Select';
 
 export default {
 	Input,
+	Select,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Forms validation in Talend UI are now available through React Hook Forms, but we only have one input wrapper for now.
To help us building forms in app faster, i propose to add the Select.

**What is the chosen solution to this problem?**
Add the Select field wrapper for React Hook Form, add the select widget, with the stories related

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
