### PR TITLE
fix(cmf): export httpInterceptors

### DIFF
--- a/packages/cmf/src/index.js
+++ b/packages/cmf/src/index.js
@@ -22,6 +22,7 @@ import localStorage from './localStorage';
 import onError from './onError';
 import reduxStorage from './reduxstorage';
 import * as mock from './mock';
+import httpInterceptors from './httpInterceptors';
 
 // DEPRECATED APIs
 import action from './action';
@@ -88,6 +89,7 @@ export default {
 	constants,
 	expression,
 	expressions,
+	httpInterceptors,
 	middlewares,
 	module: cmfModule,
 	onError,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In the context of moving our http call from gateway to public API we need to be able to configure every clients at once with interceptors.
But they are not exported

**What is the chosen solution to this problem?**

export it

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
