### PR TITLE
fix(Dataviz): Unnecessary onChange triggered

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,12 @@ Types of changes
 
 ## [unreleased]
 
+## [0.1.1]
+
+### Added
+
+- [Fixed](https://github.com/Talend/ui/pull/3134): Unnecessary onChange triggered
+
 ## [0.1.0]
 
 ### Added

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/RangeFilter/input-fields/NumberInputField.component.test.tsx
+++ b/packages/dataviz/src/components/RangeFilter/input-fields/NumberInputField.component.test.tsx
@@ -14,6 +14,14 @@ describe('Number input field', () => {
 		expect(onChange).toHaveBeenCalledWith(20);
 	});
 
+  it('Should not trigger onChange if value did not change', () => {
+    const onChange = jest.fn();
+    const component = mount(<NumberInputField value={10} onChange={onChange} />);
+
+    component.find('input').simulate('blur');
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   it('Should reset value on Esc', () => {
     const onChange = jest.fn();
     const component = mount(<NumberInputField value={10} onChange={onChange} />);

--- a/packages/dataviz/src/components/RangeFilter/input-fields/useRangeInputField.hook.ts
+++ b/packages/dataviz/src/components/RangeFilter/input-fields/useRangeInputField.hook.ts
@@ -14,8 +14,10 @@ function useRangeInputField(
 
 	function submit(stringValue: string) {
 		const parsed = parser(stringValue);
-		if (parsed) {
-			onChange(parsed);
+		if (parsed !== null) {
+			if (parsed !== rangeValue) {
+				onChange(parsed);
+			}
 		} else {
 			resetValue();
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

onChange is triggered when leaving the field without changing the value

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
