### PR TITLE
chore(DateTime/components): Remove timezone-support/date-fns-timezone

### DIFF
--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -40,7 +40,6 @@
     "classnames": "^2.2.5",
     "d3": "^6.3.0",
     "date-fns": "^1.27.2",
-    "date-fns-timezone": "^0.1.4",
     "focus-outline-manager": "^1.0.2",
     "immutable": "^3.8.1",
     "invariant": "^2.2.2",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -65,7 +65,6 @@
     "simplebar": "^4.2.2",
     "simplebar-react": "^1.2.2",
     "styled-components": "^4.4.1",
-    "timezone-support": "^1.5.5",
     "uuid": "^3.4.0"
   },
   "devDependencies": {

--- a/packages/components/src/DateTimePickers/Date/date-extraction.js
+++ b/packages/components/src/DateTimePickers/Date/date-extraction.js
@@ -2,10 +2,10 @@ import format from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import lastDayOfMonth from 'date-fns/last_day_of_month';
 import setDate from 'date-fns/set_date';
-import { convertToLocalTime, convertToTimeZone } from 'date-fns-timezone';
 
 import { convertToUTC } from '../DateTime/datetime-extraction';
 import getErrorMessage from '../shared/error-messages';
+import { convertToLocalTime, convertToTimeZone } from '../../utils/date';
 
 const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
 

--- a/packages/components/src/DateTimePickers/Date/date-extraction.js
+++ b/packages/components/src/DateTimePickers/Date/date-extraction.js
@@ -1,4 +1,3 @@
-import { listTimeZones } from 'timezone-support';
 import format from 'date-fns/format';
 import getDate from 'date-fns/get_date';
 import lastDayOfMonth from 'date-fns/last_day_of_month';
@@ -121,9 +120,17 @@ function checkSupportedDateFormat(dateFormat) {
 	}
 }
 
+/**
+ * Check if a given timezone exists. If not, an exception is thrown
+ * @param {String} timezone
+ * @returns
+ * @throws
+ */
 function checkSupportedTimezone(timezone) {
-	const timzones = listTimeZones();
-	if (!timzones.includes(timezone)) {
+	try {
+		// eslint-disable-next-line no-new
+		new Intl.DateTimeFormat(undefined, { timeZone: timezone });
+	} catch (ex) {
 		throw new Error(`Timezone: ${timezone} - NOT SUPPORTED`);
 	}
 }

--- a/packages/components/src/DateTimePickers/Date/date-extraction.test.js
+++ b/packages/components/src/DateTimePickers/Date/date-extraction.test.js
@@ -1,6 +1,7 @@
 import { subHours } from 'date-fns';
 import {
 	checkSupportedDateFormat,
+	checkSupportedTimezone,
 	extractDate,
 	extractPartsFromTextInput,
 	extractPartsFromDate,
@@ -319,6 +320,16 @@ describe('Date extraction', () => {
 
 			// then
 			expect(date).toEqual(new Date(2019, 8, 27));
+		});
+	});
+
+	describe('checkSupportedTimezone', () => {
+		it('should do nothing if the timezone exists', () => {
+			checkSupportedTimezone('Europe/Paris');
+		});
+
+		it('should throw an exception if the timezone does not exist', () => {
+			expect(() => checkSupportedTimezone('Europe/Beauvais')).toThrow();
 		});
 	});
 });

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
@@ -1,10 +1,10 @@
 import format from 'date-fns/format';
 import setSeconds from 'date-fns/set_seconds';
-import { convertToTimeZone } from 'date-fns-timezone';
 
 import getErrorMessage from '../shared/error-messages';
 import { convertDateToTimezone, extractDateOnly } from '../Date/date-extraction';
 import { checkTime, pad, timeToStr, strToTime } from '../Time/time-extraction';
+import { convertToTimeZone } from '../../utils/date';
 
 const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
 

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -6,13 +6,14 @@ import pick from 'lodash/pick';
 import { distanceInWordsToNow, format } from 'date-fns';
 import isValid from 'date-fns/is_valid';
 import parse from 'date-fns/parse';
-import { formatToTimeZone } from 'date-fns-timezone';
 import { withTranslation } from 'react-i18next';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
 import getLocale from '../../i18n/DateFnsLocale/locale';
 import styles from './CellDatetime.scss';
 import TooltipTrigger from '../../TooltipTrigger';
