### PR TITLE
chore(components): fix small typo in InlineMessage component css

### DIFF
--- a/packages/components/src/InlineMessage/InlineMessage.scss
+++ b/packages/components/src/InlineMessage/InlineMessage.scss
@@ -13,7 +13,7 @@ $tc-inline-message-icon-offset: 0.4rem !default;
 	position: relative;
 	display: flex;
 	color: $black;
-	padding-left: padding-smaller;
+	padding-left: $padding-smaller;
 
 	&-title {
 		font-weight: $font-weight-semi-bold;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The '$' sign before the css variable's name is missing

**What is the chosen solution to this problem?**
adding the missing '$' sign

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
