### PR TITLE
chore(cmf): upgrade sentry

### DIFF
--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -32,7 +32,6 @@
   },
   "homepage": "https://github.com/Talend/ui/cmf-cqrs#readme",
   "dependencies": {
-    "@babel/polyfill": "^7.8.7",
     "immutable": "^3.8.1",
     "redux-saga": "^0.15.4"
   },

--- a/packages/cmf/__tests__/onError.test.js
+++ b/packages/cmf/__tests__/onError.test.js
@@ -1,4 +1,4 @@
-import { captureException, configureScope, init, withScope } from '@sentry/browser';
+import { captureException, configureScope, init, withScope } from '@sentry/react';
 import onError from '../src/onError';
 import CONSTANTS from '../src/constant';
 import { store as mock } from '../src/mock';
@@ -217,7 +217,11 @@ describe('onError', () => {
 				},
 			};
 			onError.bootstrap(config, store);
-			expect(init).toHaveBeenCalledWith({ dsn: config.onError.SENTRY_DSN });
+			expect(init).toHaveBeenCalledWith({
+				integrations: expect.anything(),
+				_metadata: expect.anything(),
+				dsn: config.onError.SENTRY_DSN
+			});
 			const onJSError = window.addEventListener.mock.calls[0][1];
 			expect(window.removeEventListener).toHaveBeenCalledWith('error', onJSError);
 			expect(onError.hasReportFeature()).toBe(true);
@@ -237,7 +241,10 @@ describe('onError', () => {
 			};
 			onError.bootstrap(config, store);
 			expect(init).toHaveBeenCalledWith({
+				_metadata: expect.anything(),
+				integrations: expect.anything(),
 				dsn: config.onError.SENTRY_DSN,
+
 				release: config.onError.sentry.release,
 				environnement: config.onError.sentry.environnement,
 			});
@@ -265,7 +272,11 @@ describe('onError', () => {
 					},
 				},
 			});
