### PR TITLE
feat(components/QualityBar): not applicable

### DIFF
--- a/output/components.sasslint.txt
+++ b/output/components.sasslint.txt
@@ -32,6 +32,7 @@ src/QualityBar/QualityRatioBar.scss
    8:10  error  @extend must be used with a %placeholder  placeholder-in-extend
   12:10  error  @extend must be used with a %placeholder  placeholder-in-extend
   16:10  error  @extend must be used with a %placeholder  placeholder-in-extend
+  21:10  error  @extend must be used with a %placeholder  placeholder-in-extend
 
 src/RatioBar/RatioBar.scss
   42:11  error  @extend must be used with a %placeholder  placeholder-in-extend
@@ -41,5 +42,5 @@ src/Typeahead/Typeahead.scss
    33:5  error  Mixins should come before declarations               mixins-before-declarations
   185:2  error  Duplicate properties are not allowed within a block  no-duplicate-properties
 
-✖ 20 problems (19 errors, 1 warning)
+✖ 21 problems (20 errors, 1 warning)
 

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -5,6 +5,7 @@ import RatioBar from '../RatioBar';
 import {
 	QualityEmptyLine,
 	QualityInvalidLine,
+	QualityNotApplicableLine,
 	QualityType,
 	QualityValidLine,
 } from './QualityRatioBar.component';
