### PR TITLE
fix: eslint empty report is not updated

### DIFF
--- a/.travis/after_success_lint.sh
+++ b/.travis/after_success_lint.sh
@@ -3,6 +3,7 @@
 
 if [ "$TRAVIS_PULL_REQUEST" != 'false' ]; then
 	echo "Linting JavaScript files"
+	rm -rf output
 	(lerna exec --scope=@talend/react-sagas -- npm run lint:es -- -o ../../output/sagas.eslint.txt --no-color)
 	(lerna exec --scope=@talend/react-datagrid -- npm run lint:es -- -o ../../output/datagrid.eslint.txt --no-color)
 	(lerna exec --scope=@talend/react-stepper -- npm run lint:es -- -o ../../output/stepper.eslint.txt --no-color)

--- a/output/forms.eslint.txt
+++ b/output/forms.eslint.txt
@@ -1,7 +1,0 @@
-
-/home/travis/build/Talend/ui/packages/forms/src/UIForm/fieldsets/Array/Array.component.test.js
-  479:10  error  'widgets' is already declared in the upper scope  no-shadow
-  497:10  error  'widgets' is already declared in the upper scope  no-shadow
-  515:10  error  'widgets' is already declared in the upper scope  no-shadow
-
-✖ 3 problems (3 errors, 0 warnings)

--- a/output/router.eslint.txt
+++ b/output/router.eslint.txt
@@ -1,8 +1,0 @@
-
-/home/travis/build/Talend/ui/packages/router/src/expressions.test.js
-  1:1  error  '@talend/react-cmf/lib/mock' import too deep. No more than @talend/react-cmf  @talend/import-depth
-
-/home/travis/build/Talend/ui/packages/router/src/route.test.js
-  4:1  error  '@talend/react-cmf/lib/mock' import too deep. No more than @talend/react-cmf  @talend/import-depth
-
-✖ 2 problems (2 errors, 0 warnings)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the linter give an empty scan, the file is not updated
**What is the chosen solution to this problem?**
Remove the folder in the ci process in order to have the file removed if there is no lint to report for a package

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
