### PR TITLE
fix(Emphasis/TMC-24631): error in datalist when value is not a string

### DIFF
--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -17,7 +17,6 @@ function emphasiseAll(text, value) {
 	if (!value) {
 		return text;
 	}
-
 	const strValue = typeof value !== 'string' ? `${value}` : value;
 
 	return text

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -18,11 +18,13 @@ function emphasiseAll(text, value) {
 		return text;
 	}
 
+	const strValue = typeof value !== 'string' ? `${value}` : value;
+
 	return text
-		.split(new RegExp(`(${escapeRegexCharacters(value)})`, 'gi'))
+		.split(new RegExp(`(${escapeRegexCharacters(strValue)})`, 'gi'))
 		.filter(isNotEmpty)
 		.map((part, index) => {
-			if (part.toUpperCase() === value.toUpperCase()) {
+			if (part.toUpperCase() === strValue.toUpperCase()) {
 				return (
 					<em key={index} className={theme.highlight}>
 						{part}

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -17,13 +17,13 @@ function emphasiseAll(text, value) {
 	if (!value) {
 		return text;
 	}
-	const strValue = typeof value !== 'string' ? `${value}` : value;
+	const strValue = `${value}`;
 
 	return text
 		.split(new RegExp(`(${escapeRegexCharacters(strValue)})`, 'gi'))
 		.filter(isNotEmpty)
 		.map((part, index) => {
-			if (part.toUpperCase() === strValue.toUpperCase()) {
+			if (part.toLocaleUpperCase() === strValue.toLocaleUpperCase()) {
 				return (
 					<em key={index} className={theme.highlight}>
 						{part}

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -17,9 +17,10 @@ function emphasiseAll(text, value) {
 	if (!value) {
 		return text;
 	}
+	const strText = `${text}`;
 	const strValue = `${value}`;
 
-	return text
+	return strText
 		.split(new RegExp(`(${escapeRegexCharacters(strValue)})`, 'gi'))
 		.filter(isNotEmpty)
 		.map((part, index) => {

--- a/packages/components/src/Emphasis/Emphasis.test.js
+++ b/packages/components/src/Emphasis/Emphasis.test.js
@@ -57,4 +57,13 @@ describe('Emphasis', () => {
 		// then
 		expect(wrapper.find('em').length).toBe(2);
 	});
+
+	it('should emphasize if value is not string', () => {
+		const text = '85';
+		// given
+		const wrapper = shallow(<Emphasis text={text} value={8} />);
+
+		// then
+		expect(wrapper.find('em').length).toBe(1);
+	});
 });

--- a/packages/components/src/Emphasis/Emphasis.test.js
+++ b/packages/components/src/Emphasis/Emphasis.test.js
@@ -59,7 +59,7 @@ describe('Emphasis', () => {
 	});
 
 	it('should emphasize if value is not string', () => {
-		const text = '85';
+		const text = 85;
 		// given
 		const wrapper = shallow(<Emphasis text={text} value={8} />);
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TMC-24631
If value is not a string, and not in title map, Datalist throws an error when opening it

**What is the chosen solution to this problem?**
Convert value to string before escaping

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR
