### PR TITLE
fix(components/ColumnChooser): locked is not working for single column

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.5.1 ",
+  "lerna": "2.5.1",
   "version": "6.11.0",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "lerna": "2.5.1",
+  "lerna": "2.5.1 ",
   "version": "6.11.0",
   "npmClient": "yarn",
   "useWorkspaces": true,

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -15,7 +15,7 @@ const columns = [
 		header: 'icon',
 		data: { iconName: 'talend-scheduler' },
 	},
-	{ key: 'icon', label: 'Icon', hidden: true, order: 5 },
+	{ key: 'icon', label: 'Icon', hidden: true, order: 5, locked:true },
 ];
 
 storiesOf('Data/List/Column Chooser', module)

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.stories.js
@@ -15,7 +15,7 @@ const columns = [
 		header: 'icon',
 		data: { iconName: 'talend-scheduler' },
 	},
-	{ key: 'icon', label: 'Icon', hidden: true, order: 5, locked:true },
+	{ key: 'icon', label: 'Icon', hidden: true, order: 5, locked: true },
 ];
 
 storiesOf('Data/List/Column Chooser', module)

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -15,6 +15,7 @@ const extractColumnValues = column => ({
 	label: column.label,
 	order: column.order,
 	key: column.key,
+	locked: column.locked,
 });
 
 /**

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.js
@@ -15,7 +15,7 @@ const extractColumnValues = column => ({
 	label: column.label,
 	order: column.order,
 	key: column.key,
-	locked: column.locked,
+	locked: !!column.locked,
 });
 
 /**

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/hooks/columnChooserManager.hook.test.js
@@ -15,7 +15,7 @@ const initialColumns = [
 		header: 'icon',
 		data: { iconName: 'talend-scheduler' },
 	},
-	{ key: 'icon', label: 'Icon', visible: true, order: 5 },
+	{ key: 'icon', label: 'Icon', visible: true, order: 5, locked: true },
 ];
 
 const lockedLeftItems = 2;
@@ -48,17 +48,17 @@ describe('useColumnChooserManager', () => {
 		expect(hookWithNoValue.columns).toEqual([]);
 	});
 
-	it('should have some columns with the first two left locked', () => {
+	it('should have some columns with the first two & icon column locked', () => {
 		// given before each
 		// when mounting before each
 		// then
 		expect(columnChooserHook.columns).toEqual([
 			{ key: 'id', label: 'Id', locked: true, order: 1, visible: true },
 			{ key: 'name', label: 'Name', locked: true, order: 2, visible: true },
-			{ key: 'author', label: 'Author', order: 3, visible: true },
-			{ key: 'modified', label: 'Modified', order: 4, visible: true },
-			{ key: 'icon', label: 'Icon', order: 5, visible: true },
-			{ key: 'created', label: 'Created', order: 6, visible: true },
+			{ key: 'author', label: 'Author', order: 3, visible: true, locked: false },
+			{ key: 'modified', label: 'Modified', order: 4, visible: true, locked: false },
+			{ key: 'icon', label: 'Icon', order: 5, visible: true, locked: true },
+			{ key: 'created', label: 'Created', order: 6, visible: true, locked: false },
 		]);
 	});
 
@@ -94,7 +94,7 @@ describe('useColumnChooserManager', () => {
 		expect(columnChooserHook.columns[1].visible).toBe(true);
 		expect(columnChooserHook.columns[2].visible).toBe(false);
 		expect(columnChooserHook.columns[3].visible).toBe(false);
-		expect(columnChooserHook.columns[4].visible).toBe(false);
+		expect(columnChooserHook.columns[4].visible).toBe(true);
 	});
 
 	it('should filter the list of columns', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In column chooser, column config `locked` doesn't take effect.
Currently it only support to lock the first N columns. N is specified by `nbLockedLeftItems`.
**What is the chosen solution to this problem?**
Use user's config of locked if set.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
