### PR TITLE
feat(forms/FieldTemplate): Support extra custom props for label

### DIFF
--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -9,10 +9,10 @@ import Message from '../../Message';
 import { I18N_DOMAIN_FORMS } from '../../../constants';
 import theme from './FieldTemplate.scss';
 
-function Label(props) {
+function Label({ id, label, ...rest }) {
 	return (
-		<label htmlFor={props.id} className="control-label">
-			{props.label}
+		<label htmlFor={id} className="control-label" {...rest}>
+			{label}
 		</label>
 	);
 }
@@ -32,7 +32,7 @@ function FieldTemplate(props) {
 		[theme.updating]: props.valueIsUpdating,
 	});
 
-	let title = <Label id={props.id} label={props.label} />;
+	let title = <Label id={props.id} label={props.label} {...props.labelProps} />;
 
 	if (props.hint) {
 		title = (
@@ -94,6 +94,7 @@ if (process.env.NODE_ENV !== 'production') {
 		id: PropTypes.string,
 		isValid: PropTypes.bool,
 		label: PropTypes.string,
+		labelProps: PropTypes.object,
 		labelAfter: PropTypes.bool,
 		required: PropTypes.bool,
 		valueIsUpdating: PropTypes.bool,

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.test.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.test.js
@@ -4,18 +4,20 @@ import { shallow } from 'enzyme';
 import FieldTemplate from './FieldTemplate.component';
 
 describe('FieldTemplate', () => {
+	const defaultProps = {
+		isValid: true,
+		description: 'My awesome description',
+		descriptionId: 'myAwesomeField-description',
+		errorId: 'myAwesomeField-error',
+		errorMessage: 'This is wrong o_o',
+		id: 'myAwesomeField',
+		label: 'My awesome label',
+	};
+
 	it('should render with label before', () => {
 		// when
 		const wrapper = shallow(
-			<FieldTemplate
-				isValid
-				description="My awesome description"
-				descriptionId="myAwesomeField-description"
-				errorId="myAwesomeField-error"
-				errorMessage="This is wrong o_o"
-				id="myAwesomeField"
-				label="My awesome label"
-			>
+			<FieldTemplate {...defaultProps}>
 				<input id="myAwesomeField" />
 			</FieldTemplate>,
 		);
@@ -27,16 +29,7 @@ describe('FieldTemplate', () => {
 	it('should render with label after', () => {
 		// when
 		const wrapper = shallow(
-			<FieldTemplate
-				isValid
-				description="My awesome description"
-				descriptionId="myAwesomeField-description"
-				errorId="myAwesomeField-error"
-				errorMessage="This is wrong o_o"
-				id="myAwesomeField"
-				label="My awesome label"
-				labelAfter
-			>
+			<FieldTemplate {...defaultProps} labelAfter>
 				<input id="myAwesomeField" />
 			</FieldTemplate>,
 		);
@@ -53,17 +46,11 @@ describe('FieldTemplate', () => {
 		// when
 		const wrapper = shallow(
 			<FieldTemplate
-				isValid
+				{...defaultProps}
 				hint={{
 					overlayComponent: tooltipContent,
 					overlayPlacement: 'top',
 				}}
-				description="My awesome description"
-				descriptionId="myAwesomeField-description"
-				errorId="myAwesomeField-error"
-				errorMessage="This is wrong o_o"
-				id="myAwesomeField"
-				label="My awesome label"
 			>
 				<input id="myAwesomeField" />
 			</FieldTemplate>,
@@ -76,15 +63,7 @@ describe('FieldTemplate', () => {
 	it('should render invalid className', () => {
 		// when
 		const wrapper = shallow(
-			<FieldTemplate
-				isValid={false}
-				description="My awesome description"
-				descriptionId="myAwesomeField-description"
-				errorId="myAwesomeField-error"
-				errorMessage="This is wrong o_o"
-				id="myAwesomeField"
-				label="My awesome label"
-			>
+			<FieldTemplate {...defaultProps} isValid={false}>
 				<input id="myAwesomeField" />
 			</FieldTemplate>,
 		);
@@ -96,16 +75,19 @@ describe('FieldTemplate', () => {
 	it('should add animation on value with updating status', () => {
 		// when
 		const wrapper = shallow(
-			<FieldTemplate
-				isValid={false}
-				description="My awesome description"
-				descriptionId="myAwesomeField-description"
-				errorId="myAwesomeField-error"
-				errorMessage="This is wrong o_o"
-				id="myAwesomeField"
-				label="My awesome label"
-				valueIsUpdating
-			>
+			<FieldTemplate {...defaultProps} isValid={false} valueIsUpdating>
+				<input id="myAwesomeField" />
+			</FieldTemplate>,
+		);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should pass label props to the label', () => {
+		// when
+		const wrapper = shallow(
+			<FieldTemplate {...defaultProps} labelProps={{ className: 'custom-label-class' }}>
 				<input id="myAwesomeField" />
 			</FieldTemplate>,
 		);

--- a/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
@@ -22,6 +22,28 @@ exports[`FieldTemplate should add animation on value with updating status 1`] = 
 </div>
 `;
 
+exports[`FieldTemplate should pass label props to the label 1`] = `
+<div
+  className="form-group theme-template"
+>
+  <Label
+    className="custom-label-class"
+    id="myAwesomeField"
+    label="My awesome label"
+  />
+  <input
+    id="myAwesomeField"
+  />
+  <Message
+    description="My awesome description"
+    descriptionId="myAwesomeField-description"
+    errorId="myAwesomeField-error"
+    errorMessage="This is wrong o_o"
+    isValid={true}
+  />
+</div>
+`;
+
 exports[`FieldTemplate should render invalid className 1`] = `
 <div
   className="form-group theme-template has-error"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There's no way to pass a prop to the label in the field template

**What is the chosen solution to this problem?**
Support `labelProps` in `Label` props — that can be passed via the schema, via field compnoent — that is spread into `Label`
Factorize tests default props

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
