### PR TITLE
fix(Dataviz): Range ticks edge cases

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -28,7 +28,7 @@ Types of changes
 
 ## [0.3.1]
 
-### Added
+### Fixed
 
 - [Range ticks edge cases](https://github.com/Talend/ui/pull/3186):
 

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -30,7 +30,7 @@ Types of changes
 
 ### Added
 
-- [Range ticks edge cases](https://github.com/Talend/ui/pull/3180):
+- [Range ticks edge cases](https://github.com/Talend/ui/pull/3186):
 
 ## [0.3.0]
 

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,11 @@ Types of changes
 
 ## [unreleased]
 
+## [0.3.1]
+
+### Added
+
+- [Range ticks edge cases](https://github.com/Talend/ui/pull/3180):
 
 ## [0.3.0]
 

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.scss
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.scss
@@ -8,6 +8,7 @@ $module: range-filter;
 	&__slider-mark {
 		position: absolute;
 		width: 100%;
+		white-space: nowrap;
 
 		&--top {
 			transform: translateX(-50%);

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.stories.tsx
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.stories.tsx
@@ -68,6 +68,18 @@ NumberRangeFilter.args = {
 	...NumberRangeHandler,
 };
 
+export const BigNumberRangeFilter = Template.bind({});
+BigNumberRangeFilter.args = {
+	range: {
+		min: 131035911,
+		max: 831035920,
+	},
+	limits: {
+		min: 131035911,
+		max: 831035920,
+	},
+	...NumberRangeHandler,
+};
 export const DateRangeFilter = Template.bind({});
 DateRangeFilter.args = {
 	range: {

--- a/packages/dataviz/src/components/RangeFilter/handlers/DateRangeHandler/DateRangeHandler.test.tsx
+++ b/packages/dataviz/src/components/RangeFilter/handlers/DateRangeHandler/DateRangeHandler.test.tsx
@@ -60,25 +60,38 @@ describe('DateRangeHandler', () => {
 	});
 
 	it('Should create ticks', () => {
-		const ticks = DateRangeHandler.getTicks({
+		const limits = {
 			min: new Date('2000-01-01T12:00:00').getTime(),
 			max: new Date('2030-01-01T12:00:00').getTime(),
-		});
+		};
+		const ticks = DateRangeHandler.getTicks(limits);
 		expect(ticks).toEqual({
-			'946724400000': '2000-01-01',
+			[limits.min]: '2000-01-01',
 			'1262300400000': '2010-01-01',
 			'1577833200000': '2020-01-01',
-			'1893452400000': '2030-01-01',
+			[limits.max]: '2030-01-01',
 		});
 	});
 	it('Should create ticks for tiny range', () => {
-		const ticks = DateRangeHandler.getTicks({
+		const limits = {
 			min: new Date('2000-01-01T12:00:00').getTime(),
 			max: new Date('2000-01-02T12:00:00').getTime(),
-		});
+		};
+		const ticks = DateRangeHandler.getTicks(limits);
 		expect(ticks).toEqual({
-			'946724400000': '2000-01-01',
-			'946767600000': '2000-01-02',
+			[limits.min]: '2000-01-01',
+			[limits.max]: '2000-01-02',
+		});
+	});
+	it('Should have min/max even for single day range', () => {
+		const limits = {
+			min: new Date('2020-01-01T00:00:00').getTime(),
+			max: new Date('2020-01-01T23:59:59').getTime(),
+		};
+		const ticks =  DateRangeHandler.getTicks(limits);
+		expect(ticks).toEqual({
+			[limits.min]: '2020-01-01',
+			[limits.max]: '2020-01-01',
 		});
 	});
 });

--- a/packages/dataviz/src/components/RangeFilter/handlers/DateTimeRangeHandler/DateTimeRangeHandler.test.tsx
+++ b/packages/dataviz/src/components/RangeFilter/handlers/DateTimeRangeHandler/DateTimeRangeHandler.test.tsx
@@ -64,15 +64,16 @@ describe('DateTimeRangeHandler', () => {
 	});
 
 	it('Should create ticks', () => {
-		const ticks = DateRangeHandler.getTicks({
+		const limits = {
 			min: new Date('2000-01-01T12:00:00').getTime(),
 			max: new Date('2030-01-01T12:00:00').getTime(),
-		});
+		};
+		const ticks = DateRangeHandler.getTicks(limits);
 		expect(ticks).toEqual({
-			'946724400000': '2000-01-01',
+			[limits.min]: '2000-01-01',
 			'1262300400000': '2010-01-01',
 			'1577833200000': '2020-01-01',
-			'1893452400000': '2030-01-01',
+			[limits.max]: '2030-01-01',
 		});
 	});
 });

--- a/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberRangeHandler.test.tsx
+++ b/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberRangeHandler.test.tsx
@@ -55,4 +55,16 @@ describe('Number input field', () => {
 			'9530.28': '9,530.28',
 		});
 	});
+	it('Should create ticks for big number', () => {
+		const ticks = NumberRangeHandler.getTicks({
+			min: 131035911,
+			max: 831035920,
+		});
+
+		expect(ticks).toEqual({
+			'131035911': '131,035,911',
+			'500000000': '500,000,000',
+			'831035920': '831,035,920',
+		});
+	});
 });

--- a/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberRangeHandler.tsx
+++ b/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberRangeHandler.tsx
@@ -22,14 +22,20 @@ function getStep(limits: Range): string {
 }
 
 function getTicks(limits: Range): Ticks {
+	const precision = getPrecision(limits);
+	const maxDigits = Math.max(
+		formatNumber(limits.min, precision).length,
+		formatNumber(limits.max, precision).length,
+	);
+
+	// Use number of chars in formatted number to guess how many ticks we can show
+	const tickCount = maxDigits < 11 ? 3 : 1;
+
 	return formatD3Ticks(
 		limits,
 		scaleLinear()
 			.domain([limits.min, limits.max])
-			.ticks(
-				// Use only 1 tick for big number
-				limits.max < 1e10 && limits.max > 1e-10 ? 3 : 1,
-			),
+			.ticks(tickCount),
 		v => formatNumber(v, +getPrecision(limits)),
 	);
 }

--- a/packages/dataviz/src/components/RangeFilter/handlers/slider-ticks.utils.ts
+++ b/packages/dataviz/src/components/RangeFilter/handlers/slider-ticks.utils.ts
@@ -11,9 +11,10 @@ export function formatD3Ticks(
 	// It's nice, but we want to make sure we'll always show min and max values
 	const ticks: Ticks = {};
 	// Add min/max and remove duplicates, then create a map [value, label to display]
-	[limits.min, ...scale, limits.max].forEach(value => {
+	[limits.min, limits.max, ...scale].forEach((value, index) => {
 		const label = formatter(value);
-		if (!Object.values(ticks).includes(label)) {
+		// We want min and max even if they have the same label
+		if (index < 2 || !Object.values(ticks).includes(label)) {
 			ticks[value] = label;
 		}
 	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Edge case when min and max label are the same but not the actual values: the min label is missing

![image](https://user-images.githubusercontent.com/58977230/106020891-853a9e80-60c4-11eb-9c99-187b099a58f0.png)

Expected 

![image](https://user-images.githubusercontent.com/58977230/106021034-aa2f1180-60c4-11eb-8f0b-033069a9a5dc.png)

Also, number size computation was not taking ponctuation and decimals into account 

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
