### PR TITLE
fix(components/resourceslist): i18n domain is not provided

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -224,7 +224,7 @@
   63:31  error  'parent.props.rowCount' is missing in props validation                                          react/prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/ResourceList/ResourceList.component.js
-  51:3  warning  React Hook React.useCallback has a missing dependency: 't'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+  52:3  warning  React Hook React.useCallback has a missing dependency: 't'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/ResourceList/ResourceList.stories.js
   253:13  error    'collection' is missing in props validation                                                                              react/prop-types

--- a/packages/components/src/ResourceList/ResourceList.component.js
+++ b/packages/components/src/ResourceList/ResourceList.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
 
+import I18N_DOMAIN_COMPONENTS from '../constants';
 import { getTheme } from '../theme';
 
 import Resource from './Resource';
@@ -29,7 +30,7 @@ function ResourceList({
 	rowProps,
 	...rest
 }) {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const Renderer = getRowSelectionRenderer(Resource, {
 		as: renderAs,
 		getRowData: ({ index }) => collection[index],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

i18n domain is not provided to the resourcelist component

**What is the chosen solution to this problem?**

provide it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
