### PR TITLE
feat(Dates): translate date formats using Intl

### DIFF
--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -2,6 +2,8 @@ import {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
+	dateFormat,
+	dateOptions,
 	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,
@@ -176,6 +178,32 @@ describe('date', () => {
 
 			// then
 			expect(exists).toBe(false);
+		});
+	});
+
+	describe('dateFormat', () => {
+		const t = (key: string, value: { defaultValue: string}) => value.defaultValue;
+
+		it('should format date according to the format and the lang', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+
+			// when
+			const formatedDate = dateFormat(dateObj, dateOptions.MDY_LONG, 'en');
+
+			// then
+			expect(formatedDate).toEqual('May 13, 2020');
+		});
+
+		it('should format date according to the format and the lang', () => {
+			// given
+			const dateObj = new Date('2020-05-13, 20:00');
+
+			// when
+			const formatedDate = dateFormat(dateObj, dateOptions.MY_LONG, 'fr');
+
+			// then
+			expect(formatedDate).toEqual('mai 2020');
 		});
 	});
 });

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -2,8 +2,8 @@ import {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
-	dateFormat,
-	dateOptions,
+	format,
+	FORMAT,
 	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,
@@ -187,7 +187,7 @@ describe('date', () => {
 			const dateObj = new Date('2020-05-13, 20:00');
 
 			// when
-			const formatedDate = dateFormat(dateObj, dateOptions.MDY_LONG, 'en');
+			const formatedDate = format(dateObj, FORMAT.MDY_LONG, 'en');
 
 			// then
 			expect(formatedDate).toEqual('May 13, 2020');
@@ -198,7 +198,7 @@ describe('date', () => {
 			const dateObj = new Date('2020-05-13, 20:00');
 
 			// when
-			const formatedDate = dateFormat(dateObj, dateOptions.MY_LONG, 'fr');
+			const formatedDate = format(dateObj, FORMAT.MY_LONG, 'fr');
 
 			// then
 			expect(formatedDate).toEqual('mai 2020');

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -182,8 +182,6 @@ describe('date', () => {
 	});
 
 	describe('dateFormat', () => {
-		const t = (key: string, value: { defaultValue: string}) => value.defaultValue;
-
 		it('should format date according to the format and the lang', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -8,8 +8,8 @@ interface ConversionOptions {
 	sourceTimeZone?: string,
 }
 
-interface Map {
-	[key: string]: object,
+interface DateFormatOptions {
+	[key: string]: Intl.DateTimeFormatOptions,
 }
 
 /**
@@ -184,17 +184,17 @@ export function timeZoneExists(timeZone: string): boolean {
  * @enum string
  */
 export const FORMAT = {
-	/** en: June 29, 2021 / fr: 29 juin 2020 / ja: 2020年6月29日 */
+	/** en: June 29, 2021 / fr: 29 juin 2020 / ja: 2020年6月29日 / de 29. Juni 2020 */
 	MDY_LONG: 'MDY_LONG',
-	/** en: June 2020 / fr: juin 2020 / ja: 2020年6月 */
+	/** en: June 2020 / fr: juin 2020 / ja: 2020年6月 / Juni 2020 */
 	MY_LONG: 'MY_LONG',
-	/** en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29 */
+	/** en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29 / de: 29.06.2020 */
 	MDY: 'MDY',
-	/** en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00 */
+	/** en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00 / de: 29.06.20, 22:00 */
 	MDYHM: 'MDYHM',
 };
 
-const options: Map = {
+const options: DateFormatOptions = {
 	[FORMAT.MDY_LONG]: { year: 'numeric', month: 'long', day: 'numeric' },
 	[FORMAT.MY_LONG]: { year: 'numeric', month: 'long' },
 	[FORMAT.MDY]: { year: 'numeric', month: '2-digit', day: '2-digit' },
@@ -204,11 +204,11 @@ const options: Map = {
 /**
  * Format a date using Intl.
  * @param date {DateFnsFormatInput} A date: Date, string or Number
- * @param dateOption {string} Comes from FORMAT enum
+ * @param dateOption {string} Comes from `FORMAT` enum
  * @param lang {string} language
  * @returns The formated date
  */
-export const format = (date: DateFnsFormatInput, dateOption: string, lang: string): string => {
+export function format (date: DateFnsFormatInput, dateOption: string, lang: string): string {
 	return new Intl.DateTimeFormat(lang, options[dateOption]).format(parse(date));
 }; 
 

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -180,7 +180,7 @@ export const dateOptions = {
 	MY_LONG: { year: 'numeric', month: 'long' }, // en: June 2020 / fr: juin 2020 / ja: 2020年6月
 	MDY: { year: 'numeric', month: '2-digit', day: '2-digit' }, // en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29
 	MDYHM: { dateStyle: 'short', timeStyle: 'short' }, // en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00
-}
+};
 
 export const dateFormat = (date: DateFnsFormatInput, options: any, lang: string): string => {
 	return new Intl.DateTimeFormat(lang, options).format(parse(date));

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -1,4 +1,4 @@
-import format from 'date-fns/format';
+import dateFnsFormat from 'date-fns/format';
 import parse from 'date-fns/parse';
 
 type DateFnsFormatInput = Date | number | string;
@@ -6,6 +6,10 @@ type DateFnsFormatInput = Date | number | string;
 interface ConversionOptions {
 	timeZone: string,
 	sourceTimeZone?: string,
+}
+
+interface Map {
+	[key: string]: object,
 }
 
 /**
@@ -138,7 +142,7 @@ export function formatToTimeZone(date: DateFnsFormatInput, formatString: string,
 	// Replace timezone token(s) in the string format with timezone values, since format() will use local timezone
 	const dateFnsFormatWithTimeZoneValue = formatTimeZoneTokens(formatString, options.timeZone);
 
-	return format(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
+	return dateFnsFormat(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
 }
 
 /**
@@ -175,23 +179,45 @@ export function timeZoneExists(timeZone: string): boolean {
 	}
 }
 
-export const dateOptions = {
-	MDY_LONG: { year: 'numeric', month: 'long', day: 'numeric' }, // en: June 29, 2021 / fr: 29 juin 2020 / ja: 2020年6月29日
-	MY_LONG: { year: 'numeric', month: 'long' }, // en: June 2020 / fr: juin 2020 / ja: 2020年6月
-	MDY: { year: 'numeric', month: '2-digit', day: '2-digit' }, // en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29
-	MDYHM: { dateStyle: 'short', timeStyle: 'short' }, // en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00
+/**
+ * Date format options
+ * @enum string
+ */
+export const FORMAT = {
+	/** en: June 29, 2021 / fr: 29 juin 2020 / ja: 2020年6月29日 */
+	MDY_LONG: 'MDY_LONG',
+	/** en: June 2020 / fr: juin 2020 / ja: 2020年6月 */
+	MY_LONG: 'MY_LONG',
+	/** en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29 */
+	MDY: 'MDY',
+	/** en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00 */
+	MDYHM: 'MDYHM',
 };
 
-export const dateFormat = (date: DateFnsFormatInput, options: any, lang: string): string => {
-	return new Intl.DateTimeFormat(lang, options).format(parse(date));
+const options: Map = {
+	[FORMAT.MDY_LONG]: { year: 'numeric', month: 'long', day: 'numeric' },
+	[FORMAT.MY_LONG]: { year: 'numeric', month: 'long' },
+	[FORMAT.MDY]: { year: 'numeric', month: '2-digit', day: '2-digit' },
+	[FORMAT.MDYHM]: { dateStyle: 'short', timeStyle: 'short' },
+};
+
+/**
+ * Format a date using Intl.
+ * @param date {DateFnsFormatInput} A date: Date, string or Number
+ * @param dateOption {string} Comes from FORMAT enum
+ * @param lang {string} language
+ * @returns The formated date
+ */
+export const format = (date: DateFnsFormatInput, dateOption: string, lang: string): string => {
+	return new Intl.DateTimeFormat(lang, options[dateOption]).format(parse(date));
 }; 
 
 export default {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
-	dateFormat,
-	dateOptions,
+	format,
+	options,
 	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -175,10 +175,23 @@ export function timeZoneExists(timeZone: string): boolean {
 	}
 }
 
+export const dateOptions = {
+	MDY_LONG: { year: 'numeric', month: 'long', day: 'numeric' }, // en: June 29, 2021 / fr: 29 juin 2020 / ja: 2020年6月29日
+	MY_LONG: { year: 'numeric', month: 'long' }, // en: June 2020 / fr: juin 2020 / ja: 2020年6月
+	MDY: { year: 'numeric', month: '2-digit', day: '2-digit' }, // en: 06/29/2020 / fr: 29/06/2020 / ja: 2020/06/29
+	MDYHM: { dateStyle: 'short', timeStyle: 'short' }, // en: 6/29/20, 10:00 PM / fr: 29/06/2020 22:00 / ja: 2020/06/29 22:00
+}
+
+export const dateFormat = (date: DateFnsFormatInput, options: any, lang: string): string => {
+	return new Intl.DateTimeFormat(lang, options).format(parse(date));
+}; 
+
 export default {
 	convertToLocalTime,
 	convertToTimeZone,
 	convertToUTC,
+	dateFormat,
+	dateOptions,
 	formatReadableUTCOffset,
 	formatToTimeZone,
 	getUTCOffset,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The dates are not well translated.
![image](https://user-images.githubusercontent.com/35027619/123610495-ecd65080-d800-11eb-99d7-bf7664e70d8a.png)
Could be great to have a common way of translating the dates.

**What is the chosen solution to this problem?**
Provide a common way to translate the dates using Intl

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
