### PR TITLE
feat(components/headercheckbox): add intermediate state

### DIFF
--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -165,22 +165,15 @@ Count.propTypes = {
 	selected: PropTypes.number,
 };
 
-function defineComponentLeft(parentComponentLeft, selected, hideCount, selectionInProgress) {
+function defineComponentLeft(parentComponentLeft, selected, hideCount) {
 	if (parentComponentLeft) {
 		return parentComponentLeft;
 	}
 
-	if (!hideCount) {
-		if (selectionInProgress) {
-			return {
-				'before-actions': <CircularProgress size="default" />,
-			};
-		}
-		if(selected > 0) {
+	if (!hideCount && selected > 0) {
 			return {
 				'before-actions': <Count selected={selected} />,
 			};
-		}
 	}
 
 	return undefined;
@@ -199,7 +192,6 @@ export function ActionBar(props) {
 		props.components.left,
 		props.selected,
 		props.hideCount,
-		props.selectionInProgress,
 	);
 	const componentsCenter = props.components.center;
 	const componentsRight = props.components.right;
@@ -235,7 +227,6 @@ export function ActionBar(props) {
 ActionBar.propTypes = {
 	selected: PropTypes.number,
 	hideCount: PropTypes.bool,
-	selectionInProgress: PropTypes.bool,
 	children: PropTypes.node,
 	className: PropTypes.string,
 	getComponent: PropTypes.func,

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Action, Actions, ActionDropdown, ActionSplitDropdown } from '../Actions';
-import CircularProgress from '../CircularProgress';
 import Inject from '../Inject';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import css from './ActionBar.scss';

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -171,9 +171,9 @@ function defineComponentLeft(parentComponentLeft, selected, hideCount) {
 	}
 
 	if (!hideCount && selected > 0) {
-			return {
-				'before-actions': <Count selected={selected} />,
-			};
+		return {
+			'before-actions': <Count selected={selected} />,
+		};
 	}
 
 	return undefined;

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -3,6 +3,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import { Action, Actions, ActionDropdown, ActionSplitDropdown } from '../Actions';
+import CircularProgress from '../CircularProgress';
 import Inject from '../Inject';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import css from './ActionBar.scss';
@@ -164,15 +165,22 @@ Count.propTypes = {
 	selected: PropTypes.number,
 };
 
-function defineComponentLeft(parentComponentLeft, selected, hideCount) {
+function defineComponentLeft(parentComponentLeft, selected, hideCount, selectionInProgress) {
 	if (parentComponentLeft) {
 		return parentComponentLeft;
 	}
 
-	if (!hideCount && selected > 0) {
-		return {
-			'before-actions': <Count selected={selected} />,
-		};
+	if (!hideCount) {
+		if (selectionInProgress) {
+			return {
+				'before-actions': <CircularProgress size="default" />,
+			};
+		}
+		if(selected > 0) {
+			return {
+				'before-actions': <Count selected={selected} />,
+			};
+		}
 	}
 
 	return undefined;
@@ -191,6 +199,7 @@ export function ActionBar(props) {
 		props.components.left,
 		props.selected,
 		props.hideCount,
+		props.selectionInProgress,
 	);
 	const componentsCenter = props.components.center;
 	const componentsRight = props.components.right;
@@ -226,6 +235,7 @@ export function ActionBar(props) {
 ActionBar.propTypes = {
 	selected: PropTypes.number,
 	hideCount: PropTypes.bool,
+	selectionInProgress: PropTypes.bool,
 	children: PropTypes.node,
 	className: PropTypes.string,
 	getComponent: PropTypes.func,

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -289,12 +289,31 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                               title="Select All"
                             >
                               <label>
-                                <input
+                                <Checkbox
                                   checked={false}
+                                  data-feature="list.select_all"
                                   disabled={false}
+                                  intermediate={0}
                                   onChange={[MockFunction]}
                                   type="checkbox"
-                                />
+                                >
+                                  <div
+                                    className="checkbox tc-toggle theme-tc-toggle checkbox"
+                                  >
+                                    <label
+                                      data-feature="list.select_all.enable"
+                                    >
+                                      <input
+                                        checked={false}
+                                        data-checked={0}
+                                        disabled={false}
+                                        onChange={[MockFunction]}
+                                        type="checkbox"
+                                      />
+                                      <span />
+                                    </label>
+                                  </div>
+                                </Checkbox>
                                 <span
                                   className="sr-only"
                                 >
@@ -1268,12 +1287,31 @@ exports[`List should render 1`] = `
                               title="Select All"
                             >
                               <label>
-                                <input
+                                <Checkbox
                                   checked={false}
+                                  data-feature="list.select_all"
                                   disabled={false}
+                                  intermediate={0}
                                   onChange={[MockFunction]}
                                   type="checkbox"
-                                />
+                                >
+                                  <div
+                                    className="checkbox tc-toggle theme-tc-toggle checkbox"
+                                  >
+                                    <label
+                                      data-feature="list.select_all.enable"
+                                    >
+                                      <input
+                                        checked={false}
+                                        data-checked={0}
+                                        disabled={false}
+                                        onChange={[MockFunction]}
+                                        type="checkbox"
+                                      />
+                                      <span />
+                                    </label>
+                                  </div>
+                                </Checkbox>
                                 <span
                                   className="sr-only"
                                 >
@@ -2273,13 +2311,34 @@ exports[`List should render id if provided 1`] = `
                               <label
                                 htmlFor="context-header-check"
                               >
-                                <input
+                                <Checkbox
                                   checked={false}
+                                  data-feature="list.select_all"
                                   disabled={false}
                                   id="context-header-check"
+                                  intermediate={0}
                                   onChange={[MockFunction]}
                                   type="checkbox"
-                                />
+                                >
+                                  <div
+                                    className="checkbox tc-toggle theme-tc-toggle checkbox"
+                                  >
+                                    <label
+                                      data-feature="list.select_all.enable"
+                                      htmlFor="context-header-check"
+                                    >
+                                      <input
+                                        checked={false}
+                                        data-checked={0}
+                                        disabled={false}
+                                        id="context-header-check"
+                                        onChange={[MockFunction]}
+                                        type="checkbox"
+                                      />
+                                      <span />
+                                    </label>
+                                  </div>
+                                </Checkbox>
                                 <span
                                   className="sr-only"
                                 >

--- a/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.component.js
+++ b/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React, { useMemo } from 'react';
 import classnames from 'classnames';
+import Checkbox from '../../Checkbox';
 import theme from './HeaderCheckbox.scss';
 import getDefaultT from '../../translate';
 
@@ -17,18 +18,29 @@ function HeaderCheckbox({ columnData, t }) {
 		collection,
 		isSelected,
 	]);
-	const title = t('LIST_SELECT_ALL', { defaultValue: 'Select All' });
+	const partial = useMemo(
+		() => {
+			if (!collection.length) {
+				return false;
+			}
+			const selected = collection.filter(isSelected);
+			return selected.length && selected.length < collection.length;
+		}, [collection, isSelected],
+	);
 
+	const title = t('LIST_SELECT_ALL', { defaultValue: 'Select All' });
 	return (
 		<form className={classnames('tc-list-checkbox', theme['tc-list-checkbox'])}>
 			<div className="checkbox" title={title}>
 				<label htmlFor={id && `${id}-header-check`}>
-					<input
+					<Checkbox
 						id={id && `${id}-header-check`}
 						type="checkbox"
 						onChange={onToggleAll}
 						checked={checked}
+						intermediate={partial}
 						disabled={!collection.length}
+						data-feature="list.select_all"
 					/>
 					<span className="sr-only">{title}</span>
 				</label>

--- a/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.scss
+++ b/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.scss
@@ -5,7 +5,7 @@
 		display: flex;
 
 		label {
-			padding-left: $padding-large;
+			padding-left: 0;
 		}
 	}
 }

--- a/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.test.js
+++ b/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.test.js
@@ -1,9 +1,12 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import toJson from 'enzyme-to-json';
 import HeaderCheckbox from './HeaderCheckbox.component';
 
-const items = [{ id: 1, label: 'item 1' }, { id: 2, label: 'item 2' }];
+const items = [
+	{ id: 1, label: 'item 1' },
+	{ id: 2, label: 'item 2' },
+];
 
 const columnData = {
 	id: 'myList',
@@ -16,14 +19,14 @@ const columnData = {
 describe('Header "Select All" checkbox', () => {
 	it('should render a "Select All" checkbox on header when onToggleAll callback provided', () => {
 		// when
-		const wrapper = mount(<HeaderCheckbox columnData={columnData} />);
+		const wrapper = shallow(<HeaderCheckbox columnData={columnData} />);
 
 		// then
 		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 	it('should trigger onToggleAll callback on checkbox toggle', () => {
 		// when
-		const wrapper = mount(<HeaderCheckbox columnData={columnData} />);
+		const wrapper = shallow(<HeaderCheckbox columnData={columnData} />);
 
 		wrapper.find('#myList-header-check').simulate('change');
 
@@ -33,11 +36,31 @@ describe('Header "Select All" checkbox', () => {
 
 	it('should render unchecked & disabled checkbox on header when there is no items', () => {
 		// when
-		const wrapper = mount(<HeaderCheckbox columnData={{ ...columnData, collection: [] }} />);
+		const wrapper = shallow(<HeaderCheckbox columnData={{ ...columnData, collection: [] }} />);
 
 		// then
 		const checkbox = wrapper.find('#myList-header-check');
 		expect(checkbox.prop('checked')).toBe(false);
 		expect(checkbox.prop('disabled')).toBe(true);
+	});
+
+	it('should render a checked checkbox on header', () => {
+		// when
+		const wrapper = shallow(
+			<HeaderCheckbox columnData={{ ...columnData, isSelected: () => true }} />,
+		);
+
+		// then
+		expect(toJson(wrapper)).toMatchSnapshot();
+	});
+
+	it('should render a partial checkbox on header', () => {
+		// when
+		const wrapper = shallow(
+			<HeaderCheckbox columnData={{ ...columnData, isSelected: ({ id }) => id === 1 }} />,
+		);
+
+		// then
+		expect(toJson(wrapper)).toMatchSnapshot();
 	});
 });

--- a/packages/components/src/VirtualizedList/HeaderCheckbox/__snapshots__/HeaderCheckbox.test.js.snap
+++ b/packages/components/src/VirtualizedList/HeaderCheckbox/__snapshots__/HeaderCheckbox.test.js.snap
@@ -1,77 +1,115 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Header "Select All" checkbox should render a "Select All" checkbox on header when onToggleAll callback provided 1`] = `
-<VirtualizedList(HeaderCheckbox)
-  columnData={
-    Object {
-      "collection": Array [
-        Object {
-          "id": 1,
-          "label": "item 1",
-        },
-        Object {
-          "id": 2,
-          "label": "item 2",
-        },
-      ],
-      "id": "myList",
-      "isSelected": [MockFunction] {
-        "calls": Array [
-          Array [
-            Object {
-              "id": 1,
-              "label": "item 1",
-            },
-            0,
-            Array [
+<form
+  className="tc-list-checkbox theme-tc-list-checkbox"
+>
+  <div
+    className="checkbox"
+    title="Select All"
+  >
+    <label
+      htmlFor="myList-header-check"
+    >
+      <Checkbox
+        checked={false}
+        data-feature="list.select_all"
+        disabled={false}
+        id="myList-header-check"
+        intermediate={0}
+        onChange={[MockFunction]}
+        type="checkbox"
+      />
+      <span
+        className="sr-only"
+      >
+        Select All
+      </span>
+    </label>
+  </div>
+</form>
+`;
+
+exports[`Header "Select All" checkbox should render a checked checkbox on header 1`] = `
+<form
+  className="tc-list-checkbox theme-tc-list-checkbox"
+>
+  <div
+    className="checkbox"
+    title="Select All"
+  >
+    <label
+      htmlFor="myList-header-check"
+    >
+      <Checkbox
+        checked={true}
+        data-feature="list.select_all"
+        disabled={false}
+        id="myList-header-check"
+        intermediate={false}
+        onChange={
+          [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
               Object {
-                "id": 1,
-                "label": "item 1",
-              },
-              Object {
-                "id": 2,
-                "label": "item 2",
+                "type": "return",
+                "value": undefined,
               },
             ],
-          ],
-        ],
-        "results": Array [
-          Object {
-            "type": "return",
-            "value": undefined,
-          },
-        ],
-      },
-      "label": "Select item",
-      "onToggleAll": [MockFunction],
-    }
-  }
-  t={[Function]}
->
-  <form
-    className="tc-list-checkbox theme-tc-list-checkbox"
-  >
-    <div
-      className="checkbox"
-      title="Select All"
-    >
-      <label
-        htmlFor="myList-header-check"
+          }
+        }
+        type="checkbox"
+      />
+      <span
+        className="sr-only"
       >
-        <input
-          checked={false}
-          disabled={false}
-          id="myList-header-check"
-          onChange={[MockFunction]}
-          type="checkbox"
-        />
-        <span
-          className="sr-only"
-        >
-          Select All
-        </span>
-      </label>
-    </div>
-  </form>
-</VirtualizedList(HeaderCheckbox)>
+        Select All
+      </span>
+    </label>
+  </div>
+</form>
+`;
+
+exports[`Header "Select All" checkbox should render a partial checkbox on header 1`] = `
+<form
+  className="tc-list-checkbox theme-tc-list-checkbox"
+>
+  <div
+    className="checkbox"
+    title="Select All"
+  >
+    <label
+      htmlFor="myList-header-check"
+    >
+      <Checkbox
+        checked={false}
+        data-feature="list.select_all"
+        disabled={false}
+        id="myList-header-check"
+        intermediate={true}
+        onChange={
+          [MockFunction] {
+            "calls": Array [
+              Array [],
+            ],
+            "results": Array [
+              Object {
+                "type": "return",
+                "value": undefined,
+              },
+            ],
+          }
+        }
+        type="checkbox"
+      />
+      <span
+        className="sr-only"
+      >
+        Select All
+      </span>
+    </label>
+  </div>
+</form>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Intermediate state is not implemented in the HeaderCheckbox

**What is the chosen solution to this problem?**

add it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
