### PR TITLE
feat(theme): add $pale-cyan and its shades

### DIFF
--- a/packages/theme/src/theme/_colors.scss
+++ b/packages/theme/src/theme/_colors.scss
@@ -153,6 +153,20 @@ $lochmara800: #022e4d;
 $lochmara900: #011726;
 $lochmara: $lochmara500;
 
+/// Secondary color.
+///
+/// @type Color
+$pale-cyan100: #e9f5fb;
+$pale-cyan200: #d3ecf7;
+$pale-cyan300: #bde3f4;
+$pale-cyan400: #a7daf0;
+$pale-cyan500: #91d1ed;
+$pale-cyan600: #74a7bd;
+$pale-cyan700: #577d8e;
+$pale-cyan800: #3a535e;
+$pale-cyan900: #1d292f;
+$pale-cyan: $pale-cyan500;
+
 /// Greyscale.
 ///
 /// @type Color


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`$pale-cyan` is absent from tui

**What is the chosen solution to this problem?**

add it and its shades

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
