### PR TITLE
feat(component/actiondropdown): add ellipsis mode

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -275,8 +275,8 @@
   63:2  error  defaultProp "columnData" defined for isRequired propType  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
-  171:3  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
-  199:2  error  defaultProp "t" defined for isRequired propType          react/default-props-match-prop-types
+  170:3  error  Static HTML elements with event handlers require a role  jsx-a11y/no-static-element-interactions
+  198:2  error  defaultProp "t" defined for isRequired propType          react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/VirtualizedList/CellTitle/CellTitleInput.component.js
   54:6  error  The autoFocus prop should not be used, as it can reduce usability and accessibility for users  jsx-a11y/no-autofocus

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -205,13 +205,14 @@ class ActionDropdown extends React.Component {
 			className,
 			loading,
 			children,
+			ellipsis,
 			t = getDefaultT(),
 			...rest
 		} = this.props;
 
 		const Renderers = Inject.getAll(getComponent, { MenuItem, DropdownButton });
 		const injected = Inject.all(getComponent, components, InjectDropdownMenuItem);
-		const title = [
+		const title = !ellipsis && [
 			icon && <Icon name={icon} transform={iconTransform} key="icon" />,
 			!hideLabel && (
 				<span className="tc-dropdown-button-title-label" key="label">
@@ -234,7 +235,7 @@ class ActionDropdown extends React.Component {
 				})}
 			/>,
 		].filter(Boolean);
