### PR TITLE
fix(containers/DeleteResource): Redirect only when delete is successful

### DIFF
--- a/packages/containers/src/DeleteResource/sagas.js
+++ b/packages/containers/src/DeleteResource/sagas.js
@@ -88,13 +88,13 @@ export function* deleteResourceValidate(
 					labelResource: resource.get('label') || resource.get('name', ''),
 				},
 			});
+			yield call(redirect, get(action, 'data.model.redirectUrl'));
 		} else {
 			yield put({
 				type: deleteResourceConst.DIALOG_BOX_DELETE_RESOURCE_ERROR,
 				error: result.data,
 			});
 		}
-		yield call(redirect, get(action, 'data.model.redirectUrl'));
 	}
 }
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently DeleteResource will redirect to configured url regardless of result of delete request. it will redirect no matter delete is successful or not.
**What is the chosen solution to this problem?**
only redirect when delete is successful
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
