### PR TITLE
feat(Dates): translate date formats

### DIFF
--- a/packages/utils/i18next-scanner.config.js
+++ b/packages/utils/i18next-scanner.config.js
@@ -1,0 +1,15 @@
+module.exports = {
+	options: {
+		debug: true,
+		func: {
+			list: ['t'],
+			extensions: ['.js'],
+		},
+		lngs: ['en'],
+		defaultNs: 'tui-utils',
+		defaultValue: '__STRING_NOT_TRANSLATED__',
+		resource: {
+			savePath: 'i18n/{{ns}}.json',
+		},
+	},
+};

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -27,7 +27,7 @@
     "cross-env": "^7.0.3"
   },
   "dependencies": {
-    "date-fns": "^1.27.2"
+    "date-fns": "^2.22.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -2,9 +2,11 @@ import {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
+	dateFormat,
 	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,
+	localizedFormat,
 	timeZoneExists,
 } from './index';
 
@@ -104,7 +106,7 @@ describe('date', () => {
 		it('should format a locale date to a given timezone in a specifc format', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
-			const formatString = 'YYYY-MM-DD[T]HH:mm:ssZZ';
+			const formatString = "yyyy-MM-dd'T'HH:mm:ssXX";
 			const options = { timeZone: timeZones['UTC+5'] };
 
 			// when
@@ -117,7 +119,7 @@ describe('date', () => {
 		it('should not change timezone tokens that are wrapped in hooks', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
-			const formatString = 'YYYY-MM-DD[T]HH:mm:ss[Z]';
+			const formatString = "yyyy-MM-dd'T'HH:mm:ss'Z'";
 			const options = { timeZone: timeZones['UTC+5'] };
 
 			// when
@@ -176,6 +178,32 @@ describe('date', () => {
 
 			// then
 			expect(exists).toBe(false);
+		});
+	});
+
+	describe('dateFormat', () => {
+		const t = (key: string, value: { defaultValue: string}) => value.defaultValue;
+
+		it('should format date according to the format and the lang', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+
+			// when
+			const formatedDate = dateFormat(dateObj, localizedFormat(t).MDY_LONG, 'en');
+
+			// then
+			expect(formatedDate).toEqual('May 13th, 2020');
+		});
+
+		it('should format date according to the format and the lang', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+
+			// when
+			const formatedDate = dateFormat(dateObj, localizedFormat(t).MY_LONG, 'fr');
+
+			// then
+			expect(formatedDate).toEqual('mai 2020');
 		});
 	});
 });

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -11,7 +11,7 @@ interface ConversionOptions {
 }
 
 interface Map {
-	[key: string]: any
+	[key: string]: object,
   }
 
 /**
@@ -213,7 +213,7 @@ export const localizedFormat = (t: any) => ({
  * @param {string} lang The user language
  * @returns {String} The date formated using the user language.
  */
-export const dateFormat = (date: DateFnsFormatInput, localizedDateFormat: string, lang: string) => {
+export const dateFormat = (date: DateFnsFormatInput, localizedDateFormat: string, lang: string): string => {
 	return format(parse(date), localizedDateFormat, { locale: locales[lang] });
 };
 

--- a/packages/utils/yarn.lock
+++ b/packages/utils/yarn.lock
@@ -3614,10 +3614,10 @@ data-urls@^2.0.0:
     whatwg-mimetype "^2.3.0"
     whatwg-url "^8.0.0"
 
-date-fns@^1.27.2:
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
-  integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+date-fns@^2.22.1:
+  version "2.22.1"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.22.1.tgz#1e5af959831ebb1d82992bf67b765052d8f0efc4"
+  integrity sha512-yUFPQjrxEmIsMqlHhAhmxkuH769baF21Kk+nZwZGyrMoyLA+LugaQtC0+Tqf9CBUUULWwUJt6Q5ySI3LJDDCGg==
 
 deasync@^0.1.21:
   version "0.1.21"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The dates are not well translated.
![image](https://user-images.githubusercontent.com/35027619/123610495-ecd65080-d800-11eb-99d7-bf7664e70d8a.png)
Could be great to have a common way of translating the dates.

**What is the chosen solution to this problem?**

- Provide a common way to translate the dates.
- Add translation to the utils package (TODO)

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
