### PR TITLE
feat(components/CellDatetime): handling timezone

### DIFF
--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -6,6 +6,7 @@ import pick from 'lodash/pick';
 import { distanceInWordsToNow, format } from 'date-fns';
 import isValid from 'date-fns/is_valid';
 import parse from 'date-fns/parse';
+import { formatToTimeZone } from 'date-fns-timezone';
 import { withTranslation } from 'react-i18next';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
@@ -25,6 +26,11 @@ export function computeValue(cellData, columnData, t) {
 				locale: getLocale(t),
 			});
 		} else if (columnData.mode === 'format') {
+			if (columnData.timeZone) {
+				return formatToTimeZone(cellData, columnData.pattern || DATE_TIME_FORMAT, {
+					timeZone: columnData.timeZone,
+				});
+			}
 			return format(cellData, columnData.pattern || DATE_TIME_FORMAT);
 		}
 	}
@@ -45,16 +51,28 @@ export class CellDatetimeComponent extends React.Component {
 
 	render() {
 		const { cellData, columnData, t } = this.props;
+		const computedValue = computeValue(cellData, columnData, t);
+
 		const cell = (
 			<div className={classnames('cell-datetime-container', styles['cell-datetime-container'])}>
-				{computeValue(cellData, columnData, t)}
+				{computedValue}
 			</div>
 		);
 
 		if (columnData.mode === 'ago') {
+			let tooltipLabel = '';
+
+			if (columnData.timeZone) {
+				tooltipLabel = formatToTimeZone(cellData, columnData.pattern || DATE_TIME_FORMAT, {
+					timeZone: columnData.timeZone,
+				});
+			} else {
+				tooltipLabel = format(cellData, columnData.pattern || DATE_TIME_FORMAT);
+			}
+
 			return (
 				<TooltipTrigger
-					label={format(cellData, columnData.pattern || DATE_TIME_FORMAT)}
+					label={tooltipLabel}
 					tooltipPlacement={columnData.tooltipPlacement || 'bottom'}
 				>
 					{cell}

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { distanceInWordsToNow, format } from 'date-fns';
+import { formatToTimeZone } from 'date-fns-timezone';
 
 import { computeValue, CellDatetimeComponent } from './CellDatetime.component';
 import getDefaultT from '../../translate';
@@ -11,6 +12,10 @@ jest.mock('../../i18n/DateFnsLocale/locale');
 jest.mock('date-fns', () => ({
 	format: jest.fn(() => '2016-09-22 09:00:00'),
 	distanceInWordsToNow: jest.fn(() => 'about 1 month ago'),
+}));
+
+jest.mock('date-fns-timezone', () => ({
+	formatToTimeZone: jest.fn(() => '2016-09-22 09:00:00'),
 }));
 
 describe('CellDatetime', () => {
@@ -93,7 +98,7 @@ describe('CellDatetime', () => {
 		expect(format).toHaveBeenCalledWith(cellDataWithOffset, columnData.pattern);
 	});
 
-	it('should test CellDatetime render with tooltip', () => {
+	it('should render CellDatetime with tooltip in ago mode', () => {
 		// when
 		const columnData = {
 			mode: 'ago',
@@ -105,5 +110,22 @@ describe('CellDatetime', () => {
 		expect(wrapper.find('TooltipTrigger').length).toBe(1);
 		expect(wrapper.find('TooltipTrigger').getElement().props.label).toBe('2016-09-22 09:00:00');
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should format with timezone', () => {
+		// when
+		const columnData = {
+			mode: 'format',
+			pattern: 'YYYY-MM-DD HH:mm:ss',
+			timeZone: 'Pacific/Niue',
+		};
+
+		const cellData = 1474495200000;
+		computeValue(cellData, columnData);
+
+		// then
+		expect(formatToTimeZone).toHaveBeenCalledWith(cellData, columnData.pattern, {
+			timeZone: columnData.timeZone,
+		});
 	});
 });

--- a/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellDatetime/__snapshots__/CellDatetime.test.js.snap
@@ -13,7 +13,7 @@ exports[`CellDatetime should render CellDatetime 1`] = `
 </TooltipTrigger>
 `;
 
-exports[`CellDatetime should test CellDatetime render with tooltip 1`] = `
+exports[`CellDatetime should render CellDatetime with tooltip in ago mode 1`] = `
 <TooltipTrigger
   label="2016-09-22 09:00:00"
   tooltipPlacement="bottom"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently not possible to format to specific timezone using CellDatetime

**What is the chosen solution to this problem?**
Implement possibility to format to specific timezone in CellDatetime

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
