### PR TITLE
feat(cmf): change publicPath at built

### DIFF
--- a/packages/cmf/scripts/cmf-settings.js
+++ b/packages/cmf/scripts/cmf-settings.js
@@ -7,6 +7,7 @@ program
 	.version('0.0.2')
 	.option('-d, --dev', 'dev sources instead of sources')
 	.option('-q, --quiet', 'display nothing')
+	.option('-p, --public-path <type>', 'publicPath of webpack to rewrite routes')
 	.option('-r, --recursive', 'allow recursive search for json files')
 	.parse(process.argv);
 

--- a/packages/cmf/scripts/cmf-settings.merge.js
+++ b/packages/cmf/scripts/cmf-settings.merge.js
@@ -83,6 +83,9 @@ function merge(options, errorCallback) {
 				overrideRoutes(route, settings);
 			});
 		}
+		if (settings.routes && options.publicPath) {
+			settings.routes.path = options.publicPath;
+		}
 		if (settings.overrideActions) {
 			Object.keys(settings.overrideActions).forEach(id => {
 				overrideActions(id, settings);

--- a/packages/cmf/scripts/cmf-settings.utils.js
+++ b/packages/cmf/scripts/cmf-settings.utils.js
@@ -89,6 +89,7 @@ function sortObject(object) {
 		.reduce((state, key) => ({ ...state, [key]: object[key] }), {});
 }
 
+
 module.exports = {
 	concatMerge,
 	findJson,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

If we set publicPath in webpack, the router is still on "/" for routing.

**What is the chosen solution to this problem?**

This is just a POC to evaluate options we have.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
