### PR TITLE
fix(components/List/CellActions): fix safari compatibility issue for linear-gradient

### DIFF
--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.scss
@@ -101,7 +101,7 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 	&:focus,
 	&:global(.ally-focus-within) {
 		:global(.tc-list-title .cell-title-actions) {
-			background: linear-gradient(to right, transparent, $tc-list-row-active-hover-bg $padding-large);
+			background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba($tc-list-row-active-hover-bg, 100%) $padding-large);
 		}
 	}
 }
@@ -112,7 +112,7 @@ $tc-list-title-icon-size: $svg-rg-size !default;
 	&:focus,
 	&:global(.ally-focus-within) {
 		:global(.tc-list-title .cell-title-actions) {
-			background: linear-gradient(to right, transparent, $tc-list-row-selected-hover-bg $padding-large);
+			background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba($tc-list-row-selected-hover-bg, 100%) $padding-large);
 		}
 	}
 }

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -14,7 +14,7 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	height: $btn-line-height;
 
 	.cell-title-actions {
-		background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-row-hover-bg $padding-large);
+		background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba($tc-list-row-hover-bg, 100%) $padding-large);
 		opacity: 0;
 		width: 0;
 		overflow: hidden;

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.scss
@@ -27,7 +27,7 @@ $tc-list-large-field-value-color: $dove-gray !default;
 			}
 
 			.cell-title-actions {
-				background: linear-gradient(to right, rgba(255, 255, 255, 0), $tc-list-large-hover-bg 20px);
+				background: linear-gradient(90deg, rgba(255, 255, 255, 0), rgba($tc-list-large-hover-bg, 100%) 20px);
 				.btn-link {
 					padding: 0 $padding-smaller;
 				}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
A piece of shadow appears when hover on selected row.
https://jira.talendforge.org/browse/TMC-18091
![image](https://user-images.githubusercontent.com/3214228/116526381-1e6b9200-a90c-11eb-8749-330968ecca78.png)

**What is the chosen solution to this problem?**
This is because safari doesn't support some format in linear-gradient. 
- use rgba color instead of string
- use `90deg` instead of `to right`

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
