### PR TITLE
chore(i18n): change from edit to rename in EditableText

### DIFF
--- a/packages/components/src/EditableText/EditableText.component.js
+++ b/packages/components/src/EditableText/EditableText.component.js
@@ -30,7 +30,7 @@ export function PlainTextTitle({ componentClass, onEdit, disabled, text, inProgr
 			</TooltipTrigger>
 			<Action
 				name="action-edit"
-				label={t('MODIFY_TOOLTIP', { defaultValue: 'Edit' })}
+				label={t('MODIFY_TOOLTIP', { defaultValue: 'Rename' })}
 				icon="talend-pencil"
 				onClick={onEdit}
 				bsStyle="link"

--- a/packages/components/src/EditableText/__snapshots__/EditableText.test.js.snap
+++ b/packages/components/src/EditableText/__snapshots__/EditableText.test.js.snap
@@ -130,7 +130,7 @@ exports[`PlainTextTitle should render 1`] = `
     data-feature="my.custom.feature"
     hideLabel={true}
     icon="talend-pencil"
-    label="Edit"
+    label="Rename"
     name="action-edit"
     onClick={[MockFunction]}
   />
@@ -159,7 +159,7 @@ exports[`PlainTextTitle should render provided component class 1`] = `
     data-feature="my.custom.feature"
     hideLabel={true}
     icon="talend-pencil"
-    label="Edit"
+    label="Rename"
     name="action-edit"
     onClick={[MockFunction]}
   />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
change edit pencil label from "edit" to "rename"
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
