### PR TITLE
feat(components/Enumeration): Add persistent actions group

### DIFF
--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -224,7 +224,7 @@ HeaderEnumeration.propTypes = {
 	inputValue: EnumerationComponent.propTypes.inputValue,
 	inputRef: EnumerationComponent.propTypes.inputRef,
 	label: EnumerationComponent.propTypes.label,
-	t: PropTypes.func.isRequired,
+	t: PropTypes.func,
 };
 
 HeaderEnumeration.defaultProps = {

--- a/packages/components/src/Enumeration/Enumeration.component.js
+++ b/packages/components/src/Enumeration/Enumeration.component.js
@@ -77,6 +77,10 @@ EnumerationComponent.propTypes = {
 			PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
 			PropTypes.func,
 		]),
+		actionsDefaultPersistent: PropTypes.oneOfType([
+			PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+			PropTypes.func,
+		]),
 		actionsEdit: PropTypes.oneOfType([
 			PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
 			PropTypes.func,

--- a/packages/components/src/Enumeration/Enumeration.snapshot.test.js
+++ b/packages/components/src/Enumeration/Enumeration.snapshot.test.js
@@ -452,4 +452,46 @@ describe('Enumeration', () => {
 			height: '126px',
 		});
 	});
+	it('should render a group of persistent actions which will be always visible', () => {
+		const props = {
+			displayMode: 'DISPLAY_MODE_DEFAULT',
+			headerDefault: [
+				{
+					label: 'Add item',
+					icon: 'talend-plus',
+					id: 'add',
+					onClick: jest.fn(),
+				},
+			],
+			items: Array(3)
+				.fill('')
+				.map((item, index) => ({
+					values: [`Lorem ipsum dolor sit amet ${index}`],
+				})),
+			itemsProp: {
+				key: 'values',
+				getItemHeight: () => 42,
+				actionsDefault:[],
+				actionsDefaultPersistent: [
+					{
+						disabled: false,
+						label: 'Edit',
+						icon: 'talend-pencil',
+						id: 'edit',
+						onClick: jest.fn(),
+					},
+					{
+						label: 'Delete',
+						icon: 'talend-trash',
+						id: 'delete',
+						onClick: jest.fn(),
+					},
+				],
+			},
+			onAddChange: jest.fn(),
+			onAddKeyDown: jest.fn(),
+		};
+		const wrapper = mount(<Enumeration {...props} />);
+		expect(wrapper.find('.persistent').at(0).children().length).toBe(2);
+	});
 });

--- a/packages/components/src/Enumeration/Enumeration.stories.js
+++ b/packages/components/src/Enumeration/Enumeration.stories.js
@@ -320,6 +320,19 @@ const withCustomActions = {
 				},
 			];
 		},
+		actionsDefaultPersistent: item => {
+			if (item.index % 2 === 0) {
+				return [
+					{
+						label: 'Added notification',
+						icon: 'talend-bell',
+						id: 'notification',
+						onClick: action('item.onNotify'),
+					},
+				];
+			}
+			return [];
+		}
 	},
 };
 
@@ -444,6 +457,10 @@ storiesOf('Form/Controls/Enumeration', module)
 				With custom actions: <br />
 				You can pass a function to{' '}
 				<i>
+					<b>itemsProp.actionsDefaultPersistent</b>
+				</i>{' '}
+				or{' '}
+				<i>
 					<b>itemsProp.actionsDefault</b>
 				</i>{' '}
 				or{' '}
@@ -452,7 +469,9 @@ storiesOf('Form/Controls/Enumeration', module)
 				</i>
 				<br />
 				The function takes a single argument, item data(including index). returns an array of
-				actions.
+				actions. 
+				<br />
+				actionsDefaultPersistent will always be visiable in default mode whereas actionsDefault will appear on hover.
 			</p>
 
 			<Enumeration {...withCustomActions} />