-		const style = link ? 'link' : bsStyle;
+		const style = (link || ellipsis) ? 'link' : bsStyle;
 
 		function onItemSelect(object, event) {
 			if (onSelect) {
@@ -248,7 +249,9 @@ class ActionDropdown extends React.Component {
 				bsStyle={style}
 				role="button"
 				onSelect={onItemSelect}
-				className={classNames(theme['tc-dropdown-button'], 'tc-dropdown-button', className)}
+				className={classNames(theme['tc-dropdown-button'], 'tc-dropdown-button', className, {
+					[theme.ellipsis]: ellipsis,
+				})}
 				aria-label={tooltipLabel || label}
 				{...omit(rest, 'tReady')}
 				onToggle={this.onToggle}
@@ -284,7 +287,7 @@ class ActionDropdown extends React.Component {
 			</Renderers.DropdownButton>
 		);
 
-		if (hideLabel || tooltipLabel) {
+		if (hideLabel || tooltipLabel || ellipsis) {
 			return (
 				<TooltipTrigger label={tooltipLabel || label} tooltipPlacement={tooltipPlacement}>
 					{dropdown}
@@ -324,6 +327,7 @@ ActionDropdown.propTypes = {
 	label: PropTypes.string.isRequired,
 	link: PropTypes.bool,
 	loading: PropTypes.bool,
+	ellipsis: PropTypes.bool,
 	onToggle: PropTypes.func,
 	onSelect: PropTypes.func,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.component.js
@@ -212,30 +212,32 @@ class ActionDropdown extends React.Component {
 
 		const Renderers = Inject.getAll(getComponent, { MenuItem, DropdownButton });
 		const injected = Inject.all(getComponent, components, InjectDropdownMenuItem);
-		const title = !ellipsis && [
-			icon && <Icon name={icon} transform={iconTransform} key="icon" />,
-			!hideLabel && (
-				<span className="tc-dropdown-button-title-label" key="label">
-					{label}
-				</span>
-			),
-			badge && (
-				<Tag
-					className={classNames(theme['tc-dropdown-item-badge'], 'tc-dropdown-item-badge')}
-					bsStyle={badge.bsStyle || 'default'}
-				>
-					{getTabBarBadgeLabel(badge.label)}
-				</Tag>
-			),
-			<Icon
-				key="caret"
-				name="talend-caret-down"
-				className={classNames(theme['tc-dropdown-caret'], {
-					[theme['tc-dropdown-caret-open']]: this.state.isOpen,
-				})}
-			/>,
-		].filter(Boolean);
-		const style = (link || ellipsis) ? 'link' : bsStyle;
+		const title =
+			!ellipsis &&
+			[
+				icon && <Icon name={icon} transform={iconTransform} key="icon" />,
+				!hideLabel && (
+					<span className="tc-dropdown-button-title-label" key="label">
+						{label}
+					</span>
+				),
+				badge && (
+					<Tag
+						className={classNames(theme['tc-dropdown-item-badge'], 'tc-dropdown-item-badge')}
+						bsStyle={badge.bsStyle || 'default'}
+					>
+						{getTabBarBadgeLabel(badge.label)}
+					</Tag>
+				),
+				<Icon
+					key="caret"
+					name="talend-caret-down"
+					className={classNames(theme['tc-dropdown-caret'], {
+						[theme['tc-dropdown-caret-open']]: this.state.isOpen,
+					})}
+				/>,
+			].filter(Boolean);
+		const style = link || ellipsis ? 'link' : bsStyle;
 
 		function onItemSelect(object, event) {
 			if (onSelect) {

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.scss
@@ -23,6 +23,19 @@ $tc-dropdown-button-right-padding: 0.8rem;
 				transform: rotate(-180deg);
 			}
 		}
+
+		&.ellipsis {
+			&:after {
+				content: '\22ee';
+				font-size: 2em;
+				font-weight: bold;
+				vertical-align: inherit;
+			}
+
+			+ ul {
+				min-width: auto;
+			}
+		}
 	}
 
 	&-item {

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
@@ -102,6 +102,25 @@ describe('ActionDropdown', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
+
+	it('should render an ellipsis dropdown', () => {
+		// given
+		const props = {
+			id: 'dropdown-id',
+			label: 'related items',
+			icon: 'fa fa-file-excel-o',
+			items,
+			tooltipPlacement: 'right',
+			ellipsis: true,
+		};
+
+		// when
+		const wrapper = mount(<ActionDropdown {...props} />).find('DropdownButton');
+
+		// then
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
 	it('should render a button with "link" theme', () => {
 		// given
 		const props = {

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.snapshot.test.js
@@ -102,7 +102,6 @@ describe('ActionDropdown', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 	});
 
-
 	it('should render an ellipsis dropdown', () => {
 		// given
 		const props = {

--- a/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
+++ b/packages/components/src/Actions/ActionDropdown/Dropdown.stories.js
@@ -211,6 +211,10 @@ storiesOf('Buttons/Dropdown', module).add('default', () => (
 		<div id="hidelabel">
 			<ActionDropdown {...myAction} hideLabel />
 		</div>
+		<h3>With ellipsis option</h3>
+		<div id="ellipsis">
+			<ActionDropdown {...myAction} ellipsis />
+		</div>
 		<h3>Empty option</h3>
 		<div id="empty">
 			<ActionDropdown {...myAction} items={[]} hideLabel />

--- a/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
+++ b/packages/components/src/Actions/ActionDropdown/__snapshots__/ActionDropdown.snapshot.test.js.snap
@@ -179,6 +179,53 @@ exports[`ActionDropdown should render a button with icon and label 1`] = `
 </div>
 `;
 
+exports[`ActionDropdown should render an ellipsis dropdown 1`] = `
+<div class="dropdown btn-group btn-group-link">
+  <button aria-label="related items"
+          aria-describedby="42"
+          id="dropdown-id"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          type="button"
+          class="theme-tc-dropdown-button tc-dropdown-button theme-ellipsis dropdown-toggle btn btn-link"
+  >
+  </button>
+  <ul role="menu"
+      class="dropdown-menu"
+      aria-labelledby="dropdown-id"
+  >
+    <li role="presentation"
+        class="theme-tc-dropdown-item tc-dropdown-item"
+    >
+      <a icon="talend-icon"
+         label="document 1"
+         title="document 1"
+         role="menuitem"
+         tabindex="-1"
+         href="#"
+      >
+        <coral.icon name="talend-icon">
+        </coral.icon>
+        document 1
+      </a>
+    </li>
+    <li role="presentation"
+        class="theme-tc-dropdown-item tc-dropdown-item"
+    >
+      <a label="document 2"
+         title="document 2"
+         role="menuitem"
+         tabindex="-1"
+         href="#"
+      >
+        document 2
+      </a>
+    </li>
+  </ul>
+</div>
+`;
+
 exports[`ActionDropdown should render icon only with hideLabel props 1`] = `
 <div class="dropdown btn-group btn-group-default">
   <button aria-label="related items"

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.component.js
@@ -101,8 +101,7 @@ function getDefaultDisplayActions(actions, getComponent, t, id) {
 				className={classNames('cell-title-actions-menu', theme['cell-title-actions-menu'])}
 				items={remainingActions}
 				label={t('LIST_OPEN_ACTION_MENU', { defaultValue: 'Open menu' })}
-				hideLabel
-				link
+				ellipsis
 			/>,
 		);
 	}

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.scss
@@ -23,19 +23,6 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 			content: '|';
 			color: $dark-silver;
 		}
-
-		.cell-title-actions-menu {
-			&:after {
-				content: $tc-list-title-actions-ellipsis;
-				font-size: 2em;
-				font-weight: bold;
-				vertical-align: inherit;
-			}
-
-			+ ul {
-				min-width: auto;
-			}
-		}
 	}
 
 	:global {

--- a/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellTitle/__snapshots__/CellTitleActions.test.js.snap
@@ -41,7 +41,7 @@ exports[`CellTitleActions should display 2 actions and the rest in an ellipsis d
     />
     <withI18nextTranslation(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
-      hideLabel={true}
+      ellipsis={true}
       id="my-actions-ellispsis-actions"
       items={
         Array [
@@ -62,7 +62,6 @@ exports[`CellTitleActions should display 2 actions and the rest in an ellipsis d
         ]
       }
       label="Open menu"
-      link={true}
       t={[Function]}
     />
   </div>
@@ -221,7 +220,7 @@ exports[`CellTitleActions should extract dropdown actions, completed with simple
     />
     <withI18nextTranslation(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
-      hideLabel={true}
+      ellipsis={true}
       id="my-actions-ellispsis-actions"
       items={
         Array [
@@ -249,7 +248,6 @@ exports[`CellTitleActions should extract dropdown actions, completed with simple
         ]
       }
       label="Open menu"
-      link={true}
       t={[Function]}
     />
   </div>
@@ -329,7 +327,7 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
     />
     <withI18nextTranslation(ActionDropdown)
       className="cell-title-actions-menu theme-cell-title-actions-menu"
-      hideLabel={true}
+      ellipsis={true}
       id="my-actions-ellispsis-actions"
       items={
         Array [
@@ -371,7 +369,6 @@ exports[`CellTitleActions should extract only dropdown actions, when there are l
         ]
       }
       label="Open menu"
-      link={true}
       t={[Function]}
     />
   </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

the ellipsis display mode is inside list but we need it elsewhere

**What is the chosen solution to this problem?**

add a ellipsis prop to the action dropdown

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
