### PR TITLE
fix(components/DateTimeRange): display in vertical layout when there's not enough space

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -59,7 +59,7 @@
   94:2  error  defaultProp "required" has no corresponding propTypes declaration  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
-  66:5  warning  React Hook useEffect has a missing dependency: 'showHorizontalAndTest'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
+  69:5  warning  React Hook useEffect has a missing dependency: 'showHorizontalAndTest'. Either include it or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Manager/Manager.component.js
    81:2   error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -49,7 +49,10 @@ function InputDateTimeRangePicker(props) {
 			// delay for the display to update
 			setTimeout(() => {
 				const rangeContainer = containerRef.current;
-				if (rangeContainer && rangeContainer.scrollWidth > rangeContainer.offsetParent.offsetWidth) {
+				if (
+					rangeContainer &&
+					rangeContainer.scrollWidth > rangeContainer.offsetParent.offsetWidth
+				) {
 					setVertical(true);
 				}
 			});

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -49,7 +49,7 @@ function InputDateTimeRangePicker(props) {
 			// delay for the display to update
 			setTimeout(() => {
 				const rangeContainer = containerRef.current;
-				if (rangeContainer && rangeContainer.scrollWidth > rangeContainer.offsetWidth) {
+				if (rangeContainer && rangeContainer.scrollWidth > rangeContainer.offsetParent.offsetWidth) {
 					setVertical(true);
 				}
 			});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Responsive vertical layout not work anymore
**What is the chosen solution to this problem?**
fix the condition for showing vertical layout
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
