### PR TITLE
fix(dataviz): Wrong i18n namespace

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,12 @@ Types of changes
 
 ## [unreleased]
 
+## [0.1.3]
+
+### Fixed
+
+- [Wrong i18n namespace](https://github.com/Talend/ui/pull/3147):
+
 ## [0.1.2]
 
 ### Fixed

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/constants.ts
+++ b/packages/dataviz/src/constants.ts
@@ -1,1 +1,1 @@
-export const I18N_DOMAIN_DATAVIZ = 'tui-faceted-search';
+export const I18N_DOMAIN_DATAVIZ = 'tui-dataviz';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Dataviz is using faceted search namespace...

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
