### PR TITLE
feat(components/Notifications): Expose notifications types

### DIFF
--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -220,7 +220,7 @@ class NotificationsContainer extends React.Component {
 	}
 
 	onMouseEnter(event, notification) {
-		if (notification.error !== 'error' || this.props.autoLeaveError) {
+		if (notification.type !== TYPES.ERROR || this.props.autoLeaveError) {
 			this.registry.pause(notification);
 		}
 	}

--- a/packages/components/src/Notification/Notification.component.js
+++ b/packages/components/src/Notification/Notification.component.js
@@ -9,6 +9,12 @@ import theme from './Notification.scss';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import getDefaultT from '../translate';
 
+const TYPES = {
+	INFO: 'info',
+	WARNING: 'warning',
+	ERROR: 'error',
+};
+
 function CloseButtonComponent(props) {
 	return (
 		<Action
@@ -73,7 +79,7 @@ function Message({ notification }) {
 }
 
 function TimerBar({ type, autoLeaveError }) {
-	if (type === 'error' && !autoLeaveError) {
+	if (type === TYPES.ERROR && !autoLeaveError) {
 		return null;
 	}
 	return (
@@ -82,13 +88,16 @@ function TimerBar({ type, autoLeaveError }) {
 }
 
 function Notification({ notification, leaveFn, ...props }) {
-	const isError = notification.type === 'error';
-	const classes = classNames(theme['tc-notification'], 'tc-notification', {
-		[theme['tc-notification-info']]: !notification.type || notification.type === 'info',
-		'tc-notification-info': !notification.type || notification.type === 'info',
+	const isInfo = !notification.type || notification.type === TYPES.INFO;
+	const isWarning = notification.type === TYPES.WARNING;
+	const isError = notification.type === TYPES.ERROR;
 
-		[theme['tc-notification-warning']]: notification.type === 'warning',
-		'tc-notification-warning': notification.type === 'warning',
+	const classes = classNames(theme['tc-notification'], 'tc-notification', {
+		[theme['tc-notification-info']]: isInfo,
+		'tc-notification-info': isInfo,
+
+		[theme['tc-notification-warning']]: isWarning,
+		'tc-notification-warning': isWarning,
 
 		[theme['tc-notification-error']]: isError,
 		'tc-notification-error': isError,
@@ -194,7 +203,7 @@ class NotificationsContainer extends React.Component {
 	}
 
 	onClick(event, notification) {
-		if (notification.type !== 'error' || this.props.autoLeaveError) {
+		if (notification.type !== TYPES.ERROR || this.props.autoLeaveError) {
 			if (event.currentTarget.getAttribute('pin') !== 'true') {
 				event.currentTarget.setAttribute('pin', 'true');
 			} else {
@@ -218,7 +227,7 @@ class NotificationsContainer extends React.Component {
 
 	onMouseOut(event, notification) {
 		if (
-			(notification.type !== 'error' || this.props.autoLeaveError) &&
+			(notification.type !== TYPES.ERROR || this.props.autoLeaveError) &&
 			event.currentTarget.getAttribute('pin') !== 'true'
 		) {
 			this.registry.resume(notification);
@@ -228,7 +237,7 @@ class NotificationsContainer extends React.Component {
 	register(props) {
 		props.notifications
 			.filter(notification => !this.registry.isRegistered(notification))
-			.filter(notification => notification.type !== 'error' || props.autoLeaveError)
+			.filter(notification => notification.type !== TYPES.ERROR || props.autoLeaveError)
 			.forEach(notification => {
 				this.registry.register(
 					notification,
@@ -271,7 +280,7 @@ class NotificationsContainer extends React.Component {
 
 const notificationShape = {
 	id: PropTypes.any.isRequired,
-	type: PropTypes.oneOf(['info', 'warning', 'error']),
+	type: PropTypes.oneOf(Object.values(TYPES)),
 	title: PropTypes.string,
 	message: PropTypes.oneOfType([PropTypes.string, PropTypes.arrayOf(PropTypes.string)]).isRequired,
 	action: PropTypes.shape(Action.propTypes),
@@ -291,7 +300,7 @@ Message.propTypes = {
 };
 
 TimerBar.propTypes = {
-	type: PropTypes.oneOf(['info', 'warning', 'error']),
+	type: PropTypes.oneOf(Object.values(TYPES)),
 	autoLeaveError: PropTypes.bool,
 };
 
@@ -324,5 +333,7 @@ NotificationsContainer.defaultProps = {
 	autoLeaveTimeout: 4000,
 	autoLeaveError: false,
 };
+
+NotificationsContainer.TYPES = TYPES;
 
 export default NotificationsContainer;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Code using `Notification` component can use several notification types that are handled internally.

**What is the chosen solution to this problem?**
Use constants instead of _magic strings_ for this and expose them.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
