### PR TITLE
feat(components): add data-test & data-feature props to reset btn

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -2,10 +2,6 @@
 /home/travis/build/Talend/ui/packages/components/src/ActionIntercom/Intercom.component.js
   32:66  warning  React Hook useLayoutEffect has an unnecessary dependency: 'ref.current'. Either exclude it or remove the dependency array. Mutable values like 'ref.current' aren't valid dependencies because mutating them doesn't re-render the component  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/Actions/ActionButton/ActionButton.component.js
-  155:37  error  ["dataFeature"] is better written in dot notation  dot-notation
-  156:34  error  ["dataTest"] is better written in dot notation     dot-notation
-
 /home/travis/build/Talend/ui/packages/components/src/AppSwitcher/AppSwitcher.component.js
   40:10  error  Elements with the ARIA role "heading" must have the following attributes defined: aria-level  jsx-a11y/role-has-required-aria-props
 
@@ -147,16 +143,10 @@
 
 /home/travis/build/Talend/ui/packages/components/src/FilterBar/FilterBar.component.js
   123:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
-  176:31  error  ["dataFeature"] is better written in dot notation                                                                                                                                                                                                                                                            dot-notation
-  176:60  error  'data-feature' is missing in props validation                                                                                                                                                                                                                                                                react/prop-types
-  203:31  error  ["dataFeature"] is better written in dot notation                                                                                                                                                                                                                                                            dot-notation
-  203:60  error  'data-feature' is missing in props validation                                                                                                                                                                                                                                                                react/prop-types
-  204:28  error  ["dataTest"] is better written in dot notation                                                                                                                                                                                                                                                               dot-notation
-  204:54  error  'data-test' is missing in props validation                                                                                                                                                                                                                                                                   react/prop-types
-  223:29  error  ["dataTest"] is better written in dot notation                                                                                                                                                                                                                                                               dot-notation
-  223:58  error  ["dataTest"] is better written in dot notation                                                                                                                                                                                                                                                               dot-notation
-  224:32  error  ["dataFeature"] is better written in dot notation                                                                                                                                                                                                                                                            dot-notation
-  224:64  error  ["dataFeature"] is better written in dot notation                                                                                                                                                                                                                                                            dot-notation
+  223:44  error  ["dataTest"] is better written in dot notation                                                                                                                                                                                                                                                               dot-notation
+  224:50  error  ["dataFeature"] is better written in dot notation                                                                                                                                                                                                                                                            dot-notation
+  245:2   error  Unnecessarily computed property ['data-test'] found                                                                                                                                                                                                                                                          no-useless-computed-key
+  247:2   error  Unnecessarily computed property ['data-feature'] found                                                                                                                                                                                                                                                       no-useless-computed-key
 
 /home/travis/build/Talend/ui/packages/components/src/GridLayout/Tile/Tile.component.js
   27:4  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
@@ -321,5 +311,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 160 problems (140 errors, 20 warnings)
-  16 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 152 problems (132 errors, 20 warnings)
+  11 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -152,9 +152,6 @@ function ActionButton(props) {
 		[theme['btn-disabled']]: btnIsDisabled,
 	});
 
