### PR TITLE
feat(Components/DateRangePicker): add inline display mode

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -59,7 +59,7 @@
   94:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
-  59:5  warning  React Hook useEffect has a missing dependency: 'showHorizontalAndTest'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+  66:5  warning  React Hook useEffect has a missing dependency: 'showHorizontalAndTest'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Manager/Manager.component.js
    79:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated

--- a/packages/components/src/DateTimePickers/DateRange/Input/Input.component.js
+++ b/packages/components/src/DateTimePickers/DateRange/Input/Input.component.js
@@ -14,7 +14,7 @@ const Input = forwardRef((props, ref) => {
 	const { placeholder } = inputManagement;
 
 	return (
-		<div>
+		<div className="range-input">
 			<label htmlFor={props.id} className="control-label">
 				{label}
 			</label>

--- a/packages/components/src/DateTimePickers/DateRange/Input/__snapshots__/Input.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateRange/Input/__snapshots__/Input.component.test.js.snap
@@ -12,7 +12,9 @@ exports[`Date.Input should render 1`] = `
   onChange={[MockFunction]}
   onFocus={[MockFunction]}
 >
-  <div>
+  <div
+    className="range-input"
+  >
     <label
       className="control-label"
     >

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -51,4 +51,13 @@ storiesOf('Form/Controls/DatePicker/Date Range', module)
 				<DatePicker selectedDate={new Date(2019, 9, 24)} endDate={new Date(2019, 9, 30)} />
 			</DateManager>
 		</div>
+	))
+	.add('Inline', () => (
+		<InputDateRangePicker
+			id="my-date-picker"
+			name="daterange"
+			onBlur={action('onBlur')}
+			onChange={action('onChange')}
+			display="inline"
+		/>
 	));

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/DateRangePicker.stories.js
@@ -58,6 +58,6 @@ storiesOf('Form/Controls/DatePicker/Date Range', module)
 			name="daterange"
 			onBlur={action('onBlur')}
 			onChange={action('onChange')}
-			display="inline"
+			inline
 		/>
 	));

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
@@ -60,6 +60,12 @@ export default function InputDateRangePicker(props) {
 		}
 		handlers.onChange(event, payload, referenceElement);
 	}
+
+	const isDisplayInline = props.display === 'inline';
+	const className = classnames('date-picker', theme['date-picker'], {
+		'date-range-picker-inline': isDisplayInline,
+		[theme['date-range-picker-inline']]: isDisplayInline,
+	});
 	return (
 		<DateRange.Manager
 			startDate={props.startDate}
@@ -72,7 +78,7 @@ export default function InputDateRangePicker(props) {
 					const { onStartChange, onEndChange } = inputManagement;
 					return (
 						<FocusManager
-							className={classnames(theme['date-picker'], 'date-picker')}
+							className={className}
 							divRef={containerRef}
 							onClick={handlers.onClick}
 							onFocusIn={handlers.onFocus}
@@ -134,5 +140,6 @@ InputDateRangePicker.propTypes = {
 	onBlur: PropTypes.func,
 	startDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
 	endDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
+	display: PropTypes.string,
 	t: PropTypes.func,
 };

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
@@ -61,7 +61,7 @@ export default function InputDateRangePicker(props) {
 		handlers.onChange(event, payload, referenceElement);
 	}
 
-	const isDisplayInline = props.display === 'inline';
+	const isDisplayInline = !!props.inline;
 	const className = classnames('date-picker', theme['date-picker'], {
 		'date-range-picker-inline': isDisplayInline,
 		[theme['date-range-picker-inline']]: isDisplayInline,
@@ -140,6 +140,6 @@ InputDateRangePicker.propTypes = {
 	onBlur: PropTypes.func,
 	startDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
 	endDate: PropTypes.oneOfType([PropTypes.instanceOf(Date), PropTypes.number, PropTypes.string]),
-	display: PropTypes.string,
+	inline: PropTypes.bool,
 	t: PropTypes.func,
 };

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.scss
@@ -18,5 +18,5 @@
 	}
 }
 .date-range-picker-inline {
-	@include range-picker-inline
+	@include range-picker-inline;
 }

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.scss
@@ -17,3 +17,6 @@
 		}
 	}
 }
+.date-range-picker-inline {
+	@include range-picker-inline
+}

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/README.md
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/README.md
@@ -8,7 +8,7 @@ This is a date range picker for selecting a period, composed by 2 date pickers a
 | endDate | `Date`, a `number` (timestamp) or `string` in the specified format (defined by props.dateFormat) | initial end date |
 | onChange  | function | Trigger when date or error change (event, errorMessage, date)<br/>- Return the event object with <br/>`startDate`/`endDate`: date selected,<br/>`origin`: can be `START_PICKER` or `END_PICKER`, you can use this to distinguish if there's change on start date or end date,<br/>`errors`: contains the error code and message. empty if range is valid |
 | onBlur    | function | Trigger when the component loose focus (outside the picker AND the input) from either start date or end date|
-| display | string | Default value is undefined. If set to `inline`, it will display range picker in a inline mode which the labels and inputs are in one line |
+| inline | boolean | If set this to true, it will display range picker in a inline mode which the labels and inputs are in one line |
 
 `dateFormat` and `useSeconds` set on InputDateRangePicker will be passed to individual InputDatePicker and still take effect.
 

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/README.md
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/README.md
@@ -1,0 +1,15 @@
+# Date Range Picker
+This is a date range picker for selecting a period, composed by 2 date pickers as start date and end date.
+
+## props
+| name | type | description |
+|------|------|-------------|
+| startDate | `Date`, or `number` (timestamp) or `string` in the specified format (defined by props.dateFormat) | initial start date |
+| endDate | `Date`, a `number` (timestamp) or `string` in the specified format (defined by props.dateFormat) | initial end date |
+| onChange  | function | Trigger when date or error change (event, errorMessage, date)<br/>- Return the event object with <br/>`startDate`/`endDate`: date selected,<br/>`origin`: can be `START_PICKER` or `END_PICKER`, you can use this to distinguish if there's change on start date or end date,<br/>`errors`: contains the error code and message. empty if range is valid |
+| onBlur    | function | Trigger when the component loose focus (outside the picker AND the input) from either start date or end date|
+| display | string | Default value is undefined. If set to `inline`, it will display range picker in a inline mode which the labels and inputs are in one line |
+
+`dateFormat` and `useSeconds` set on InputDateRangePicker will be passed to individual InputDatePicker and still take effect.
+
+

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -61,4 +61,14 @@ storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 				useSeconds
 			/>
 		</div>
+	))
+	.add('Inline', () => (
+		<div>
+			<InputDateTimeRangePicker
+				id="my-datetime-range-picker"
+				onChange={action('onChange')}
+				onBlur={action('onBlur')}
+				display="inline"
+			/>
+		</div>
 	));

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/DateTimeRangePicker.stories.js
@@ -68,7 +68,7 @@ storiesOf('Form/Controls/DatePicker/Date Time Range', module)
 				id="my-datetime-range-picker"
 				onChange={action('onChange')}
 				onBlur={action('onBlur')}
-				display="inline"
+				inline
 			/>
 		</div>
 	));

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -35,10 +35,10 @@ function InputDateTimeRangePicker(props) {
 	const className = classnames({
 		'range-picker': !vertical,
 		[theme['range-picker']]: !vertical,
-		'range-picker-vertical': vertical,
-		[theme['range-picker-vertical']]: vertical,
-		'range-picker-inline': isDisplayInline,
-		[theme['range-picker-inline']]: isDisplayInline,
+		'range-picker-vertical': vertical && !isDisplayInline,
+		[theme['range-picker-vertical']]: vertical && !isDisplayInline,
+		'date-time-range-picker-inline': isDisplayInline,
+		[theme['date-time-range-picker-inline']]: isDisplayInline,
 	});
 
 	const showHorizontalAndTest = React.useMemo(() => {
@@ -74,7 +74,7 @@ function InputDateTimeRangePicker(props) {
 			<DateTimeRangeContext.Consumer>
 				{({ startDateTime, endDateTime, onStartChange, onEndChange }) => (
 					<div className={className} ref={containerRef}>
-						<div className="range-picker-start">
+						<div className="range-input">
 							<label htmlFor={props.id} className="control-label">
 								{props.t('TC_DATE_PICKER_RANGE_FROM', { defaultValue: 'From' })}
 							</label>
@@ -93,7 +93,7 @@ function InputDateTimeRangePicker(props) {
 						<span className={classnames(theme.arrow, 'arrow')}>
 							<Icon name="talend-arrow-right" className={classnames(theme.icon, 'icon')} />
 						</span>
-						<div className="range-picker-end">
+						<div className="range-input">
 							<label htmlFor={props.id} className="control-label">
 								{props.t('TC_DATE_PICKER__RANGE_TO', { defaultValue: 'To' })}
 							</label>

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -24,15 +24,22 @@ const PROPS_TO_OMIT_FOR_INPUT = [
 ];
 
 function InputDateTimeRangePicker(props) {
-	const { id, dateFormat, useSeconds, onChange, onBlur } = props;
+	const { id, dateFormat, useSeconds, onChange, onBlur, display } = props;
 	const inputProps = omit(props, PROPS_TO_OMIT_FOR_INPUT);
 
 	const [vertical, setVertical] = useState(false);
 	const containerRef = useRef();
 
-	const className = vertical
-		? classnames(theme['range-picker-vertical'], 'range-picker-vertical')
-		: classnames(theme['range-picker'], 'range-picker');
+	const isDisplayInline = display === 'inline';
+
+	const className = classnames({
+		'range-picker': !vertical,
+		[theme['range-picker']]: !vertical,
+		'range-picker-vertical': vertical,
+		[theme['range-picker-vertical']]: vertical,
+		'range-picker-inline': isDisplayInline,
+		[theme['range-picker-inline']]: isDisplayInline,
+	});
 
 	const showHorizontalAndTest = React.useMemo(() => {
 		return function showHorizontal() {
@@ -67,7 +74,7 @@ function InputDateTimeRangePicker(props) {
 			<DateTimeRangeContext.Consumer>
 				{({ startDateTime, endDateTime, onStartChange, onEndChange }) => (
 					<div className={className} ref={containerRef}>
-						<div>
+						<div className="range-picker-start">
 							<label htmlFor={props.id} className="control-label">
 								{props.t('TC_DATE_PICKER_RANGE_FROM', { defaultValue: 'From' })}
 							</label>
@@ -86,7 +93,7 @@ function InputDateTimeRangePicker(props) {
 						<span className={classnames(theme.arrow, 'arrow')}>
 							<Icon name="talend-arrow-right" className={classnames(theme.icon, 'icon')} />
 						</span>
-						<div>
+						<div className="range-picker-end">
 							<label htmlFor={props.id} className="control-label">
 								{props.t('TC_DATE_PICKER__RANGE_TO', { defaultValue: 'To' })}
 							</label>
@@ -139,6 +146,7 @@ InputDateTimeRangePicker.propTypes = {
 		PropTypes.number,
 		PropTypes.string,
 	]),
+	display: PropTypes.string,
 	t: PropTypes.func,
 };
 

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -24,13 +24,13 @@ const PROPS_TO_OMIT_FOR_INPUT = [
 ];
 
 function InputDateTimeRangePicker(props) {
-	const { id, dateFormat, useSeconds, onChange, onBlur, display } = props;
+	const { id, dateFormat, useSeconds, onChange, onBlur, inline } = props;
 	const inputProps = omit(props, PROPS_TO_OMIT_FOR_INPUT);
 
 	const [vertical, setVertical] = useState(false);
 	const containerRef = useRef();
 
-	const isDisplayInline = display === 'inline';
+	const isDisplayInline = !!inline;
 
 	const className = classnames({
 		'range-picker': !vertical,
@@ -146,7 +146,7 @@ InputDateTimeRangePicker.propTypes = {
 		PropTypes.number,
 		PropTypes.string,
 	]),
-	display: PropTypes.string,
+	inline: PropTypes.string,
 	t: PropTypes.func,
 };
 

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
@@ -67,9 +67,8 @@ describe('InputDateTimeRangePicker', () => {
 		let wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} />);
 		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(0);
 
-		const display = 'inline';
 		wrapper = mount(
-			<InputDateTimeRangePicker id="range-picker" onChange={noop} display={display} />,
+			<InputDateTimeRangePicker id="range-picker" onChange={noop} inline />,
 		);
 		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(1);
 	});

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
@@ -65,12 +65,12 @@ describe('InputDateTimeRangePicker', () => {
 
 	describe('should display inline', () => {
 		let wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} />);
-		expect(wrapper.find('div.range-picker-inline').length).toEqual(0);
+		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(0);
 		
 		const display = 'inline';
 		wrapper = mount(
 			<InputDateTimeRangePicker id="range-picker" onChange={noop} display={display} />,
 		);
-		expect(wrapper.find('div.range-picker-inline').length).toEqual(1);
+		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(1);
 	});
 });

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import noop from 'lodash/noop';
 import { mount } from 'enzyme';
 import toJson from 'enzyme-to-json';
 
@@ -60,5 +61,16 @@ describe('InputDateTimeRangePicker', () => {
 			// then
 			expect(onChange).toBeCalledWith(event, payload);
 		});
+	});
+
+	describe('should display inline', () => {
+		let wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} />);
+		expect(wrapper.find('div.range-picker-inline').length).toEqual(0);
+		
+		const display = 'inline';
+		wrapper = mount(
+			<InputDateTimeRangePicker id="range-picker" onChange={noop} display={display} />,
+		);
+		expect(wrapper.find('div.range-picker-inline').length).toEqual(1);
 	});
 });

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
@@ -66,7 +66,7 @@ describe('InputDateTimeRangePicker', () => {
 	describe('should display inline', () => {
 		let wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} />);
 		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(0);
-		
+
 		const display = 'inline';
 		wrapper = mount(
 			<InputDateTimeRangePicker id="range-picker" onChange={noop} display={display} />,

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.test.js
@@ -67,9 +67,7 @@ describe('InputDateTimeRangePicker', () => {
 		let wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} />);
 		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(0);
 
-		wrapper = mount(
-			<InputDateTimeRangePicker id="range-picker" onChange={noop} inline />,
-		);
+		wrapper = mount(<InputDateTimeRangePicker id="range-picker" onChange={noop} inline />);
 		expect(wrapper.find('div.date-time-range-picker-inline').length).toEqual(1);
 	});
 });

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
@@ -30,3 +30,15 @@
 		}
 	}
 }
+
+.range-picker-inline {
+	:global(.range-picker-start),
+	:global(.range-picker-end) {
+		display: flex;
+		align-items: center;
+	}
+
+	:global(.control-label) {
+		margin-right: $padding-small;
+	}
+}

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
@@ -31,14 +31,6 @@
 	}
 }
 
-.range-picker-inline {
-	:global(.range-picker-start),
-	:global(.range-picker-end) {
-		display: flex;
-		align-items: center;
-	}
-
-	:global(.control-label) {
-		margin-right: $padding-small;
-	}
+.date-time-range-picker-inline {
+	@include range-picker-inline
 }

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.scss
@@ -32,5 +32,5 @@
 }
 
 .date-time-range-picker-inline {
-	@include range-picker-inline
+	@include range-picker-inline;
 }

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
@@ -17,7 +17,7 @@ exports[`InputDateTimeRangePicker should render 1`] = `
       className="range-picker theme-range-picker"
     >
       <div
-        className="range-picker-start"
+        className="range-input"
       >
         <label
           className="control-label"
@@ -283,7 +283,7 @@ exports[`InputDateTimeRangePicker should render 1`] = `
         </Icon>
       </span>
       <div
-        className="range-picker-end"
+        className="range-input"
       >
         <label
           className="control-label"
@@ -563,7 +563,7 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
       className="range-picker theme-range-picker"
     >
       <div
-        className="range-picker-start"
+        className="range-input"
       >
         <label
           className="control-label"
@@ -860,7 +860,7 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
         </Icon>
       </span>
       <div
-        className="range-picker-end"
+        className="range-input"
       >
         <label
           className="control-label"

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
@@ -14,9 +14,11 @@ exports[`InputDateTimeRangePicker should render 1`] = `
     startDateTime="2019-12-01 00:00:00"
   >
     <div
-      className="theme-range-picker range-picker"
+      className="range-picker theme-range-picker"
     >
-      <div>
+      <div
+        className="range-picker-start"
+      >
         <label
           className="control-label"
           htmlFor="my-picker"
@@ -280,7 +282,9 @@ exports[`InputDateTimeRangePicker should render 1`] = `
           />
         </Icon>
       </span>
-      <div>
+      <div
+        className="range-picker-end"
+      >
         <label
           className="control-label"
           htmlFor="my-picker"
@@ -556,9 +560,11 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
 >
   <DateTimeRange.Manager>
     <div
-      className="theme-range-picker range-picker"
+      className="range-picker theme-range-picker"
     >
-      <div>
+      <div
+        className="range-picker-start"
+      >
         <label
           className="control-label"
           htmlFor="my-picker"
@@ -853,7 +859,9 @@ exports[`InputDateTimeRangePicker should render with default time 1`] = `
           />
         </Icon>
       </span>
-      <div>
+      <div
+        className="range-picker-end"
+      >
         <label
           className="control-label"
           htmlFor="my-picker"

--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -44,6 +44,17 @@
 	align-items: flex-end;
 }
 
+@mixin range-picker-inline {
+	:global(.range-input) {
+		display: flex;
+		align-items: center;
+	}
+
+	:global(.control-label) {
+		margin: 0 $padding-small;
+	}
+}
+
 @mixin arrow {
 	height: $tc-range-picker-arrow-height;
 	padding: 0 $padding-smaller;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TMC needs a rang picker displayed in `inline` mode.
We have defined an `inline` type Date Range Picker in guidelines but not implemented yet: 
https://company-57688.frontify.com/document/92132#/ui-controls/date-time-picker-1561102408
![image](https://user-images.githubusercontent.com/3214228/111726024-11866800-88a3-11eb-8266-b84e991ef086.png)

This PR is to implement inline display mode.

**What is the chosen solution to this problem?**
Add `props.display="inline"` for display Date Range Picker inline.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