+
+import { formatToTimeZone } from '../../utils/date';
 
 const DATE_TIME_FORMAT = 'YYYY-MM-DD HH:mm:ss';
 

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -95,8 +95,7 @@ describe('CellDatetime', () => {
 		const cellDataWithOffset = cellData + timezoneOffset * 60 * 1000;
 		const hours = 11 + timezoneOffset / 60;
 		const isOneDigitHours = hours.toString().length === 1;
-		const expectedStrDate = `2016-09-22 ${isOneDigitHours ? 0 : ''}${11 + timezoneOffset / 60
-			}:00:00`;
+		const expectedStrDate = `2016-09-22 ${isOneDigitHours ? 0 : ''}${11 + timezoneOffset / 60}:00:00`;
 		const computedStrOffset = computeValue(cellDataWithOffset, columnData);
 		// then
 		expect(computedStrOffset).toEqual(expectedStrDate);

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -1,11 +1,11 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { distanceInWordsToNow, format } from 'date-fns';
-import { formatToTimeZone } from 'date-fns-timezone';
 
 import { computeValue, CellDatetimeComponent } from './CellDatetime.component';
 import getDefaultT from '../../translate';
 import getLocale from '../../i18n/DateFnsLocale/locale';
+import { formatToTimeZone } from '../../utils/date';
 
 jest.mock('../../i18n/DateFnsLocale/locale');
 
@@ -14,13 +14,19 @@ jest.mock('date-fns', () => ({
 	distanceInWordsToNow: jest.fn(() => 'about 1 month ago'),
 }));
 
-jest.mock('date-fns-timezone', () => ({
+jest.mock('../../utils/date', () => ({
 	formatToTimeZone: jest.fn(() => '2016-09-22 09:00:00'),
 }));
 
 describe('CellDatetime', () => {
 	beforeAll(() => {
 		getLocale.mockImplementation(() => 'getLocale');
+	});
+
+	afterAll(() => {
+		jest.unmock('../../i18n/DateFnsLocale/locale');
+		jest.unmock('date-fns');
+		jest.unmock('../../utils/date');
 	});
 
 	it('should render CellDatetime', () => {
@@ -89,9 +95,8 @@ describe('CellDatetime', () => {
 		const cellDataWithOffset = cellData + timezoneOffset * 60 * 1000;
 		const hours = 11 + timezoneOffset / 60;
 		const isOneDigitHours = hours.toString().length === 1;
-		const expectedStrDate = `2016-09-22 ${isOneDigitHours ? 0 : ''}${
-			11 + timezoneOffset / 60
-		}:00:00`;
+		const expectedStrDate = `2016-09-22 ${isOneDigitHours ? 0 : ''}${11 + timezoneOffset / 60
+			}:00:00`;
 		const computedStrOffset = computeValue(cellDataWithOffset, columnData);
 		// then
 		expect(computedStrOffset).toEqual(expectedStrDate);

--- a/packages/components/src/utils/date.js
+++ b/packages/components/src/utils/date.js
@@ -75,7 +75,6 @@ function formatTimeZoneTokens(dateFormat, timeZone) {
 	});
 }
 
-
 /**
  * Converts the given date from the given time zone to the local time and returns a new Date object.
  * @param {Date|Number|String} date Date to format

--- a/packages/components/src/utils/date.js
+++ b/packages/components/src/utils/date.js
@@ -1,0 +1,126 @@
+import format from 'date-fns/format';
+import parse from 'date-fns/parse';
+
+/**
+ * Get the offset between a timezone and the UTC time (in minutes)
+ * @param {String} timeZone Timezone IANA name
+ * @returns {Number}
+ * 
+ * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
+ */
+function getUTCOffset(timeZone) {
+	// Build localized formats for UTC and the target timezone
+	const formatOptions = {
+		hourCycle: 'h23',
+		year: 'numeric',
+		month: 'numeric',
+		day: 'numeric',
+		hour: 'numeric',
+		minute: 'numeric'
+	};
+
+	const locale = 'en-US';
+	const utcFormat = new Intl.DateTimeFormat(locale, { ...formatOptions, timeZone: 'Etc/UTC' });
+	const timezoneFormat = new Intl.DateTimeFormat(locale, { ...formatOptions, timeZone });
+
+	// Create the same date in UTC timezone and the target timezone
+	const date = new Date();
+	const utcDate = new Date(utcFormat.format(date));
+	const timezoneDate = new Date(timezoneFormat.format(date));
+
+	// Compute delta between dates
+	return (timezoneDate - utcDate) / (1000 * 60);
+}
+
+/**
+ * Ensure a numeric value is expressed on two digits (01, 02, 10 ...)
+ * @param {Number} value
+ * @returns {String}
+ */
+function padTwoDigits(value) {
+	return value > 9 ? value : `0${value}`;
+}
+
+/**
+ * Format an UTC offset from minutes to [+/-][HH][separator][mm]
+ * @param {Number} offset UTC offset
+ * @param {String} separator Separator between hours and minutes
+ * @returns {String} Formatted UTC offset
+ */
+function formatUtcOffset(offset, separator) {
+	const sign = offset >= 0 ? '+' : '-';
+
+	const absoluteOffset = Math.abs(offset);
+	const min = absoluteOffset % 60;
+	const hours = (absoluteOffset - min) / 60;
+
+	return `${sign}${padTwoDigits(hours)}${separator}${padTwoDigits(min)}`;
+}
+
+/**
+ * Replace timezone token(s) in the date format pattern to a specific timezone's value(s).
+ * This should be maintained along with the date-fns formats (see linked API doc).
+ * @param {String} dateFormat
+ * @param {String} timeZone
+ * @returns {String}
+ * 
+ * @see https://date-fns.org/v1.27.2/docs/format
+ * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js#L131
+ */
+function formatTimeZoneTokens(dateFormat, timeZone) {
+	return dateFormat.replace(/z|ZZ?/g, match => {
+		const offset = getUTCOffset(timeZone);
+		const separator = match === 'Z' ? ':' : '';
+		return formatUtcOffset(offset, separator);
+	});
+}
+
+
+/**
+ * Converts the given date from the given time zone to the local time and returns a new Date object.
+ * @param {Date|Number|String} date Date to format
+ * @param {*} options 
+ * 
+ * @see https://github.com/prantlf/date-fns-timezone/blob/HEAD/docs/API.md#converttolocaltime
+ */
+export function convertToLocalTime(date, options) {
+	const parsedDate = parse(date);
+	const offset = getUTCOffset(options.timeZone) + parsedDate.getTimezoneOffset();
+
+	return new Date(parsedDate.getTime() - offset * 60 * 1000);
+}
+
+/**
+ * Converts the given date from the local time to the given time zone and returns a new Date object.
+ * @param {Date|Number|String} date Date to format
+ * @param {*} options
+ * @param {*} options.timeZone
+ * @returns {Date}
+ * 
+ * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/convertToTimeZone.js
+ */
+export function convertToTimeZone(date, options) {
+	const parsedDate = parse(date);
+	const offset = getUTCOffset(options.timeZone) + parsedDate.getTimezoneOffset();
+
+	return new Date(parsedDate.getTime() + offset * 60 * 1000);
+}
+
+/**
+ * Returns the formatted date string in the given format, after converting it to the given time zone.
+ * @param {Date|Number|String} date Date to format
+ * @param {String} formatString Output format (see date-fns supported formats)
+ * @param {Object} options
+ * @param {String} options.timeZone Target timezone
+ * @returns {String}
+ * 
+ * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js
+ */
+export function formatToTimeZone(date, formatString, options) {
+	const dateConvertedToTimezone = convertToTimeZone(date, options);
+
+	// Replace timezone token(s) in the string format with timezone values, since format() will use local timezone
+	const dateFnsFormatWithTimeZoneValue = formatTimeZoneTokens(formatString, options.timeZone);
+
+	return format(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
+}

--- a/packages/components/src/utils/date.test.js
+++ b/packages/components/src/utils/date.test.js
@@ -1,0 +1,77 @@
+import { formatToTimeZone, convertToLocalTime, convertToTimeZone } from './date';
+
+describe('date', () => {
+	// "Locale date" here means Europe/Paris, according to the test command described in package.json
+
+	const timeZones = {
+		'GMT+5': 'Asia/Oral',
+		'GMT-3': 'America/Sao_Paulo',
+	};
+
+	describe('convertToLocalTime', () => {
+		it('should convert a date object of a timezone to the locale timezone', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+			const options = { timeZone: timeZones['GMT+5'] };
+
+			// when
+			const localDate = convertToLocalTime(dateObj, options);
+
+			// then
+			expect(localDate).toEqual(new Date('2020-05-13, 17:00'));
+		});
+
+		it('should convert a date string of a timezone to the locale timezone', () => {
+			// given
+			const dateObj = '2020-05-13T20:00:00';
+			const options = { timeZone: timeZones['GMT-3'] };
+
+			// when
+			const localDate = convertToLocalTime(dateObj, options);
+
+			// then
+			expect(localDate).toEqual(new Date('2020-05-14, 01:00'));
+		});
+	});
+
+	describe('convertToTimeZone', () => {
+		it('should convert a locale date object to the given timezone time', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+			const options = { timeZone: timeZones['GMT+5'] };
+
+			// when
+			const localDate = convertToTimeZone(dateObj, options);
+
+			// then
+			expect(localDate).toEqual(new Date('2020-05-13, 23:00'));
+		});
+
+		it('should convert a locale date string to the given timezone time', () => {
+			// given
+			const dateObj = '2020-05-13T20:00:00';
+			const options = { timeZone: timeZones['GMT-3'] };
+
+			// when
+			const localDate = convertToTimeZone(dateObj, options);
+
+			// then
+			expect(localDate).toEqual(new Date('2020-05-13, 15:00'));
+		});
+	});
+
+	describe('formatToTimeZone', () => {
+		it('should format a locale date to a given timezone in a specifc format', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+			const formatString = 'YYYY-MM-DD[T]HH:mm:ssZZ';
+			const options = { timeZone: timeZones['GMT+5'] };
+
+			// when
+			const localDate = formatToTimeZone(dateObj, formatString, options);
+
+			// then
+			expect(localDate).toEqual('2020-05-13T23:00:00+0500');
+		});
+	});
+});

--- a/packages/http/src/http.common.js
+++ b/packages/http/src/http.common.js
@@ -67,7 +67,7 @@ export async function handleBody(response) {
 export async function handleHttpResponse(response) {
 	if (!testHTTPCode.isSuccess(response.status)) {
 		const error = new Error(response.status);
-		error.response = response;
+		Object.assign(error, await handleBody(response));
 		throw error;
 	}
 	if (response.status === HTTP_STATUS.NO_CONTENT) {

--- a/packages/http/src/http.common.test.js
+++ b/packages/http/src/http.common.test.js
@@ -102,6 +102,9 @@ describe('#handleHttpResponse', () => {
 			}),
 		).catch(response => {
 			expect(response instanceof Error).toBe(true);
+			expect(response.data).toEqual({
+				foo: 42,
+			});
 			done();
 		});
 	});

--- a/yarn.lock
+++ b/yarn.lock
@@ -6254,7 +6254,7 @@ comma-separated-tokens@^1.0.0:
   resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.8.tgz#632b80b6117867a158f1080ad498b2fbe7e3f5ea"
   integrity sha512-GHuDRO12Sypu2cV70d1dkA2EUmXHgntrzbpvOB+Qy+49ypNfGgFQIC2fhhXbnyrJRynDCAARsT7Ou0M6hirpfw==
 
-commander@2, commander@2.19.0, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.19.0:
+commander@2, commander@^2.19.0, commander@^2.8.1, commander@^2.9.0, commander@~2.19.0:
   version "2.19.0"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.19.0.tgz#f6198aa84e5b83c46054b94ddedbfed5ee9ff12a"
   integrity sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg==
@@ -7465,15 +7465,7 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns-timezone@^0.1.4:
-  version "0.1.4"
-  resolved "https://registry.yarnpkg.com/date-fns-timezone/-/date-fns-timezone-0.1.4.tgz#bc9fac78aae9a7bdb847f3ab4ce6d14f9fb9a55f"
-  integrity sha512-npnZn1eIeHV8A3Hqw86mn6CjH+qMe0TSCs4anpD4Rouf+mE9eIJuaHviIpNmGL9GiDmcUoiaKdkX5ihf+yZQZA==
-  dependencies:
-    date-fns "^1.29.0"
-    timezone-support "^1.5.5"
-
-date-fns@^1.27.2, date-fns@^1.29.0:
+date-fns@^1.27.2:
   version "1.30.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
@@ -19853,13 +19845,6 @@ timers-browserify@^2.0.4:
   integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
-
-timezone-support@^1.5.5:
-  version "1.8.1"
-  resolved "https://registry.yarnpkg.com/timezone-support/-/timezone-support-1.8.1.tgz#0a8c04d0614be6fccdd2280aaad5072fa5d31e5f"
-  integrity sha512-+pKzxoUe4PZXaQcswceJlA+69oRyyu1uivnYKdpsC7eGzZiuvTLbU4WYPqTKslEsoSvjN8k/u/6qNfGikBB/wA==
-  dependencies:
-    commander "2.19.0"
 
 timsort@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`timezone-support` is a dependency of UI/components while only a single method is used in Talend/UI (to check if a timezone exists).
`date-fns-timezone` uses `timezone-support`.
`timezone-support` is the heaviest dependency of UI/components.
`timezone-support` and `date-fns-timezone` haven't been maintained for years.

**What is the chosen solution to this problem?**
Leverage `timezone-support` and `date-fns-timezone` duties to [`Intl.DateTimeFormat`](https://developer.mozilla.org/fr/docs/Web/JavaScript/Reference/Global_Objects/Intl/DateTimeFormat), add tests, drop `timezone-support`.

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
