### PR TITLE
chore(Date): remove cycle deps

### DIFF
--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -40,17 +40,11 @@
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/Manager/Manager.component.js
   31:5  warning  React Hook useEffect has missing dependencies: 'getDateOptions' and 'state.date'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/date-extraction.js
-  7:1  error  Dependency cycle detected  import/no-cycle
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateRange/Manager/Manager.component.js
   49:5  warning  React Hook useEffect has missing dependencies: 'options', 'state.endDate.value', and 'state.startDate.value'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/Manager/Manager.component.js
   42:5  warning  React Hook useEffect has missing dependencies: 'getDateOptions', 'onChange', and 'state.datetime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
-
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
-  6:1  error  Dependency cycle detected  import/no-cycle
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
   26:5  warning  React Hook useEffect has missing dependencies: 'state.endDateTime' and 'state.startDateTime'. Either include them or remove the dependency array  react-hooks/exhaustive-deps
@@ -71,6 +65,10 @@
   188:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
   188:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
   188:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
+
+/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
+  8:30  error  Missing file extension for "../../utils/date"        import/extensions
+  8:30  error  Unable to resolve path to module '../../utils/date'  import/no-unresolved
 
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.component.js
    55:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated

--- a/output/components.eslint.txt
+++ b/output/components.eslint.txt
@@ -66,10 +66,6 @@
   188:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
   188:39  error  Use callback in setState when referencing the previous state                                                                                                                                                                                                                                                 react/no-access-state-in-setstate
 
-/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
-  8:30  error  Missing file extension for "../../utils/date"        import/extensions
-  8:30  error  Unable to resolve path to module '../../utils/date'  import/no-unresolved
-
 /home/travis/build/Talend/ui/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.component.js
    55:2  error  componentWillReceiveProps is deprecated since React 16.9.0, use UNSAFE_componentWillReceiveProps instead, see https://reactjs.org/docs/react-component.html#unsafe_componentwillreceiveprops. Use https://github.com/reactjs/react-codemod#rename-unsafe-lifecycles to automatically update your components  react/no-deprecated
   187:5  error  `tabIndex` should only be declared on interactive elements                                                                                                                                                                                                                                                   jsx-a11y/no-noninteractive-tabindex
@@ -306,5 +302,5 @@
   673:44  error  ["icon"] is better written in dot notation       dot-notation
   679:56  error  ["resizable"] is better written in dot notation  dot-notation
 
-✖ 147 problems (127 errors, 20 warnings)
+✖ 145 problems (125 errors, 20 warnings)
   7 errors and 0 warnings potentially fixable with the `--fix` option.

--- a/packages/components/src/DateTimePickers/Date/date-extraction.js
+++ b/packages/components/src/DateTimePickers/Date/date-extraction.js
@@ -3,9 +3,8 @@ import getDate from 'date-fns/get_date';
 import lastDayOfMonth from 'date-fns/last_day_of_month';
 import setDate from 'date-fns/set_date';
 
-import { convertToUTC } from '../DateTime/datetime-extraction';
 import getErrorMessage from '../shared/error-messages';