-			expect(init).toHaveBeenCalledWith({ dsn: 'foo' });
+			expect(init).toHaveBeenCalledWith({
+				integrations: expect.anything(),
+				_metadata: expect.anything(),
+				dsn: 'foo',
+			});
 		});
 		it('report should call captureException', () => {
 			config = {

--- a/packages/cmf/__tests__/onError.test.js
+++ b/packages/cmf/__tests__/onError.test.js
@@ -3,7 +3,7 @@ import onError from '../src/onError';
 import CONSTANTS from '../src/constant';
 import { store as mock } from '../src/mock';
 
-jest.mock('@sentry/browser', () => ({
+jest.mock('@sentry/react', () => ({
 	captureException: jest.fn(),
 	configureScope: jest.fn(),
 	init: jest.fn(config => {
@@ -219,7 +219,6 @@ describe('onError', () => {
 			onError.bootstrap(config, store);
 			expect(init).toHaveBeenCalledWith({
 				integrations: expect.anything(),
-				_metadata: expect.anything(),
 				dsn: config.onError.SENTRY_DSN
 			});
 			const onJSError = window.addEventListener.mock.calls[0][1];
@@ -241,7 +240,6 @@ describe('onError', () => {
 			};
 			onError.bootstrap(config, store);
 			expect(init).toHaveBeenCalledWith({
-				_metadata: expect.anything(),
 				integrations: expect.anything(),
 				dsn: config.onError.SENTRY_DSN,
 
@@ -274,7 +272,6 @@ describe('onError', () => {
 			});
 			expect(init).toHaveBeenCalledWith({
 				integrations: expect.anything(),
-				_metadata: expect.anything(),
 				dsn: 'foo',
 			});
 		});

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -35,7 +35,8 @@
     "cmf-settings": "./scripts/cmf-settings.js"
   },
   "dependencies": {
-    "@sentry/browser": "^5.11.1",
+    "@sentry/react": "^6.2.3",
+    "@sentry/tracing": "^6.2.3",
     "deepmerge": "^1.5.1",
     "hoist-non-react-statics": "^2.5.5",
     "immutable": "^3.8.1",

--- a/packages/cmf/src/index.js
+++ b/packages/cmf/src/index.js
@@ -1,7 +1,7 @@
 /**
  * @module react-cmf
  */
-
+import * as SentryReact from '@sentry/react';
 import actions from './actions';
 import actionCreator from './actionCreator';
 
@@ -43,6 +43,9 @@ function registerInternals(context) {
 	actionCreator.register('cmf.saga.stop', actions.saga.stop, context);
 	expression.registerMany(expressions, context);
 }
+
+// make it global because we can t share sentry
+window.SentryReact = SentryReact;
 
 export {
 	App,

--- a/packages/cmf/src/onError.js
+++ b/packages/cmf/src/onError.js
@@ -1,5 +1,6 @@
 import get from 'lodash/get';
-import { captureException, configureScope, init, withScope } from '@sentry/browser';
+import { captureException, configureScope, init, withScope } from '@sentry/react';
+import { Integrations } from '@sentry/tracing';
 import { assertTypeOf } from './assert';
 import CONST from './constant';
 import actions from './actions';
@@ -150,7 +151,7 @@ function setupSentry(options = {}) {
 
 	window.removeEventListener('error', onJSError);
 	try {
-		init({ dsn: ref.SENTRY_DSN, ...options });
+		init({ dsn: ref.SENTRY_DSN, ...options, integrations: [new Integrations.BrowserTracing()].concat(options.integrations || []) });
 	} catch (error) {
 		// eslint-disable-next-line no-console
 		console.error(error);

--- a/packages/generator/package.json
+++ b/packages/generator/package.json
@@ -43,7 +43,6 @@
   },
   "devDependencies": {
     "@babel/core": "^7.11.5",
-    "@babel/polyfill": "^7.8.7",
     "@babel/preset-env": "^7.11.5",
     "@babel/register": "^7.8.3",
     "babel-eslint": "^10.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -821,14 +821,6 @@
     "@babel/helper-create-regexp-features-plugin" "^7.12.13"
     "@babel/helper-plugin-utils" "^7.12.13"
 
-"@babel/polyfill@^7.8.7":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.12.1.tgz#1f2d6371d1261bbd961f3c5d5909150e12d0bd96"
-  integrity sha512-X0pi0V6gxLi6lFZpGmeNa4zxtwEmCs42isWLNjZZDE0Y8yVfgu0T2OAHlzBbdYlqbW/YXVvoBHpATEM+goCj8g==
-  dependencies:
-    core-js "^2.6.5"
-    regenerator-runtime "^0.13.4"
-
 "@babel/preset-env@^7.11.5", "@babel/preset-env@^7.12.1", "@babel/preset-env@^7.4.5", "@babel/preset-env@^7.8.7":
   version "7.13.10"
   resolved "https://registry.yarnpkg.com/@babel/preset-env/-/preset-env-7.13.10.tgz#b5cde31d5fe77ab2a6ab3d453b59041a1b3a5252"
@@ -2287,56 +2279,79 @@
   resolved "https://registry.yarnpkg.com/@rooks/use-mutation-observer/-/use-mutation-observer-4.9.2.tgz#ab41e24e298f51c752fdcdfe991b117b316ac26c"
   integrity sha512-K8SLLPTBP6dYaVQjI/3U5OhVsSaHj83Ksj1mYNB2ULYXnKlMfwtll+KXFU8snusv4QKyWbyQOP4uIoI2eDUggA==
 
-"@sentry/browser@^5.11.1":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-5.30.0.tgz#c28f49d551db3172080caef9f18791a7fd39e3b3"
-  integrity sha512-rOb58ZNVJWh1VuMuBG1mL9r54nZqKeaIlwSlvzJfc89vyfd7n6tQ1UXMN383QBz/MS5H5z44Hy5eE+7pCrYAfw==
+"@sentry/browser@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-6.2.3.tgz#b622b3fb62340574e395b6ae12ffbb9d25d98bd4"
+  integrity sha512-QUqrZdAosY2MPAUfJYpyCT+dA6v7A2h8imO8R3Lbi0hRSPr+L7zjqHgFs3CTHJLmLV74cxHt6rVVUPSksYNQDQ==
   dependencies:
-    "@sentry/core" "5.30.0"
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/core" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/core@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-5.30.0.tgz#6b203664f69e75106ee8b5a2fe1d717379b331f3"
-  integrity sha512-TmfrII8w1PQZSZgPpUESqjB+jC6MvZJZdLtE/0hZ+SrnKhW3x5WlYLvTXZpcWePYBku7rl2wn1RZu6uT0qCTeg==
+"@sentry/core@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-6.2.3.tgz#ed5d21fd8b18ddc289d04c669393a437fb09639f"
+  integrity sha512-GpfHoSJiXchVXgyaMWVtIPVw2t97KkD1OJ4JdL3/TeH3auX5XvsN5iHTk+x/Er8t13IpOnvidH1xWdV1dnax2w==
   dependencies:
-    "@sentry/hub" "5.30.0"
-    "@sentry/minimal" "5.30.0"
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/hub" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/hub@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-5.30.0.tgz#2453be9b9cb903404366e198bd30c7ca74cdc100"
-  integrity sha512-2tYrGnzb1gKz2EkMDQcfLrDTvmGcQPuWxLnJKXJvYTQDGLlEvi2tWz1VIHjunmOvJrB5aIQLhm+dcMRwFZDCqQ==
+"@sentry/hub@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-6.2.3.tgz#07fba07627b7523f69f8b862f00cd197e5e4e5bd"
+  integrity sha512-D5Horfo2l0p52S7KPvy7qwWNMrE4IsCN8ODbfcCsfJu7hEXJmItbkbohIVSqO5neukhn5nu+x8kyCe9Q5u1Q6g==
   dependencies:
-    "@sentry/types" "5.30.0"
-    "@sentry/utils" "5.30.0"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/minimal@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-5.30.0.tgz#ce3d3a6a273428e0084adcb800bc12e72d34637b"
-  integrity sha512-BwWb/owZKtkDX+Sc4zCSTNcvZUq7YcH3uAVlmh/gtR9rmUvbzAA3ewLuB3myi4wWRAMEtny6+J/FN/x+2wn9Xw==
+"@sentry/minimal@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/minimal/-/minimal-6.2.3.tgz#462ce7739fa85fd7d6dd13d56d20f17ff91e46d0"
+  integrity sha512-Gpn9x4NQAG7E94EK1+hAz9GUcYrffTuqJ/XgqvHYk0jsHZ6RfsXYrmBac0ZwUxOivMf2t0n5opK0v5rhMDfF2w==
   dependencies:
-    "@sentry/hub" "5.30.0"
-    "@sentry/types" "5.30.0"
+    "@sentry/hub" "6.2.3"
+    "@sentry/types" "6.2.3"
     tslib "^1.9.3"
 
-"@sentry/types@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-5.30.0.tgz#19709bbe12a1a0115bc790b8942917da5636f402"
-  integrity sha512-R8xOqlSTZ+htqrfteCWU5Nk0CDN5ApUTvrlvBuiH1DyP6czDZ4ktbZB0hAgBlVcK0U+qpD3ag3Tqqpa5Q67rPw==
-
-"@sentry/utils@5.30.0":
-  version "5.30.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-5.30.0.tgz#9a5bd7ccff85ccfe7856d493bffa64cabc41e980"
-  integrity sha512-zaYmoH0NWWtvnJjC9/CBseXMtKHm/tm40sz3YfJRxeQjyzRqNQPgivpd9R/oDJCYj999mzdW382p/qi2ypjLww==
+"@sentry/react@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/react/-/react-6.2.3.tgz#66e8a2073acd74677e4daf850e165273eb8eea7a"
+  integrity sha512-T2mBD9ZFxzLQ3Kc5cey7A5fBA+qN67NdmRw9W1Grk6cEoJIrQYg3LnFbM5YnBBK86ciXQlgz7ZsF7rbjRcmWMQ==
   dependencies:
-    "@sentry/types" "5.30.0"
+    "@sentry/browser" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
+    hoist-non-react-statics "^3.3.2"
+    tslib "^1.9.3"
+
+"@sentry/tracing@^6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/tracing/-/tracing-6.2.3.tgz#fefa55b1f2265973a747b30da14a54b779b5090e"
+  integrity sha512-OnQZKp7qVera+Z4ly6hgybGgyf10p2VDXqwueXkMVeLD+PwlPG8a8NMpKkZ+QxwRbQbSFhRLQaib3NX34tusBQ==
+  dependencies:
+    "@sentry/hub" "6.2.3"
+    "@sentry/minimal" "6.2.3"
+    "@sentry/types" "6.2.3"
+    "@sentry/utils" "6.2.3"
+    tslib "^1.9.3"
+
+"@sentry/types@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-6.2.3.tgz#0c06a475a51d28c73a69b05f0d43db05310ec241"
+  integrity sha512-BpA+9FherWgYlkMD/82bGFh/gAqZNlZX5UE8vWLKyyzNyOEEz3v9ScxE8dOSWE4v5iXJR1O3jjxaTcRQxPVgCA==
+
+"@sentry/utils@6.2.3":
+  version "6.2.3"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-6.2.3.tgz#c96539571a67fb2eed56897133649f35309e3f74"
+  integrity sha512-YnkJm97wSvck39eRpqWjIuuwbvzPilvAcMqhbUy9yK/UBQMDGUzAKCOKH40udw1DwMUCWjJ71mOCDgUorE4Fog==
+  dependencies:
+    "@sentry/types" "6.2.3"
     tslib "^1.9.3"
 
 "@sinonjs/commons@^1", "@sinonjs/commons@^1.3.0", "@sinonjs/commons@^1.7.0":


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

sentry API is v5 and only for pure JS.
Since then Sentry has published a sentry for react in their v6 API.

**What is the chosen solution to this problem?**

upgrade CMF to v6

Crappy work: Because of the bundle impact sentry has, I propose to expose @sentry/react has a global variable `SentryReact`. Sentry is now really modular and Sentry variable refer to `@sentry/browser`. They propose bundle for all integration except react with only all in one bundles.

So you can use the doc and API just replace Sentry by SentryReact global.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
