### PR TITLE
fix(Drawer): add transitioned props for BCompat

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -36,14 +36,14 @@ function DrawerAnimation(props) {
 					transform: 'translateX(100%)',
 					...STYLES[transitionState],
 				};
-				return React.cloneElement(children, { style, transitioned: transitionState === 'entered' });
+				return children({ style, transitioned: transitionState === 'entered', transitionState });
 			}}
 		</Transition>
 	);
 }
 
 DrawerAnimation.propTypes = {
-	children: PropTypes.node,
+	children: PropTypes.func,
 	withTransition: PropTypes.bool,
 	onTransitionComplete: PropTypes.func,
 };

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -36,7 +36,7 @@ function DrawerAnimation(props) {
 					transform: 'translateX(100%)',
 					...STYLES[transitionState],
 				};
-				return React.cloneElement(children, { style });
+				return React.cloneElement(children, { style, transitioned: transitionState === 'entered' });
 			}}
 		</Transition>
 	);

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -37,7 +37,7 @@ function WithDrawer({ drawers, children }) {
 							}
 							key={get(drawer, 'props.route.path', key)}
 						>
-							{({style, ...props}) => (
+							{({ style, ...props }) => (
 								<div className="tc-with-drawer-wrapper" style={style}>
 									{React.cloneElement(drawer, props)}
 								</div>

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -37,7 +37,11 @@ function WithDrawer({ drawers, children }) {
 							}
 							key={get(drawer, 'props.route.path', key)}
 						>
-							<div className="tc-with-drawer-wrapper">{drawer}</div>
+							{({style, ...props}) => (
+								<div className="tc-with-drawer-wrapper" style={style}>
+									{React.cloneElement(drawer, props)}
+								</div>
+							)}
 						</Drawer.Animation>
 					))}
 			</TransitionGroup>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Before #2958 drawer receive a transitioned props.
Since then the props do not exists anymore

**What is the chosen solution to this problem?**

add it back once transition is done.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
