### PR TITLE
feat(date/utils): Conversion source timezone + token parsing

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/utils",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Various utilities",
   "main": "lib/index.js",
   "repository": {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -113,6 +113,19 @@ describe('date', () => {
 			// then
 			expect(localDate).toEqual('2020-05-13T23:00:00+0500');
 		});
+
+		it('should not change timezone tokens that are wrapped in hooks', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+			const formatString = 'YYYY-MM-DD[T]HH:mm:ss[Z]';
+			const options = { timeZone: timeZones['UTC+5'] };
+
+			// when
+			const localDate = formatToTimeZone(dateObj, formatString, options);
+
+			// then
+			expect(localDate).toEqual('2020-05-13T23:00:00Z');
+		});
 	});
 
 	describe('convertToUTC', () => {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -12,15 +12,17 @@ describe('date', () => {
 	// "Locale date" here means Europe/Paris, according to the test command described in package.json
 
 	const timeZones = {
-		'GMT+5': 'Asia/Oral',
-		'GMT-3': 'America/Sao_Paulo',
+		'UTC+5': 'Asia/Oral',
+		'UTC+1': 'Europe/London',
+		'UTC-3': 'America/Sao_Paulo',
+		'UTC-6': 'America/Belize',
 	};
 
 	describe('convertToLocalTime', () => {
 		it('should convert a date object of a timezone to the locale timezone', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
-			const options = { timeZone: timeZones['GMT+5'] };
+			const options = { timeZone: timeZones['UTC+5'] };
 
 			// when
 			const localDate = convertToLocalTime(dateObj, options);
@@ -32,7 +34,7 @@ describe('date', () => {
 		it('should convert a date string of a timezone to the locale timezone', () => {
 			// given
 			const dateObj = '2020-05-13T20:00:00';
-			const options = { timeZone: timeZones['GMT-3'] };
+			const options = { timeZone: timeZones['UTC-3'] };
 
 			// when
 			const localDate = convertToLocalTime(dateObj, options);
@@ -46,7 +48,7 @@ describe('date', () => {
 		it('should convert a locale date object to the given timezone time', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
-			const options = { timeZone: timeZones['GMT+5'] };
+			const options = { timeZone: timeZones['UTC+5'] };
 
 			// when
 			const localDate = convertToTimeZone(dateObj, options);
@@ -58,13 +60,28 @@ describe('date', () => {
 		it('should convert a locale date string to the given timezone time', () => {
 			// given
 			const dateObj = '2020-05-13T20:00:00';
-			const options = { timeZone: timeZones['GMT-3'] };
+			const options = { timeZone: timeZones['UTC-3'] };
 
 			// when
 			const localDate = convertToTimeZone(dateObj, options);
 
 			// then
 			expect(localDate).toEqual(new Date('2020-05-13, 15:00'));
+		});
+
+		it('should convert a date from a specific timezone to the target timezone time', () => {
+			// given
+			const dateObj = '2020-05-13T20:00:00';
+			const options = {
+				sourceTimeZone: timeZones['UTC+1'],
+				timeZone: timeZones['UTC-6'],
+			};
+
+			// when
+			const localDate = convertToTimeZone(dateObj, options);
+
+			// then
+			expect(localDate).toEqual(new Date('2020-05-13, 13:00'));
 		});
 	});
 
@@ -88,7 +105,7 @@ describe('date', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
 			const formatString = 'YYYY-MM-DD[T]HH:mm:ssZZ';
-			const options = { timeZone: timeZones['GMT+5'] };
+			const options = { timeZone: timeZones['UTC+5'] };
 
 			// when
 			const localDate = formatToTimeZone(dateObj, formatString, options);

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -5,6 +5,7 @@ type DateFnsFormatInput = Date | number | string;
 
 interface ConversionOptions {
 	timeZone: string,
+	sourceTimeZone?: string,
 }
 
 /**
@@ -61,7 +62,7 @@ function formatUTCOffset(offset: number, separator: string): string {
  * @param offset Timezone offset to UTC expressed in minutes
  * @returns The human readable offset (+03:00, -06:00 ...)
  */
- export function formatReadableUTCOffset(offset: number): string {
+export function formatReadableUTCOffset(offset: number): string {
 	return formatUTCOffset(offset, ':');
 }
 
@@ -107,8 +108,16 @@ export function convertToLocalTime(date: DateFnsFormatInput, options: Conversion
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/convertToTimeZone.js
  */
 export function convertToTimeZone(date: DateFnsFormatInput, options: ConversionOptions): Date {
+	const { timeZone, sourceTimeZone } = options;
+
 	const parsedDate = parse(date);
-	const offset = getUTCOffset(options.timeZone) + parsedDate.getTimezoneOffset();
+
+	let offset = getUTCOffset(timeZone) + parsedDate.getTimezoneOffset();
+
+	if (sourceTimeZone) {
+		offset -= new Date().getTimezoneOffset();
+		offset -= getUTCOffset(sourceTimeZone);
+	}
 
 	return new Date(parsedDate.getTime() + offset * 60 * 1000);
 }
@@ -117,8 +126,7 @@ export function convertToTimeZone(date: DateFnsFormatInput, options: ConversionO
  * Returns the formatted date string in the given format, after converting it to the given time zone.
  * @param {DateFnsFormatInput} date Date to format
  * @param {string} formatString Output format (see date-fns supported formats)
- * @param {Object} options
- * @param {string} options.timeZone Target timezone
+ * @param {ConversionOptions} options
  * @returns {string}
  *
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -77,7 +77,7 @@ export function formatReadableUTCOffset(offset: number): string {
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js#L131
  */
 function formatTimeZoneTokens(dateFormat: string, timeZone: string): string {
-	return dateFormat.replace(/z|ZZ?/g, match => {
+	return dateFormat.replace(/(?<!\[)(z|ZZ?)/g, match => {
 		const offset = getUTCOffset(timeZone);
 		const separator = match === 'Z' ? ':' : '';
 		return formatUTCOffset(offset, separator);

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -100,7 +100,8 @@ export function convertToLocalTime(date: DateFnsFormatInput, options: Conversion
 }
 
 /**
- * Converts the given date from the local time to the given time zone and returns a new Date object.
+ * Converts the given date from the local time (or from specified source timezone) to
+ * the given timezone and returns a new Date object.
  * @param {DateFnsFormatInput} date Date to format
  * @param {ConversionOptions} options
  * @returns {Date}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- When using `convertToTimeZone`, input date is always considered as locale.
- Using date-fns's format `[]` to add static strings in formats doesn't work well with timezones.

**What is the chosen solution to this problem?**
- Support sourceTimeZone in convertToTimeZone so that caller can specify which timezone the input date is from
- Update regex that matches timezone tokens in date format string to ignore such tokens when they are preceed with `[` (using negative lookbehind)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