-	buttonProps['data-feature'] = rest.dataFeature || rest['data-feature'];
-	buttonProps['data-test'] = rest.dataTest || rest['data-test'];
-
 	let ariaLabel = tooltipLabel || label;
 	if (inProgress) {
 		ariaLabel = t('ACTION_IN_PROGRESS', {

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -152,6 +152,9 @@ function ActionButton(props) {
 		[theme['btn-disabled']]: btnIsDisabled,
 	});
 
+	buttonProps['data-feature'] = rest['data-feature'];
+	buttonProps['data-test'] = rest['data-test'];
+
 	let ariaLabel = tooltipLabel || label;
 	if (inProgress) {
 		ariaLabel = t('ACTION_IN_PROGRESS', {

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -152,8 +152,8 @@ function ActionButton(props) {
 		[theme['btn-disabled']]: btnIsDisabled,
 	});
 
-	buttonProps['data-feature'] = rest['data-feature'];
-	buttonProps['data-test'] = rest['data-test'];
+	buttonProps['data-feature'] = rest['dataFeature'] || rest['data-feature'];
+	buttonProps['data-test'] = rest['dataTest'] || rest['data-test'];
 
 	let ariaLabel = tooltipLabel || label;
 	if (inProgress) {

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -152,8 +152,8 @@ function ActionButton(props) {
 		[theme['btn-disabled']]: btnIsDisabled,
 	});
 
-	buttonProps['data-feature'] = rest['dataFeature'] || rest['data-feature'];
-	buttonProps['data-test'] = rest['dataTest'] || rest['data-test'];
+	buttonProps['data-feature'] = rest.dataFeature || rest['data-feature'];
+	buttonProps['data-test'] = rest.dataTest || rest['data-test'];
 
 	let ariaLabel = tooltipLabel || label;
 	if (inProgress) {

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -173,7 +173,7 @@ export class FilterBarComponent extends React.Component {
 					hideLabel
 					icon="talend-search"
 					bsStyle="link"
-					data-feature={this.props['dataFeature']}
+					data-feature={this.props['dataFeature'] || this.props['data-feature'] }
 					tooltipPlacement={this.props.tooltipPlacement}
 					role="search"
 				/>

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -50,10 +50,9 @@ function FilterInput(props) {
 	} = props;
 
 	const placeholderLabel = placeholder || t('LIST_FILTER_LABEL', { defaultValue: 'Filter' });
-
 	const inputProps = {
-		'data-test': rest['dataTest'],
-		'data-feature': rest['dataFeature'],
+		'data-test': rest.dataTest,
+		'data-feature': rest.dataFeature,
 		id,
 		name: 'search',
 		type: 'search',
@@ -99,7 +98,8 @@ FilterInput.propTypes = {
 	onFilter: PropTypes.func.isRequired,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,
-	'data-test': PropTypes.string,
+	dataTest: PropTypes.string,
+	dataFeature: PropTypes.string,
 	disabled: PropTypes.bool,
 	t: PropTypes.func.isRequired,
 };
@@ -173,7 +173,7 @@ export class FilterBarComponent extends React.Component {
 					hideLabel
 					icon="talend-search"
 					bsStyle="link"
-					data-feature={this.props['data-feature']}
+					data-feature={this.props['dataFeature']}
 					tooltipPlacement={this.props.tooltipPlacement}
 					role="search"
 				/>
@@ -200,8 +200,8 @@ export class FilterBarComponent extends React.Component {
 					/>
 					<FilterInput
 						disabled={this.props.disabled}
-						dataFeature={this.props['data-feature']}
-						dataTest={this.props['data-test']}
+						dataFeature={this.props['dataFeature'] || this.props['data-feature']}
+						dataTest={this.props['dataTest'] || this.props['data-test']}
 						autoFocus={this.props.autoFocus}
 						id={this.props.id && `${this.props.id}-input`}
 						debounceMinLength={this.props.debounceMinLength}
@@ -220,8 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
-							data-test={this.props['data-test'] && `${this.props['data-test']}-reset`}
-							data-feature={this.props['data-feature'] && `${this.props['data-feature']}-reset`}
+							dataTest={this.props['dataTest'] && `${this.props['dataTest']}-reset`}
+							dataFeature={this.props['dataFeature'] && `${this.props['dataFeature']}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}
@@ -241,8 +241,8 @@ FilterBarComponent.propTypes = {
 	autoFocus: PropTypes.bool,
 	id: PropTypes.string,
 	className: PropTypes.string,
-	'data-test': PropTypes.string,
-	'data-feature': PropTypes.string,
+	dataTest: PropTypes.string,
+	dataFeature: PropTypes.string,
 	debounceMinLength: PropTypes.number,
 	debounceTimeout: PropTypes.number,
 	docked: PropTypes.bool,

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -173,7 +173,7 @@ export class FilterBarComponent extends React.Component {
 					hideLabel
 					icon="talend-search"
 					bsStyle="link"
-					data-feature={dataFeature || this.props['data-feature'] }
+					data-feature={dataFeature || this.props['data-feature']}
 					tooltipPlacement={this.props.tooltipPlacement}
 					role="search"
 				/>

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -220,8 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
-							dataTest={dataTest && `${this.props['dataTest']}-reset`}
-							dataFeature={dataFeature && `${this.props['dataFeature']}-reset`}
+							dataTest={dataTest && `${dataTest}-reset`}
+							dataFeature={dataFeature && `${dataFeature}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}
@@ -242,9 +242,9 @@ FilterBarComponent.propTypes = {
 	id: PropTypes.string,
 	className: PropTypes.string,
 	dataTest: PropTypes.string,
-	['data-test']: PropTypes.string,
+	'data-test': PropTypes.string,
 	dataFeature: PropTypes.string,
-	['data-feature']: PropTypes.string,
+	'data-feature': PropTypes.string,
 	debounceMinLength: PropTypes.number,
 	debounceTimeout: PropTypes.number,
 	docked: PropTypes.bool,

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -220,8 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
-							data-test={`${this.props['data-test']}-reset`}
-							data-feature={`${this.props['data-feature']}-reset`}
+							data-test={this.props['data-test'] && `${this.props['data-test']}-reset`}
+							data-feature={this.props['data-feature'] && `${this.props['data-feature']}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -162,7 +162,7 @@ export class FilterBarComponent extends React.Component {
 	}
 
 	render() {
-		const { t } = this.props;
+		const { t, dataFeature, dataTest } = this.props;
 		if (this.props.dockable && this.props.docked) {
 			return (
 				<Action
@@ -173,7 +173,7 @@ export class FilterBarComponent extends React.Component {
 					hideLabel
 					icon="talend-search"
 					bsStyle="link"
-					data-feature={this.props['dataFeature'] || this.props['data-feature'] }
+					data-feature={dataFeature || this.props['data-feature'] }
 					tooltipPlacement={this.props.tooltipPlacement}
 					role="search"
 				/>
@@ -200,8 +200,8 @@ export class FilterBarComponent extends React.Component {
 					/>
 					<FilterInput
 						disabled={this.props.disabled}
-						dataFeature={this.props['dataFeature'] || this.props['data-feature']}
-						dataTest={this.props['dataTest'] || this.props['data-test']}
+						dataFeature={dataFeature || this.props['data-feature']}
+						dataTest={dataTest || this.props['data-test']}
 						autoFocus={this.props.autoFocus}
 						id={this.props.id && `${this.props.id}-input`}
 						debounceMinLength={this.props.debounceMinLength}
@@ -220,8 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
-							dataTest={this.props['dataTest'] && `${this.props['dataTest']}-reset`}
-							dataFeature={this.props['dataFeature'] && `${this.props['dataFeature']}-reset`}
+							dataTest={dataTest && `${this.props['dataTest']}-reset`}
+							dataFeature={dataFeature && `${this.props['dataFeature']}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}
@@ -242,7 +242,9 @@ FilterBarComponent.propTypes = {
 	id: PropTypes.string,
 	className: PropTypes.string,
 	dataTest: PropTypes.string,
+	['data-test']: PropTypes.string,
 	dataFeature: PropTypes.string,
+	['data-feature']: PropTypes.string,
 	debounceMinLength: PropTypes.number,
 	debounceTimeout: PropTypes.number,
 	docked: PropTypes.bool,

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -52,7 +52,8 @@ function FilterInput(props) {
 	const placeholderLabel = placeholder || t('LIST_FILTER_LABEL', { defaultValue: 'Filter' });
 
 	const inputProps = {
-		'data-test': rest['data-test'],
+		'data-test': rest['dataTest'],
+		'data-feature': rest['dataFeature'],
 		id,
 		name: 'search',
 		type: 'search',
@@ -199,7 +200,8 @@ export class FilterBarComponent extends React.Component {
 					/>
 					<FilterInput
 						disabled={this.props.disabled}
-						data-test={this.props['data-test']}
+						dataFeature={this.props['data-feature']}
+						dataTest={this.props['data-test']}
 						autoFocus={this.props.autoFocus}
 						id={this.props.id && `${this.props.id}-input`}
 						debounceMinLength={this.props.debounceMinLength}
@@ -218,6 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
+							data-test={this.props['data-test'] && `${this.props['data-test']}-reset`}
+							data-feature={this.props['data-feature'] && `${this.props['data-feature']}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -51,8 +51,8 @@ function FilterInput(props) {
 
 	const placeholderLabel = placeholder || t('LIST_FILTER_LABEL', { defaultValue: 'Filter' });
 	const inputProps = {
-		'data-test': rest.dataTest,
-		'data-feature': rest.dataFeature,
+		'data-test': rest['data-test'],
+		'data-feature': rest['data-feature'],
 		id,
 		name: 'search',
 		type: 'search',
@@ -98,8 +98,8 @@ FilterInput.propTypes = {
 	onFilter: PropTypes.func.isRequired,
 	placeholder: PropTypes.string,
 	value: PropTypes.string,
-	dataTest: PropTypes.string,
-	dataFeature: PropTypes.string,
+	'data-test': PropTypes.string,
+	'data-feature': PropTypes.string,
 	disabled: PropTypes.bool,
 	t: PropTypes.func.isRequired,
 };
@@ -162,7 +162,7 @@ export class FilterBarComponent extends React.Component {
 	}
 
 	render() {
-		const { t, dataFeature, dataTest } = this.props;
+		const { t } = this.props;
 		if (this.props.dockable && this.props.docked) {
 			return (
 				<Action
@@ -173,7 +173,7 @@ export class FilterBarComponent extends React.Component {
 					hideLabel
 					icon="talend-search"
 					bsStyle="link"
-					data-feature={dataFeature || this.props['data-feature']}
+					data-feature={this.props['data-feature']}
 					tooltipPlacement={this.props.tooltipPlacement}
 					role="search"
 				/>
@@ -200,8 +200,8 @@ export class FilterBarComponent extends React.Component {
 					/>
 					<FilterInput
 						disabled={this.props.disabled}
-						dataFeature={dataFeature || this.props['data-feature']}
-						dataTest={dataTest || this.props['data-test']}
+						data-feature={this.props['data-feature']}
+						data-test={this.props['data-test']}
 						autoFocus={this.props.autoFocus}
 						id={this.props.id && `${this.props.id}-input`}
 						debounceMinLength={this.props.debounceMinLength}
@@ -220,8 +220,8 @@ export class FilterBarComponent extends React.Component {
 						<Action
 							className={theme.remove}
 							id={this.props.id && `${this.props.id}-cross-icon`}
-							dataTest={dataTest && `${dataTest}-reset`}
-							dataFeature={dataFeature && `${dataFeature}-reset`}
+							data-test={`${this.props['data-test']}-reset`}
+							data-feature={`${this.props['data-feature']}-reset`}
 							bsStyle="link"
 							icon="talend-cross"
 							label={t('LIST_FILTER_REMOVE', { defaultValue: 'Remove filter' })}
@@ -241,9 +241,7 @@ FilterBarComponent.propTypes = {
 	autoFocus: PropTypes.bool,
 	id: PropTypes.string,
 	className: PropTypes.string,
-	dataTest: PropTypes.string,
 	'data-test': PropTypes.string,
-	dataFeature: PropTypes.string,
 	'data-feature': PropTypes.string,
 	debounceMinLength: PropTypes.number,
 	debounceTimeout: PropTypes.number,

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -44,7 +44,7 @@ describe('FilterBar', () => {
 	it('should accept data-test attribute', () => {
 		// given
 		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" focus />,
+			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" />,
 		);
 		// then
 		expect(filterInstance.find('input').prop('data-test')).toEqual('my.test');
@@ -57,6 +57,24 @@ describe('FilterBar', () => {
 		);
 		// then
 		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
+	});
+
+	it('should propagate and compose data-test attribute to the clear selection button', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" focus />,
+		);
+		// then
+		expect(filterInstance.find('button').prop('data-test')).toEqual('my.test-reset');
+	});
+
+	it('should propagate and compose data-feature attribute to the clear selection button', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" focus />,
+		);
+		// then
+		expect(filterInstance.find('button').prop('data-test')).toEqual('my.test-reset');
 	});
 
 	it('should be able to switch autofocus to false', () => {

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -43,7 +43,7 @@ describe('FilterBar', () => {
 
 	it('should accept data-test attribute', () => {
 		// given
-		const filterInstance = mount(<FilterBarComponent {...defaultProps} data-test="my.test" />);
+		const filterInstance = mount(<FilterBarComponent {...defaultProps} dataTest="my.test" value="filter text" focus />);
 		// then
 		expect(filterInstance.find('input').prop('data-test')).toEqual('my.test');
 	});
@@ -57,19 +57,28 @@ describe('FilterBar', () => {
 		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
 	});
 
-	it('should reuse data-feature for reset button custom attribute', () => {
+	it('should accept dataFeature prop', () => {
 		// given
 		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} focus data-feature="my.feature" value="filter text" />,
+			<FilterBarComponent {...defaultProps} dataFeature="my.feature" />,
+		);
+		// then
+		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
+	});
+
+	it('should reuse dataFeature props for reset button custom attribute', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} focus dataFeature="my.feature" value="filter text" />,
 		);
 		// then
 		expect(filterInstance.find('button').prop('data-feature')).toEqual('my.feature-reset');
 	});
 
-	it('should reuse data-test for reset button custom attribute', () => {
+	it('should reuse dataTest prop for reset button "data-teste" custom attribute', () => {
 		// given
 		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" />,
+			<FilterBarComponent {...defaultProps} dataTest="my.test" value="filter text" />,
 		);
 		// then
 		expect(filterInstance.find('button').prop('data-test')).toEqual('my.test-reset');

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -48,6 +48,33 @@ describe('FilterBar', () => {
 		expect(filterInstance.find('input').prop('data-test')).toEqual('my.test');
 	});
 
+	it('should accept data-feature attribute', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} data-feature="my.feature" />,
+		);
+		// then
+		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
+	});
+
+	it('should reuse data-feature for reset button custom attribute', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} focus data-feature="my.feature" value="filter text" />,
+		);
+		// then
+		expect(filterInstance.find('button').prop('data-feature')).toEqual('my.feature-reset');
+	});
+
+	it('should reuse data-test for reset button custom attribute', () => {
+		// given
+		const filterInstance = mount(
+			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" />,
+		);
+		// then
+		expect(filterInstance.find('button').prop('data-test')).toEqual('my.test-reset');
+	});
+
 	it('should be able to switch autofocus to false', () => {
 		// given
 		const filterInstance = shallow(<FilterBarComponent {...defaultProps} autoFocus={false} />);

--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -44,7 +44,7 @@ describe('FilterBar', () => {
 	it('should accept data-test attribute', () => {
 		// given
 		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} dataTest="my.test" value="filter text" focus />,
+			<FilterBarComponent {...defaultProps} data-test="my.test" value="filter text" focus />,
 		);
 		// then
 		expect(filterInstance.find('input').prop('data-test')).toEqual('my.test');
@@ -57,31 +57,6 @@ describe('FilterBar', () => {
 		);
 		// then
 		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
-	});
-
-	it('should accept dataFeature prop', () => {
-		// given
-		const filterInstance = mount(<FilterBarComponent {...defaultProps} dataFeature="my.feature" />);
-		// then
-		expect(filterInstance.find('input').prop('data-feature')).toEqual('my.feature');
-	});
-
-	it('should reuse dataFeature props for reset button custom attribute', () => {
-		// given
-		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} focus dataFeature="my.feature" value="filter text" />,
-		);
-		// then
-		expect(filterInstance.find('button').prop('data-feature')).toEqual('my.feature-reset');
-	});
-
-	it('should reuse dataTest prop for reset button "data-teste" custom attribute', () => {
-		// given
-		const filterInstance = mount(
-			<FilterBarComponent {...defaultProps} dataTest="my.test" value="filter text" />,
-		);
-		// then
-		expect(filterInstance.find('button').prop('data-test')).toEqual('my.test-reset');
 	});
 
 	it('should be able to switch autofocus to false', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
QA wants to target reset button easily

**What is the chosen solution to this problem?**
Add a data-test and a data-feature prop that will end up in data-test and data-feature attribute in html elements

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