@@ -72,6 +73,20 @@ export function QualityBar({ invalid, valid, empty, onClick, getDataFeature, dig
 						? e =>
 								onClick(e, {
 									type: QualityType.EMPTY,
+								})
+						: null
+				}
+				dataFeature={getDataFeature ? getDataFeature(QualityType.EMPTY) : null}
+				value={empty}
+				percentage={emptyPercentage}
+				t={t}
+			/>
+			<QualityNotApplicableLine
+				onClick={
+					onClick
+						? e =>
+								onClick(e, {
+									type: QualityType.QualityNotApplicableLine,
 								})
 						: null
 				}

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -20,7 +20,7 @@ import I18N_DOMAIN_COMPONENTS from '../constants';
  * @param {number} naRaw number of not applicable raw
  * @param {number} digits number of digits we want to keep
  */
-export function getQualityPercentagesRounded(invalid, empty, valid, na, digits = 0) {
+export function getQualityPercentagesRounded(invalid, empty, valid, na = 0, digits = 0) {
 	let sumValues = 0;
 	let sumRounded = 0;
 	const digitMultiplier = Math.pow(10, digits);

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -19,13 +19,13 @@ import I18N_DOMAIN_COMPONENTS from '../constants';
  * @param {number} validRaw number of invalid raw
  * @param {number} digits number of digits we want to keep
  */
-export function getQualityPercentagesRounded(invalid, empty, valid, digits = 0) {
+export function getQualityPercentagesRounded(invalid, empty, valid, na, digits = 0) {
 	let sumValues = 0;
 	let sumRounded = 0;
 	const digitMultiplier = Math.pow(10, digits);
 	const multiplier = 100 * digitMultiplier;
 
-	const total = invalid + empty + valid;
+	const total = invalid + empty + valid + na;
 
 	sumValues = (invalid * multiplier) / total;
 	const invalidRounded = Math.round(sumValues - sumRounded) / digitMultiplier;
@@ -38,18 +38,21 @@ export function getQualityPercentagesRounded(invalid, empty, valid, digits = 0) 
 	sumValues += (valid * multiplier) / total;
 	const validRounded = Math.round(sumValues - sumRounded) / digitMultiplier;
 
-	return [invalidRounded, emptyRounded, validRounded];
+	sumValues += (na * multiplier) / total;
+	const naRounded = Math.round(sumValues - sumRounded) / digitMultiplier;
+
+	return [invalidRounded, emptyRounded, validRounded, naRounded];
 }
 
-export function QualityBar({ invalid, valid, empty, onClick, getDataFeature, digits = 1 }) {
+export function QualityBar({ invalid, valid, empty, na, onClick, getDataFeature, digits = 1 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
-	const [invalidPercentage, emptyPercentage, validPercentage] = getQualityPercentagesRounded(
-		invalid,
-		empty,
-		valid,
-		digits,
-	);
+	const [
+		invalidPercentage,
+		emptyPercentage,
+		validPercentage,
+		naPercentage,
+	] = getQualityPercentagesRounded(invalid, empty, valid, na, digits);
 
 	return (
 		<RatioBar.Composition>
@@ -86,13 +89,13 @@ export function QualityBar({ invalid, valid, empty, onClick, getDataFeature, dig
 					onClick
 						? e =>
 								onClick(e, {
-									type: QualityType.QualityNotApplicableLine,
+									type: QualityType.NA,
 								})
 						: null
 				}
-				dataFeature={getDataFeature ? getDataFeature(QualityType.EMPTY) : null}
-				value={empty}
-				percentage={emptyPercentage}
+				dataFeature={getDataFeature ? getDataFeature(QualityType.NA) : null}
+				value={na}
+				percentage={naPercentage}
 				t={t}
 			/>
 			<QualityValidLine
@@ -117,6 +120,7 @@ QualityBar.propTypes = {
 	invalid: PropTypes.number.isRequired,
 	empty: PropTypes.number.isRequired,
 	valid: PropTypes.number.isRequired,
+	na: PropTypes.number.isRequired,
 	onClick: PropTypes.func,
 	getDataFeature: PropTypes.func,
 	digits: PropTypes.number,

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -15,8 +15,9 @@ import I18N_DOMAIN_COMPONENTS from '../constants';
  * This function round up the percentages to make it to 100%
  * based on https://stackoverflow.com/questions/13483430/how-to-make-rounded-percentages-add-up-to-100#answer-13483486
  * @param {number} invalidRaw number of invalid raw
- * @param {number} emptyRaw number of invalid raw
- * @param {number} validRaw number of invalid raw
+ * @param {number} emptyRaw number of empty raw
+ * @param {number} validRaw number of valid raw
+ * @param {number} naRaw number of not applicable raw
  * @param {number} digits number of digits we want to keep
  */
 export function getQualityPercentagesRounded(invalid, empty, valid, na, digits = 0) {

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -38,6 +38,7 @@ export function getQualityPercentagesRounded(invalid, empty, valid, na, digits =
 
 	sumValues += (valid * multiplier) / total;
 	const validRounded = Math.round(sumValues - sumRounded) / digitMultiplier;
+	sumRounded = Math.round(sumValues);
 
 	sumValues += (na * multiplier) / total;
 	const naRounded = Math.round(sumValues - sumRounded) / digitMultiplier;

--- a/packages/components/src/QualityBar/QualityBar.component.test.js
+++ b/packages/components/src/QualityBar/QualityBar.component.test.js
@@ -21,7 +21,7 @@ describe('QualityBar', () => {
 			expect(wrapper.find('QualityValidLine').props().percentage).toBe(53.5);
 			expect(wrapper.find('QualityValidLine').props().value).toBe(523);
 		});
-		it('should render a chart with non applicable', () => {
+		it('should render a chart with not applicable', () => {
 			// given
 			const props = {
 				valid: 523,

--- a/packages/components/src/QualityBar/QualityBar.component.test.js
+++ b/packages/components/src/QualityBar/QualityBar.component.test.js
@@ -10,6 +10,7 @@ describe('QualityBar', () => {
 				valid: 523,
 				invalid: 123,
 				empty: 332,
+				na: 100,
 			};
 			// when
 			const wrapper = shallow(<QualityBar {...props} />);
@@ -20,6 +21,8 @@ describe('QualityBar', () => {
 			expect(wrapper.find('QualityEmptyLine').props().value).toBe(332);
 			expect(wrapper.find('QualityValidLine').props().percentage).toBe(53.5);
 			expect(wrapper.find('QualityValidLine').props().value).toBe(523);
+			expect(wrapper.find('QualityNotApplicableLine').props().percentage).toBe(9.3);
+			expect(wrapper.find('QualityNotApplicableLine').props().value).toBe(100);
 		});
 		it('should render an chart with action button', () => {
 			// given

--- a/packages/components/src/QualityBar/QualityBar.component.test.js
+++ b/packages/components/src/QualityBar/QualityBar.component.test.js
@@ -4,7 +4,24 @@ import { QualityBar } from './QualityBar.component';
 
 describe('QualityBar', () => {
 	describe('QualityBar component', () => {
-		it('should render an chart', () => {
+		it('should render a chart', () => {
+			// given
+			const props = {
+				valid: 523,
+				invalid: 123,
+				empty: 332,
+			};
+			// when
+			const wrapper = shallow(<QualityBar {...props} />);
+			// then
+			expect(wrapper.find('QualityInvalidLine').props().percentage).toBe(12.6);
+			expect(wrapper.find('QualityInvalidLine').props().value).toBe(123);
+			expect(wrapper.find('QualityEmptyLine').props().percentage).toBe(33.9);
+			expect(wrapper.find('QualityEmptyLine').props().value).toBe(332);
+			expect(wrapper.find('QualityValidLine').props().percentage).toBe(53.5);
+			expect(wrapper.find('QualityValidLine').props().value).toBe(523);
+		});
+		it('should render a chart with non applicable', () => {
 			// given
 			const props = {
 				valid: 523,

--- a/packages/components/src/QualityBar/QualityBar.component.test.js
+++ b/packages/components/src/QualityBar/QualityBar.component.test.js
@@ -15,11 +15,11 @@ describe('QualityBar', () => {
 			// when
 			const wrapper = shallow(<QualityBar {...props} />);
 			// then
-			expect(wrapper.find('QualityInvalidLine').props().percentage).toBe(12.6);
+			expect(wrapper.find('QualityInvalidLine').props().percentage).toBe(11.4);
 			expect(wrapper.find('QualityInvalidLine').props().value).toBe(123);
-			expect(wrapper.find('QualityEmptyLine').props().percentage).toBe(33.9);
+			expect(wrapper.find('QualityEmptyLine').props().percentage).toBe(30.8);
 			expect(wrapper.find('QualityEmptyLine').props().value).toBe(332);
-			expect(wrapper.find('QualityValidLine').props().percentage).toBe(53.5);
+			expect(wrapper.find('QualityValidLine').props().percentage).toBe(48.5);
 			expect(wrapper.find('QualityValidLine').props().value).toBe(523);
 			expect(wrapper.find('QualityNotApplicableLine').props().percentage).toBe(9.3);
 			expect(wrapper.find('QualityNotApplicableLine').props().value).toBe(100);
@@ -31,6 +31,7 @@ describe('QualityBar', () => {
 				valid: 523,
 				invalid: 123,
 				empty: 332,
+				na: 100,
 				onClick: mockFunctionAction,
 				getDataFeature: qualityType => {
 					return `data-feature-${qualityType}`;
@@ -59,6 +60,11 @@ describe('QualityBar', () => {
 			expect(
 				wrapper.find('div').filterWhere(item => {
 					return item.prop('data-feature') === 'data-feature-empty';
+				}).length,
+			).toBe(1);
+			expect(
+				wrapper.find('div').filterWhere(item => {
+					return item.prop('data-feature') === 'data-feature-na';
 				}).length,
 			).toBe(1);
 		});

--- a/packages/components/src/QualityBar/QualityBar.stories.js
+++ b/packages/components/src/QualityBar/QualityBar.stories.js
@@ -15,6 +15,8 @@ stories
 					<QualityBar invalid={30} valid={30} empty={30} />
 					<div>Very invalid</div>
 					<QualityBar invalid={30} valid={0} empty={0} />
+					<div>not applicable</div>
+					<QualityBar invalid={30} valid={0} empty={0} na={20} />
 					<div>Best quality ever</div>
 					<QualityBar invalid={0} valid={30} empty={0} />
 					<div>Nothing to see here</div>

--- a/packages/components/src/QualityBar/QualityBar.stories.js
+++ b/packages/components/src/QualityBar/QualityBar.stories.js
@@ -15,7 +15,7 @@ stories
 					<QualityBar invalid={30} valid={30} empty={30} />
 					<div>Very invalid</div>
 					<QualityBar invalid={30} valid={0} empty={0} />
-					<div>not applicable</div>
+					<div>Not applicable</div>
 					<QualityBar invalid={30} valid={0} empty={0} na={20} />
 					<div>Best quality ever</div>
 					<QualityBar invalid={0} valid={30} empty={0} />

--- a/packages/components/src/QualityBar/QualityRatioBar.component.js
+++ b/packages/components/src/QualityBar/QualityRatioBar.component.js
@@ -32,6 +32,7 @@ export const QualityType = {
 	VALID: 'valid',
 	INVALID: 'invalid',
 	EMPTY: 'empty',
+	NA: 'na',
 };
 
 export function QualityInvalidLine({ value, percentage, t, dataFeature, onClick }) {
@@ -93,3 +94,23 @@ export function QualityEmptyLine({ value, percentage, t, dataFeature, onClick })
 	);
 }
 QualityEmptyLine.propTypes = qualityBarLinePropTypes;
+
+export function QualityNotApplicableLine({ value, percentage, t, dataFeature, onClick }) {
+	return (
+		<RatioBar.Line
+			percentage={percentage}
+			tooltipLabel={t('NOT_APPLICABLE_VALUES', {
+				defaultValue: '{{value}} not applicable value ({{percentage}}%)',
+				defaultValue_plural: '{{value}} not applicable values ({{percentage}}%)',
+				count: value,
+				percentage,
+				value: formatNumber(value),
+			})}
+			dataFeature={dataFeature}
+			onClick={onClick}
+			value={value}
+			className={theme('tc-ratio-bar-line-quality-na')}
+		/>
+	);
+}
+QualityNotApplicableLine.propTypes = qualityBarLinePropTypes;

--- a/packages/components/src/QualityBar/QualityRatioBar.scss
+++ b/packages/components/src/QualityBar/QualityRatioBar.scss
@@ -16,3 +16,8 @@
 	@extend .tc-ratio-bar-lines;
 	background-color: $chestnut-rose;
 }
+
+.tc-ratio-bar-line-quality-na {
+	@extend .tc-ratio-bar-lines;
+	background-color: $lightning-yellow;
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
adding another metric in the quality bar which is not applicable see : https://jira.talendforge.org/browse/TDS-5711

**What is the chosen solution to this problem?**
adding it 

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
