### PR TITLE
fix(components/Badge): Readonly badge cursor

### DIFF
--- a/packages/components/src/Badge/Badge.scss
+++ b/packages/components/src/Badge/Badge.scss
@@ -40,12 +40,9 @@ $tc-badge-disabled-opacity: 0.62;
 .tc-badge {
 	display: inline-flex;
 	max-width: 23.5rem;
-	cursor: pointer;
 
-	&.tc-badge-readonly {
-		.tc-badge-button {
-			cursor: default;
-		}
+	&:not(.tc-badge-readonly) {
+		cursor: pointer;
 	}
 
 	.tc-badge-button {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Read-only badges should have the default cursor, but as it is, pointer cursor is shown when hovering parent element.

**What is the chosen solution to this problem?**
Only apply pointer cursor on non ".readonly" badges

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
