### PR TITLE
feat(UIForm): Support custom root tag

### DIFF
--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -348,7 +348,7 @@ export class UIFormComponent extends React.Component {
 				id={this.props.id}
 				method={this.props.method}
 				name={this.props.name}
-				noValidate={this.props.noHtml5Validate}
+				noValidate={this.props.as === 'form' ? this.props.noHtml5Validate : undefined}
 				onReset={this.props.onReset}
 				onSubmit={this.onSubmit}
 				target={this.props.target}

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -336,8 +336,10 @@ export class UIFormComponent extends React.Component {
 			);
 		};
 
+		const Element = this.props.as;
+
 		return (
-			<form
+			<Element
 				acceptCharset={this.props.acceptCharset}
 				action={this.props.action}
 				autoComplete={this.props.autoComplete}
@@ -355,10 +357,11 @@ export class UIFormComponent extends React.Component {
 				<WidgetContext.Provider value={{ ...widgets, ...this.state.widgets }}>
 					{formTemplate({ children: this.props.children, widgetsRenderer, buttonsRenderer })}
 				</WidgetContext.Provider>
-			</form>
+			</Element>
 		);
 	}
 }
+
 const I18NUIForm = withTranslation(I18N_DOMAIN_FORMS)(UIFormComponent);
 
 if (process.env.NODE_ENV !== 'production') {
@@ -382,6 +385,10 @@ if (process.env.NODE_ENV !== 'production') {
 		 * If not provided, a single submit button is displayed.
 		 */
 		actions: PropTypes.arrayOf(Buttons.propTypes.schema),
+		/**
+		 * Tag used to render the form (defaults to "form")
+		 */
+		as: PropTypes.string,
 		/**
 		 * User callback: Custom validation function.
 		 * Prototype: function customValidation(schema, value, properties)
@@ -420,6 +427,7 @@ I18NUIForm.defaultProps = {
 	noHtml5Validate: true,
 	buttonBlockClass: 'form-actions',
 	properties: {},
+	as: 'form',
 };
 UIFormComponent.defaultProps = I18NUIForm.defaultProps;
 

--- a/packages/forms/src/UIForm/UIForm.component.test.js
+++ b/packages/forms/src/UIForm/UIForm.component.test.js
@@ -23,13 +23,36 @@ describe('UIForm component', () => {
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
 
+	it('should render a custom tag', () => {
+		// when
+		const wrapper = mount(<UIFormComponent {...data} {...props} as="customtag" />);
+
+		// then
+		expect(wrapper.find('customtag.tf-uiform')).toHaveLength(1);
+	});
+
 	it('should render form with ids concatenated with ; if nested', () => {
 		// when
 		const instance = mount(<UIFormComponent {...nestedData} {...props} idSeparator=";" />);
 		// then
-		expect(instance.find('Text').at(0).prop('id')).toEqual('myFormId;content');
-		expect(instance.find('Text').at(1).prop('id')).toEqual('timestamp;value');
-		expect(instance.find('Text').at(2).prop('id')).toEqual('timestamp;gmt_offset');
+		expect(
+			instance
+				.find('Text')
+				.at(0)
+				.prop('id'),
+		).toEqual('myFormId;content');
+		expect(
+			instance
+				.find('Text')
+				.at(1)
+				.prop('id'),
+		).toEqual('timestamp;value');
+		expect(
+			instance
+				.find('Text')
+				.at(2)
+				.prop('id'),
+		).toEqual('timestamp;gmt_offset');
 	});
 
 	it('should render form in text display mode', () => {
@@ -107,7 +130,10 @@ describe('UIForm component', () => {
 			const event = { target: { value: newValue } };
 
 			// when
-			wrapper.find('input').at(0).simulate('change', event);
+			wrapper
+				.find('input')
+				.at(0)
+				.simulate('change', event);
 
 			// then
 			expect(props.onChange).toBeCalledWith(expect.anything(), {
@@ -172,7 +198,10 @@ describe('UIForm component', () => {
 			props.onTrigger.mockReturnValueOnce(Promise.resolve({}));
 
 			// when
-			wrapper.find('input').at(1).simulate('blur');
+			wrapper
+				.find('input')
+				.at(1)
+				.simulate('blur');
 
 			// then
 			expect(props.onTrigger).not.toBeCalled();
@@ -258,7 +287,10 @@ describe('UIForm component', () => {
 			const wrapper = mount(<UIForm {...data} {...props} />);
 
 			// when
-			wrapper.find('button').at(0).simulate('click');
+			wrapper
+				.find('button')
+				.at(0)
+				.simulate('click');
 
 			// then
 			expect(props.onTrigger).toBeCalledWith(expect.anything(), {

--- a/packages/forms/src/UIForm/__snapshots__/UIForm.container.test.js.snap
+++ b/packages/forms/src/UIForm/__snapshots__/UIForm.container.test.js.snap
@@ -97,6 +97,7 @@ Object {
 
 exports[`UIForm container should render form 2`] = `
 <withI18nextTranslation(TalendUIForm)
+  as="form"
   autoComplete="off"
   buttonBlockClass="form-actions"
   className="my-form-class"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It's not possible to use an UIform as part of another form as nesting form is not allowed in HTML

**What is the chosen solution to this problem?**

Support custom html tag when rendering the form


**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
