### PR TITLE
fix(utils/dates): fix formatTimeZoneTokens function for Safari

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@talend/utils",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "description": "Various utilities",
   "main": "lib/index.js",
   "repository": {

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -81,7 +81,7 @@ export function formatReadableUTCOffset(offset: number): string {
  * @see https://github.com/prantlf/date-fns-timezone/blob/master/src/formatToTimeZone.js#L131
  */
 function formatTimeZoneTokens(dateFormat: string, timeZone: string): string {
-	return dateFormat.replace(/(?<!\[)(z|ZZ?)/g, match => {
+	return dateFormat.replace(/(z|ZZ?)(?!\])/g, match => {
 		const offset = getUTCOffset(timeZone);
 		const separator = match === 'Z' ? ':' : '';
 		return formatUTCOffset(offset, separator);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Function `formatTimeZoneTokens` uses regex with lookbehind identifier, which Safari currently doesn't support.
**What is the chosen solution to this problem?**
Use lookahead instead.
**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
