### PR TITLE
fix(theme): chesnut-rose is the new black

### DIFF
--- a/packages/components/src/QualityBar/QualityRatioBar.scss
+++ b/packages/components/src/QualityBar/QualityRatioBar.scss
@@ -14,5 +14,5 @@
 }
 .tc-ratio-bar-line-quality-invalid {
 	@extend .tc-ratio-bar-lines;
-	background-color: $jaffa;
+	background-color: $chestnut-rose;
 }

--- a/packages/theme/src/theme/_datagrid.scss
+++ b/packages/theme/src/theme/_datagrid.scss
@@ -1,6 +1,6 @@
 $td-quality-bar-valid-background-color: $rio-grande !default;
 $td-quality-bar-empty-background-color: $dove-gray !default;
-$td-quality-bar-invalid-background-color: $jaffa !default;
+$td-quality-bar-invalid-background-color: $chestnut-rose !default;
 
 $td-body-font-family: $font-family-monospace !default;
 $td-body-background-color: rgba($slate-gray, 0.1) !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

invalid colour shloud no longer be representated by jaffa. chestnut-rose should be used instead

**What is the chosen solution to this problem?**

change it in the datagrid and in the qualitybar component

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
