### PR TITLE
feat(TDOPS-14/TreeView): added ability to pass className for a TreeViewItem

### DIFF
--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -257,6 +257,30 @@ const withDisabledItems = {
 	...withAddAction,
 };
 
+const withClassNames = {
+	...withAddAction,
+	structure: [
+		{ name: 'hitmonlee', children: [{ name: 'Hitmonchan' }], isOpened: false, className: 'test-class' },
+		{ name: 'pikachu', children: [{ name: 'raichu' }], isOpened: true, className: 'test-class' },
+		{
+			id: 'selected',
+			name: 'Abra',
+			isOpened: true,
+			children: [
+				{
+					name: 'Kadabra',
+					isOpened: true,
+					children: [
+						{
+							name: 'Alakazam',
+						},
+					],
+				},
+			],
+		},
+	]
+}
+
 withDisabledItems.structure = structureWithDisabledActions;
 
 const hugeStructure = [
@@ -482,6 +506,33 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<h3>Default property-set without icons: </h3>
 			<div style={style}>
 				<TreeView {...withAddAction} structure={structureWithoutIcons} />
+			</div>
+		</div>
+	))
+	.add('Items classNames', () => (
+		<div>
+			<h1>TreeView</h1>
+			<h3>Definition</h3>
+			<p>A view component to display any tree structure, like folders or categories.</p>
+			<h3>You can pass custom class names to a tree view items </h3>
+			<style>
+				{`
+					.test-class {
+					  background: rgba(0,0,0,0.1);
+						animation: mymove 2s infinite;
+					}
+					.test-class .tc-treeview-item {
+						cursor: copy;
+					}
+
+					@keyframes mymove {
+						0% {opacity: 1;}
+						50% {opacity: 0.4;}
+						100% {opacity: 1;}
+					}`}
+			</style>
+			<div style={style}>
+				<TreeView {...withClassNames} />
 			</div>
 		</div>
 	));

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -279,7 +279,7 @@ const withClassNames = {
 			],
 		},
 	]
-}
+};
 
 withDisabledItems.structure = structureWithDisabledActions;
 

--- a/packages/components/src/TreeView/FolderTreeView.stories.js
+++ b/packages/components/src/TreeView/FolderTreeView.stories.js
@@ -518,7 +518,7 @@ storiesOf('Data/Tree/FolderTreeView', module)
 			<style>
 				{`
 					.test-class {
-					  background: rgba(0,0,0,0.1);
+						background: rgba(0,0,0,0.1);
 						animation: mymove 2s infinite;
 					}
 					.test-class .tc-treeview-item {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.component.js
@@ -75,6 +75,7 @@ class TreeViewItem extends React.Component {
 			name: PropTypes.string.isRequired,
 			disabled: PropTypes.bool,
 			isOpened: PropTypes.bool,
+			className: PropTypes.string,
 			children: PropTypes.arrayOf(PropTypes.object),
 			icon: PropTypes.oneOfType([PropTypes.bool, PropTypes.string, PropTypes.object]),
 			actions: PropTypes.arrayOf(
@@ -215,6 +216,7 @@ class TreeViewItem extends React.Component {
 			icon,
 			counter = children.length,
 			disabled,
+			className,
 		} = item;
 		const paddingLeft = `${(level - 1) * (PADDING + CARET_WIDTH) + BASE_PADDING}px`;
 		const showOpenedFolder = !!(children.length && (isOpened || this.state.hovered));
@@ -230,7 +232,7 @@ class TreeViewItem extends React.Component {
 				aria-setsize={siblings.length}
 				aria-selected={this.isSelected()}
 				aria-disabled={disabled}
-				className={classNames('tc-treeview-item-li', css['tc-treeview-li'])}
+				className={classNames('tc-treeview-item-li', css['tc-treeview-li'], className)}
 				onClick={e => {
 					e.stopPropagation();
 					return !disabled && onSelect(e, item);

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.test.js
@@ -154,6 +154,18 @@ describe('TreeView item', () => {
 		expect(wrapper.find('TreeViewIcon').dive().getElement()).toMatchSnapshot();
 	});
 
+	it('should render items with classNames', () => {
+		// when
+		const propsWithIconAndTooltip = {
+			...propsWithIcons,
+			item: { ...itemWithIcon, className: 'test-class'},
+		};
+
+		const wrapper = shallow(<TreeViewItem {...propsWithIconAndTooltip} />);
+
+		expect(wrapper.find('li').props().className).toContain('test-class');
+	});
+
 	it('should toggle item on toggle button click', () => {
 		// given
 		const props = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In TMC we use FolderTreeView for a failed plan rerun dialog and we have some specific state of plan steps, we need a way to highlight deleted and added tasks and change cursors for them. It's too specific to add cursors and background customization directly in the TreeViewItem, so it's better to do it on the TMC app.

**What is the chosen solution to this problem?**

Added ability to pass className to a TreeViewItem

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
