### PR TITLE
fix(dataviz): Missing i18n namespace

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,14 +26,20 @@ Types of changes
 
 ## [unreleased]
 
+## [0.1.2]
+
+### Fixed
+
+- [Missing i18n namespace](https://github.com/Talend/ui/pull/3145):
+
 ## [0.1.1]
 
-### Added
+### Fixed
 
-- [Fixed](https://github.com/Talend/ui/pull/3134): Unnecessary onChange triggered
+- [Unnecessary onChange triggered](https://github.com/Talend/ui/pull/3134):
 
 ## [0.1.0]
 
 ### Added
 
-- [Added](https://github.com/Talend/ui/pull/3133): Add "pattern" color support in tooltip
+- [Add "pattern" color support in tooltip](https://github.com/Talend/ui/pull/3133):

--- a/packages/dataviz/src/components/BarChart/barChart.tooltip.ts
+++ b/packages/dataviz/src/components/BarChart/barChart.tooltip.ts
@@ -2,6 +2,9 @@ import i18next from 'i18next';
 import { ChartEntry } from './barChart.types';
 import { TooltipEntry } from '../TooltipContent/TooltipContent.component';
 import { VerticalBarChartEntry } from './VerticalBarChart/VerticalBarChart.component';
+import { I18N_DOMAIN_DATAVIZ } from '../../constants';
+
+const t = i18next.getFixedT(null, I18N_DOMAIN_DATAVIZ);
 
 export enum ValueType {
 	MIN = 'MIN',
@@ -13,14 +16,11 @@ export enum ValueType {
 
 function getFilteredValueLabel(valueType: ValueType): string {
 	return {
-		[ValueType.MIN]: i18next.t('MIN_MATCHING_FILTER', 'Min value matching your filter'),
-		[ValueType.MAX]: i18next.t('MAX_MATCHING_FILTER_MAX', 'Max value matching your filter'),
-		[ValueType.AVERAGE]: i18next.t('AVERAGE_MATCHING_FILTER', 'Average of values matching your filter'),
-		[ValueType.SUM]: i18next.t('SUM_MATCHING_FILTER', 'Sum of values matching your filter'),
-		[ValueType.OCCURRENCES]: i18next.t(
-			'OCCURRENCES_MATCHING_FILTER',
-			'Occurrences matching your filter',
-		),
+		[ValueType.MIN]: t('MIN_MATCHING_FILTER', 'Min value matching your filter'),
+		[ValueType.MAX]: t('MAX_MATCHING_FILTER_MAX', 'Max value matching your filter'),
+		[ValueType.AVERAGE]: t('AVERAGE_MATCHING_FILTER', 'Average of values matching your filter'),
+		[ValueType.SUM]: t('SUM_MATCHING_FILTER', 'Sum of values matching your filter'),
+		[ValueType.OCCURRENCES]: t('OCCURRENCES_MATCHING_FILTER', 'Occurrences matching your filter'),
 	}[valueType];
 }
 
@@ -31,21 +31,21 @@ function getDatasetValueLabel(valueType: ValueType, hasFilteredValue: boolean): 
 	 */
 	switch (valueType) {
 		case ValueType.MIN:
-			label = i18next.t('MIN', 'Min');
+			label = t('MIN', 'Min');
 			break;
 		case ValueType.MAX:
-			label = i18next.t('MAX', 'Max');
+			label = t('MAX', 'Max');
 			break;
 		case ValueType.AVERAGE:
-			label = i18next.t('AVERAGE', 'Average');
+			label = t('MEAN', 'Mean');
 			break;
 		case ValueType.SUM:
-			label = i18next.t('SUM', 'Sum');
+			label = t('SUM', 'Sum');
 			break;
 		case ValueType.OCCURRENCES:
 			label = hasFilteredValue
-				? i18next.t('OCCURRENCES_IN_DATASET', 'Occurrences in entire dataset')
-				: i18next.t('SUM', 'Occurrences');
+				? t('OCCURRENCES_IN_DATASET', 'Occurrences in entire dataset')
+				: t('SUM', 'Occurrences');
 			break;
 		default:
 			label = valueType;
@@ -85,8 +85,8 @@ export function getHorizontalBarChartTooltip(entry: ChartEntry<string>, valueTyp
 	return [
 		...getValuesLines(entry, valueType),
 		{
-			key: i18next.t('RECORD', 'Record'),
-			value: entry.key || i18next.t('EMPTY', 'Empty'),
+			key: t('RECORD', 'Record'),
+			value: entry.key || t('EMPTY', 'Empty'),
 		},
 	];
 }
@@ -96,11 +96,11 @@ export function getVerticalBarChartTooltip(entry: VerticalBarChartEntry): Toolti
 		...getValuesLines(entry, ValueType.OCCURRENCES),
 		entry.key.min === entry.key.max
 			? {
-					key: i18next.t('VALUE', 'Value'),
+					key: t('VALUE', 'Value'),
 					value: entry.label,
 			  }
 			: {
-					key: i18next.t('RANGE', 'Range'),
+					key: t('RANGE', 'Range'),
 					value: entry.label,
 			  },
 	];

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.tsx
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.tsx
@@ -8,6 +8,7 @@ import DateInputField from './input-fields/DateInputField.component';
 import NumberInputField from './input-fields/NumberInputField.component';
 import { formatDate, formatNumber, getFractionDigits } from '../../formatters/formatters';
 import { DataType, Range } from '../../types';
+import { I18N_DOMAIN_DATAVIZ } from '../../constants';
 
 export interface RangeFilterProps {
 	id?: string;
@@ -64,7 +65,7 @@ function RangeFilter({
 	onSliderChange,
 	onAfterChange,
 }: RangeFilterProps): JSX.Element {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DATAVIZ);
 
 	const precision = Math.max(getFractionDigits(limits.min), getFractionDigits(limits.max));
 	const marks = useMemo(() => getMarks(dataType, limits, precision), [limits, dataType, precision]);
@@ -72,7 +73,6 @@ function RangeFilter({
 
 	// Prevent onAfterChange to be triggered twice
 	let onAfterChangedCalled = false;
-
 
 	return (
 		<div className={styles['range-filter']}>

--- a/packages/dataviz/src/constants.ts
+++ b/packages/dataviz/src/constants.ts
@@ -1,0 +1,1 @@
+export const I18N_DOMAIN_DATAVIZ = 'tui-faceted-search';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

i18n namespace is not used in charts components, keys are not translated in apps

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
