### PR TITLE
feat(TDOPS-14/FolderTreeView): added disabled list item state

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -267,7 +267,6 @@
 /home/travis/build/Talend/ui/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
    99:3  error  defaultProp "level" defined for isRequired propType  react/default-props-match-prop-types
   210:4  error  'item.hidden' is missing in props validation         react/prop-types
-  255:7  error  Expected property shorthand                          object-shorthand
 
 /home/travis/build/Talend/ui/packages/components/src/Typeahead/Typeahead.component.js
   90:3  warning  React Hook useMemo has an unnecessary dependency: 'items'. Either exclude it or remove the dependency array  react-hooks/exhaustive-deps
@@ -309,5 +308,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 148 problems (128 errors, 20 warnings)
-  8 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 147 problems (127 errors, 20 warnings)
+  7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -265,8 +265,9 @@
   104:2  error  defaultProp "id" defined for isRequired propType  react/default-props-match-prop-types
 
 /home/travis/build/Talend/ui/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
-   98:3  error  defaultProp "level" defined for isRequired propType  react/default-props-match-prop-types
-  209:4  error  'item.hidden' is missing in props validation         react/prop-types
+   99:3  error  defaultProp "level" defined for isRequired propType  react/default-props-match-prop-types
+  210:4  error  'item.hidden' is missing in props validation         react/prop-types
+  255:7  error  Expected property shorthand                          object-shorthand
 
 /home/travis/build/Talend/ui/packages/components/src/Typeahead/Typeahead.component.js
   90:3  warning  React Hook useMemo has an unnecessary dependency: 'items'. Either exclude it or remove the dependency array  react-hooks/exhaustive-deps
@@ -308,5 +309,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 147 problems (127 errors, 20 warnings)
-  7 errors and 0 warnings potentially fixable with the `--fix` option.
+✖ 148 problems (128 errors, 20 warnings)
+  8 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -222,7 +222,6 @@ const structureWithDisabledActions = [
 	},
 ];
 
-
 const defaultProps = {
 	id: 'my-treeview',
 	structure,
@@ -255,7 +254,7 @@ withActions.structure = structureWithActions;
 
 const withDisabledItems = {
 	...withAddAction,
-}
+};
 
 withDisabledItems.structure = structureWithDisabledActions;
 
@@ -442,7 +441,10 @@ storiesOf('Data/Tree/FolderTreeView', module)
 		<div>
 			<h1>TreeView</h1>
 			<h3>Definition</h3>
-			<p>When an element cannot be selected the whole line is 0.54 opacity, with a not-allowed cursor.</p>
+			<p>
+				When an element cannot be selected the whole line is 0.54 opacity, with a not-allowed
+				cursor.
+			</p>
 			<h3>An example with disabled items: </h3>
 			<div style={style}>
 				<TreeView {...withDisabledItems} />

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -216,7 +216,8 @@ const structureWithDisabledActions = [
 		],
 	},
 	{
-		name: 'pikachu',
+		id: 'selected',
+		name: 'Selected item',
 		isOpened: true,
 		actions,
 	},

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -188,6 +188,41 @@ const structureWithActions = [
 	},
 ];
 
