### PR TITLE
feat(ActionDropdown): allow applying transformation on action dropdown icon

### DIFF
--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -192,6 +192,7 @@ class ActionDropdown extends React.Component {
 			bsStyle = 'default',
 			hideLabel,
 			icon,
+			iconTransform,
 			items = [],
 			badge,
 			label,
@@ -211,7 +212,7 @@ class ActionDropdown extends React.Component {
 		const Renderers = Inject.getAll(getComponent, { MenuItem, DropdownButton });
 		const injected = Inject.all(getComponent, components, InjectDropdownMenuItem);
 		const title = [
-			icon && <Icon name={icon} key="icon" />,
+			icon && <Icon name={icon} transform={iconTransform} key="icon" />,
 			!hideLabel && (
 				<span className="tc-dropdown-button-title-label" key="label">
 					{label}
@@ -304,6 +305,7 @@ ActionDropdown.propTypes = {
 	noCaret: PropTypes.bool,
 	pullRight: PropTypes.bool,
 	icon: PropTypes.string,
+	iconTransform: PropTypes.string,
 	items: PropTypes.oneOfType([
 		PropTypes.arrayOf(
 			PropTypes.shape({

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
@@ -184,7 +184,7 @@ describe('ActionDropdown', () => {
 		// given
 		const props = {
 			id: 'dropdown-id',
-			label: 'button label',
+			label: 'Button label',
 			icon: 'talend-ellipsis',
 			iconTransform: 'rotate-90',
 		};

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
@@ -179,4 +179,20 @@ describe('ActionDropdown', () => {
 		// then
 		expect(wrapper.html()).toMatchSnapshot();
 	});
+
+	it('should apply transformation on icon', () => {
+		// given
+		const props = {
+			id: 'dropdown-id',
+			label: 'button label',
+			icon: 'talend-ellipsis',
+			iconTransform: 'rotate-90',
+		};
+
+		// when
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownButton');
+
+		// then
+		expect(wrapper.html()).toMatchSnapshot();
+	});
 });

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`ActionDropdown should apply transformation on icon 1`] = `
 <div class="dropdown btn-group btn-group-default">
-  <button aria-label="button label"
+  <button aria-label="Button label"
           id="dropdown-id"
           role="button"
           aria-haspopup="true"
@@ -17,7 +17,7 @@ exports[`ActionDropdown should apply transformation on icon 1`] = `
     >
     </svg>
     <span class="tc-dropdown-button-title-label">
-      button label
+      Button label
     </span>
     <svg name="talend-caret-down"
          class="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -1,5 +1,49 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`ActionDropdown should apply transformation on icon 1`] = `
+<div class="dropdown btn-group btn-group-default">
+  <button aria-label="button label"
+          id="dropdown-id"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          type="button"
+          class="theme-tc-dropdown-button tc-dropdown-button dropdown-toggle btn btn-default"
+  >
+    <svg name="talend-ellipsis"
+         class="theme-tc-svg-icon tc-svg-icon theme-rotate-90"
+         focusable="false"
+         aria-hidden="true"
+    >
+    </svg>
+    <span class="tc-dropdown-button-title-label">
+      button label
+    </span>
+    <svg name="talend-caret-down"
+         class="theme-tc-svg-icon tc-svg-icon theme-tc-dropdown-caret"
+         focusable="false"
+         aria-hidden="true"
+    >
+    </svg>
+  </button>
+  <ul role="menu"
+      class="dropdown-menu"
+      aria-labelledby="dropdown-id"
+  >
+    <li role="presentation"
+        class="disabled"
+    >
+      <a role="menuitem"
+         tabindex="-1"
+         href="#"
+      >
+        No options
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`ActionDropdown should render "no option" item when items array is empty 1`] = `
 <ul role="menu"
     class="dropdown-menu"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow applying icon transformation on icon in ActionDropdown

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
