### PR TITLE
fix(EnumerationWidget): focus input on validate add when not connected

### DIFF
--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -729,6 +729,7 @@ class EnumerationForm extends React.Component {
 				]),
 			};
 			this.onChange(event, payload);
+            this.input.focus();
 			if (isSingleAdd) {
 				successHandler();
 			}

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -729,7 +729,7 @@ class EnumerationForm extends React.Component {
 				]),
 			};
 			this.onChange(event, payload);
-            this.input.focus();
+			this.input.focus();
 			if (isSingleAdd) {
 				successHandler();
 			}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
when adding a line using the validate and add button, the input is not refocused so that we can continue typing in not connected mode

**What is the chosen solution to this problem?**
force focusing it

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
