### PR TITLE
fix(Dataviz): Show special chars in tooltip

### DIFF
--- a/packages/dataviz/.storybook/preview.js
+++ b/packages/dataviz/.storybook/preview.js
@@ -13,7 +13,7 @@ export const decorators = [
 		i18n.changeLanguage(context.globals.locale);
 		return (
 			<I18nextProvider i18n={i18n}>
-				<IconsProvider />
+				<IconsProvider bundles={['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg']} />
 				<Story />
 			</I18nextProvider>
 		);

--- a/packages/dataviz/CHANGELOG.md
+++ b/packages/dataviz/CHANGELOG.md
@@ -26,6 +26,11 @@ Types of changes
 
 ## [unreleased]
 
+## [0.4.5]
+
+### Fixed
+
+- [show special chars in tooltip](https://github.com/Talend/ui/pull/3327)
 
 ## [0.4.4]
 

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/react-dataviz",
-  "version": "0.4.4",
+  "version": "0.4.5",
   "description": "Talend charts and visualization components",
   "main": "lib/index.js",
   "mainSrc": "src/index.ts",

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.component.tsx
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.component.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import classNames from 'classnames';
+import { FormatValue } from '@talend/react-components';
 import styles from './TooltipContent.component.scss';
 import { ChartStyle } from '../../types';
 
@@ -7,6 +8,7 @@ export interface TooltipContentProps {
 	entries: TooltipEntry[];
 	chartStyle?: ChartStyle;
 }
+
 function TooltipContent({ entries, chartStyle = ChartStyle.VALUE }: TooltipContentProps) {
 	return (
 		<dl className={classNames(styles['dataviz-tooltip'], styles[`dataviz-tooltip--${chartStyle}`])}>
@@ -14,7 +16,7 @@ function TooltipContent({ entries, chartStyle = ChartStyle.VALUE }: TooltipConte
 				<div className={styles['dataviz-tooltip__entry']} key={key}>
 					<dt className={styles['dataviz-tooltip__key']}>{key}</dt>
 					<dd>
-						<span className={styles['dataviz-tooltip__value']}>{value}</span>
+						<FormatValue className={styles['dataviz-tooltip__value']} value={value} />
 					</dd>
 				</div>
 			))}

--- a/packages/dataviz/src/components/TooltipContent/TooltipContent.stories.tsx
+++ b/packages/dataviz/src/components/TooltipContent/TooltipContent.stories.tsx
@@ -18,7 +18,7 @@ export default {
 		entries: [
 			{
 				key: 'First line',
-				value: '50',
+				value: '  5   0  ',
 			},
 			{
 				key: 'Second line',

--- a/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
+++ b/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
@@ -8,7 +8,9 @@ exports[`TooltipContent Should render 1`] = `
     </dt>
     <dd>
       <span class="theme-dataviz-tooltip__value">
-        value1
+        <span>
+          value1
+        </span>
       </span>
     </dd>
   </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

- Tooltip doesn't show special/blank chars:
<pre>  5   0  </pre>
![image](https://user-images.githubusercontent.com/58977230/121360005-523ace00-c934-11eb-9672-e094f5287251.png)

**What is the chosen solution to this problem?**

- Use `FormatValue` component (already used in bars)
![image](https://user-images.githubusercontent.com/58977230/121360146-73032380-c934-11eb-9a44-bbf756445d2a.png)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
