### PR TITLE
fix(icons): build prod mode

### DIFF
--- a/packages/icons/webpack.umd.js
+++ b/packages/icons/webpack.umd.js
@@ -31,7 +31,7 @@ module.exports = (env = {}) => ({
 		new CopyPlugin({
 			patterns: [
 				{
-					from: 'umd.dependencies.json',
+					from: `umd${env.production ? '.min' : ''}.dependencies.json`,
 					to: `TalendIcons${env.production ? '.min' : ''}.js.dependencies.json`,
 				},
 			],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Icons is often the first dependency to be loaded.
But it's manifest add react in dev mode.
https://unpkg.com/browse/@talend/icons@6.26.0/dist/TalendIcons.min.js.dependencies.json


**What is the chosen solution to this problem?**

Switch to manifest prod in webpack.
![Screen Shot 2021-05-25 at 08 57 22](https://user-images.githubusercontent.com/19857479/119453588-dfc4ce00-bd37-11eb-91c2-357f48a843a3.png)


**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
