### PR TITLE
feat(VirtualizedList): add CellQualityBar renderer

### DIFF
--- a/packages/components/src/FilterBar/FilterBar.test.js
+++ b/packages/components/src/FilterBar/FilterBar.test.js
@@ -5,6 +5,7 @@ import { FilterBarComponent } from './FilterBar.component';
 import Icon from '../Icon';
 
 let defaultProps = {};
+const debounceTimeout = 500;
 
 describe('FilterBar', () => {
 	beforeEach(() => {
@@ -175,7 +176,6 @@ describe('FilterBar', () => {
 
 	it('should call onFilter with debounce options', done => {
 		// given
-		const debounceTimeout = 300;
 		const props = {
 			...defaultProps,
 			debounceTimeout,
@@ -194,7 +194,6 @@ describe('FilterBar', () => {
 
 	it('should call onFilter with debounceMinLength options', done => {
 		// given
-		const debounceTimeout = 300;
 		const props = {
 			...defaultProps,
 			debounceTimeout,

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -34,6 +34,7 @@ function CustomList(props) {
 				dataKey="isValid"
 				columnData={{ displayMode: List.VList.Boolean.displayMode.ICON }}
 			/>
+			<List.VList.QualityBar label="Quality" dataKey="quality" />
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />
 			<List.VList.Text label="Author" dataKey="author" />

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -298,6 +298,13 @@ for (let i = 0; i < 100; i += 1) {
 		className: 'item-0-class',
 		persistentActions,
 		titleActions,
+		quality: {
+			invalid: 1,
+			empty: 2,
+			valid: 3,
+			na: 4,
+			onClick: action('onQualityClick'),
+		},
 	});
 }
 

--- a/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.component.js
+++ b/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.component.js
@@ -1,0 +1,9 @@
+import React from 'react';
+import QualityBar from '../../QualityBar';
+
+export const CellQualityBar = ({ cellData }) => cellData && <QualityBar {...cellData} /> || null;
+
+CellQualityBar.displayName = 'VirtualizedList(CellQualityBar)';
+CellQualityBar.propTypes = {
+	cellData: QualityBar.propTypes.isRequired,
+};

--- a/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.test.js
+++ b/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.test.js
@@ -11,7 +11,6 @@ const props = {
 	na: 4,
 	onClick: noop,
 	getDataFeature: noop,
-	// digits: PropTypes.number,
 };
 
 describe('CellQualityBar', () => {

--- a/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.test.js
+++ b/packages/components/src/VirtualizedList/CellQualityBar/CellQualityBar.test.js
@@ -1,0 +1,27 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import noop from 'lodash/noop';
+
+import { CellQualityBar } from './CellQualityBar.component';
+
+const props = {
+	invalid: 1,
+	empty: 2,
+	valid: 3,
+	na: 4,
+	onClick: noop,
+	getDataFeature: noop,
+	// digits: PropTypes.number,
+};
+
+describe('CellQualityBar', () => {
+	it('should render an empty quality bar', () => {
+		const wrapper = mount(<CellQualityBar />);
+		expect(wrapper.html()).toBe(null);
+	});
+
+	it('should render a valid quality bar', () => {
+		const wrapper = mount(<CellQualityBar cellData={props} />);
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/VirtualizedList/CellQualityBar/QualityBarColumn.component.js
+++ b/packages/components/src/VirtualizedList/CellQualityBar/QualityBarColumn.component.js
@@ -1,0 +1,19 @@
+import React from 'react';
+import { defaultColumnConfiguration } from '../Content.component';
+import { CellQualityBar } from './CellQualityBar.component';
+
+export const cellType = 'qualityBar';
+export const qualityBarColumnConfiguration = {
+	cellRenderer: props => <CellQualityBar {...props} />,
+};
+
+// this is a fake component to be usable in JSX,
+// but the element is used as props object internally (VirtualizedList / RV)
+export default function QualityBarColumn() {
+	return null;
+}
+
+QualityBarColumn.defaultProps = {
+	...defaultColumnConfiguration,
+	...qualityBarColumnConfiguration,
+};

--- a/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
@@ -1,0 +1,34 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellQualityBar should render a valid quality bar 1`] = `
+<div class="tc-ratio-bar theme-tc-ratio-bar">
+  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid"
+       tabindex="0"
+       style="flex-basis: 10%;"
+       role="button"
+       aria-describedby="42"
+  >
+  </div>
+  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty"
+       tabindex="0"
+       style="flex-basis: 20%;"
+       role="button"
+       aria-describedby="42"
+  >
+  </div>
+  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na"
+       tabindex="0"
+       style="flex-basis: 40%;"
+       role="button"
+       aria-describedby="42"
+  >
+  </div>
+  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid"
+       tabindex="0"
+       style="flex-basis: 30%;"
+       role="button"
+       aria-describedby="42"
+  >
+  </div>
+</div>
+`;

--- a/packages/components/src/VirtualizedList/CellQualityBar/index.js
+++ b/packages/components/src/VirtualizedList/CellQualityBar/index.js
@@ -1,0 +1,4 @@
+import QualityBarColumn, { cellType, qualityBarColumnConfiguration } from './QualityBarColumn.component';
+
+export { cellType, QualityBarColumn };
+export default qualityBarColumnConfiguration;

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -897,7 +897,7 @@ storiesOf('Data/List/VirtualizedList', module)
 			<h1>Virtualized List</h1>
 
 			<section style={{ height: '50vh' }}>
-				<VirtualizedList collection={[]} id="my-list">
+				<VirtualizedList collection={collection} id="my-list">
 					<VirtualizedList.Text label="Id" dataKey="id" />
 					<VirtualizedList.Text label="Description (non sortable)" dataKey="description" />
 					<VirtualizedList.Text label="Author" dataKey="author" />

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -892,30 +892,6 @@ storiesOf('Data/List/VirtualizedList', module)
 			</section>
 		</div>
 	))
-	.add('List > with quality bar', () => (
-		<div className="virtualized-list">
-			<h1>Virtualized List</h1>
-
-			<section style={{ height: '50vh' }}>
-				<VirtualizedList collection={collection} id="my-list">
-					<VirtualizedList.Text label="Id" dataKey="id" />
-					<VirtualizedList.Text label="Description (non sortable)" dataKey="description" />
-					<VirtualizedList.Text label="Author" dataKey="author" />
-					<VirtualizedList.QualityBar label="Quality" dataKey="quality" />
-					<VirtualizedList.Datetime
-						label="Created"
-						dataKey="created"
-						columnData={{ mode: 'format' }}
-					/>
-					<VirtualizedList.Datetime
-						label="Modified"
-						dataKey="modified"
-						columnData={{ mode: 'format' }}
-					/>
-				</VirtualizedList>
-			</section>
-		</div>
-	))
 	.add('List > custom noRowsRenderer', () => (
 		<div className="virtualized-list">
 			<h1>Virtualized List</h1>

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -213,6 +213,13 @@ const collection = [
 		display: 'text',
 		className: 'item-0-class',
 		titleActions: fewTitleActions,
+		quality: {
+			invalid: 1,
+			empty: 2,
+			valid: 3,
+			na: 4,
+			onClick: action('onQualityClick'),
+		}
 	},
 	{
 		id: 1,
@@ -224,6 +231,13 @@ const collection = [
 		display: 'text',
 		className: 'item-1-class',
 		titleActions: lotOfTitleActions,
+		quality: {
+			invalid: 1,
+			empty: 2,
+			valid: 3,
+			na: 4,
+			onClick: action('onQualityClick'),
+		}
 	},
 	{
 		id: 2,
@@ -864,6 +878,30 @@ storiesOf('Data/List/VirtualizedList', module)
 					<VirtualizedList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} />
 					<VirtualizedList.Text label="Description (non sortable)" dataKey="description" />
 					<VirtualizedList.Text label="Author" dataKey="author" />
+					<VirtualizedList.Datetime
+						label="Created"
+						dataKey="created"
+						columnData={{ mode: 'format' }}
+					/>
+					<VirtualizedList.Datetime
+						label="Modified"
+						dataKey="modified"
+						columnData={{ mode: 'format' }}
+					/>
+				</VirtualizedList>
+			</section>
+		</div>
+	))
+	.add('List > with quality bar', () => (
+		<div className="virtualized-list">
+			<h1>Virtualized List</h1>
+
+			<section style={{ height: '50vh' }}>
+				<VirtualizedList collection={[]} id="my-list">
+					<VirtualizedList.Text label="Id" dataKey="id" />
+					<VirtualizedList.Text label="Description (non sortable)" dataKey="description" />
+					<VirtualizedList.Text label="Author" dataKey="author" />
+					<VirtualizedList.QualityBar label="Quality" dataKey="quality" />
 					<VirtualizedList.Datetime
 						label="Created"
 						dataKey="created"

--- a/packages/components/src/VirtualizedList/index.js
+++ b/packages/components/src/VirtualizedList/index.js
@@ -11,6 +11,7 @@ import { TitleColumn } from './CellTitle';
 import { BooleanColumn } from './CellBoolean';
 import { LabelColumn } from './CellLabel';
 import { IconTextColumn } from './CellIconText';
+import { QualityBarColumn } from './CellQualityBar';
 import HeaderResizable from './HeaderResizable';
 import RowCollapsiblePanel from './RowCollapsiblePanel';
 
@@ -30,6 +31,7 @@ VirtualizedList.Title = TitleColumn;
 VirtualizedList.Boolean = BooleanColumn;
 VirtualizedList.Label = LabelColumn;
 VirtualizedList.IconText = IconTextColumn;
+VirtualizedList.QualityBar = QualityBarColumn;
 VirtualizedList.RowCollapsiblePanel = RowCollapsiblePanel;
 VirtualizedList.HeaderResizable = HeaderResizable;
 VirtualizedList.cellDictionary = cellDictionary;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Add a Cell quality bar renderer to be reused.

![image](https://user-images.githubusercontent.com/1674329/123238273-a5895080-d4de-11eb-85a3-19996f9dc6b9.png)

Direct demo link: http://3351.talend.surge.sh/components/?path=/story/data-list-list-composition--default

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
