### PR TITLE
fix(SubHeaderBar): EditMode is not passed to EditableText

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -251,7 +251,7 @@
   135:13  error  'children' is missing in props validation  react/prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
-  129:2  error  defaultProp "t" has no corresponding propTypes declaration  react/default-props-match-prop-types
+  130:2  error  defaultProp "t" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
   13:3  error  Arrow function should not return assignment  no-return-assign

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -64,6 +64,7 @@ function TitleSubHeader({
 							onEdit={handleEdit}
 							onCancel={handleCancel}
 							onSubmit={handleSubmit}
+							editMode={isEditMode}
 							{...rest}
 						/>
 					) : (

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -55,15 +55,11 @@ describe('TitleSubHeader', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
 		const findEditableText = () => wrapper.find('[feature="subheaderbar.rename"]');
 
-		findEditableText()
-			.props()
-			.onEdit();
+		findEditableText().props().onEdit();
 
 		expect(findEditableText().props().editMode).toEqual(true);
 
-		findEditableText()
-			.props()
-			.onCancel();
+		findEditableText().props().onCancel();
 
 		expect(findEditableText().props().editMode).toEqual(false);
 	});

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -51,6 +51,22 @@ describe('TitleSubHeader', () => {
 			'tc-subheader-details theme-tc-subheader-details tc-subheader-details-blink theme-tc-subheader-details-blink',
 		);
 	});
+	it('should go in edit mode', () => {
+		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
+		const findEditableText = () => wrapper.find('[feature="subheaderbar.rename"]');
+
+		findEditableText()
+			.props()
+			.onEdit();
+
+		expect(findEditableText().props().editMode).toEqual(true);
+
+		findEditableText()
+			.props()
+			.onCancel();
+
+		expect(findEditableText().props().editMode).toEqual(false);
+	});
 });
 
 describe('TitleSubHeader', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It's not possible to use SubHeaderBar title edition without storing the `editMode` in the consumer app.
https://user-images.githubusercontent.com/58977230/106452398-1c6a7200-6488-11eb-84b2-7b5fd4c2eca9.mp4

**What is the chosen solution to this problem?**

Pass down the `editMode` flag stored in the component
https://user-images.githubusercontent.com/58977230/106452520-4b80e380-6488-11eb-8d4e-309710d5d39b.mp4

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
