### PR TITLE
feat(chore) : add minimal height on typehead

### DIFF
--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -83,6 +83,8 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 				state.placement = newPlacement;
 				// eslint-disable-next-line no-param-reassign
 				state.styles.popper.maxHeight = `${maxHeight}px`;
+				// eslint-disable-next-line no-param-reassign
+				state.styles.popper.minHeight = `${height}px`;
 			},
 		}),
 		[],

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -157,7 +157,7 @@ export function renderItemsContainerFactory(
 				<div
 					ref={containerProps.ref}
 					className={theme['items-body']}
-					style={{ maxHeight: styles.popper.maxHeight }}
+					style={{ maxHeight: styles.popper.maxHeight, minHeight: styles.popper.minHeight }}
 				>
 					{render(
 						content,

--- a/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
+++ b/packages/components/src/Typeahead/__snapshots__/Typeahead.snapshot.test.js.snap
@@ -50,6 +50,7 @@ exports[`Typeahead injection should use render props to inject extra components 
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >
@@ -181,6 +182,7 @@ exports[`Typeahead items should render typeahead items with match 1`] = `
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >
@@ -442,6 +444,7 @@ exports[`Typeahead items should render typeahead with loading entry 1`] = `
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >
@@ -507,6 +510,7 @@ exports[`Typeahead items should render typeahead with object items 1`] = `
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >
@@ -710,6 +714,7 @@ exports[`Typeahead items should render typeahead with string items 1`] = `
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >
@@ -823,6 +828,7 @@ exports[`Typeahead items should render typeahead without items 1`] = `
       style={
         Object {
           "maxHeight": undefined,
+          "minHeight": undefined,
         }
       }
     >

--- a/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/MultiSelectTagWidget/__snapshots__/MultiSelectTagWidget.test.js.snap
@@ -68,6 +68,7 @@ exports[`MultiSelectTagWidget should render multiSelectTagWidget dropdown 1`] = 
     style={
       Object {
         "maxHeight": undefined,
+        "minHeight": undefined,
       }
     }
   >
@@ -125,6 +126,7 @@ exports[`MultiSelectTagWidget should render section title when items has categor
     style={
       Object {
         "maxHeight": undefined,
+        "minHeight": undefined,
       }
     }
   >
@@ -201,6 +203,7 @@ exports[`MultiSelectTagWidget should take default message when there isnt items 
     style={
       Object {
         "maxHeight": undefined,
+        "minHeight": undefined,
       }
     }
   >


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Problem: when too many tags on a dataset, suggestion list on add tags is not displayed

**What is the chosen solution to this problem?**
fix a min height to have always suggestion displayed

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

**[ ] This PR introduces a breaking change**

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
