### PR TITLE
feat(forms/TimezoneList): Add 'UTC' prefix to timezone dropdown options

### DIFF
--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.component.test.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.component.test.js
@@ -1,0 +1,58 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import TimezoneList from './TimezoneList.component';
+
+jest.mock('../Datalist', () => {
+	return function DataList() { };
+});
+
+describe('TimezoneList component', () => {
+	afterAll(() => {
+		jest.unmock('../Datalist');
+	});
+
+	it('should render the timezone dropdown widget', () => {
+		// given
+		const lang = 'fr';
+
+		const cldrTimezones = {
+			[lang]: {
+				main: {
+					fr: {
+						dates: {
+							timeZoneNames: {
+								zone: {
+									Africa: {
+										Abidjan: { exemplarCity: 'Abidjan' },
+										Freetown: { exemplarCity: 'Freetown' },
+									},
+									Europe: {
+										Paris: { exemplarCity: 'Paris' },
+										Kiev: { exemplarCity: 'Kiev' },
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		};
+
+		const props = { schema: { lang, cldrTimezones } };
+
+		// when
+		const wrapper = shallow(<TimezoneList {...props} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should throw an error if cldr translations are missing', () => {
+		// given
+		const props = { schema: { lang: 'en' } };
+
+		// when/then
+		expect(() => shallow(<TimezoneList {...props} />)).toThrow();
+	});
+});

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.js
@@ -24,7 +24,7 @@ export function getTimezones(lang, cldrTimezones) {
 	const getTimezoneInfo = (timezone, translatedName) => {
 		const timezoneName = translatedName || get(zones, `${timezone.replaceAll('/', '.')}.exemplarCity`, timezone);
 		const offset = talendUtils.date.getUTCOffset(timezone);
-		const name = `(${talendUtils.date.formatReadableUTCOffset(offset)}) ${timezoneName}`;
+		const name = `(UTC ${talendUtils.date.formatReadableUTCOffset(offset)}) ${timezoneName}`;
 
 		return { name, timezoneName, offset, value: timezone };
 	};

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
@@ -1,0 +1,76 @@
+import { getTimezones } from './TimezoneList.utils';
+
+describe('getTimezones', () => {
+	const cldrTimezones = {
+		en: {
+			main: {
+				en: {
+					dates: {
+						timeZoneNames: {
+							zone: {
+								Africa: {
+									Abidjan: { exemplarCity: '[EN] Abidjan' },
+									Freetown: { exemplarCity: '[EN] Freetown' },
+								},
+								Europe: {
+									Paris: { exemplarCity: '[EN] Paris' },
+									Kiev: { exemplarCity: '[EN] Kiev' },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		fr: {
+			main: {
+				fr: {
+					dates: {
+						timeZoneNames: {
+							zone: {
+								Africa: {
+									Abidjan: { exemplarCity: '[FR] Abidjan' },
+									Freetown: { exemplarCity: '[FR] Freetown' },
+								},
+								Europe: {
+									Paris: { exemplarCity: '[FR] Paris' },
+									Kiev: { exemplarCity: '[FR] Kiev' },
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	};
+
+	it('should return the list of timezones ready to be used by the DataList', () => {
+		// when
+		const timezones = getTimezones('fr', cldrTimezones);
+
+		// then
+		expect(timezones).toEqual([
+			{ name: '(UTC +00:00) [FR] Abidjan', timezoneName: '[FR] Abidjan', offset: 0, value: 'Africa/Abidjan' },
+			{ name: '(UTC +00:00) [FR] Freetown', timezoneName: '[FR] Freetown', offset: 0, value: 'Africa/Freetown' },
+			{ name: '(UTC +02:00) [FR] Paris', timezoneName: '[FR] Paris', offset: 120, value: 'Europe/Paris' },
+			{ name: '(UTC +03:00) [FR] Kiev', timezoneName: '[FR] Kiev', offset: 180, value: 'Europe/Kiev' },
+		]);
+	});
+
+	it('should fallback to English language if specified language has no translation provided', () => {
+		// when
+		const timezones = getTimezones('es', cldrTimezones);
+
+		// then
+		expect(timezones).toEqual([
+			{ name: '(UTC +00:00) [EN] Abidjan', timezoneName: '[EN] Abidjan', offset: 0, value: 'Africa/Abidjan' },
+			{ name: '(UTC +00:00) [EN] Freetown', timezoneName: '[EN] Freetown', offset: 0, value: 'Africa/Freetown' },
+			{ name: '(UTC +02:00) [EN] Paris', timezoneName: '[EN] Paris', offset: 120, value: 'Europe/Paris' },
+			{ name: '(UTC +03:00) [EN] Kiev', timezoneName: '[EN] Kiev', offset: 180, value: 'Europe/Kiev' },
+		]);
+	});
+
+	it('should throw an error when no translation is available', () => {
+		expect(() => getTimezones('es', {})).toThrow();
+	});
+});

--- a/packages/forms/src/UIForm/fields/TimezoneList/__snapshots__/TimezoneList.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/TimezoneList/__snapshots__/TimezoneList.component.test.js.snap
@@ -1,0 +1,96 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`TimezoneList component should render the timezone dropdown widget 1`] = `
+<DataList
+  schema={
+    Object {
+      "cldrTimezones": Object {
+        "fr": Object {
+          "main": Object {
+            "fr": Object {
+              "dates": Object {
+                "timeZoneNames": Object {
+                  "zone": Object {
+                    "Africa": Object {
+                      "Abidjan": Object {
+                        "exemplarCity": "Abidjan",
+                      },
+                      "Freetown": Object {
+                        "exemplarCity": "Freetown",
+                      },
+                    },
+                    "Europe": Object {
+                      "Kiev": Object {
+                        "exemplarCity": "Kiev",
+                      },
+                      "Paris": Object {
+                        "exemplarCity": "Paris",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      "lang": "fr",
+      "options": Object {
+        "titleMap": Array [
+          Object {
+            "name": "(UTC +00:00) Abidjan",
+            "offset": 0,
+            "timezoneName": "Abidjan",
+            "value": "Africa/Abidjan",
+          },
+          Object {
+            "name": "(UTC +00:00) Freetown",
+            "offset": 0,
+            "timezoneName": "Freetown",
+            "value": "Africa/Freetown",
+          },
+          Object {
+            "name": "(UTC +02:00) Paris",
+            "offset": 120,
+            "timezoneName": "Paris",
+            "value": "Europe/Paris",
+          },
+          Object {
+            "name": "(UTC +03:00) Kiev",
+            "offset": 180,
+            "timezoneName": "Kiev",
+            "value": "Europe/Kiev",
+          },
+        ],
+      },
+      "restricted": true,
+      "titleMap": Array [
+        Object {
+          "name": "(UTC +00:00) Abidjan",
+          "offset": 0,
+          "timezoneName": "Abidjan",
+          "value": "Africa/Abidjan",
+        },
+        Object {
+          "name": "(UTC +00:00) Freetown",
+          "offset": 0,
+          "timezoneName": "Freetown",
+          "value": "Africa/Freetown",
+        },
+        Object {
+          "name": "(UTC +02:00) Paris",
+          "offset": 120,
+          "timezoneName": "Paris",
+          "value": "Europe/Paris",
+        },
+        Object {
+          "name": "(UTC +03:00) Kiev",
+          "offset": 180,
+          "timezoneName": "Kiev",
+          "value": "Europe/Kiev",
+        },
+      ],
+    }
+  }
+/>
+`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
![image](https://user-images.githubusercontent.com/38908846/123094272-fe98ac00-d42c-11eb-83d3-c7e459e42f45.png)
Timezone dropdown options are supposed to display "UTC" as a prefix before showing the UTC offset of the timezone.

**What is the chosen solution to this problem?**
Add it

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