--- a/packages/components/src/Enumeration/Items/Item/Item.component.js
+++ b/packages/components/src/Enumeration/Items/Item/Item.component.js
@@ -38,7 +38,7 @@ function itemDefaultActionsClasses() {
 }
 
 function Item({ id, item, searchCriteria, showCheckboxes, style, t }) {
-	const { key, actions, onSelectItem, persistentActions = [] } = item.itemProps;
+	const { key, actions, onSelectItem, persistentActions } = item.itemProps;
 	const actualLabel = item[key] instanceof Array ? item[key].join(',') : item[key];
 
 	function getAction(action, index) {
@@ -127,7 +127,7 @@ function Item({ id, item, searchCriteria, showCheckboxes, style, t }) {
 		<div role="row" className={itemClasses(item.isSelected)} id={id} style={style}>
 			{getActionLabel()}
 			<div className={itemDefaultActionsClasses()} role="gridcell">
-				{persistentActions.length > 0 && (
+				{persistentActions && (
 					<div className="persistent">
 						{persistentActions
 							.filter(action => !action.disabled)

--- a/packages/components/src/Enumeration/Items/Item/Item.component.js
+++ b/packages/components/src/Enumeration/Items/Item/Item.component.js
@@ -38,7 +38,7 @@ function itemDefaultActionsClasses() {
 }
 
 function Item({ id, item, searchCriteria, showCheckboxes, style, t }) {
-	const { key, actions, onSelectItem } = item.itemProps;
+	const { key, actions, onSelectItem, persistentActions = [] } = item.itemProps;
 	const actualLabel = item[key] instanceof Array ? item[key].join(',') : item[key];
 
 	function getAction(action, index) {
@@ -127,6 +127,13 @@ function Item({ id, item, searchCriteria, showCheckboxes, style, t }) {
 		<div role="row" className={itemClasses(item.isSelected)} id={id} style={style}>
 			{getActionLabel()}
 			<div className={itemDefaultActionsClasses()} role="gridcell">
+				{persistentActions.length > 0 && (
+					<div className="persistent">
+						{persistentActions
+							.filter(action => !action.disabled)
+							.map((action, index) => getAction(action, index))}
+					</div>
+				)}
 				{actions
 					.filter(action => !action.disabled)
 					.map((action, index) => getAction(action, index))}

--- a/packages/components/src/Enumeration/Items/Item/Item.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.scss
@@ -9,7 +9,7 @@ $tc-enumeration-input-margin: 10px;
 $tc-enumeration-item-font-size: 14px;
 $tc-enumeration-item-btn-height: 16px;
 $tc-enumeration-item-error-padding: 0 $padding-normal;
-$selected-item-color: #fafafa;
+$selected-item-color: #FAFAFA;
 $item-checkbox-margin: 5px;
 $item-checkbox-height: 10px;
 $item-checkbox-width: 20px;
@@ -129,6 +129,3 @@ $item-checkbox-width: 20px;
 	background-color: rgba(250, 250, 250, 1);
 }
 
-.tc-enumeration-item-actions-persistent {
-	visibility: visible;
-}

--- a/packages/components/src/Enumeration/Items/Item/Item.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.scss
@@ -7,6 +7,7 @@ $tc-enumeration-item-error-color: red !default;
 $tc-item-padding-top-bottom: 7px !default;
 $tc-enumeration-input-margin: 10px;
 $tc-enumeration-item-font-size: 14px;
+$tc-enumeration-item-btn-height: 16px;
 $tc-enumeration-item-error-padding: 0 $padding-normal;
 $selected-item-color: #fafafa;
 $item-checkbox-margin: 5px;
@@ -32,7 +33,7 @@ $item-checkbox-width: 20px;
 
 	:global(.btn-link) {
 		padding: 0 $padding-smaller;
-		height: $tc-enumeration-item-font-size;
+		height: $tc-enumeration-item-btn-height;
 
 		:global(.tc-svg-icon) {
 			height: $tc-enumeration-item-font-size;
@@ -62,6 +63,10 @@ $item-checkbox-width: 20px;
 		flex-grow: 0;
 		align-items: center;
 		margin: auto $tc-enumeration-smaller-padding;
+
+		:global(.persistent) {
+			visibility: visible;
+		}
 	}
 
 	.editable {
@@ -122,4 +127,8 @@ $item-checkbox-width: 20px;
 .tc-enumeration-item:hover:not(.selected-item),
 .tc-enumeration-item:not(.selected-item):global(.ally-focus-within) {
 	background-color: rgba(250, 250, 250, 1);
+}
+
+.tc-enumeration-item-actions-persistent {
+	visibility: visible;
 }

--- a/packages/components/src/Enumeration/Items/Items.component.js
+++ b/packages/components/src/Enumeration/Items/Items.component.js
@@ -59,9 +59,14 @@ class Items extends React.PureComponent {
 				if (typeof actions === 'function') {
 					actions = actions(itemWithIndex);
 				}
+				let persistentActions = this.props.itemsProp.actionsDefaultPersistent;
+				if (typeof persistentActions === 'function') {
+					persistentActions = persistentActions(itemWithIndex);
+				}
 				const itemPropDefault = {
 					key: this.props.itemsProp.key,
 					actions,
+					persistentActions,
 					onSelectItem: this.props.itemsProp.onSelectItem,
 				};
 				itemWithIndex.itemProps = itemPropDefault;
@@ -161,6 +166,7 @@ Items.propTypes = {
 		onAbortItem: PropTypes.func,
 		onSelectItem: PropTypes.func,
 		actionsDefault: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
+		actionsDefaultPersistent: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
 		actionsEdit: PropTypes.arrayOf(PropTypes.shape(Action.propTypes)),
 	}).isRequired,
 	...ItemEditPropTypes,

--- a/packages/components/src/Enumeration/Items/Items.component.js
+++ b/packages/components/src/Enumeration/Items/Items.component.js
@@ -59,7 +59,7 @@ class Items extends React.PureComponent {
 				if (typeof actions === 'function') {
 					actions = actions(itemWithIndex);
 				}
-				let persistentActions = this.props.itemsProp.actionsDefaultPersistent || [];
+				let persistentActions = this.props.itemsProp.actionsDefaultPersistent;
 				if (typeof persistentActions === 'function') {
 					persistentActions = persistentActions(itemWithIndex);
 				}

--- a/packages/components/src/Enumeration/Items/Items.component.js
+++ b/packages/components/src/Enumeration/Items/Items.component.js
@@ -59,7 +59,7 @@ class Items extends React.PureComponent {
 				if (typeof actions === 'function') {
 					actions = actions(itemWithIndex);
 				}
-				let persistentActions = this.props.itemsProp.actionsDefaultPersistent;
+				let persistentActions = this.props.itemsProp.actionsDefaultPersistent || [];
 				if (typeof persistentActions === 'function') {
 					persistentActions = persistentActions(itemWithIndex);
 				}

--- a/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
@@ -5086,7 +5086,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi",
@@ -5106,7 +5106,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="0-item"
@@ -6017,7 +6017,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi",
@@ -6045,7 +6045,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="0-item"
@@ -7174,7 +7174,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi",
@@ -7202,7 +7202,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="0-item"
@@ -7448,7 +7448,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi2",
@@ -7476,7 +7476,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="1-item"
@@ -10040,7 +10040,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi",
@@ -10068,7 +10068,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="0-item"
@@ -10310,7 +10310,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi2",
@@ -10338,7 +10338,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="1-item"
@@ -11861,7 +11861,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi",
@@ -11889,7 +11889,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="0-item"
@@ -12131,7 +12131,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
-                                  "persistentActions": Array [],
+                                  "persistentActions": undefined,
                                 },
                                 "values": Array [
                                   "titi2",
@@ -12159,7 +12159,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
-                                "persistentActions": Array [],
+                                "persistentActions": undefined,
                               }
                             }
                             key="1-item"

--- a/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
+++ b/packages/forms/src/deprecated/widgets/EnumerationWidget/__snapshots__/EnumerationWidget.test.js.snap
@@ -5086,6 +5086,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi",
@@ -5105,6 +5106,7 @@ exports[`EnumerationWidget should delete an item with callHandler 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="0-item"
@@ -6015,6 +6017,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi",
@@ -6042,6 +6045,7 @@ exports[`EnumerationWidget should select an item 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="0-item"
@@ -7170,6 +7174,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi",
@@ -7197,6 +7202,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="0-item"
@@ -7442,6 +7448,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi2",
@@ -7469,6 +7476,7 @@ exports[`EnumerationWidget should select multiple  items 1`] = `
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="1-item"
@@ -10032,6 +10040,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi",
@@ -10059,6 +10068,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="0-item"
@@ -10300,6 +10310,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi2",
@@ -10327,6 +10338,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="1-item"
@@ -11849,6 +11861,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi",
@@ -11876,6 +11889,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="0-item"
@@ -12117,6 +12131,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                   ],
                                   "key": "values",
                                   "onSelectItem": [Function],
+                                  "persistentActions": Array [],
                                 },
                                 "values": Array [
                                   "titi2",
@@ -12144,6 +12159,7 @@ exports[`EnumerationWidget upload file should trigger a event when the user clic
                                 ],
                                 "key": "values",
                                 "onSelectItem": [Function],
+                                "persistentActions": Array [],
                               }
                             }
                             key="1-item"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For the `Enumeration` component, currently we can set actions of item with `props.acitonsDefault`, but default actions are hidden, only appear on hover.

**What is the chosen solution to this problem?**
add new actions group `props.actionsDefaultPersistent`, actions of this group will be always visible.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
