### PR TITLE
chore: add react-router-dom in dependencies.json

### DIFF
--- a/versions/dependencies.json
+++ b/versions/dependencies.json
@@ -63,6 +63,7 @@
   "react-redux": "^5.0.7",
   "react-router": "^3.2.0",
   "react-router-redux": "^4.0.8",
+  "react-router-dom": "^5.2.0",
   "react-test-renderer": "^16.13.1",
   "react-transition-group": "^2.3.1",
   "react-use": "^13.27.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add min version of react-router-dom to 5.2

**What is the chosen solution to this problem?**
Add min version of react-router-dom to 5.2

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
