### PR TITLE
fix(Dataviz): Fix truncated/misplaced tooltip

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,13 @@ Types of changes
 
 ## [unreleased]
 
+## [0.2.3]
+
+### Fixed
+
+- [Fix truncated/misplaced tooltip](https://github.com/Talend/ui/pull/3183):
+
+
 ## [0.2.2]
 
 ### Fixed

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.tsx
+++ b/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.tsx
@@ -82,7 +82,6 @@ function HorizontalBarChart({
 				/>
 
 				<Tooltip
-					allowEscapeViewBox={{ x: false, y: true }}
 					isAnimationActive={false}
 					content={<TooltipContent />}
 					cursor={<TooltipCursor dataFeature={dataFeature} />}

--- a/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.tsx
+++ b/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.tsx
@@ -84,7 +84,6 @@ function VerticalBarChart({
 					}
 				/>
 				<Tooltip
-					allowEscapeViewBox={{ x: false, y: true }}
 					isAnimationActive={false}
 					content={TooltipContent}
 					cursor={<TooltipCursor dataFeature={dataFeature} />}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Tooltip is getting out of the viewport

![image](https://user-images.githubusercontent.com/58977230/105473111-02b57780-5c9d-11eb-8de3-b7bdada3f0c7.png)

**What is the chosen solution to this problem?**

Keep tooltip inside the view:

![image](https://user-images.githubusercontent.com/58977230/105473245-2d073500-5c9d-11eb-8883-b2b136650e38.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