+const structureWithDisabledActions = [
+	{
+		name: 'doge',
+		isOpened: true,
+		children: [
+			{
+				name: 'dogecoin',
+				actions,
+			},
+		],
+		actions,
+	},
+	{
+		name: 'hitmonlee',
+		isOpened: false,
+		disabled: true,
+		icon: {
+			name: 'talend-warning',
+			tooltipLabel: 'New version of the Pokemon is available',
+		},
+		children: [
+			{
+				name: 'raichu',
+				actions,
+			},
+		],
+	},
+	{
+		name: 'pikachu',
+		isOpened: true,
+		actions,
+	},
+];
+
+
 const defaultProps = {
 	id: 'my-treeview',
 	structure,
@@ -217,6 +252,12 @@ const withActions = {
 	...withAddAction,
 };
 withActions.structure = structureWithActions;
+
+const withDisabledItems = {
+	...withAddAction,
+}
+
+withDisabledItems.structure = structureWithDisabledActions;
 
 const hugeStructure = [
 	{
@@ -394,6 +435,17 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<h3>Default property-set with remove action example: </h3>
 			<div style={style}>
 				<TreeView {...withActions} />
+			</div>
+		</div>
+	))
+	.add('with disabled items', () => (
+		<div>
+			<h1>TreeView</h1>
+			<h3>Definition</h3>
+			<p>When an element cannot be selected the whole line is 0.54 opacity, with a not-allowed cursor.</p>
+			<h3>An example with disabled items: </h3>
+			<div style={style}>
+				<TreeView {...withDisabledItems} />
 			</div>
 		</div>
 	))

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -252,7 +252,7 @@ class TreeViewItem extends React.Component {
 				<div
 					className={classNames('tc-treeview-item', css['tc-treeview-item'], {
 						[css.disabled]: disabled,
-						'disabled': disabled,
+						disabled: disabled,
 					})}
 					style={{ paddingLeft }}
 				>

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -236,7 +236,8 @@ class TreeViewItem extends React.Component {
 					return !disabled && onSelect(e, item);
 				}}
 				onKeyDown={e =>
-					!disabled && onKeyDown(e, this.containerRef, {
+					!disabled &&
+					onKeyDown(e, this.containerRef, {
 						...item,
 						hasChildren: children.length,
 						isOpened,

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -73,6 +73,7 @@ class TreeViewItem extends React.Component {
 		item: PropTypes.shape({
 			id: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
 			name: PropTypes.string.isRequired,
+			disabled: PropTypes.bool,
 			isOpened: PropTypes.bool,
 			children: PropTypes.arrayOf(PropTypes.object),
 			icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.object]),
@@ -213,6 +214,7 @@ class TreeViewItem extends React.Component {
 			actions,
 			icon,
 			counter = children.length,
+			disabled,
 		} = item;
 		const paddingLeft = `${(level - 1) * (PADDING + CARET_WIDTH) + BASE_PADDING}px`;
 		const showOpenedFolder = !!(children.length && (isOpened || this.state.hovered));
@@ -248,7 +250,10 @@ class TreeViewItem extends React.Component {
 				}}
 			>
 				<div
-					className={classNames('tc-treeview-item', css['tc-treeview-item'])}
+					className={classNames('tc-treeview-item', css['tc-treeview-item'], {
+						[css.disabled]: disabled,
+						'disabled': disabled,
+					})}
 					style={{ paddingLeft }}
 				>
 					{children.length ? (

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -252,7 +252,7 @@ class TreeViewItem extends React.Component {
 				<div
 					className={classNames('tc-treeview-item', css['tc-treeview-item'], {
 						[css.disabled]: disabled,
-						disabled: disabled,
+						disabled,
 					})}
 					style={{ paddingLeft }}
 				>

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -229,13 +229,14 @@ class TreeViewItem extends React.Component {
 				aria-posinset={index}
 				aria-setsize={siblings.length}
 				aria-selected={this.isSelected()}
+				aria-disabled={disabled}
 				className={classNames('tc-treeview-item-li', css['tc-treeview-li'])}
 				onClick={e => {
 					e.stopPropagation();
 					return !disabled && onSelect(e, item);
 				}}
 				onKeyDown={e =>
-					onKeyDown(e, this.containerRef, {
+					!disabled && onKeyDown(e, this.containerRef, {
 						...item,
 						hasChildren: children.length,
 						isOpened,

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -232,7 +232,7 @@ class TreeViewItem extends React.Component {
 				className={classNames('tc-treeview-item-li', css['tc-treeview-li'])}
 				onClick={e => {
 					e.stopPropagation();
-					return onSelect(e, item);
+					return !disabled && onSelect(e, item);
 				}}
 				onKeyDown={e =>
 					onKeyDown(e, this.containerRef, {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
@@ -26,6 +26,19 @@ $item-height: 4rem;
 
 		transition: 200ms ease-out;
 
+		&.disabled {
+			opacity: 0.54;
+			cursor: not-allowed;
+
+			.tc-treeview-item-name {
+				color: $black;
+			}
+
+			svg {
+				fill: rgba($black, 0.25);
+			}
+		}
+
 		.tc-treeview-toggle {
 			position: absolute;
 			padding: 1rem;
@@ -90,6 +103,10 @@ $item-height: 4rem;
 
 		:global(.btn-link) {
 			visibility: visible;
+		}
+
+		&.disabled {
+			background: none;
 		}
 	}
 

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.scss
@@ -83,22 +83,28 @@ $item-height: 4rem;
 	}
 
 	&[aria-selected='true'] > .tc-treeview-item {
-		background: rgba($black, 0.05);
+		background: rgba($scooter, 0.2);
 		font-weight: 600;
 		color: $black;
 
 		.tc-treeview-folder {
-			fill: $lightning-yellow;
+			fill: $brand-primary;
 		}
 	}
 
 	.tc-treeview-item:hover,
 	&:focus > .tc-treeview-item {
-		background: rgba($black, 0.05);
+		background: $wild-sand;
 		color: $scooter;
 
 		.tc-treeview-folder {
-			fill: $lightning-yellow;
+			fill: $brand-primary;
+		}
+
+		.tc-treeview-toggle {
+			svg {
+				fill: $scooter;
+			}
 		}
 
 		:global(.btn-link) {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -134,10 +134,12 @@ describe('TreeView item', () => {
 
 		const wrapper = shallow(<TreeViewItem {...props} onSelect={onSelect} />);
 		wrapper.find('li').simulate('click', { stopPropagation });
+		wrapper.find('li').simulate('keyDown', { keyCode: 13 });
 
 		// then
 		expect(onSelect.mock.calls.length).toBe(0);
 		expect(stopPropagation.mock.calls.length).toBe(1);
+		expect(wrapper.find('li').props()['aria-disabled']).toBeTruthy();
 	});
 
 	it('should render items with icon and tooltip', () => {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -120,6 +120,26 @@ describe('TreeView item', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('test disabled item not calling onSelect', () => {
+		// when
+		const onSelect = jest.fn();
+		const stopPropagation = jest.fn();
+		const props = {
+			...defaultProps,
+			item: {
+				...defaultProps.item,
+				disabled: true,
+			}
+		};
+
+		const wrapper = shallow(<TreeViewItem {...props} onSelect={onSelect} />);
+		wrapper.find('li').simulate('click', { stopPropagation });
+
+		// then
+		expect(onSelect.mock.calls.length).toBe(0);
+		expect(stopPropagation.mock.calls.length).toBe(1);
+	});
+
 	it('should render items with icon and tooltip', () => {
 		// when
 		const propsWithIconAndTooltip = {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -129,7 +129,7 @@ describe('TreeView item', () => {
 			item: {
 				...defaultProps.item,
 				disabled: true,
-			}
+			},
 		};
 
 		const wrapper = shallow(<TreeViewItem {...props} onSelect={onSelect} />);
@@ -149,12 +149,7 @@ describe('TreeView item', () => {
 
 		const wrapper = shallow(<TreeViewItem {...propsWithIconAndTooltip} />);
 
-		expect(
-			wrapper
-				.find('TreeViewIcon')
-				.dive()
-				.getElement(),
-		).toMatchSnapshot();
+		expect(wrapper.find('TreeViewIcon').dive().getElement()).toMatchSnapshot();
 	});
 
 	it('should toggle item on toggle button click', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The common component should be updated:

- to update the style of the active state, hover state
- and introduce the disabled state style

More details: https://jira.talendforge.org/browse/TDOPS-14
Link to frontify: https://company-57688.frontify.com/document/92132#/ui-controls/tree-view

**What is the chosen solution to this problem?**

Fixed css

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
