### PR TITLE
fix(FocusManager): Persist syntheticevent

### DIFF
--- a/packages/components/src/FocusManager/FocusManager.component.js
+++ b/packages/components/src/FocusManager/FocusManager.component.js
@@ -27,6 +27,7 @@ export default class FocusManager extends Component {
 
 	onBlur = event => {
 		if (this.props.onFocusOut) {
+			event.persist();
 			this.timeout = setTimeout(() => this.props.onFocusOut(event));
 		}
 	};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In react <17, persist() had to be called when using a SyntheticEvent asynchronously

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
