### PR TITLE
fix(Typeahead): update position when items list changes

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -268,6 +268,9 @@
    98:3  error  defaultProp "level" defined for isRequired propType  react/default-props-match-prop-types
   209:4  error  'item.hidden' is missing in props validation         react/prop-types
 
+/home/travis/build/Talend/ui/packages/components/src/Typeahead/Typeahead.component.js
+  90:3  warning  React Hook useMemo has an unnecessary dependency: 'items'. Either exclude it or remove the dependency array  react-hooks/exhaustive-deps
+
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.component.js
   63:2  error  defaultProp "columnData" defined for isRequired propType  react/default-props-match-prop-types
 
@@ -305,5 +308,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 146 problems (127 errors, 19 warnings)
+✖ 147 problems (127 errors, 20 warnings)
   7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -87,7 +87,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 				state.styles.popper.minHeight = `${height}px`;
 			},
 		}),
-		[],
+		[rest.items],
 	);
 
 	const withInitialState = useMemo(

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -37,7 +37,7 @@ function getItems(items, dataFeature) {
  *
  * <Typeahead {...props} />
  */
-function Typeahead({ onToggle, icon, position, docked, ...rest }) {
+function Typeahead({ onToggle, icon, position, docked, items, ...rest }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
 	const [referenceElement, setReferenceElement] = useState(null);
@@ -87,7 +87,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 				state.styles.popper.minHeight = `${height}px`;
 			},
 		}),
-		[rest.items],
+		[items],
 	);
 
 	const withInitialState = useMemo(
@@ -236,7 +236,7 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 	const defaultRenderersProps = {
 		renderItem,
 		renderItemsContainer: renderItemsContainerFactory(
-			rest.items,
+			items,
 			noResultText,
 			rest.searching,
 			searchingText,
@@ -260,11 +260,11 @@ function Typeahead({ onToggle, icon, position, docked, ...rest }) {
 		...inputProps,
 		highlightedSectionIndex: rest.onKeyDown ? rest.focusedSectionIndex : highlightedSectionIndex,
 		highlightedItemIndex: rest.onKeyDown ? rest.focusedItemIndex : highlightedItemIndex,
-		items: getItems(rest.items, rest.dataFeature),
+		items: getItems(items, rest.dataFeature),
 		itemProps: ({ itemIndex }) => ({
 			onMouseDown: event => event.preventDefault(),
 			onClick: rest.onSelect,
-			'aria-disabled': rest.items[itemIndex] && rest.items[itemIndex].disabled,
+			'aria-disabled': items[itemIndex] && items[itemIndex].disabled,
 		}),
 	};
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When popper make positioning of the items at the top of input, if using search, the item length changes but the position of the items is unchanged which leads to : 

![image](https://user-images.githubusercontent.com/14272767/116279338-b3914e00-a787-11eb-8049-85ff76b61f4e.png)


**What is the chosen solution to this problem?**
making adding items as dependency of memoized function withInViewport
items is not used in the function but i guess its needed as a dep anyway ...

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
