### PR TITLE
fix(components/SubHeaderBar): icon style ponderation

### DIFF
--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
@@ -18,7 +18,7 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 	margin: 0;
 	height: 100%;
 
-	&-icon {
+	& &-icon {
 		align-self: center;
 		width: $tc-input-subheader-size-large;
 		height: $tc-input-subheader-size-large;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Styled components used in the Design System have a better ponderation (<style> vs <link>)

**What is the chosen solution to this problem?**
Increase the weight of the icon on the `SubHeaderBar`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
