### PR TITLE
fix(components/Typeahead): fit in viewport

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -69,9 +69,9 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 			fn: ({ state }) => {
 				const GAP = 45; // the offset between the end of items container and screen boundaries
 				const inputDimensions = state.rects.reference;
-				const { x, height } = inputDimensions;
-				const offsetTop = x - GAP;
-				const offsetBottom = window.innerHeight - x - height - GAP;
+				const { y, height } = inputDimensions;
+				const offsetTop = y - GAP;
+				const offsetBottom = window.innerHeight - y - height - GAP;
 				const placements = state.placement.split('-');
 				let newPlacement = state.placement;
 				if (placements[0] === 'top' && offsetBottom > offsetTop) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Using `MultiSelectTag` with a long list can hide `Typeahead` overflow
http://talend.surge.sh/forms/?path=/story/uiform-v2-core-fields--core-multiselecttag

**What is the chosen solution to this problem?**
Fix its max-height computation
http://3227.talend.surge.sh/forms/?path=/story/uiform-v2-core-fields--core-multiselecttag

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
