### PR TITLE
fix(Components/InputDatePicker): Error with the focus

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -55,9 +55,6 @@
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
   26:5  warning  React Hook useEffect has missing dependencies: 'state.endDateTime' and 'state.startDateTime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
-  43:24  error  'setPopperElement' is assigned a value but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
   94:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
@@ -305,5 +302,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 146 problems (127 errors, 19 warnings)
+✖ 145 problems (126 errors, 19 warnings)
   7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -36,7 +36,6 @@ function onMouseDown(event) {
 export default function InputDatePicker(props) {
 	const popoverId = `date-picker-${props.id || uuid.v4()}`;
 
-	const inputRef = useRef(null);
 	const containerRef = useRef(null);
 
 	const [referenceElement, setReferenceElement] = useState(null);
@@ -71,8 +70,7 @@ export default function InputDatePicker(props) {
 				id={popoverId}
 				role="button"
 				className={theme.popper}
-				onFocus={() => setReferenceElement(inputRef.current)}
-				ref={inputRef}
+				ref={setPopperElement}
 				style={styles.popper}
 				{...attributes.popper}
 				onMouseDown={onMouseDown}
@@ -86,7 +84,7 @@ export default function InputDatePicker(props) {
 		<DatePicker.Manager
 			value={props.value}
 			dateFormat={props.dateFormat}
-			onChange={(...args) => handlers.onChange(...args, inputRef.current)}
+			onChange={(...args) => handlers.onChange(...args, referenceElement)}
 			useUTC={props.useUTC}
 			timezone={props.timezone}
 		>
@@ -97,7 +95,7 @@ export default function InputDatePicker(props) {
 				onFocusIn={handlers.onFocus}
 				onFocusOut={handlers.onBlur}
 				onKeyDown={event => {
-					handlers.onKeyDown(event, inputRef.current);
+					handlers.onKeyDown(event, referenceElement);
 				}}
 			>
 				{datePicker}

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -71,7 +71,8 @@ export default function InputDatePicker(props) {
 				id={popoverId}
 				role="button"
 				className={theme.popper}
-				ref={setPopperElement}
+				onFocus={() => setReferenceElement(inputRef.current)}
+				ref={inputRef}
 				style={styles.popper}
 				{...attributes.popper}
 				onMouseDown={onMouseDown}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
An error appear after doing a change in the date picker (TypeError: Cannot read property 'focus' of null)

To reproduce it, Click on the input and choose another date.

https://user-images.githubusercontent.com/32456736/109135629-92948880-7757-11eb-8922-98c3167c452a.mp4


**What is the chosen solution to this problem?**
fix the ref attribute and the call to the onChange

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
