### PR TITLE
fix(container): context.store.dispatch not a function

### DIFF
--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -1,4 +1,5 @@
 import cmf from '@talend/react-cmf';
+import get from 'lodash/get';
 
 /**
  * add support for expression in actions.
@@ -38,12 +39,13 @@ export function getActionsProps(context, ids, model) {
 
 	const props = infos.map(info => {
 		const newprops = {};
-		if (context && context.store && context.store.dispatch) {
+		const dispatch = get(context, 'store.dispatch');
+		if (dispatch) {
 			newprops.onClick = (event, data) => {
 				if (info.actionCreator) {
-					context.store.dispatch(cmf.action.getActionObject(context, info.id, event, data));
+					dispatch(cmf.action.getActionObject(context, info.id, event, data));
 				} else {
-					context.store.dispatch({
+					dispatch({
 						model,
 						...info.payload,
 					});

--- a/packages/containers/src/actionAPI.js
+++ b/packages/containers/src/actionAPI.js
@@ -36,19 +36,23 @@ export function getActionsProps(context, ids, model) {
 		return id;
 	});
 
-	const props = infos.map(info => ({
-		onClick(event, data) {
-			if (info.actionCreator) {
-				context.store.dispatch(cmf.action.getActionObject(context, info.id, event, data));
-			} else {
-				context.store.dispatch({
-					model,
-					...info.payload,
-				});
-			}
-		},
-		...evalExpressions(info, context, { model }),
-	}));
+	const props = infos.map(info => {
+		const newprops = {};
+		if (context && context.store && context.store.dispatch) {
+			newprops.onClick = (event, data) => {
+				if (info.actionCreator) {
+					context.store.dispatch(cmf.action.getActionObject(context, info.id, event, data));
+				} else {
+					context.store.dispatch({
+						model,
+						...info.payload,
+					});
+				}
+			};
+		}
+		Object.assign(newprops, evalExpressions(info, context, { model }));
+		return newprops;
+	});
 
 	if (onlyOne) {
 		return props[0];


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we have on some event handler the following error:
context.store.dispatch is not a function

This is due to the call to the old actionAPI script in a mapstatetoprops.
Yes we don t have store.dispatch in mapstatetoprops.


**What is the chosen solution to this problem?**

There is no risk here because the code were not working before so we just get ride of that uncaught JS error.
Check if we have context.store.dispatch before adding onclick



**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
