### PR TITLE
fix(RangePicker): make the global div fit the content

### DIFF
--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -36,6 +36,7 @@
 
 @mixin date-picker {
 	display: flex;
+    width: fit-content;
 }
 
 @mixin range-picker {

--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -36,7 +36,7 @@
 
 @mixin date-picker {
 	display: flex;
-    width: fit-content;
+	width: fit-content;
 }
 
 @mixin range-picker {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This bug was raised on TDS side : https://jira.talendforge.org/browse/TDS-5775
The issue is that focusing the global div opens the picker

**What is the chosen solution to this problem?**
making the global div fit the content so that click outside of the div doesnt trigger an opening of the piker

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
