### PR TITLE
feat(Dataviz): Add pattern color in tooltip

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+Guiding Principles
+
+-   Changelogs are for humans, not machines.
+-   There should be an entry for every single version.
+-   The same types of changes should be grouped.
+-   Versions and sections should be linkable.
+-   The latest version comes first.
+-   The release date of each version is displayed.
+-   Mention whether you follow Semantic Versioning.
+
+Types of changes
+
+-   `Added` for new features.
+-   `Changed` for changes in existing functionality.
+-   `Deprecated` for soon-to-be removed features.
+-   `Removed` for now removed features.
+-   `Fixed` for any bug fixes.
+-   `Security` in case of vulnerabilities.
+
+## [unreleased]
+
+## [0.1.0]
+
+### Added
+
+- [Added](https://github.com/Talend/ui/pull/3133): Add "pattern" color support in tooltip

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.0.6",
+  "version": "0.1.0",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.tsx
+++ b/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.tsx
@@ -4,11 +4,7 @@ import { FormatValue } from '@talend/react-components';
 import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
 import styles from './ColoredBar.component.scss';
-
-export enum ChartStyle {
-	VALUE = 'value',
-	PATTERN = 'pattern',
-}
+import { ChartStyle } from '../../../types';
 
 type BarRenderProps = RectangleProps & {
 	index?: number;
@@ -16,6 +12,7 @@ type BarRenderProps = RectangleProps & {
 	barType: 'primary' | 'secondary';
 	chartStyle: ChartStyle;
 };
+
 function ColoredBar({
 	height,
 	width,

--- a/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.test.tsx
+++ b/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { mount } from 'enzyme';
 import HorizontalBarChart from './HorizontalBarChart.component';
-import { ChartStyle } from '../ColoredBar/ColoredBar.component';
+import { ChartStyle } from '../../../types';
 
 describe('Horizontal bar chart', () => {
 	it('Should trigger onBarClick', () => {

--- a/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.tsx
+++ b/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.tsx
@@ -10,8 +10,9 @@ import {
 	useBarChart,
 } from '../useBarChart.hook';
 import FixedBarSizeWrapper from './FixedHeightBarWrapper/FixedHeightBarWrapper.component';
-import ColoredBar, { ChartStyle } from '../ColoredBar/ColoredBar.component';
+import ColoredBar from '../ColoredBar/ColoredBar.component';
 import TooltipCursor from '../TooltipCursor/TooltipCursor.component';
+import { ChartStyle } from '../../../types';
 
 export interface HorizontalBarChartProps {
 	data: ChartEntry<string>[];

--- a/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.stories.tsx
+++ b/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.stories.tsx
@@ -5,6 +5,7 @@ import HorizontalBarChart, { HorizontalBarChartProps } from './index';
 import { ChartEntry } from '../barChart.types';
 import { getHorizontalBarChartTooltip, ValueType } from '../barChart.tooltip';
 import TooltipContent from '../../TooltipContent/TooltipContent.component';
+import { ChartStyle } from '../../../types';
 
 const data: ChartEntry<string>[] = [
 	{
@@ -55,6 +56,12 @@ export const PatternChart = Template.bind({});
 PatternChart.args = {
 	data,
 	chartStyle: HorizontalBarChart.ChartStyle.PATTERN,
+	getTooltipContent: entry => (
+		<TooltipContent
+			entries={getHorizontalBarChartTooltip(entry, ValueType.OCCURRENCES)}
+			chartStyle={ChartStyle.PATTERN}
+		/>
+	),
 };
 
 export const TooManyBars = Template.bind({});
@@ -64,7 +71,7 @@ TooManyBars.parameters = {
 	},
 };
 TooManyBars.args = {
-	chartStyle: HorizontalBarChart.ChartStyle.PATTERN,
+	chartStyle: HorizontalBarChart.ChartStyle.VALUE,
 	data: [...Array(10)].flatMap(() => data),
 };
 
@@ -75,7 +82,7 @@ SpecialValues.parameters = {
 	},
 };
 SpecialValues.args = {
-	chartStyle: HorizontalBarChart.ChartStyle.PATTERN,
+	chartStyle: HorizontalBarChart.ChartStyle.VALUE,
 	data: [
 		{
 			key: 'Bar should be at least 3px long',

--- a/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.tsx
+++ b/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.tsx
@@ -10,8 +10,8 @@ import {
 	SECONDARY_BAR_ANIMATION_PROPS,
 	useBarChart,
 } from '../useBarChart.hook';
-import ColoredBar, { ChartStyle } from '../ColoredBar/ColoredBar.component';
-import { DataType, Range } from '../../../types';
+import ColoredBar from '../ColoredBar/ColoredBar.component';
+import { ChartStyle, DataType, Range } from '../../../types';
 import TooltipCursor from '../TooltipCursor/TooltipCursor.component';
 
 export type VerticalBarChartEntry = ChartEntry<Range> & {

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.component.scss
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.component.scss
@@ -27,4 +27,10 @@ $module: dataviz-tooltip;
 		margin-left: 5px;
 		color: $scooter;
 	}
+
+	&--pattern {
+		.#{$module}__value {
+			color: $jaffa;
+		}
+	}
 }

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.component.tsx
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.component.tsx
@@ -1,12 +1,15 @@
 import React from 'react';
+import classNames from 'classnames';
 import styles from './TooltipContent.component.scss';
+import { ChartStyle } from '../../types';
 
 export interface TooltipContentProps {
 	entries: TooltipEntry[];
+	chartStyle?: ChartStyle;
 }
-function TooltipContent({ entries }: TooltipContentProps) {
+function TooltipContent({ entries, chartStyle = ChartStyle.VALUE }: TooltipContentProps) {
 	return (
-		<dl className={styles['dataviz-tooltip']}>
+		<dl className={classNames(styles['dataviz-tooltip'], styles[`dataviz-tooltip--${chartStyle}`])}>
 			{entries.map(({ key, value }) => (
 				<div className={styles['dataviz-tooltip__entry']} key={key}>
 					<dt className={styles['dataviz-tooltip__key']}>{key}</dt>
@@ -24,4 +27,6 @@ export interface TooltipEntry {
 	value: string;
 }
 
-export default TooltipContent;
+export default Object.assign(TooltipContent, {
+	ChartStyle,
+});

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.stories.tsx
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.stories.tsx
@@ -14,19 +14,23 @@ export default {
 			</div>
 		),
 	],
-	args: {},
+	args: {
+		entries: [
+			{
+				key: 'First line',
+				value: '50',
+			},
+			{
+				key: 'Second line',
+				value: '50',
+			},
+		],
+	},
 } as Meta;
 
 export const Default = Template.bind({});
-Default.args = {
-	entries: [
-		{
-			key: 'First line',
-			value: '50',
-		},
-		{
-			key: 'Second line',
-			value: '50',
-		},
-	],
+
+export const Pattern = Template.bind({});
+Pattern.args = {
+	chartStyle: TooltipContent.ChartStyle.PATTERN,
 };

--- a/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
+++ b/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`TooltipContent Should render 1`] = `
-<dl class="theme-dataviz-tooltip">
+<dl class="theme-dataviz-tooltip theme-dataviz-tooltip--value">
   <div class="theme-dataviz-tooltip__entry">
     <dt class="theme-dataviz-tooltip__key">
       key1

--- a/packages/dataviz/src/types/index.ts
+++ b/packages/dataviz/src/types/index.ts
@@ -8,3 +8,8 @@ export enum DataType {
 	DATE = 'DATE',
 	NUMBER = 'NUMBER',
 }
+
+export enum ChartStyle {
+	VALUE = 'value',
+	PATTERN = 'pattern',
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Tooltip values are blue, which doesn't match with the "orange" pattern charts

**What is the chosen solution to this problem?**

Provide a chartStyle prop to the tooltip content and add color support
![image](https://user-images.githubusercontent.com/58977230/102514280-92f41180-408c-11eb-8760-be2eb5daefa3.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
