### PR TITLE
fix(Dataviz): Reset tooltip line margin

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,12 @@ Types of changes
 
 ## [unreleased]
 
+## [0.1.4]
+
+### Fixed
+
+- [Reset tooltip line margin](https://github.com/Talend/ui/pull/3158):
+
 ## [0.1.3]
 
 ### Fixed

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.component.scss
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.component.scss
@@ -14,6 +14,7 @@ $module: dataviz-tooltip;
 	}
 
 	&__key {
+		margin-top: 0; // override dt margin
 		font-weight: $font-weight-regular;
 		line-height: $line-height-base;
 		color: $white;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

dt margin-top is not reset

![image](https://user-images.githubusercontent.com/58977230/104212204-3e4a7900-5435-11eb-83e5-2dab95a74d8a.png)


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
