### PR TITLE
fix(components): style in about dialog

### DIFF
--- a/packages/components/src/AboutDialog/AboutDialog.scss
+++ b/packages/components/src/AboutDialog/AboutDialog.scss
@@ -28,11 +28,6 @@
 					padding: $padding-smaller;
 					text-align: left;
 				}
-
-				td + td,
-				th + th {
-					border-left: 8rem solid transparent;
-				}
 			}
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Style is broken :

<img width="695" alt="CleanShot 2021-06-30 at 22 51 51@2x" src="https://user-images.githubusercontent.com/2909671/124030048-173d2f00-d9f6-11eb-9b89-c776a00d1011.png">

**What is the chosen solution to this problem?**
<img width="681" alt="CleanShot 2021-06-30 at 22 51 44@2x" src="https://user-images.githubusercontent.com/2909671/124030017-0987a980-d9f6-11eb-9edd-3cb441ca055a.png">

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
