### PR TITLE
feat(components/ratiobar): add errors count

### DIFF
--- a/packages/components/src/RatioBar/RatioBar.component.js
+++ b/packages/components/src/RatioBar/RatioBar.component.js
@@ -2,13 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Trans } from 'react-i18next';
 import { RatioBarComposition } from './RatioBarComposition.component';
-import { EmptyLine, FilledLine } from './RatioBarLines.component';
+import { EmptyLine, FilledLine, ErrorLine } from './RatioBarLines.component';
 import { getTheme } from '../theme';
 import ratioBarTheme from './RatioBar.scss';
 
 const theme = getTheme(ratioBarTheme);
 
-function getFilledValues(amount, total) {
+function getFilledValues(amount, total, errors) {
 	if (!amount || amount < 0) {
 		return { percentage: 0, amount: 0 };
 	}
@@ -18,6 +18,17 @@ function getFilledValues(amount, total) {
 	}
 
 	return { percentage: (amount / total) * 100, amount };
+}
+function getErrorValues(amount, total, errors) {
+	if (!errors || errors < 0) {
+		return { percentage: 0, amount: 0 };
+	}
+
+	if (errors > total) {
+		return { percentage: 100, amount };
+	}
+
+	return { percentage: (errors / total) * 100, amount };
 }
 
 function getEmptyValues(amount, total) {
@@ -31,7 +42,7 @@ function getEmptyValues(amount, total) {
 	return { percentage: (1 - amount / total) * 100, amount: total - amount };
 }
 
-function getLabel(amount, total) {
+function getLabel(amount, errors, total) {
 	if (!amount && amount !== 0) {
 		return (
 			<div className={theme('tc-ratio-bar-counter')}>
@@ -43,26 +54,29 @@ function getLabel(amount, total) {
 	}
 	return (
 		<div className={theme('tc-ratio-bar-counter')}>
-			<strong>{amount}</strong>/{total}
+			<strong>{amount + errors}</strong>/{total}
 		</div>
 	);
 }
 
-export function RatioBar({ amount, total, hideLabel = false }) {
+export function RatioBar({ amount, total, errors = 0, hideLabel = false }) {
 	const filled = getFilledValues(amount, total);
-	const empty = getEmptyValues(amount, total);
+	const error = getFilledValues(errors, total);
+	const empty = getEmptyValues(amount + errors, total);
 
 	return (
 		<RatioBarComposition>
 			<FilledLine percentage={filled.percentage} value={filled.amount} />
+			<ErrorLine percentage={error.percentage} value={error.amount} />
 			<EmptyLine percentage={empty.percentage} value={empty.amount} />
-			{!hideLabel && getLabel(amount, total)}
+			{!hideLabel && getLabel(amount, errors, total)}
 		</RatioBarComposition>
 	);
 }
 
 RatioBar.propTypes = {
 	amount: PropTypes.number,
+	errors: PropTypes.number,
 	total: PropTypes.number.isRequired,
 	hideLabel: PropTypes.bool,
 };

--- a/packages/components/src/RatioBar/RatioBar.component.js
+++ b/packages/components/src/RatioBar/RatioBar.component.js
@@ -8,7 +8,7 @@ import ratioBarTheme from './RatioBar.scss';
 
 const theme = getTheme(ratioBarTheme);
 
-function getFilledValues(amount, total, errors) {
+function getFilledValues(amount, total) {
 	if (!amount || amount < 0) {
 		return { percentage: 0, amount: 0 };
 	}
@@ -18,17 +18,6 @@ function getFilledValues(amount, total, errors) {
 	}
 
 	return { percentage: (amount / total) * 100, amount };
-}
-function getErrorValues(amount, total, errors) {
-	if (!errors || errors < 0) {
-		return { percentage: 0, amount: 0 };
-	}
-
-	if (errors > total) {
-		return { percentage: 100, amount };
-	}
-
-	return { percentage: (errors / total) * 100, amount };
 }
 
 function getEmptyValues(amount, total) {

--- a/packages/components/src/RatioBar/RatioBar.component.test.js
+++ b/packages/components/src/RatioBar/RatioBar.component.test.js
@@ -67,6 +67,31 @@ describe('RatioBar', () => {
 		});
 	});
 
+	it('should render a classic ratio bar with errors', () => {
+		// given
+		const props = {
+			amount: 5,
+			total: 12,
+			errors: 2,
+		};
+		// when
+		const wrapper = shallow(<RatioBar {...props} />);
+		// then
+		expect(wrapper.find('FilledLine').props()).toEqual({
+			percentage: 41.66666666666667,
+			value: 5,
+		});
+		expect(wrapper.find('EmptyLine').props()).toEqual({
+			percentage: 41.666666666666664,
+			value: 5,
+		});
+		expect(wrapper.find('ErrorLine').props()).toEqual({
+			percentage: 16.666666666666664,
+			value: 2,
+		});
+		expect(wrapper.find('.tc-ratio-bar-counter').text()).toEqual('7/12');
+	});
+
 	it('should render a classic ratio bar without label', () => {
 		// given
 		const props = {

--- a/packages/components/src/RatioBar/RatioBar.scss
+++ b/packages/components/src/RatioBar/RatioBar.scss
@@ -40,11 +40,16 @@ $ratio-bar-hover-height: 8px;
 
 	.tc-ratio-bar-line-empty {
 		@extend .tc-ratio-bar-lines;
-		background-color: $silver;
+		background-color: $lochmara100;
 	}
 
 	.tc-ratio-bar-line-filled {
 		@extend .tc-ratio-bar-lines;
-		background-color: $regal-blue;
+		background-color: $lochmara500;
+	}
+
+	.tc-ratio-bar-line-error {
+		@extend .tc-ratio-bar-lines;
+		background-color: $chestnut-rose;
 	}
 }

--- a/packages/components/src/RatioBar/RatioBar.stories.js
+++ b/packages/components/src/RatioBar/RatioBar.stories.js
@@ -21,6 +21,8 @@ stories
 					<RatioBar amount={12} total={12} />
 					<div>With an amount of 532/1000</div>
 					<RatioBar amount={532} total={1000} />
+					<div>With an amount of 10/20 with 1 error</div>
+					<RatioBar amount={10} errors={1} total={20} />
 					<div>With an amount of 532/1000 and no label</div>
 					<RatioBar amount={532} total={1000} hideLabel />
 				</div>

--- a/packages/components/src/RatioBar/RatioBarLines.component.js
+++ b/packages/components/src/RatioBar/RatioBarLines.component.js
@@ -32,3 +32,16 @@ export function EmptyLine({ value, percentage }) {
 	);
 }
 EmptyLine.propTypes = ratioBarLinePropTypes;
+
+
+export function ErrorLine({ value, percentage }) {
+	return (
+		<RatioBarLine
+			percentage={percentage}
+			value={value}
+			className={theme('tc-ratio-bar-line-error')}
+		/>
+	);
+}
+ErrorLine.propTypes = ratioBarLinePropTypes;
+


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We need to display the erros count in a ratio bar
![image](https://user-images.githubusercontent.com/26482371/122560549-03cab500-d041-11eb-8543-750c16461be2.png)


**What is the chosen solution to this problem?**

Add a new `errors` prop

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
