### PR TITLE
feat(TPSVC-15539): add data attributes to the forms

### DIFF
--- a/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
+++ b/packages/forms/src/UIForm/fields/Datalist/Datalist.component.js
@@ -11,6 +11,7 @@ import { I18N_DOMAIN_FORMS } from '../../../constants';
 import callTrigger from '../../trigger';
 import { DID_MOUNT } from './constants';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
+import { extractDataAttributes } from '../../utils/properties';
 
 export function escapeRegexCharacters(str) {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -188,6 +189,7 @@ class Datalist extends Component {
 						'aria-invalid': !this.props.isValid,
 						'aria-required': this.props.schema.required,
 						'aria-describedby': `${descriptionId} ${errorId}`,
+						...extractDataAttributes(this.props.schema),
 					}}
 				/>
 			</FieldTemplate>

--- a/packages/forms/stories-core/json/fields/core-datalist.json
+++ b/packages/forms/stories-core/json/fields/core-datalist.json
@@ -90,7 +90,8 @@
       "key": "simpleDatalist",
       "title": "Simple Datalist",
       "description": "This datalist accepts values that are not in the list of suggestions",
-      "widget": "datalist"
+      "widget": "datalist",
+      "data-test": "datalist.simple"
     },
     {
       "key": "restrictedDatalist",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Following https://github.com/Talend/ui/pull/2959, I need to add `data-*` attributes to the datalist component to ease the automated test.

**What is the chosen solution to this problem?**
Update UIForms to add the `data-*` properties available in the `uiSchema` to the generated HTML elements.
```
{
      "key": "simpleDatalist",
      "title": "Simple Datalist",
      "description": "This datalist accepts values that are not in the list of suggestions",
      "widget": "datalist",
      "data-test": "datalist.simple"
},
```
Will result in
`<input data-test="datalist.simple" type="text" id="simpleDatalist" value="Pine[apple]" ...>`

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
