### PR TITLE
fix(theme): hover disabled buttons

### DIFF
--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -166,6 +166,7 @@ storiesOf('Buttons/Button', module)
 			hideLabel: [false, true],
 			inProgress: [true, false],
 			disabled: [false, true],
-			tooltipLabel: [undefined, 'Tooltip custom label'],
+			tooltip: [true],
+			tooltipLabel: ['Tooltip custom label'],
 		}),
 	);

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -159,6 +159,7 @@ storiesOf('Buttons/Button', module)
 		'combinations',
 		withPropsCombinations(ActionButton, {
 			label: ['Click me'],
+			bsStyle: ['default', 'primary', 'success', 'info', 'warning', 'danger', 'link', 'info btn-inverse'],
 			icon: ['talend-dataprep'],
 			'data-feature': ['my.feature'],
 			onClick: [action('You clicked me')],

--- a/packages/theme/src/theme/_buttons.scss
+++ b/packages/theme/src/theme/_buttons.scss
@@ -68,6 +68,9 @@
 		&:hover,
 		&:focus,
 		&.focus {
+			color: var(--t-button-color);
+			background-color: var(--t-button-background-color);
+			border-color: var(--t-button-border-color);
 			opacity: 0.54;
 			cursor: not-allowed;
 		}
@@ -142,6 +145,12 @@
 		&:hover,
 		&:active {
 			--t-button-background-color: var(--t-button-secondary-background--hover);
+		}
+
+		&[disabled] {
+			&:hover {
+				--t-button-background-color: transparent;
+			}
 		}
 	}
 

--- a/packages/theme/src/theme/_visual-helpers.scss
+++ b/packages/theme/src/theme/_visual-helpers.scss
@@ -1,6 +1,7 @@
 /// Define button colors based on its background
 /// @access public
 /// @param {Color} $btn-bg [$btn-default-bg] - button background color to tint
+/// @deprecated
 @mixin btn-colors($btn-bg: $btn-default-bg) {
 	box-shadow: 0 (-1 * $btn-box-shadow-width) 0 rgba(0, 0, 0, 0.15) inset;
 
@@ -44,6 +45,7 @@
 /// Define inverse button colors based on the button color
 /// @access public
 /// @param {Color} $btn-color [$btn-default-bg] - button background color to tint
+/// @deprecated
 @mixin btn-inverse-colors($btn-color: $btn-default-bg) {
 	// we have a border but we cannot use box-sizing: border-box because we don't have a height.
 	// so we change the line-height to match 3.5rem ($btn-line-height) - borders
@@ -186,6 +188,7 @@
 	}
 }
 
+/// @deprecated
 @mixin btn-tertiary-colors($color: $btn-default-bg) {
 	&.btn-tertiary {
 		background-color: transparent;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When a button is `btn btn-info btn-inverse`, the background is wrong while hovering it

**What is the chosen solution to this problem?**
Be more precise to override bootstrap-sass properties
http://3365.talend.surge.sh/components/?path=/story/buttons-button--combinations

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
