### PR TITLE
fix(FormatValue): Preserve whitespaces

### DIFF
--- a/packages/components/src/FormatValue/FormatValue.component.js
+++ b/packages/components/src/FormatValue/FormatValue.component.js
@@ -71,7 +71,7 @@ function replaceCharacterByIcon(value, t) {
 					/>
 				);
 			}
-			return <span>{value}</span>;
+			return <span className={classNames(theme['td-value'], 'td-value')}>{value}</span>;
 	}
 }
 

--- a/packages/components/src/FormatValue/FormatValue.scss
+++ b/packages/components/src/FormatValue/FormatValue.scss
@@ -2,6 +2,10 @@ $svg-tab-width: 2.6rem !default;
 $svg-other-characters: 0.3rem !default;
 $svg-color: #ccc !default;
 
+.td-value {
+	white-space: pre;
+}
+
 .td-white-space-character {
 	vertical-align: text-bottom;
 	color: $svg-color;

--- a/packages/components/src/FormatValue/FormatValue.stories.js
+++ b/packages/components/src/FormatValue/FormatValue.stories.js
@@ -5,7 +5,7 @@ import FormatValue from './FormatValue.component';
 storiesOf('Data/Formatter/FormatValue', module).add('default', () => {
 	return (
 		<FormatValue
-			value={`   Show special chars and newline
+			value={`   Show special     chars and newline
 	  `}
 		/>
 	);

--- a/packages/components/src/FormatValue/__snapshots__/FormatValue.test.js.snap
+++ b/packages/components/src/FormatValue/__snapshots__/FormatValue.test.js.snap
@@ -17,7 +17,9 @@ exports[`FormatValue should replace the leading/trainling white space and the li
     className="theme-td-white-space-character td-white-space-character"
     name="talend-empty-space"
   />
-  <span>
+  <span
+    className="theme-td-value td-value"
+  >
     loreum lo
   </span>
   <span>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

- Multiple whitespaces are preserved only at the start/end of the string and collapsed otherwise: 
<pre> Show special    chars and newline</pre>
![image](https://user-images.githubusercontent.com/58977230/121349576-f8cda180-c929-11eb-9076-db826b13f480.png)

**What is the chosen solution to this problem?**

- Preserve whitespace inside the text 
![image](https://user-images.githubusercontent.com/58977230/121349723-24508c00-c92a-11eb-9b90-275fb0f4e3b8.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
