### PR TITLE
fix(Collapsible): tooltip only when label is there for element

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -8,9 +8,6 @@
 /home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
   146:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
 
-/home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
-  175:50  error  Expected property shorthand  object-shorthand
-
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Core/Tree/Tree.component.js
   4:1  error  Dependency cycle via ./TreeNode.component:1=>../Tree:4                                             import/no-cycle
   5:1  error  Dependency cycle via ./TreeNodeList.component:1=>../TreeNode:4=>./TreeNode.component:1=>../Tree:4  import/no-cycle
@@ -319,5 +316,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 156 problems (136 errors, 20 warnings)
-  16 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 155 problems (135 errors, 20 warnings)
+  15 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -6,7 +6,10 @@
   40:10  error  Elements with the ARIA role "heading" must have the following attributes defined: aria-level  jsx-a11y/role-has-required-aria-props
 
 /home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
-  142:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
+  146:4  error  Visible, non-interactive elements with click handlers must have at least one keyboard listener  jsx-a11y/click-events-have-key-events
+
+/home/travis/build/Talend/ui/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+  175:50  error  Expected property shorthand  object-shorthand
 
 /home/travis/build/Talend/ui/packages/components/src/DataViewer/Core/Tree/Tree.component.js
   4:1  error  Dependency cycle via ./TreeNode.component:1=>../Tree:4                                             import/no-cycle
@@ -316,5 +319,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 155 problems (135 errors, 20 warnings)
-  15 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 156 problems (136 errors, 20 warnings)
+  16 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
@@ -84,11 +84,15 @@ function renderHeaderItem({ displayMode, className, ...headerItem }, key) {
 		}
 		default: {
 			const { element, label, tooltipLabel, tooltipPlacement } = headerItem;
-			return (
-				<TooltipTrigger key={key} label={tooltipLabel || label} tooltipPlacement={tooltipPlacement}>
-					<div className={css[className]}>{element || label}</div>
-				</TooltipTrigger>
-			);
+			const labelExist = tooltipLabel || label;
+            if (labelExist) {
+                return (
+                    <TooltipTrigger key={key} label={labelExist} tooltipPlacement={tooltipPlacement}>
+                        <div className={css[className]}>{element || labelExist}</div>
+                    </TooltipTrigger>
+                );
+            }
+            return (<div className={css[className]}>{element || labelExist}</div>);
 		}
 	}
 }

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.component.js
@@ -85,14 +85,14 @@ function renderHeaderItem({ displayMode, className, ...headerItem }, key) {
 		default: {
 			const { element, label, tooltipLabel, tooltipPlacement } = headerItem;
 			const labelExist = tooltipLabel || label;
-            if (labelExist) {
-                return (
-                    <TooltipTrigger key={key} label={labelExist} tooltipPlacement={tooltipPlacement}>
-                        <div className={css[className]}>{element || labelExist}</div>
-                    </TooltipTrigger>
-                );
-            }
-            return (<div className={css[className]}>{element || labelExist}</div>);
+			if (labelExist) {
+				return (
+					<TooltipTrigger key={key} label={labelExist} tooltipPlacement={tooltipPlacement}>
+						<div className={css[className]}>{element || labelExist}</div>
+					</TooltipTrigger>
+				);
+			}
+			return <div className={css[className]}>{element || labelExist}</div>;
 		}
 	}
 }

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -172,7 +172,7 @@ storiesOf('Layout/CollapsiblePanel', module)
 			<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 			<CollapsiblePanel
 				id="panel-header-2"
-				header={[{ label: 'Header with actions' }, { element: element }]}
+				header={[{ label: 'Header with actions' }, { element }]}
 			/>
 			<CollapsiblePanel
 				id="panel-header-element-withbutton"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -119,7 +119,7 @@ const descriptiveDetail = {
 	className: 'detail',
 };
 
-const element = (<ActionButton {...buttonDownload}/>);
+const element = (<div> my custom element <ActionButton {...buttonDownload}/></div>);
 
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -3,6 +3,7 @@ import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 
 import CollapsiblePanel from './CollapsiblePanel.component';
