### PR TITLE
fix(Dataviz): Bars without filter should be blue when in range

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,12 @@ Types of changes
 
 ## [unreleased]
 
+## [0.2.1]
+
+### Fixed
+
+- [Show blue bars for entries without filtered values](https://github.com/Talend/ui/pull/3163):
+
 ## [0.2.0]
 
 ### Added

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.test.tsx
+++ b/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.test.tsx
@@ -36,7 +36,7 @@ describe('Profiling chart panel', () => {
 		expect(component.find('RangeFilter')).toHaveLength(1);
 	});
 
-	it('Should syn bar chart with range filter', () => {
+	it('Should sync bar chart with range filter', () => {
 		const component = shallow(
 			<VerticalChartFilter
 				data={[
@@ -49,8 +49,21 @@ describe('Profiling chart panel', () => {
 					{
 						value: 10,
 						filteredValue: 10,
-						label: '[20, 30[',
-						key: { min: 20, max: 30 },
+						label: '[20, 25[',
+						key: { min: 20, max: 25 },
+					},
+					{
+						// bars without existing filter value appear as not filtered
+						filteredValue: undefined,
+						value: 10,
+						label: '[25, 30[',
+						key: { min: 25, max: 30 },
+					},
+					{
+						value: 10,
+						filteredValue: 10,
+						label: '[30, 40[',
+						key: { min: 30, max: 40 },
 					},
 					{
 						value: 10,
@@ -70,7 +83,7 @@ describe('Profiling chart panel', () => {
 			((component
 				.find('VerticalBarChart')
 				.prop('data')! as unknown) as VerticalBarChartEntry[]).map(entry => entry.filteredValue),
-		).toEqual([0, 10, 0]);
+		).toEqual([0, 10, undefined, 0, 0]);
 	});
 
 	it('Should handle bars with bounds outside range limits', () => {

--- a/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.tsx
+++ b/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.tsx
@@ -53,7 +53,9 @@ function VerticalChartFilter({
 					showXAxis={showXAxis}
 					data={data.map(entry => ({
 						...entry,
-						filteredValue: entry.filteredValue && isInActiveRange(entry) ? entry.filteredValue : 0,
+						value: entry.value!,
+						// undefined (no filter applied) !== 0 (not matching value)
+						filteredValue: isInActiveRange(entry) ? entry.filteredValue : 0,
 					}))}
 					dataFeature={barDataFeature}
 					onBarClick={onBarClick}

--- a/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.stories.tsx
+++ b/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.stories.tsx
@@ -42,6 +42,7 @@ Number.args = {
 			key: { min: 2300, max: 2400 },
 			label: '[2300, 2400[',
 			value: 400,
+			filteredValue: 0,
 		},
 		{
 			key: { min: 2400, max: 2500 },


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When provided data does not contain filtered value, all bars are grey
```
{
    key: { min: 2500, max: 2600 },
    label: '[2500, 2600[',
    value: 400,
    filteredValue: undefined
},
```

![image](https://user-images.githubusercontent.com/58977230/104889490-979f3480-596e-11eb-8d21-5df8bec3a5d0.png)


**What is the chosen solution to this problem?**

Don't set 0 (no filtered occurences) but keep undefined (no filter)

![image](https://user-images.githubusercontent.com/58977230/104889328-5870e380-596e-11eb-9ef4-19884d67eb66.png)


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
