### PR TITLE
fix(utils): Make @talend/utils public

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/utils",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Various utilities",
   "main": "lib/index.js",
   "repository": {

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -28,5 +28,8 @@
   },
   "dependencies": {
     "date-fns": "^1.27.2"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
@talend/utils is not public.

**What is the chosen solution to this problem?**
Explicitely make it public.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
