### PR TITLE
chore: try to enforce status on the PR

### DIFF
--- a/.github/workflows/lerna-ci.yml
+++ b/.github/workflows/lerna-ci.yml
@@ -11,6 +11,16 @@ jobs:
     name: Build and test
 
     steps:
+      - name: Set PR Status to pending
+        if: github.ref != 'refs/heads/master'
+        uses: niteoweb/pull_request_status_action@v1.0.0
+        with:
+          pr_number: ${{ github.event.number }}
+          state: pending
+          repository: Talend/ui
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Checkout sources
         uses: actions/checkout@v2
 
@@ -88,10 +98,7 @@ jobs:
         uses: niteoweb/pull_request_status_action@v1.0.0
         with:
           pr_number: ${{ github.event.number }}
-          # Any of the (error | failure | pending | success) states
-          state: ${{ failure() ? 'failure'}}
+          state: ${{ steps.test.conclusion == 'success' && 'success' || 'failure'}}
           repository: Talend/ui
-
         env:
-          # Default Github Token
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/lerna-ci.yml
+++ b/.github/workflows/lerna-ci.yml
@@ -37,6 +37,7 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test
+        id: test
         run: yarn test
 
       - name: Lint
@@ -81,3 +82,16 @@ jobs:
           build-script: 'prepublishOnly'
           pattern: './packages/*/dist/*.{js,css,json}'
           exclude: '{**/*.html,**/*.map,**/node_modules/**}'
+
+      - name: Set PR Status
+        if: github.ref != 'refs/heads/master'
+        uses: niteoweb/pull_request_status_action@v1.0.0
+        with:
+          pr_number: ${{ github.event.number }}
+          # Any of the (error | failure | pending | success) states
+          state: ${{ failure() ? 'failure'}}
+          repository: Talend/ui
+
+        env:
+          # Default Github Token
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -54,7 +54,7 @@ describe('Action', () => {
 		wrapper.simulate('click', {});
 
 		// then
-		expect(onClick.mock.calls.length).toBe(1);
+		expect(onClick.mock.calls.length).toBe(2);
 		expect(onClick).toHaveBeenCalledWith(
 			{},
 			{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current github action CI do not enforce status before merge and it doesn t seems possible ...

**What is the chosen solution to this problem?**

try different approach:

* use a custom action to force the check status

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
