### PR TITLE
fix(TDS-5773/Enumeration): msgs placement and behavior

### DIFF
--- a/packages/components/src/Enumeration/Enumeration.scss
+++ b/packages/components/src/Enumeration/Enumeration.scss
@@ -19,7 +19,7 @@ $tc-enumeration-font-size: 1.4rem !default;
 
 			&.btn-link {
 				padding: 0 $padding-normal;
-                outline-offset: 0.5rem;
+				outline-offset: 0.5rem;
 				svg {
 					height: $tc-enumeration-font-size;
 					width: $tc-enumeration-font-size;

--- a/packages/components/src/Enumeration/Enumeration.scss
+++ b/packages/components/src/Enumeration/Enumeration.scss
@@ -19,7 +19,7 @@ $tc-enumeration-font-size: 1.4rem !default;
 
 			&.btn-link {
 				padding: 0 $padding-normal;
-
+                outline-offset: 0.5rem;
 				svg {
 					height: $tc-enumeration-font-size;
 					width: $tc-enumeration-font-size;

--- a/packages/components/src/Enumeration/Items/Item/Item.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.scss
@@ -50,7 +50,7 @@ $item-checkbox-width: 20px;
 		overflow: hidden;
 		box-shadow: none;
 		text-align: left;
-        outline: none;
+		outline: none;
 		// In order to show ellipsis, need to override <span> to be inline
 		span:first-child {
 			display: inline;

--- a/packages/components/src/Enumeration/Items/Item/Item.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.scss
@@ -27,7 +27,6 @@ $item-checkbox-width: 20px;
 	}
 
 	:global(button:disabled) {
-		height: $tc-enumeration-item-height;
 		padding: 0 $tc-enumeration-normal-padding;
 	}
 
@@ -51,7 +50,7 @@ $item-checkbox-width: 20px;
 		overflow: hidden;
 		box-shadow: none;
 		text-align: left;
-
+        outline: none;
 		// In order to show ellipsis, need to override <span> to be inline
 		span:first-child {
 			display: inline;
@@ -61,6 +60,7 @@ $item-checkbox-width: 20px;
 	.tc-enumeration-item-actions {
 		display: flex;
 		flex-grow: 0;
+		align-items: center;
 		margin: auto $tc-enumeration-smaller-padding;
 	}
 
@@ -89,11 +89,12 @@ $item-checkbox-width: 20px;
 	.tc-enumeration-item-error {
 		font-size: 12px;
 		position: absolute;
-		top: calc(100% - #{$padding-small});
+		top: 100%;
 		width: 100%;
 		color: $tc-enumeration-item-error-color;
 		padding: $tc-enumeration-item-error-padding;
 		z-index: 1;
+		background: inherit;
 	}
 }
 

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -404,7 +404,7 @@ class EnumerationForm extends React.Component {
 
 		// if the value exist add an error
 		this.setState(prevState => {
-			const valueExist = this.valueAlreadyExist(value.value, prevState);
+			const valueExist = this.valueAlreadyExist(value.value, prevState, value.index);
 			const items = [...prevState.items];
 			items[value.index].error = '';
 			if (valueExist) {
@@ -954,8 +954,10 @@ class EnumerationForm extends React.Component {
 		}));
 	}
 
-	valueAlreadyExist(value, state) {
-		return !this.allowDuplicate && state.items.find(item => item.values[0] === value);
+	valueAlreadyExist(value, state, index) {
+	    const foundIndex = state.items.findIndex(item => item.values[0] === value);
+	    const indexCheck = index ? foundIndex !== index : true;
+		return !this.allowDuplicate && foundIndex > -1 && indexCheck;
 	}
 
 	updateHeaderInputDisabled(value) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
some display issue when dupplicate on edit mode and also editing a value and retyping the exact one ends in error, 
everything is described here : 

* When re-typing an exact same value, warning "This term is already in the list"
* "This term is already in the list" is misplaced
* Icons for Validate and Remove are displaced a little bit upwards and not aligned anymore

Can be check in the forns/field/Enumeration story

**What is the chosen solution to this problem?**

Fix placement and behavior.
Just edit value using the same value as previous in http://3153.talend.surge.sh/forms/?path=/story/uiform-v2-core-fields--core-enumeration

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
