### PR TITLE
fix(components): ListComposition/DefaultSort - simplify body of defaultSort function

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -154,7 +154,7 @@
   102:7  warning  Dangerous property 'dangerouslySetInnerHTML' found  react/no-danger
 
 /home/travis/build/Talend/ui/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
-  33:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
+  27:61  warning  React Hook useMemo has unnecessary dependencies: 'sortFunctions' and 'sortParams'. Either exclude them or remove the dependency array. Outer scope values like 'sortParams' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/ListView/Header/HeaderInput.component.js
   68:5  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.js
@@ -1,19 +1,13 @@
 import { useMemo, useState } from 'react';
-import isNil from 'lodash/isNil';
 
 function getDefaultSortFunction({ sortBy, isDescending }) {
 	const direction = isDescending ? -1 : 1;
 
 	return function defaultSort(a, b) {
-		const valueA = isNil(a[sortBy]) ? '' : a[sortBy];
-		const valueB = isNil(b[sortBy]) ? '' : b[sortBy];
-
-		const result =
-			isNaN(valueA) || isNaN(valueB)
-				? valueA
-						.toString()
-						.localeCompare(valueB.toString(), undefined, { numeric: true, sensitivity: 'base' })
-				: valueA - valueB;
+		const result = new Intl.Collator(undefined, { sensitivity: 'base', numeric: true }).compare(
+			a[sortBy],
+			b[sortBy],
+		);
 
 		return result * direction;
 	};

--- a/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.test.js
+++ b/packages/components/src/List/ListComposition/Manager/hooks/useCollectionSort.hook.test.js
@@ -41,6 +41,21 @@ const collection = [
 		lastName: 'Dixon',
 		id: 4,
 	},
+	{
+		firstName: '1',
+		lastName: '2',
+		id: 5,
+	},
+	{
+		firstName: '11',
+		lastName: '11',
+		id: 6,
+	},
+	{
+		firstName: '5',
+		lastName: '5',
+		id: 7,
+	},
 ];
 
 const natural = [
@@ -80,11 +95,14 @@ describe('useCollectionSort', () => {
 
 		// then
 		const sortedCollection = wrapper.find('#mainChild').prop('sortedCollection');
-		expect(sortedCollection[0].firstName).toEqual('Conner');
-		expect(sortedCollection[1].firstName).toEqual('Copeland');
-		expect(sortedCollection[2].firstName).toEqual('Louisa');
-		expect(sortedCollection[3].firstName).toEqual('Luann');
-		expect(sortedCollection[4].firstName).toEqual('Shelly');
+		expect(sortedCollection[0].firstName).toEqual('1');
+		expect(sortedCollection[1].firstName).toEqual('5');
+		expect(sortedCollection[2].firstName).toEqual('11');
+		expect(sortedCollection[3].firstName).toEqual('Conner');
+		expect(sortedCollection[4].firstName).toEqual('Copeland');
+		expect(sortedCollection[5].firstName).toEqual('Louisa');
+		expect(sortedCollection[6].firstName).toEqual('Luann');
+		expect(sortedCollection[7].firstName).toEqual('Shelly');
 	});
 
 	it('should sort with new sort params set', () => {
@@ -136,11 +154,14 @@ describe('useCollectionSort', () => {
 
 		// then
 		const sortedCollection = wrapper.find('#mainChild').prop('sortedCollection');
-		expect(sortedCollection[0].firstName).toEqual('Louisa');
-		expect(sortedCollection[1].firstName).toEqual('Copeland');
-		expect(sortedCollection[2].firstName).toEqual('Luann');
-		expect(sortedCollection[3].firstName).toEqual('Conner');
-		expect(sortedCollection[4].firstName).toEqual('Shelly');
+		expect(sortedCollection[0].firstName).toEqual('1');
+		expect(sortedCollection[1].firstName).toEqual('11');
+		expect(sortedCollection[2].firstName).toEqual('5');
+		expect(sortedCollection[3].firstName).toEqual('Louisa');
+		expect(sortedCollection[4].firstName).toEqual('Copeland');
+		expect(sortedCollection[5].firstName).toEqual('Luann');
+		expect(sortedCollection[6].firstName).toEqual('Conner');
+		expect(sortedCollection[7].firstName).toEqual('Shelly');
 	});
 
 	it('should use a natural sort order', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Replace the function body of DefaultSort to use Intl.Collator(...).compare()
Doc to Intl.Collator : https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Objets_globaux/Intl/Collator
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
