### PR TITLE
chore(Storybook): use latest icons

### DIFF
--- a/packages/components/.storybook/config.js
+++ b/packages/components/.storybook/config.js
@@ -26,7 +26,7 @@ addDecorator(storyFn => <ThemeProvider>{storyFn()}</ThemeProvider>);
 addDecorator(storyFn => (
 	<>
 		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+			bundles={['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg']}
 		/>
 		{storyFn()}
 	</>

--- a/packages/containers/.storybook/config.js
+++ b/packages/containers/.storybook/config.js
@@ -36,7 +36,7 @@ addDecorator(withA11y);
 addDecorator(storyFn => (
 	<>
 		<IconsProvider
-			bundles={['https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg']}
+			bundles={['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg']}
 		/>
 		{storyFn()}
 	</>

--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -15,9 +15,7 @@ function withIconsProvider(story) {
 	return (
 		<>
 			<IconsProvider
-				bundles={[
-					'https://statics-dev.cloud.talend.com/@talend/icons/6.1.4/dist/svg-bundle/all.svg',
-				]}
+				bundles={['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg']}
 			/>
 			{story()}
 		</>

--- a/packages/stepper/.storybook/config.js
+++ b/packages/stepper/.storybook/config.js
@@ -14,7 +14,7 @@ addDecorator(withInfo);
 addDecorator(checkA11y);
 addDecorator(story => (
 	<React.Fragment>
-		<IconsProvider />
+		<IconsProvider bundles={['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg']} />
 		{story()}
 	</React.Fragment>
 ));


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icon bundle URL is hardcoded (with the version) which it's hard to maintain

**What is the chosen solution to this problem?**
Use unpkg to retrieve the last version before thinking of a better way to achieve it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
