### PR TITLE
fix(TDOPS-756/ActionButton) - show tooltip when the tooltipLabel is set

### DIFF
--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -208,7 +208,7 @@ function ActionButton(props) {
 
 	// 2 ways to display the tooltip via props: `hideLabel` and `tooltip`.
 	// warning: when `tooltip` is set to false, then no tooltip even if `hideLabel` is set
-	const shouldDisplayTooltip = (hideLabel && tooltip !== false) || tooltip;
+	const shouldDisplayTooltip = (hideLabel || tooltip || tooltipLabel) && tooltip !== false;
 	if (ariaLabel && shouldDisplayTooltip) {
 		btn = (
 			<TooltipTrigger

--- a/packages/components/src/Actions/ActionButton/ActionButton.test.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.test.js
@@ -258,6 +258,23 @@ describe('Action', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render tooltip with tooltipLabel when the tooltip property is not set', () => {
+		// when
+		const wrapper = shallow(<ActionButton {...myAction} tooltipLabel='My tooltip label' />);
+
+		// then
+		expect(wrapper.find('TooltipTrigger')).toHaveLength(1);
+		expect(wrapper.find('TooltipTrigger').prop('label')).toBe('My tooltip label');
+	});
+
+	it('should not render tooltip with tooltipLabel when the tooltip property is set to false', () => {
+		// when
+		const wrapper = shallow(<ActionButton {...myAction} tooltip={false} tooltipLabel='My tooltip label' />);
+
+		// then
+		expect(wrapper.find('TooltipTrigger')).toHaveLength(0);
+	});
+
 	it('should trigger action if set up onMouseDown event', () => {
 		// given
 		const wrapper = shallow(<ActionButton extra="extra" {...mouseDownAction} />);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
ActionButton - Tooltip label is not displayed if the tooltip property is not set
Caused by:
https://github.com/Talend/ui/pull/3345/files#diff-5d480c14248b485032c877f7aba5d51b71b554e753287e1155af4cd96e149e07R211

**What is the chosen solution to this problem?**
show tooltip when the tooltipLabel is set even if the tooltip property is not set
https://jira.talendforge.org/browse/TDOPS-756

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
