### PR TITLE
fix(dataviz): remove locale as peer dep

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -24,6 +24,8 @@ Types of changes
 -   `Fixed` for any bug fixes.
 -   `Security` in case of vulnerabilities.
 
+## [unreleased]
+
 ## [0.4.2]
 
 ### Fixed

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,7 +26,9 @@ Types of changes
 
 ## [0.4.2]
 
-- [fix(dataviz): remove locale as peer dep](https://github.com/Talend/ui/pull/3216)
+### Fixed
+
+- [remove locale as peer dep](https://github.com/Talend/ui/pull/3216)
 
 ## [0.4.1]
 

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -24,7 +24,9 @@ Types of changes
 -   `Fixed` for any bug fixes.
 -   `Security` in case of vulnerabilities.
 
-## [unreleased]
+## [0.4.2]
+
+- [fix(dataviz): remove locale as peer dep](https://github.com/Talend/ui/pull/3216)
 
 ## [0.4.1]
 

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -76,8 +76,6 @@
   "peerDependencies": {
     "@talend/bootstrap-theme": "^6.1.7",
     "@talend/icons": "^6.2.2",
-    "@talend/locales-tui": ">=5.29.0",
-    "@talend/locales-tui-dataviz": "0.0.1",
     "@talend/react-components": "^6.4.0",
     "i18next": "^15.1.3",
     "react": "^16.14.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

dataviz is not served from CDN because of peer dep

**What is the chosen solution to this problem?**

remove peer deps for non UMD dependencies

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
