### PR TITLE
fix(DatePicker): ref error

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -55,6 +55,9 @@
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
   26:5  warning  React Hook useEffect has missing dependencies: 'state.endDateTime' and 'state.startDateTime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
+/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+  1:17  error  'useRef' is defined but never used  @typescript-eslint/no-unused-vars
+
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
   94:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
@@ -302,5 +305,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 145 problems (126 errors, 19 warnings)
+✖ 146 problems (127 errors, 19 warnings)
   7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -55,9 +55,6 @@
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
   26:5  warning  React Hook useEffect has missing dependencies: 'state.endDateTime' and 'state.startDateTime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
-  1:17  error  'useRef' is defined but never used  @typescript-eslint/no-unused-vars
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
   94:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
@@ -305,5 +302,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 146 problems (127 errors, 19 warnings)
+✖ 145 problems (126 errors, 19 warnings)
   7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -1,4 +1,4 @@
-import React, { useRef, useState } from 'react';
+import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import uuid from 'uuid';

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -36,9 +36,6 @@ function onMouseDown(event) {
 export default function InputDatePicker(props) {
 	const popoverId = `date-picker-${props.id || uuid.v4()}`;
 
-	const inputRef = useRef(null);
-	const containerRef = useRef(null);
-
 	const [referenceElement, setReferenceElement] = useState(null);
 	const [popperElement, setPopperElement] = useState(null);
 	const { styles, attributes } = usePopper(referenceElement, popperElement, {
@@ -54,7 +51,7 @@ export default function InputDatePicker(props) {
 		disabled: props.disabled,
 		handleBlur: props.onBlur,
 		handleChange: props.onChange,
-		handleKeyDown: () => focusOnCalendar(containerRef.current),
+		handleKeyDown: () => focusOnCalendar(popperElement),
 	});
 
 	const inputProps = omit(props, PROPS_TO_OMIT_FOR_INPUT);
@@ -75,6 +72,7 @@ export default function InputDatePicker(props) {
 				style={styles.popper}
 				{...attributes.popper}
 				onMouseDown={onMouseDown}
+				key="popper"
 			>
 				<DatePicker.Picker {...props} />
 			</div>
@@ -85,18 +83,17 @@ export default function InputDatePicker(props) {
 		<DatePicker.Manager
 			value={props.value}
 			dateFormat={props.dateFormat}
-			onChange={(...args) => handlers.onChange(...args, inputRef.current)}
+			onChange={(...args) => handlers.onChange(...args, referenceElement)}
 			useUTC={props.useUTC}
 			timezone={props.timezone}
 		>
 			<FocusManager
 				className={classnames(theme['date-picker'], 'date-picker')}
-				divRef={containerRef}
 				onClick={handlers.onClick}
 				onFocusIn={handlers.onFocus}
 				onFocusOut={handlers.onBlur}
 				onKeyDown={event => {
-					handlers.onKeyDown(event, inputRef.current);
+					handlers.onKeyDown(event, referenceElement);
 				}}
 			>
 				{datePicker}

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.component.test.js.snap
@@ -40,29 +40,6 @@ exports[`InputDateTimePicker should render 1`] = `
           >
             <FocusManager
               className="theme-date-picker date-picker"
-              divRef={
-                Object {
-                  "current": <div
-                    class="theme-date-picker date-picker"
-                    tabindex="-1"
-                  >
-                    <input
-                      autocomplete="off"
-                      class="form-control"
-                      id="my-picker-date-picker-input"
-                      placeholder="YYYY-MM-DD"
-                      style="width: 47px;"
-                      type="text"
-                      value="2017-04-04"
-                    />
-                    <span
-                      style="font-weight: 400; font-size: 1.6rem; visibility: hidden; position: absolute;"
-                    >
-                      YYYY-MM-DD
-                    </span>
-                  </div>,
-                }
-              }
               onClick={[Function]}
               onFocusIn={[Function]}
               onFocusOut={[Function]}

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
@@ -71,29 +71,6 @@ exports[`InputDateTimeRangePicker should render 1`] = `
                   >
                     <FocusManager
                       className="theme-date-picker date-picker"
-                      divRef={
-                        Object {
-                          "current": <div
-                            class="theme-date-picker date-picker"
-                            tabindex="-1"
-                          >
-                            <input
-                              autocomplete="off"
-                              class="form-control"
-                              id="my-picker-start-date-picker-input"
-                              placeholder="YYYY-MM-DD"
-                              style="width: 47px;"
-                              type="text"
-                              value="2019-12-01"
-                            />
-                            <span
-                              style="font-weight: 400; font-size: 1.6rem; visibility: hidden; position: absolute;"
-                            >
-                              YYYY-MM-DD
-                            </span>
-                          </div>,
-                        }
-                      }
                       onClick={[Function]}
                       onFocusIn={[Function]}
                       onFocusOut={[Function]}
@@ -361,29 +338,6 @@ exports[`InputDateTimeRangePicker should render 1`] = `
                   >
                     <FocusManager
                       className="theme-date-picker date-picker"
-                      divRef={
-                        Object {
-                          "current": <div
-                            class="theme-date-picker date-picker"
-                            tabindex="-1"
-                          >
-                            <input
-                              autocomplete="off"
-                              class="form-control"
-                              id="my-picker-end-date-picker-input"
-                              placeholder="YYYY-MM-DD"
-                              style="width: 47px;"
-                              type="text"
-                              value="2019-12-11"
-                            />
-                            <span
-                              style="font-weight: 400; font-size: 1.6rem; visibility: hidden; position: absolute;"
-                            >
-                              YYYY-MM-DD
-                            </span>
-                          </div>,
-                        }
-                      }
                       onClick={[Function]}
                       onFocusIn={[Function]}
                       onFocusOut={[Function]}
@@ -695,29 +649,6 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
                   >
                     <FocusManager
                       className="theme-date-picker date-picker"
-                      divRef={
-                        Object {
-                          "current": <div
-                            class="theme-date-picker date-picker"
-                            tabindex="-1"
-                          >
-                            <input
-                              autocomplete="off"
-                              class="form-control"
-                              id="my-picker-start-date-picker-input"
-                              placeholder="YYYY-MM-DD"
-                              style="width: 47px;"
-                              type="text"
-                              value=""
-                            />
-                            <span
-                              style="font-weight: 400; font-size: 1.6rem; visibility: hidden; position: absolute;"
-                            >
-                              YYYY-MM-DD
-                            </span>
-                          </div>,
-                        }
-                      }
                       onClick={[Function]}
                       onFocusIn={[Function]}
                       onFocusOut={[Function]}
@@ -1016,29 +947,6 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
                   >
                     <FocusManager
                       className="theme-date-picker date-picker"
-                      divRef={
-                        Object {
-                          "current": <div
-                            class="theme-date-picker date-picker"
-                            tabindex="-1"
-                          >
-                            <input
-                              autocomplete="off"
-                              class="form-control"
-                              id="my-picker-end-date-picker-input"
-                              placeholder="YYYY-MM-DD"
-                              style="width: 47px;"
-                              type="text"
-                              value=""
-                            />
-                            <span
-                              style="font-weight: 400; font-size: 1.6rem; visibility: hidden; position: absolute;"
-                            >
-                              YYYY-MM-DD
-                            </span>
-                          </div>,
-                        }
-                      }
                       onClick={[Function]}
                       onFocusIn={[Function]}
                       onFocusOut={[Function]}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On date selection in date picker, there is an error because the reference are not defined.
In fact the references in the component are not clear, there are duplications and only one of the duplications is set. That causes the problem of null object because all of them are used in parts of the code.

**What is the chosen solution to this problem?**
Remove the duplications, set only 1 ref for the input et 1 ref for the popper div.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
