### PR TITLE
fix(components/DatePicker): Fix style for start of range

### DIFF
--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -97,6 +97,19 @@ class DatePicker extends React.PureComponent {
 		return false;
 	}
 
+	/**
+	 * Check if selection is a valid range.
+	 * - if start/end not selected, then it's invalid;
+	 * - if start/end are selected, but end < start, then it's invalid
+	 */
+	isRangeValid() {
+		const { selectedDate, startDate, endDate } = this.props;
+		return (
+			(startDate && isAfter(selectedDate, startDate)) ||
+			(endDate && isBefore(selectedDate, endDate))
+		);
+	}
+
 	selectDate(event, date, year, monthIndex) {
 		if (!this.isCurrentMonth(date)) {
 			if (date < startOfMonth(new Date(year, monthIndex))) {
@@ -157,9 +170,10 @@ class DatePicker extends React.PureComponent {
 								const dayTheme = {};
 								const isStart = this.isStartDate(date);
 								const isEnd = this.isEndDate(date);
-								const isInRange = this.isDateWithinRange(date);
+								const isRangeValid = this.isRangeValid();
+								const isInRange = isStart || isEnd || this.isDateWithinRange(date);
 
-								if (isInRange) {
+								if (isRangeValid && isInRange) {
 									const isMiddle = !isStart && !isEnd && isInRange;
 									cellTheme[theme['date-range']] = isInRange;
 									cellTheme[theme['range-middle']] = isMiddle;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -12,6 +12,7 @@ import getDate from 'date-fns/get_date';
 import getMonth from 'date-fns/get_month';
 import getYear from 'date-fns/get_year';
 import setMonth from 'date-fns/set_month';
+import startOfDay from 'date-fns/start_of_day';
 import startOfMonth from 'date-fns/start_of_month';
 
 import theme from './DatePicker.scss';
@@ -70,7 +71,7 @@ class DatePicker extends React.PureComponent {
 	isDateWithinRange(date) {
 		const { selectedDate, startDate, endDate } = this.props;
 		if (startDate && isAfter(selectedDate, startDate)) {
-			return isWithinRange(date, startDate, selectedDate);
+			return isWithinRange(date, startOfDay(startDate), selectedDate);
 		} else if (endDate && isBefore(selectedDate, endDate)) {
 			return isWithinRange(date, selectedDate, endDate);
 		}
@@ -95,19 +96,6 @@ class DatePicker extends React.PureComponent {
 			return isSameDay(date, endDate);
 		}
 		return false;
-	}
-
-	/**
-	 * Check if selection is a valid range.
-	 * - if start/end not selected, then it's invalid;
-	 * - if start/end are selected, but end < start, then it's invalid
-	 */
-	isRangeValid() {
-		const { selectedDate, startDate, endDate } = this.props;
-		return (
-			(startDate && isAfter(selectedDate, startDate)) ||
-			(endDate && isBefore(selectedDate, endDate))
-		);
 	}
 
 	selectDate(event, date, year, monthIndex) {
@@ -170,10 +158,9 @@ class DatePicker extends React.PureComponent {
 								const dayTheme = {};
 								const isStart = this.isStartDate(date);
 								const isEnd = this.isEndDate(date);
-								const isRangeValid = this.isRangeValid();
-								const isInRange = isStart || isEnd || this.isDateWithinRange(date);
+								const isInRange = this.isDateWithinRange(date);
 
-								if (isRangeValid && isInRange) {
+								if (isInRange) {
 									const isMiddle = !isStart && !isEnd && isInRange;
 									cellTheme[theme['date-range']] = isInRange;
 									cellTheme[theme['range-middle']] = isMiddle;

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -164,7 +164,6 @@ describe('DatePicker', () => {
 		expect(middleTableCell.prop('className')).toContain('theme-range-middle');
 	});
 
-
 	it('should apply range style to startDate when time is not 00:00', () => {
 		// given
 		const props = {
@@ -182,7 +181,7 @@ describe('DatePicker', () => {
 
 		// when
 		const wrapper = mount(<DatePicker {...props} />);
-		const startDateTableCell = wrapper.find('td').at(3);// 2021-04-01
+		const startDateTableCell = wrapper.find('td').at(3); // 2021-04-01
 
 		// then
 		expect(startDateTableCell.prop('className')).toContain('theme-range-start');

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.test.js
@@ -65,12 +65,9 @@ describe('DatePicker', () => {
 		);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-day')
-				.at(1)
-				.prop('className'),
-		).not.toContain('theme-today');
+		expect(wrapper.find('.tc-date-picker-day').at(1).prop('className')).not.toContain(
+			'theme-today',
+		);
 		expect(
 			wrapper
 				.find('.tc-date-picker-day')
@@ -96,12 +93,9 @@ describe('DatePicker', () => {
 		);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-day')
-				.at(0)
-				.prop('className'),
-		).not.toContain('theme-selected');
+		expect(wrapper.find('.tc-date-picker-day').at(0).prop('className')).not.toContain(
+			'theme-selected',
+		);
 		expect(
 			wrapper
 				.find('.tc-date-picker-day')
@@ -127,12 +121,7 @@ describe('DatePicker', () => {
 		);
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-day')
-				.at(0)
-				.prop('disabled'),
-		).toBe(false);
+		expect(wrapper.find('.tc-date-picker-day').at(0).prop('disabled')).toBe(false);
 		expect(
 			wrapper
 				.find('.tc-date-picker-day')
@@ -175,6 +164,31 @@ describe('DatePicker', () => {
 		expect(middleTableCell.prop('className')).toContain('theme-range-middle');
 	});
 
+
+	it('should apply range style to startDate when time is not 00:00', () => {
+		// given
+		const props = {
+			calendar: {
+				year: 2021,
+				monthIndex: 3,
+			},
+			startDate: new Date(2021, 3, 1, 1, 0, 0), // 2021-04-01 01:00:00
+			selectedDate: new Date(2021, 3, 7), // 2021-04-07 00:00:00
+			// add the following props to prevent prop type warnings
+			onSelect: jest.fn(),
+			goToPreviousMonth: jest.fn(),
+			goToNextMonth: jest.fn(),
+		};
+
+		// when
+		const wrapper = mount(<DatePicker {...props} />);
+		const startDateTableCell = wrapper.find('td').at(3);// 2021-04-01
+
+		// then
+		expect(startDateTableCell.prop('className')).toContain('theme-range-start');
+		expect(startDateTableCell.prop('className')).toContain('theme-date-range');
+	});
+
 	it('should select date', () => {
 		// given
 		const calendar = { year: YEAR, monthIndex: MONTH_INDEX };
@@ -209,29 +223,14 @@ describe('DatePicker', () => {
 				goToNextMonth={jest.fn()}
 			/>,
 		);
-		expect(
-			wrapper
-				.find('.tc-date-picker-day')
-				.at(0)
-				.prop('tabIndex'),
-		).toBe(-1);
+		expect(wrapper.find('.tc-date-picker-day').at(0).prop('tabIndex')).toBe(-1);
 
 		// when
 		wrapper.setProps({ allowFocus: true });
 
 		// then
-		expect(
-			wrapper
-				.find('.tc-date-picker-day')
-				.at(0)
-				.prop('tabIndex'),
-		).toBe(-1);
-		expect(
-			wrapper
-				.find('.tc-date-picker-day[data-value]')
-				.at(0)
-				.prop('tabIndex'),
-		).toBe(0);
+		expect(wrapper.find('.tc-date-picker-day').at(0).prop('tabIndex')).toBe(-1);
+		expect(wrapper.find('.tc-date-picker-day[data-value]').at(0).prop('tabIndex')).toBe(0);
 	});
 
 	it('should have 6 weeks', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For DateTimeRange Picker, the style of range start is broken when select any time other than 00:00.
![image](https://user-images.githubusercontent.com/3214228/113682232-81934b80-96f5-11eb-9b7e-2760a430e599.png)


**What is the chosen solution to this problem?**
Use `startOfDay(startDate)` when checking if a date is in range.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
