### PR TITLE
feat(utils/date): Provide UTC offset format function

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Various utilities",
   "main": "lib/index.js",
   "repository": {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -2,6 +2,7 @@ import {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
+	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,
 	timeZoneExists,
@@ -65,6 +66,21 @@ describe('date', () => {
 			// then
 			expect(localDate).toEqual(new Date('2020-05-13, 15:00'));
 		});
+	});
+
+	describe('formatReadableUTCOffset', () => {
+		test.each(
+			[
+				[0, '+00:00'],
+				[600, '+10:00'],
+				[-360, '-06:00'],
+			]
+		)(
+			'it should format a %s minutes offset',
+			(offset: number, expectedOffset: string) => {
+				expect(formatReadableUTCOffset(offset)).toEqual(expectedOffset);
+			}
+		);
 	});
 
 	describe('formatToTimeZone', () => {

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -57,6 +57,15 @@ function formatUTCOffset(offset: number, separator: string): string {
 }
 
 /**
+ * Format a human-readable UTC offset
+ * @param offset Timezone offset to UTC expressed in minutes
+ * @returns The human readable offset (+03:00, -06:000 ...)
+ */
+ export function formatReadableUTCOffset(offset: number): string {
+	return formatUTCOffset(offset, ':');
+}
+
+/**
  * Replace timezone token(s) in the date format pattern to a specific timezone's value(s).
  * This should be maintained along with the date-fns formats (see linked API doc).
  * @param {string} dateFormat
@@ -161,6 +170,7 @@ export default {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
+	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,
 	timeZoneExists,

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -59,7 +59,7 @@ function formatUTCOffset(offset: number, separator: string): string {
 /**
  * Format a human-readable UTC offset
  * @param offset Timezone offset to UTC expressed in minutes
- * @returns The human readable offset (+03:00, -06:000 ...)
+ * @returns The human readable offset (+03:00, -06:00 ...)
  */
  export function formatReadableUTCOffset(offset: number): string {
 	return formatUTCOffset(offset, ':');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There's no common way to transform for humans timezone offsets (+00:00, -06:00 ...).

**What is the chosen solution to this problem?**
Expose helper.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
