### PR TITLE
feat(router-bridge/SidePanel): support route basename

### DIFF
--- a/.changeset/angry-bobcats-promise.md
+++ b/.changeset/angry-bobcats-promise.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-containers': minor
+'@talend/router-bridge': minor
+---
+
+feat(router-bridge/SidePanel): support route basename

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -72,8 +72,11 @@ function getActionsWrapped(actions) {
 	});
 }
 
-function getSelectedAction(currentRoute, actions) {
-	return actions.find(action => action.href && isBasePathOf(action.href, currentRoute));
+function getSelectedAction(currentRoute, actions, basename) {
+	const getFullPath = href => (basename ? `${basename}${href}`.replaceAll('//', '/') : href);
+	return actions.find(
+		action => action.href && isBasePathOf(getFullPath(action.href), currentRoute),
+	);
 }
 
 /**
@@ -140,7 +143,7 @@ export function mapStateToProps(state, ownProps) {
 	const currentRoute = window.location.pathname;
 	props.actions = getActions(state, ownProps, currentRoute);
 	if (ownProps.actions) {
-		props.selected = getSelectedAction(currentRoute, props.actions);
+		props.selected = getSelectedAction(currentRoute, props.actions, ownProps.basename);
 	}
 	return props;
 }

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -72,8 +72,8 @@ function getActionsWrapped(actions) {
 	});
 }
 
-function getSelectedAction(currentRoute, actions, basename) {
-	const getFullPath = href => (basename ? `${basename}${href}`.replaceAll('//', '/') : href);
+function getSelectedAction(currentRoute, actions) {
+	const getFullPath = href => `${window.basename || ''}${href}`.replaceAll('//', '/');
 	return actions.find(
 		action => action.href && isBasePathOf(getFullPath(action.href), currentRoute),
 	);
@@ -143,7 +143,7 @@ export function mapStateToProps(state, ownProps) {
 	const currentRoute = window.location.pathname;
 	props.actions = getActions(state, ownProps, currentRoute);
 	if (ownProps.actions) {
-		props.selected = getSelectedAction(currentRoute, props.actions, ownProps.basename);
+		props.selected = getSelectedAction(currentRoute, props.actions);
 	}
 	return props;
 }

--- a/packages/router-bridge/src/router/index.js
+++ b/packages/router-bridge/src/router/index.js
@@ -26,7 +26,7 @@ try {
 	useParams = reactRouterV5.useParams;
 	useRouteMatch = reactRouterV5.useRouteMatch;
 
-	history = createBrowserHistory();
+	history = createBrowserHistory({ basename: window.publicPath || '/' });
 	Router = (...props) => <reactRouterV5.Router {...props} history={history} />;
 } catch (e) {
 	if (process.env.NODE_ENV !== 'production') {

--- a/packages/router-bridge/src/router/index.js
+++ b/packages/router-bridge/src/router/index.js
@@ -26,7 +26,7 @@ try {
 	useParams = reactRouterV5.useParams;
 	useRouteMatch = reactRouterV5.useRouteMatch;
 
-	history = createBrowserHistory({ basename: window.publicPath || '/' });
+	history = createBrowserHistory({ basename: window.basename || '/' });
 	Router = (...props) => <reactRouterV5.Router {...props} history={history} />;
 } catch (e) {
 	if (process.env.NODE_ENV !== 'production') {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This is part of the changes to allow apps to be served on a common domain with a different basename (`http://my-domain/appName`).

- Router bridge
Some apps use router bridge to be compatible with react-router v3 and v5. In v5 mode, history is created at file import/execution. But we need to pass the route basename at history creation.

- Side panel
The container check which route is the current one. But it is only based on the router conf, and not the basename.

**What is the chosen solution to this problem?**

- Router bridge
Use window.basename that the apps will init.

- Side panel
Container takes window.basename to build the url to compare

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