+import { ActionButton } from '../Actions';
 
 const keyValueContent = [
 	{
@@ -118,6 +119,8 @@ const descriptiveDetail = {
 	className: 'detail',
 };
 
+const element = (<ActionButton {...buttonDownload}/>);
+
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (
 		<div className="col-lg-offset-1 col-lg-10">
@@ -156,9 +159,6 @@ storiesOf('Layout/CollapsiblePanel', module)
 				Coucou
 			</CollapsiblePanel>
 			<CollapsiblePanel id="panel-default-3" header={[{ label: 'No content panel' }]} />
-			<CollapsiblePanel id="panel-default-4" header={[{ label: 'Uncontrolled panel' }]}>
-				Coucou
-			</CollapsiblePanel>
 		</div>
 	))
 	.add('Header', () => (
@@ -167,8 +167,12 @@ storiesOf('Layout/CollapsiblePanel', module)
 			<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 			<CollapsiblePanel
 				id="panel-header-2"
-				header={[{ label: 'Header with actions' }, buttonDownload]}
+				header={[{ label: 'Header with actions' }, { element: element }]}
 			/>
+			<CollapsiblePanel
+                id="panel-header-element-withbutton"
+                header={[{ label: 'Header with element having actions' }, buttonDownload]}
+            />
 			<CollapsiblePanel id="panel-header-3" header={[{ label: 'Header with badge' }, badge]} />
 			<CollapsiblePanel
 				id="panel-header-4"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -119,7 +119,12 @@ const descriptiveDetail = {
 	className: 'detail',
 };
 
-const element = (<div> my custom element <ActionButton {...buttonDownload}/></div>);
+const element = (
+	<div>
+		{' '}
+		my custom element <ActionButton {...buttonDownload} />
+	</div>
+);
 
 storiesOf('Layout/CollapsiblePanel', module)
 	.add('Default', () => (
@@ -170,9 +175,9 @@ storiesOf('Layout/CollapsiblePanel', module)
 				header={[{ label: 'Header with actions' }, { element: element }]}
 			/>
 			<CollapsiblePanel
-                id="panel-header-element-withbutton"
-                header={[{ label: 'Header with element having actions' }, buttonDownload]}
-            />
+				id="panel-header-element-withbutton"
+				header={[{ label: 'Header with element having actions' }, buttonDownload]}
+			/>
 			<CollapsiblePanel id="panel-header-3" header={[{ label: 'Header with badge' }, badge]} />
 			<CollapsiblePanel
 				id="panel-header-4"

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.test.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.test.js
@@ -3,6 +3,7 @@ import { Button } from 'react-bootstrap';
 import { mount } from 'enzyme';
 
 import CollapsiblePanel from './CollapsiblePanel.component';
+import TooltipTrigger from '../TooltipTrigger';
 
 const version1 = {
 	label: 'Version 1 94a06b6a3a85bc415add5fdb31dcceebf96b8182',
@@ -134,6 +135,29 @@ describe('CollapsiblePanel', () => {
 		const wrapper = mount(panelInstance);
 
 		// then
+        expect(wrapper.find(TooltipTrigger).length).toBe(3);
 		expect(wrapper.find('h3').getElement().props.children).toEqual('Custom label');
 	});
+
+	it('should render custom element without tooltip', () => {
+        // given
+        const customElement = <h3>Custom label</h3>;
+        const propsPanelWithCustomElement = {
+            ...propsPanelWithActions,
+            header: [
+                {
+                    element: customElement,
+                    className: 'custom-col',
+                },
+                ...propsPanelWithActions.header,
+            ],
+        };
+
+        const panelInstance = <CollapsiblePanel {...propsPanelWithCustomElement} />;
+        // when
+        const wrapper = mount(panelInstance);
+
+        // then
+        expect(wrapper.find(TooltipTrigger).length).toBe(2);
+    });
 });

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.test.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.test.js
@@ -77,10 +77,7 @@ describe('CollapsiblePanel', () => {
 
 		// when
 		const wrapper = mount(panelInstance);
-		wrapper
-			.find(Button)
-			.at(0)
-			.simulate('click');
+		wrapper.find(Button).at(0).simulate('click');
 
 		// then
 		expect(propsDescriptivePanel.onSelect).toBeCalled();
@@ -92,10 +89,7 @@ describe('CollapsiblePanel', () => {
 
 		// when
 		const wrapper = mount(panelInstance);
-		wrapper
-			.find(Button)
-			.at(0)
-			.simulate('click');
+		wrapper.find(Button).at(0).simulate('click');
 
 		// then
 		expect(propsPanelWithActions.onToggle).toBeCalled();
@@ -135,29 +129,29 @@ describe('CollapsiblePanel', () => {
 		const wrapper = mount(panelInstance);
 
 		// then
-        expect(wrapper.find(TooltipTrigger).length).toBe(3);
+		expect(wrapper.find(TooltipTrigger).length).toBe(3);
 		expect(wrapper.find('h3').getElement().props.children).toEqual('Custom label');
 	});
 
 	it('should render custom element without tooltip', () => {
-        // given
-        const customElement = <h3>Custom label</h3>;
-        const propsPanelWithCustomElement = {
-            ...propsPanelWithActions,
-            header: [
-                {
-                    element: customElement,
-                    className: 'custom-col',
-                },
-                ...propsPanelWithActions.header,
-            ],
-        };
+		// given
+		const customElement = <h3>Custom label</h3>;
+		const propsPanelWithCustomElement = {
+			...propsPanelWithActions,
+			header: [
+				{
+					element: customElement,
+					className: 'custom-col',
+				},
+				...propsPanelWithActions.header,
+			],
+		};
 
-        const panelInstance = <CollapsiblePanel {...propsPanelWithCustomElement} />;
-        // when
-        const wrapper = mount(panelInstance);
+		const panelInstance = <CollapsiblePanel {...propsPanelWithCustomElement} />;
+		// when
+		const wrapper = mount(panelInstance);
 
-        // then
-        expect(wrapper.find(TooltipTrigger).length).toBe(2);
-    });
+		// then
+		expect(wrapper.find(TooltipTrigger).length).toBe(2);
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
tooltip on actions inside custom element are messed up
![image](https://user-images.githubusercontent.com/14272767/103781166-40c46180-5036-11eb-91b0-38de13d9f2f6.png)

**What is the chosen solution to this problem?**
have the TooltipTrigger around the custom element only when label or tooltipLabel is passed in props

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
