### PR TITLE
feat(components/HeaderBar): Accept custom AppNotification component

### DIFF
--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -219,6 +219,21 @@ function HeaderBar(props) {
 	const AppSwitcherComponent =
 		props.AppSwitcher || Inject.get(props.getComponent, 'AppSwitcher', AppSwitcher);
 
+	let notificationCenter;
+	const { NotificationCenter } = props;
+	if (NotificationCenter) {
+		notificationCenter = <NotificationCenter />;
+	} else if (props.notification) {
+		console.warn('Deprecated: use @talend/notification-center');
+		notificationCenter = (
+			<Components.AppNotification
+				getComponent={props.getComponent}
+				{...props.notification}
+				t={props.t}
+			/>
+		);
+	}
+
 	let intercom;
 	const { Intercom: CustomIntercom } = props;
 	if (CustomIntercom) {
@@ -242,13 +257,7 @@ function HeaderBar(props) {
 					<Components.CallToAction getComponent={props.getComponent} {...props.callToAction} />
 				)}
 				{props.search && <Components.Search getComponent={props.getComponent} {...props.search} />}
-				{props.notification && (
-					<Components.AppNotification
-						getComponent={props.getComponent}
-						{...props.notification}
-						t={props.t}
-					/>
-				)}
+				{notificationCenter}
 				{intercom && (
 					<li
 						role="presentation"
@@ -363,6 +372,7 @@ if (process.env.NODE_ENV !== 'production') {
 	HeaderBar.propTypes = {
 		AppSwitcher: PropTypes.func,
 		Intercom: PropTypes.func,
+		NotificationCenter: PropTypes.func,
 		logo: PropTypes.shape(omit(Logo.propTypes, 't')),
 		brand: PropTypes.shape({
 			isSeparated: PropTypes.bool,

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -257,7 +257,18 @@ function HeaderBar(props) {
 					<Components.CallToAction getComponent={props.getComponent} {...props.callToAction} />
 				)}
 				{props.search && <Components.Search getComponent={props.getComponent} {...props.search} />}
-				{notificationCenter}
+				{notificationCenter && (
+					<li
+						role="presentation"
+						className={theme(
+							'tc-header-bar-notification-center',
+							'tc-header-bar-action',
+							'separated',
+						)}
+					>
+						{notificationCenter}
+					</li>
+				)}
 				{intercom && (
 					<li
 						role="presentation"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Current Header does not allow to use a custom component for notifications.

**What is the chosen solution to this problem?**
Like Intercom, add a new props to allow to use a custom component.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
