### PR TITLE
chore: trigger webhook to update cdn content after a release

### DIFF
--- a/.github/workflows/dataviz-autopublish.yml
+++ b/.github/workflows/dataviz-autopublish.yml
@@ -54,5 +54,6 @@ jobs:
 
       - name: Update Talend CDN content
         id: cdn
-        run: curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
+        run: |
+          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
 

--- a/.github/workflows/dataviz-autopublish.yml
+++ b/.github/workflows/dataviz-autopublish.yml
@@ -52,3 +52,7 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
 
+      - name: Update Talend CDN content
+        id: cdn
+        run: curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,3 +54,9 @@ jobs:
           draft: false
           prerelease: false
       - run: yarn && yarn build-demo && npx surge --project .static --domain ${{ steps.set-variables.outputs.DEMO_DOMAIN }} --token ${{ secrets.SURGE_TOKEN }}
+
+  update-cdn-content:
+    needs: publish-npm
+    runs-on: ubuntu-latest
+    steps:
+      - run: curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,4 +59,5 @@ jobs:
     needs: publish-npm
     runs-on: ubuntu-latest
     steps:
-      - run: curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
+      - run: |
+          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a Talend/ui release is done, CDN content should be updated manually

**What is the chosen solution to this problem?**
Once the packages are on NPM, let's trigger the Github Action from [Talend/cdn-content](https://github.com/Talend/cdn-content/actions?query=workflow%3A%22Download+CDN+content+to+git%22) in order to create or update the PR

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
