### PR TITLE
feat(components/SubHeaderBar): Support custom props for title and subtitle

### DIFF
--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -30,22 +30,27 @@ function TitleSubHeader({
 			onEdit(...args);
 		}
 	}
+
 	function handleCancel(...args) {
 		setIsEditMode(false);
 		if (onCancel) {
 			onCancel(...args);
 		}
 	}
+
 	function handleSubmit(...args) {
 		setIsEditMode(false);
 		if (onSubmit) {
 			onSubmit(...args);
 		}
 	}
+
 	if (loading) {
 		return <Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />;
 	}
+
 	const InjectedEditableText = Inject.get(getComponent, 'EditableText', EditableText);
+
 	return (
 		<div
 			className={theme('tc-subheader-details', {
@@ -69,7 +74,7 @@ function TitleSubHeader({
 						/>
 					) : (
 						<TooltipTrigger label={title} tooltipPlacement="bottom">
-							<h1 className={theme('tc-subheader-details-text-title-wording')}>{title}</h1>
+							<h1 className={theme('tc-subheader-details-text-title-wording')} {...rest.titleProps}>{title}</h1>
 						</TooltipTrigger>
 					)}
 				</div>
@@ -79,15 +84,16 @@ function TitleSubHeader({
 	);
 }
 
-function DefaultSubTitle({ subTitle }) {
-	return <small className={theme('tc-subheader-details-text-subtitle')}>{subTitle}</small>;
+function DefaultSubTitle({ subTitle, subTitleProps }) {
+	return <small className={theme('tc-subheader-details-text-subtitle')} {...subTitleProps}>{subTitle}</small>;
 }
 
 DefaultSubTitle.propTypes = {
 	subTitle: PropTypes.oneOfType([PropTypes.element, PropTypes.string]),
+	subTitleProps: PropTypes.object,
 };
 
-function SubTitle({ subTitleLoading, subTitle, subTitleAs: SubTitleAs = DefaultSubTitle }) {
+function SubTitle({ subTitleLoading, subTitle, subTitleAs: SubTitleAs = DefaultSubTitle, ...rest }) {
 	if (subTitleLoading) {
 		return (
 			<Skeleton
@@ -99,7 +105,7 @@ function SubTitle({ subTitleLoading, subTitle, subTitleAs: SubTitleAs = DefaultS
 	}
 
 	if (subTitle) {
-		return <SubTitleAs subTitle={subTitle} />;
+		return <SubTitleAs subTitle={subTitle} {...rest} />;
 	}
 
 	return null;
@@ -121,6 +127,7 @@ TitleSubHeader.propTypes = {
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
 	onCancel: PropTypes.func,
+	t: PropTypes.func,
 	...Inject.PropTypes,
 };
 

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import Skeleton from '../../Skeleton';
 import Icon from '../../Icon';
 import Action from '../../Actions/Action';
@@ -9,48 +9,65 @@ import TitleSubHeader, { SubTitle } from './TitleSubHeader.component';
 
 describe('TitleSubHeader', () => {
 	let defaultProps;
-	beforeEach(
-		() =>
-			(defaultProps = {
-				title: 'myTitle',
-				onEdit: jest.fn(),
-				onSubmit: jest.fn(),
-			}),
-	);
+
+	beforeEach(() => {
+		defaultProps = {
+			title: 'myTitle',
+			onEdit: jest.fn(),
+			onSubmit: jest.fn(),
+		};
+	});
+
 	it('should render', () => {
-		const wrapper = shallow(<TitleSubHeader {...defaultProps} iconId="myIconId" />);
+		const wrapper = shallow(<TitleSubHeader {...defaultProps} />);
+		expect(wrapper.find(Action)).toHaveLength(0);
+		expect(wrapper.find('h1')).toHaveLength(1);
+		expect(wrapper.find('button')).toHaveLength(0);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
-	it('should render Icon', () => {
+
+	it('should render with title', () => {
+		const wrapper = shallow(<TitleSubHeader {...defaultProps} />);
+		expect(wrapper.find('h1').getElement().props.children).toEqual('myTitle');
+	});
+
+	it('should render with an icon', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} iconId="myIconId" />);
 		expect(wrapper.find(Icon)).toHaveLength(1);
 		expect(wrapper.find(Icon).get(0).props.name).toEqual('myIconId');
+		expect(wrapper.getElement()).toMatchSnapshot();
 	});
+
 	it('should not render Icon', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} />);
 		expect(wrapper.find(Icon)).toHaveLength(0);
 	});
+
 	it('should render plain text title', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable={false} />);
 		expect(wrapper.find(TitleSubHeader)).toHaveLength(0);
 		expect(wrapper.find('h1')).toHaveLength(1);
 	});
+
 	it('should render EditableText', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
 		expect(wrapper.find(EditableText)).toHaveLength(1);
 		expect(wrapper.find(EditableText).get(0).props.feature).toBe('subheaderbar.rename');
 		expect(wrapper.find('h1')).toHaveLength(0);
 	});
+
 	it('should render skeleton', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} loading />);
 		expect(wrapper.find(Skeleton)).toHaveLength(1);
 	});
+
 	it('should render inProgress', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} inProgress />);
 		expect(wrapper.props().className).toEqual(
 			'tc-subheader-details theme-tc-subheader-details tc-subheader-details-blink theme-tc-subheader-details-blink',
 		);
 	});
+
 	it('should go in edit mode', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
 		const findEditableText = () => wrapper.find('[feature="subheaderbar.rename"]');
@@ -63,26 +80,16 @@ describe('TitleSubHeader', () => {
 
 		expect(findEditableText().props().editMode).toEqual(false);
 	});
-});
 
