### PR TITLE
fix(components/tag): theme provider

### DIFF
--- a/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
+++ b/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
@@ -68,11 +68,13 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
               >
                 on TDP
               </div>
-              <coral.tag class="theme-undefined"
-                         aria-describedby="42"
-              >
-                XML
-              </coral.tag>
+              <coral.themeprovider>
+                <coral.tag class="theme-undefined"
+                           aria-describedby="42"
+                >
+                  XML
+                </coral.tag>
+              </coral.themeprovider>
             </div>
           </div>
         </button>
@@ -95,9 +97,11 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
     <div class="panel-body">
       <dl class="theme-content">
         <dt class="theme-label">
-          <coral.tag>
-            Content
-          </coral.tag>
+          <coral.themeprovider>
+            <coral.tag>
+              Content
+            </coral.tag>
+          </coral.themeprovider>
         </dt>
         <dd class="theme-description">
           Description3
@@ -176,11 +180,13 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
               >
                 on TDP
               </div>
-              <coral.tag class="theme-undefined"
-                         aria-describedby="42"
-              >
-                XML
-              </coral.tag>
+              <coral.themeprovider>
+                <coral.tag class="theme-undefined"
+                           aria-describedby="42"
+                >
+                  XML
+                </coral.tag>
+              </coral.themeprovider>
             </div>
           </div>
         </button>
@@ -200,9 +206,11 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
     <div class="panel-body">
       <dl class="theme-content">
         <dt class="theme-label">
-          <coral.tag>
-            Content
-          </coral.tag>
+          <coral.themeprovider>
+            <coral.tag>
+              Content
+            </coral.tag>
+          </coral.themeprovider>
         </dt>
         <dd class="theme-description">
           Description3
@@ -281,11 +289,13 @@ exports[`CollapsiblePanel should render default without content 1`] = `
               >
                 on TDP
               </div>
-              <coral.tag class="theme-undefined"
-                         aria-describedby="42"
-              >
-                XML
-              </coral.tag>
+              <coral.themeprovider>
+                <coral.tag class="theme-undefined"
+                           aria-describedby="42"
+                >
+                  XML
+                </coral.tag>
+              </coral.themeprovider>
             </div>
           </div>
         </button>

--- a/packages/components/src/Tag/Tag.component.js
+++ b/packages/components/src/Tag/Tag.component.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Tag as CoralTag } from '@talend/design-system';
+import { Tag as CoralTag, ThemeProvider as CoralThemeProvider } from '@talend/design-system';
 
 /**
  * Proxy to https://design.talend.com/?path=/docs/components-tag--default-story#tag
@@ -23,7 +23,11 @@ const Tag = ({ bsStyle, ...rest }) => {
 		default:
 			break;
 	}
-	return <StyledTag {...rest} />;
+	return (
+		<CoralThemeProvider>
+			<StyledTag {...rest} />
+		</CoralThemeProvider>
+	);
 };
 
 Tag.displayName = 'Tag';

--- a/packages/components/src/Tag/__snapshots__/Tag.test.js.snap
+++ b/packages/components/src/Tag/__snapshots__/Tag.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Tag should render 1`] = `
-<Tag>
-  The lazy quick brown fox jumps over the lazy dog
-</Tag>
+<ThemeProvider>
+  <Tag>
+    The lazy quick brown fox jumps over the lazy dog
+  </Tag>
+</ThemeProvider>
 `;

--- a/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
@@ -1,7 +1,9 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CellLabel should default render 1`] = `
-<coral.tag.information id="25">
-  my label
-</coral.tag.information>
+<coral.themeprovider>
+  <coral.tag.information id="25">
+    my label
+  </coral.tag.information>
+</coral.themeprovider>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Theme Provider can be missing using angularjs powered host(s)

**What is the chosen solution to this problem?**
Use Theme Provider for each Tag

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
