### PR TITLE
chore: remove demo when PR is closed

### DIFF
--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -1,4 +1,4 @@
-name: Cleanup - Production stacks NR
+name: Cleanup - Remove surge demo
 
 on:
   pull_request:

--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -1,0 +1,21 @@
+name: Cleanup - Production stacks NR
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  cleanup:
+    name: Remove NR on surge
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Use Node.js 14
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Push to surge
+        run: |
+          npm install -g surge
+          surge teardown ${{ github.event.pull_request.number }}.cdn.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -16,6 +16,4 @@ jobs:
           node-version: 14
 
       - name: Push to surge
-        run: |
-          npm install -g surge
-          surge teardown ${{ github.event.pull_request.number }}.cdn.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge teardown ${{ github.event.pull_request.number }}.cdn.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -16,4 +16,4 @@ jobs:
           node-version: 14
 
       - name: Push to surge
-        run: npx surge teardown ${{ github.event.pull_request.number }}.cdn.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+        run: npx surge teardown ${{ github.event.pull_request.number }}.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Demo on surge is never removed, unless we do it manually

**What is the chosen solution to this problem?**
Remove the demo on surge when PR is closed or merged

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