-describe('TitleSubHeader', () => {
-	let defaultProps;
-	beforeEach(() => {
-		defaultProps = {
-			title: 'myTitle',
-			onEdit: jest.fn(),
-		};
-	});
-	it('should render', () => {
-		const wrapper = shallow(<TitleSubHeader {...defaultProps} subTitle="mySubTitle" />);
-		expect(wrapper.find(Action)).toHaveLength(0);
-		expect(wrapper.find('h1')).toHaveLength(1);
-		expect(wrapper.find('button')).toHaveLength(0);
-		expect(wrapper.getElement()).toMatchSnapshot();
-	});
-	it('should render with title', () => {
-		const wrapper = shallow(<TitleSubHeader {...defaultProps} />);
-		expect(wrapper.find('h1').getElement().props.children).toEqual('myTitle');
+	it('should render pass extra props to the title', () => {
+		// given
+		const titleProps = { 'data-test': '123' };
+
+		// when
+		const wrapper = shallow(<TitleSubHeader {...defaultProps} titleProps={titleProps} />);
+
+		// then
+		expect(wrapper.find('[data-test="123"]')).toHaveLength(1);
 	});
 });
 
@@ -113,5 +120,16 @@ describe('SubTitle', () => {
 		);
 		expect(wrapper.find(Tag)).not.toBe(null);
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render pass extra props to the subtitle', () => {
+		// given
+		const subTitleProps = { 'data-test': '345' };
+
+		// when
+		const wrapper = mount(<SubTitle {...defaultProps} subTitleProps={subTitleProps} />);
+
+		// then
+		expect(wrapper.find(('[data-test="345"]'))).toHaveLength(1);
 	});
 });

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/__snapshots__/TitleSubHeader.test.js.snap
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/__snapshots__/TitleSubHeader.test.js.snap
@@ -24,10 +24,6 @@ exports[`TitleSubHeader should render 1`] = `
 <div
   className="tc-subheader-details theme-tc-subheader-details"
 >
-  <Icon
-    className="tc-subheader-details-icon theme-tc-subheader-details-icon"
-    name="myIconId"
-  />
   <div
     className="tc-subheader-details-text theme-tc-subheader-details-text"
   >
@@ -52,10 +48,14 @@ exports[`TitleSubHeader should render 1`] = `
 </div>
 `;
 
-exports[`TitleSubHeader should render 2`] = `
+exports[`TitleSubHeader should render with an icon 1`] = `
 <div
   className="tc-subheader-details theme-tc-subheader-details"
 >
+  <Icon
+    className="tc-subheader-details-icon theme-tc-subheader-details-icon"
+    name="myIconId"
+  />
   <div
     className="tc-subheader-details-text theme-tc-subheader-details-text"
   >
@@ -74,7 +74,6 @@ exports[`TitleSubHeader should render 2`] = `
       </TooltipTrigger>
     </div>
     <SubTitle
-      subTitle="mySubTitle"
       t={[Function]}
     />
   </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We need a way to pass down props to `<h1 />` and `<small />` elements rendered (by default) by `SubHeaderBar`.

**What is the chosen solution to this problem?**
Spread new props (`titleProps` and `subTitle`) where they belong.
Reorganized tests (merged `describe()`)

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
