### PR TITLE
fix(components/ListView): showToggleAll prop change

### DIFF
--- a/packages/components/src/ListView/Items/Items.component.js
+++ b/packages/components/src/ListView/Items/Items.component.js
@@ -39,7 +39,6 @@ export class ItemsComponent extends React.PureComponent {
 		this.renderToggleAllOrItem = this.renderToggleAllOrItem.bind(this);
 		this.renderToggleAll = this.renderToggleAll.bind(this);
 
-		this.hasToggleAll = this.props.showToggleAll && this.props.items.length > 1;
 		this.cache = new CellMeasurerCache({
 			defaultHeight: props.getItemHeight ? props.getItemHeight() : ROW_HEIGHT,
 			fixedWidth: true,
@@ -199,6 +198,8 @@ export class ItemsComponent extends React.PureComponent {
 	}
 
 	render() {
+		this.hasToggleAll = this.props.showToggleAll && this.props.items.length > 1;
+
 		return (
 			<div className={itemsClasses}>
 				<AutoSizer>

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -25,7 +25,7 @@ function ListView(props) {
 		<div className={listviewClasses()}>
 			<HeaderListView {...props} />
 			{props.items.length ? (
-				<ItemsListView {...props} />
+				<Items {...props} />
 			) : (
 				<span className={theme['empty-message']}>{label}</span>
 			)}
@@ -45,12 +45,6 @@ ListView.propTypes = {
 ListView.defaultProps = {
 	items: [],
 };
-
-function ItemsListView(props) {
-	return <Items {...props} />;
-}
-
-ItemsListView.propTypes = Items.propTypes;
 
 function HeaderListView(props) {
 	const {

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -38,7 +38,7 @@ ListView.DISPLAY_MODES = { DISPLAY_MODE_DEFAULT, DISPLAY_MODE_SEARCH };
 ListView.displayName = 'ListView';
 
 ListView.propTypes = {
-	displayMode: PropTypes.string,
+	displayMode: PropTypes.oneOf(Object.values(ListView.DISPLAY_MODES)),
 	items: PropTypes.arrayOf(PropTypes.object),
 };
 

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -33,6 +33,8 @@ function ListView(props) {
 	);
 }
 
+ListView.DISPLAY_MODES = { DISPLAY_MODE_DEFAULT, DISPLAY_MODE_SEARCH };
+
 ListView.displayName = 'ListView';
 
 ListView.propTypes = {
@@ -48,17 +50,7 @@ function ItemsListView(props) {
 	return <Items {...props} />;
 }
 
-ItemsListView.propTypes = {
-	getItemHeight: PropTypes.func,
-	id: PropTypes.string,
-	items: ListView.propTypes.items,
-	isSwitchBox: PropTypes.bool,
-	onToggleAll: PropTypes.func,
-	searchCriteria: PropTypes.string,
-	toggleAllChecked: PropTypes.bool,
-	showToggleAll: PropTypes.bool,
-	t: PropTypes.func,
-};
+ItemsListView.propTypes = Items.propTypes;
 
 function HeaderListView(props) {
 	const {

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -87,7 +87,7 @@ HeaderListView.defaultProps = {
 };
 
 HeaderListView.propTypes = {
-	displayMode: PropTypes.string,
+	displayMode: PropTypes.oneOf(Object.values(ListView.DISPLAY_MODES)),
 	headerDefault: PropTypes.arrayOf(PropTypes.object),
 	headerInput: PropTypes.arrayOf(PropTypes.object),
 	headerLabel: PropTypes.string,

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -28,7 +28,7 @@ const props = {
 
 const searchProps = {
 	...props,
-	displayMode: 'DISPLAY_MODE_SEARCH',
+	displayMode: ListView.DISPLAY_MODES.DISPLAY_MODE_SEARCH,
 	headerInput: [
 		{
 			label: 'Remove search',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a parent changes the `showToggleAll` prop in its `ListView` component, nothing happens because actual effect is the result of prop computation that happens in component's construct, not at render time.

**What is the chosen solution to this problem?**
Move computation at render time. Also, expose the component's various display modes and remove an intermediate component that does nothing.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
