### PR TITLE
chore(List/CellLabel): specify bstyle for cellLabel

### DIFF
--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -35,7 +35,7 @@ function CustomList(props) {
 				columnData={{ displayMode: List.VList.Boolean.displayMode.ICON }}
 			/>
 			<List.VList.QualityBar label="Quality" dataKey="quality" />
-			<List.VList.Label label="TabLabel" dataKey="tagLabel" />
+			<List.VList.Label label="TagLabel" dataKey="tagLabel" />
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />
 			<List.VList.Text label="Author" dataKey="author" />

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -35,6 +35,7 @@ function CustomList(props) {
 				columnData={{ displayMode: List.VList.Boolean.displayMode.ICON }}
 			/>
 			<List.VList.QualityBar label="Quality" dataKey="quality" />
+			<List.VList.Label label="TabLabel" dataKey="tagLabel" />
 			<List.VList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} disableSort />
 			<List.VList.Text label="Description" dataKey="description" disableSort />
 			<List.VList.Text label="Author" dataKey="author" />

--- a/packages/components/src/List/ListComposition/collection.js
+++ b/packages/components/src/List/ListComposition/collection.js
@@ -305,6 +305,7 @@ for (let i = 0; i < 100; i += 1) {
 			na: 4,
 			onClick: action('onQualityClick'),
 		},
+		tagLabel: { label: 'incorrect', style: 'warning' },
 	});
 }
 

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
@@ -5,10 +5,10 @@ import Tag from '../../Tag';
 /**
  * Cell renderer that displays a label
  */
-function CellLabel({ cellData, rowIndex, style = 'info', ...rest }) {
+function CellLabel({ cellData, rowIndex, ...rest }) {
 	return (
-		<Tag id={`${rowIndex}`} bsStyle={cellData.style}>
-			{cellData.label}
+		<Tag id={`${rowIndex}`} bsStyle={cellData.style || 'info'}>
+			{typeof cellData === 'string' ? cellData : cellData.label}
 		</Tag>
 	);
 }
@@ -16,11 +16,16 @@ function CellLabel({ cellData, rowIndex, style = 'info', ...rest }) {
 CellLabel.displayName = 'VirtualizedList(CellLabel)';
 CellLabel.propTypes = {
 	// The cell value : props.rowData[props.dataKey]
-	cellData: PropTypes.string,
+	cellData: PropTypes.oneOf([
+		PropTypes.string,
+		PropTypes.shape({
+			label: PropTypes.string,
+			// the bootstrap style info, danger, warning, success
+			style: PropTypes.string,
+		}),
+	]),
 	// The collection item index.
 	rowIndex: PropTypes.number,
-	// the bootstrap style info, danger, warning, success
-	style: PropTypes.string,
 };
 
 export default CellLabel;

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
@@ -5,10 +5,10 @@ import Tag from '../../Tag';
 /**
  * Cell renderer that displays a label
  */
-function CellLabel({ cellData, rowIndex }) {
+function CellLabel({ cellData, rowIndex, style = 'info', ...rest }) {
 	return (
-		<Tag id={`${rowIndex}`} bsStyle="info">
-			{cellData}
+		<Tag id={`${rowIndex}`} bsStyle={cellData.style}>
+			{cellData.label}
 		</Tag>
 	);
 }
@@ -19,6 +19,8 @@ CellLabel.propTypes = {
 	cellData: PropTypes.string,
 	// The collection item index.
 	rowIndex: PropTypes.number,
+	// the bootstrap style info, danger, warning, success
+	style: PropTypes.string,
 };
 
 export default CellLabel;

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
@@ -6,8 +6,9 @@ import Tag from '../../Tag';
  * Cell renderer that displays a label
  */
 function CellLabel({ cellData, rowIndex }) {
+	const label = typeof cellData === 'string' ? cellData : cellData.label;
 	return (
-		<Tag id={`${rowIndex}`} bsStyle={cellData.style || 'info'}>
+		<Tag id={`${rowIndex}`} bsStyle={cellData.style || 'info'} title={label}>
 			{typeof cellData === 'string' ? cellData : cellData.label}
 		</Tag>
 	);

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.component.js
@@ -5,7 +5,7 @@ import Tag from '../../Tag';
 /**
  * Cell renderer that displays a label
  */
-function CellLabel({ cellData, rowIndex, ...rest }) {
+function CellLabel({ cellData, rowIndex }) {
 	return (
 		<Tag id={`${rowIndex}`} bsStyle={cellData.style || 'info'}>
 			{typeof cellData === 'string' ? cellData : cellData.label}

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.test.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.test.js
@@ -7,7 +7,7 @@ import CellLabel from './CellLabel.component';
 describe('CellLabel', () => {
 	it('should default render', () => {
 		// given
-		const label = 'my label';
+		const label = { label: 'my label', style: 'info' };
 		// when
 		const wrapper = mount(<CellLabel cellData={label} rowIndex={25} />);
 		// then

--- a/packages/components/src/VirtualizedList/CellLabel/CellLabel.test.js
+++ b/packages/components/src/VirtualizedList/CellLabel/CellLabel.test.js
@@ -5,9 +5,18 @@ import { mount } from 'enzyme';
 import CellLabel from './CellLabel.component';
 
 describe('CellLabel', () => {
-	it('should default render', () => {
+	it('should default render an object', () => {
 		// given
 		const label = { label: 'my label', style: 'info' };
+		// when
+		const wrapper = mount(<CellLabel cellData={label} rowIndex={25} />);
+		// then
+		expect(wrapper.html()).toMatchSnapshot();
+	});
+
+	it('should default render a string', () => {
+		// given
+		const label = 'my label';
 		// when
 		const wrapper = mount(<CellLabel cellData={label} rowIndex={25} />);
 		// then

--- a/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`CellLabel should default render 1`] = `
+exports[`CellLabel should default render a string 1`] = `
+<coral.tag.information id="25">
+  my label
+</coral.tag.information>
+`;
+
+exports[`CellLabel should default render an object 1`] = `
 <coral.tag.information id="25">
   my label
 </coral.tag.information>

--- a/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellLabel/__snapshots__/CellLabel.test.js.snap
@@ -1,13 +1,17 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CellLabel should default render a string 1`] = `
-<coral.tag.information id="25">
+<coral.tag.information id="25"
+                       title="my label"
+>
   my label
 </coral.tag.information>
 `;
 
 exports[`CellLabel should default render an object 1`] = `
-<coral.tag.information id="25">
+<coral.tag.information id="25"
+                       title="my label"
+>
   my label
 </coral.tag.information>
 `;

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -219,7 +219,7 @@ const collection = [
 			valid: 3,
 			na: 4,
 			onClick: action('onQualityClick'),
-		}
+		},
 	},
 	{
 		id: 1,
@@ -237,7 +237,7 @@ const collection = [
 			valid: 3,
 			na: 4,
 			onClick: action('onQualityClick'),
-		}
+		},
 	},
 	{
 		id: 2,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
CellLabel's bstyle is by default info and it can't be changed

**What is the chosen solution to this problem?**
adding support for an object for cellData in order to pass bstyle

**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
