### PR TITLE
fix(DatePicker): Missing root export

### DIFF
--- a/packages/components/src/index.js
+++ b/packages/components/src/index.js
@@ -23,6 +23,7 @@ import ConfirmDialog from './ConfirmDialog';
 import Datalist from './Datalist';
 import { ModelViewer, RecordsViewer } from './DataViewer';
 import {
+	DatePicker,
 	InputDatePicker,
 	InputDateRangePicker,
 	InputDateTimePicker,
@@ -102,6 +103,7 @@ export {
 	CollapsiblePanel,
 	ConfirmDialog,
 	Datalist,
+	DatePicker,
 	ModelViewer,
 	RecordsViewer,
 	InputDatePicker,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

https://github.com/Talend/ui/pull/3138 was missing root level exports

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
