### PR TITLE
fix(datagrid): The semantic type case is not retained

### DIFF
--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
@@ -14,7 +14,6 @@ $td-grip-resize-width: 6px !default;
 	&::first-letter {
 		text-transform: uppercase;
 	}
-	text-transform: lowercase;
 }
 
 .td-header-component {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Ticket: https://jira.talendforge.org/browse/TDC-5216

When we are on dataset preparation semantic type is lowercase instead of case as type in semantic type option

**What is the chosen solution to this problem?**

update style of header description type datagrid

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

**[ ] This PR introduces a breaking change**

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