-import { convertToLocalTime, convertToTimeZone } from '../../utils/date';
+import { convertToUTC, convertToLocalTime, convertToTimeZone } from '../../utils/date';
 
 const INTERNAL_INVALID_DATE = new Date('INTERNAL_INVALID_DATE');
 

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.js
@@ -18,22 +18,6 @@ function isEmpty(value) {
 }
 
 /**
- * Convert a date in local TZ to UTC
- */
-function convertToUTC(date) {
-	return new Date(
-		Date.UTC(
-			date.getFullYear(),
-			date.getMonth(),
-			date.getDate(),
-			date.getHours(),
-			date.getMinutes(),
-			date.getSeconds(),
-		),
-	);
-}
-
-/**
  * Extract time
  * @param date {Date} The date to extract
  * @param useSeconds {boolean} Indicates if we should extract seconds
@@ -270,7 +254,6 @@ function updatePartsOnTimeChange(timePickerPayload, date, options) {
 }
 
 export {
-	convertToUTC,
 	extractParts,
 	extractPartsFromDateTime,
 	extractPartsFromTextInput,

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
@@ -5,6 +5,7 @@ import setSeconds from 'date-fns/set_seconds';
 import setDate from 'date-fns/set_date';
 import startOfSecond from 'date-fns/start_of_second';
 import getErrorMessage from './error-messages';
+import { convertToUTC } from '../../utils/date';
 
 const splitDateAndTimePartsRegex = new RegExp(/^\s*(.*)\s+((.*):(.*)(:.*)?)\s*$/);
 const timePartRegex = new RegExp(/^(.*):(.*)$/);
@@ -108,23 +109,6 @@ function isDateValid(date, options) {
 	}
 
 	return date instanceof Date && !isNaN(date.getTime());
-}
-
-/**
- * Convert a date in local TZ to UTC
- * Ex: 2015-05-23 23:58:46 (current TZ) --> 2015-05-23 23:58:46 (UTC)
- */
-function convertToUTC(date) {
-	return new Date(
-		Date.UTC(
-			date.getFullYear(),
-			date.getMonth(),
-			date.getDate(),
-			date.getHours(),
-			date.getMinutes(),
-			date.getSeconds(),
-		),
-	);
 }
 
 /**

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/date-extraction.js
@@ -5,7 +5,7 @@ import setSeconds from 'date-fns/set_seconds';
 import setDate from 'date-fns/set_date';
 import startOfSecond from 'date-fns/start_of_second';
 import getErrorMessage from './error-messages';
-import { convertToUTC } from '../../utils/date';
+import { convertToUTC } from '../../../utils/date';
 
 const splitDateAndTimePartsRegex = new RegExp(/^\s*(.*)\s+((.*):(.*)(:.*)?)\s*$/);
 const timePartRegex = new RegExp(/^(.*):(.*)$/);

--- a/packages/components/src/utils/date.js
+++ b/packages/components/src/utils/date.js
@@ -16,7 +16,7 @@ function getUTCOffset(timeZone) {
 		month: 'numeric',
 		day: 'numeric',
 		hour: 'numeric',
-		minute: 'numeric'
+		minute: 'numeric',
 	};
 
 	const locale = 'en-US';
@@ -123,7 +123,6 @@ export function formatToTimeZone(date, formatString, options) {
 
 	return format(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
 }
-
 
 /**
  * Convert a date in local TZ to UTC

--- a/packages/components/src/utils/date.js
+++ b/packages/components/src/utils/date.js
@@ -5,7 +5,7 @@ import parse from 'date-fns/parse';
  * Get the offset between a timezone and the UTC time (in minutes)
  * @param {String} timeZone Timezone IANA name
  * @returns {Number}
- * 
+ *
  * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones
  */
 function getUTCOffset(timeZone) {
@@ -63,7 +63,7 @@ function formatUtcOffset(offset, separator) {
  * @param {String} dateFormat
  * @param {String} timeZone
  * @returns {String}
- * 
+ *
  * @see https://date-fns.org/v1.27.2/docs/format
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js#L131
  */
@@ -78,8 +78,8 @@ function formatTimeZoneTokens(dateFormat, timeZone) {
 /**
  * Converts the given date from the given time zone to the local time and returns a new Date object.
  * @param {Date|Number|String} date Date to format
- * @param {*} options 
- * 
+ * @param {*} options
+ *
  * @see https://github.com/prantlf/date-fns-timezone/blob/HEAD/docs/API.md#converttolocaltime
  */
 export function convertToLocalTime(date, options) {
@@ -95,7 +95,7 @@ export function convertToLocalTime(date, options) {
  * @param {*} options
  * @param {*} options.timeZone
  * @returns {Date}
- * 
+ *
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/convertToTimeZone.js
  */
 export function convertToTimeZone(date, options) {
@@ -112,7 +112,7 @@ export function convertToTimeZone(date, options) {
  * @param {Object} options
  * @param {String} options.timeZone Target timezone
  * @returns {String}
- * 
+ *
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js
  */
 export function formatToTimeZone(date, formatString, options) {
@@ -122,4 +122,21 @@ export function formatToTimeZone(date, formatString, options) {
 	const dateFnsFormatWithTimeZoneValue = formatTimeZoneTokens(formatString, options.timeZone);
 
 	return format(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
+}
+
+
+/**
+ * Convert a date in local TZ to UTC
+ */
+export function convertToUTC(date) {
+	return new Date(
+		Date.UTC(
+			date.getFullYear(),
+			date.getMonth(),
+			date.getDate(),
+			date.getHours(),
+			date.getMinutes(),
+			date.getSeconds(),
+		),
+	);
 }

--- a/packages/components/src/utils/date.js
+++ b/packages/components/src/utils/date.js
@@ -126,6 +126,7 @@ export function formatToTimeZone(date, formatString, options) {
 
 /**
  * Convert a date in local TZ to UTC
+ * 20:00 in local TZ become 20:00 in UTC
  */
 export function convertToUTC(date) {
 	return new Date(

--- a/packages/components/src/utils/date.test.js
+++ b/packages/components/src/utils/date.test.js
@@ -1,4 +1,4 @@
-import { formatToTimeZone, convertToLocalTime, convertToTimeZone } from './date';
+import { formatToTimeZone, convertToLocalTime, convertToTimeZone, convertToUTC } from './date';
 
 describe('date', () => {
 	// "Locale date" here means Europe/Paris, according to the test command described in package.json
@@ -72,6 +72,14 @@ describe('date', () => {
 
 			// then
 			expect(localDate).toEqual('2020-05-13T23:00:00+0500');
+		});
+	});
+	describe('convertToUTC', () => {
+		it('should do convertion of bad date', () => {
+			// lets create Date object in local TZ
+			const dateObj = new Date('2020-05-13, 20:00');
+			expect(convertToUTC(dateObj).getUTCHours()).toBe(20);
+			expect(convertToUTC(dateObj).getUTCMinutes()).toBe(0);
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**


/home/travis/build/Talend/ui/packages/components/src/DateTimePickers/Date/date-extraction.js
  7:1  error  Dependency cycle detected  import/no-cycle

**What is the chosen solution to this problem?**

move convertToUTC in global date util

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
