### PR TITLE
feat(http): Get response payload on error

### DIFF
--- a/packages/http/src/http.common.js
+++ b/packages/http/src/http.common.js
@@ -67,7 +67,7 @@ export async function handleBody(response) {
 export async function handleHttpResponse(response) {
 	if (!testHTTPCode.isSuccess(response.status)) {
 		const error = new Error(response.status);
-		error.response = response;
+		Object.assign(error, await handleBody(response));
 		throw error;
 	}
 	if (response.status === HTTP_STATUS.NO_CONTENT) {

--- a/packages/http/src/http.common.test.js
+++ b/packages/http/src/http.common.test.js
@@ -102,6 +102,9 @@ describe('#handleHttpResponse', () => {
 			}),
 		).catch(response => {
 			expect(response instanceof Error).toBe(true);
+			expect(response.data).toEqual({
+				foo: 42,
+			});
 			done();
 		});
 	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Payload is not resquested when a call fails

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
