### PR TITLE
fix(ActionButton): remove empty tooltip when no label

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -206,7 +206,7 @@ function ActionButton(props) {
 		);
 	}
 
-	if (hideLabel || tooltip || tooltipLabel) {
+	if ((tooltipLabel || label) && (hideLabel || tooltip)) {
 		btn = (
 			<TooltipTrigger
 				label={tooltipLabel || label}

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -226,6 +226,22 @@ describe('Action', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render tooltip when there is a label with hideLabel property', () => {
+		// when
+		const wrapper = shallow(<ActionButton name="custom_name" label="a label" hideLabel />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should NOT render tooltip when there is an empty label with hideLabel property', () => {
+		// when
+		const wrapper = shallow(<ActionButton name="custom_name" label="" hideLabel />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
 	it('should trigger action if set up onMouseDown event', () => {
 		// given
 		const wrapper = shallow(<ActionButton extra="extra" {...mouseDownAction} />);
@@ -278,6 +294,7 @@ describe('Action', () => {
 		expect(wrapper.find('OverlayTrigger').length).toBe(1);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+
 	it('should called ref method on overlay', () => {
 		// given
 		const myRefFunc = jest.fn();
@@ -294,6 +311,7 @@ describe('Action', () => {
 		// then
 		expect(myRefFunc).toHaveBeenCalled();
 	});
+
 	it('should called ref method on button', () => {
 		// Given
 		const myRefFunc = jest.fn();

--- a/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
+++ b/packages/components/src/Actions/ActionButton/__snapshots__/ActionButton.test.js.snap
@@ -1,5 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`Action should NOT render tooltip when there is an empty label with hideLabel property 1`] = `
+<Button
+  active={false}
+  aria-label=""
+  block={false}
+  bsClass="btn"
+  bsStyle="default"
+  className="btn-icon-only"
+  disabled={false}
+  name="custom_name"
+  onClick={[Function]}
+  onMouseDown={[Function]}
+  role={null}
+/>
+`;
+
 exports[`Action should apply transformation on icon 1`] = `
 <Button
   active={false}
@@ -239,6 +255,27 @@ exports[`Action should render action with html property name = props.name if set
     Click me
   </span>
 </Button>
+`;
+
+exports[`Action should render tooltip when there is a label with hideLabel property 1`] = `
+<TooltipTrigger
+  label="a label"
+  tooltipPlacement="top"
+>
+  <Button
+    active={false}
+    aria-label="a label"
+    block={false}
+    bsClass="btn"
+    bsStyle="default"
+    className="btn-icon-only"
+    disabled={false}
+    name="custom_name"
+    onClick={[Function]}
+    onMouseDown={[Function]}
+    role={null}
+  />
+</TooltipTrigger>
 `;
 
 exports[`Action should reverse icon/label 1`] = `


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When using ActionButton component for displaying only an icon (without labels) with `hideLabel`, prevent an empty tooltip to be displayed.

![image](https://user-images.githubusercontent.com/1674329/122798191-988f1600-d2c0-11eb-9de9-a8831d15cf7f.png)

**What is the chosen solution to this problem?**

Review the tooltip condition.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
