### PR TITLE
fix(dataviz): add dev umd

### DIFF
--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -27,7 +27,7 @@ Types of changes
 ## [unreleased]
 
 
-## [0.4.3]
+## [0.4.4]
 
 ### Fixed
 

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -31,6 +31,12 @@ Types of changes
 
 ### Fixed
 
+- [genereate dev UMD](https://github.com/Talend/ui/pull/3261)
+
+## [0.4.3]
+
+### Fixed
+
 - [upgrade talend-scripts to fix manifest](https://github.com/Talend/ui/pull/3259)
 
 ## [0.4.2]

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,13 +1,15 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",
   "types": "./lib/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "talend-scripts build:lib:umd",
+    "prepublishOnly": "yarn build:umd:dev && build:umd:prod",
+    "build:umd:dev": "talend-scripts build:lib:umd --dev",
+    "build:umd:prod": "talend-scripts build:lib:umd",
     "build": "talend-scripts build:ts:lib",
     "prepare": "npm run build",
     "extract-i18n": "i18next-scanner --config i18next-scanner.config.js",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

404 happens on project using dataviz in dev mode.

**What is the chosen solution to this problem?**

Add dataviz umd for dev

![Screen Shot 2021-04-01 at 09 40 20](https://user-images.githubusercontent.com/19857479/113260247-501e1880-92ce-11eb-81f2-5b3102606891.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
