### PR TITLE
chore(release): trigger GitHub Action after release

### DIFF
--- a/.github/workflows/dataviz-autopublish.yml
+++ b/.github/workflows/dataviz-autopublish.yml
@@ -55,5 +55,5 @@ jobs:
       - name: Update Talend CDN content
         id: cdn
         run: |
-          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
+          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download-talend-ui.yml/dispatches --data '{"ref": "main"}'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,4 +60,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: |
-          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download.yml/dispatches --data '{"ref": "main"}'
+          curl -XPOST -u "frassinier:${{ secrets.PERSONAL_ACCESS_TOKEN }}" -H "Accept: application/vnd.github.everest-preview+json" -H "Content-Type: application/json" https://api.github.com/repos/talend/cdn-content/actions/workflows/download-talend-ui.yml/dispatches --data '{"ref": "main"}'


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
CDN related GitHub action name has changed
 
**What is the chosen solution to this problem?**
Update its name

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
