### PR TITLE
chore: gh action release note content

### DIFF
--- a/.github/workflows/release-variables.sh
+++ b/.github/workflows/release-variables.sh
@@ -13,7 +13,7 @@ DEMO_DOMAIN="${CURRENT_VERSION//[.]/-}.talend.surge.sh"
 echo "Demo: $DEMO_DOMAIN"
 
 # Generate changelog
-CHANGELOG=$(git log --date=short --pretty="%ad %s" v$PREVIOUS_VERSION..master | tail -n +2)
+CHANGELOG=$(git log --date=short --pretty="%ad %s" v$PREVIOUS_VERSION..HEAD | tail -n +2)
 DEMO="Demo: http://$DEMO_DOMAIN"$'\n'
 TITLE=$'# Changelog\n'
 FEATURES=$'## Features\n'


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Releases are done automatically via GH Actions on master or any branche like maintenance branches.

During the process, it generates the changelog, by requesting the logs from last release. But this works only on master because it requests the logs from last release **to master**.

On maintenance branches, it results in error
```
fatal: ambiguous argument 'v6.10.0..master': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
```
My guess is that actions pulls only the wanted branch, and master doesn't exist on the run environment.

**What is the chosen solution to this problem?**
Change it to request logs from last release to **HEAD**.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
