### PR TITLE
feat(components/VirtualizedList): MappedCellData

### DIFF
--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -11,14 +11,19 @@ function CellMappedData(props) {
 
 	let cellContent;
 
+	const getMappedValue = value => {
+		const mappedValue = valuesMap[value] || value;
+		return mappedValue !== undefined ? mappedValue : null;
+	};
+
 	if (Array.isArray(cellData)) {
 		cellContent = cellData
-			.map(value => valuesMap[value] || value || null)
+			.map(getMappedValue)
 			.filter(value => !!value)
 			.sort((a, b) => a.toString().localeCompare(b.toString()))
 			.join(', ');
 	} else {
-		cellContent = valuesMap[cellData] || cellData || null;
+		cellContent = getMappedValue(cellData);
 	}
 
 	return <DefaultCellRenderer {...props} cellData={cellContent} columnData={restColumnData} />;

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import isArray from 'lodash/isArray';
+
+import { defaultColumnConfiguration } from '../Content.component';
+
+const { cellRenderer: DefaultCellRenderer } = defaultColumnConfiguration;
+
+function CellMappedData(props) {
+	const { cellData, columnData } = props;
+	const { valuesMap, ...restColumnData } = columnData;
+
+	let cellContent;
+
+	if (isArray(cellData)) {
+		cellContent = cellData
+			.map(value => valuesMap[value] || value || null)
+			.filter(value => !!value)
+			.sort((a, b) => a.localeCompare(b))
+			.join(', ');
+	} else {
+		cellContent = valuesMap[cellData] || cellData || null;
+	}
+
+	return <DefaultCellRenderer {...props} cellData={cellContent} columnData={restColumnData} />;
+}
+
+CellMappedData.propTypes = {
+	cellData: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
+	columnData: PropTypes.shape({
+		valuesMap: PropTypes.object,
+	}),
+};
+
+export default CellMappedData;

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -19,7 +19,7 @@ function CellMappedData(props) {
 	if (Array.isArray(cellData)) {
 		cellContent = cellData
 			.map(getMappedValue)
-			.filter(value => !!value)
+			.filter(value => value !== undefined && value !== null && value !== '')
 			.sort((a, b) => a.toString().localeCompare(b.toString()))
 			.join(', ');
 	} else {

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import isArray from 'lodash/isArray';
 
 import { defaultColumnConfiguration } from '../Content.component';
 
@@ -12,7 +11,7 @@ function CellMappedData(props) {
 
 	let cellContent;
 
-	if (isArray(cellData)) {
+	if (Array.isArray(cellData)) {
 		cellContent = cellData
 			.map(value => valuesMap[value] || value || null)
 			.filter(value => !!value)

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -15,7 +15,7 @@ function CellMappedData(props) {
 		cellContent = cellData
 			.map(value => valuesMap[value] || value || null)
 			.filter(value => !!value)
-			.sort((a, b) => a.localeCompare(b))
+			.sort((a, b) => a.toString().localeCompare(b.toString()))
 			.join(', ');
 	} else {
 		cellContent = valuesMap[cellData] || cellData || null;

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.js
@@ -7,7 +7,7 @@ const { cellRenderer: DefaultCellRenderer } = defaultColumnConfiguration;
 
 function CellMappedData(props) {
 	const { cellData, columnData } = props;
-	const { valuesMap, ...restColumnData } = columnData;
+	const { valuesMap, separator = ', ', ...restColumnData } = columnData;
 
 	let cellContent;
 
@@ -21,7 +21,7 @@ function CellMappedData(props) {
 			.map(getMappedValue)
 			.filter(value => value !== undefined && value !== null && value !== '')
 			.sort((a, b) => a.toString().localeCompare(b.toString()))
-			.join(', ');
+			.join(separator);
 	} else {
 		cellContent = getMappedValue(cellData);
 	}
@@ -33,6 +33,7 @@ CellMappedData.propTypes = {
 	cellData: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
 	columnData: PropTypes.shape({
 		valuesMap: PropTypes.object,
+		separator: PropTypes.string,
 	}),
 };
 

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
@@ -11,14 +11,14 @@ describe('CellMappedData', () => {
 		'two': 2,
 	};
 
-	const columnData = { valuesMap };
+	const defaultColumnData = { valuesMap };
 
 	it('should render checked mapped data cell for a string value', () => {
 		// given
 		const cellData = 'value_1';
 
 		// when
-		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);
+		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={defaultColumnData} />);
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
@@ -27,6 +27,21 @@ describe('CellMappedData', () => {
 	it('should render checked mapped data cell for a collection of values', () => {
 		// given
 		const cellData = ['value_1', null, 'not_mapped', 1, 'two', undefined];
+
+		// when
+		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={defaultColumnData} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render checked mapped data cell for a collection of values', () => {
+		// given
+		const cellData = ['value_1', 'value_2'];
+		const columnData = {
+			...defaultColumnData,
+			separator: ' / ',
+		};
 
 		// when
 		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+
+import CellMappedData from './CellMappedData.component';
+
+describe('CellMappedData', () => {
+	const valuesMap = {
+		'value_1': 'Value 1',
+		'value_2': 'Value 2',
+	};
+
+	const columnData = { valuesMap };
+
+	it('should render checked mapped data cell for a string value', () => {
+		// given
+		const cellData = 'value_1';
+
+		// when
+		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	it('should render checked mapped data cell for a collection of values', () => {
+		// given
+		const cellData = ['value_1', null, 'not_mapped'];
+
+		// when
+		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);
+
+		// then
+		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+});

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
@@ -7,6 +7,8 @@ describe('CellMappedData', () => {
 	const valuesMap = {
 		'value_1': 'Value 1',
 		'value_2': 'Value 2',
+		1: 'One',
+		'two': 2,
 	};
 
 	const columnData = { valuesMap };
@@ -24,7 +26,7 @@ describe('CellMappedData', () => {
 
 	it('should render checked mapped data cell for a collection of values', () => {
 		// given
-		const cellData = ['value_1', null, 'not_mapped'];
+		const cellData = ['value_1', null, 'not_mapped', 1, 'two'];
 
 		// when
 		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);

--- a/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/CellMappedData.component.test.js
@@ -26,7 +26,7 @@ describe('CellMappedData', () => {
 
 	it('should render checked mapped data cell for a collection of values', () => {
 		// given
-		const cellData = ['value_1', null, 'not_mapped', 1, 'two'];
+		const cellData = ['value_1', null, 'not_mapped', 1, 'two', undefined];
 
 		// when
 		const wrapper = shallow(<CellMappedData cellData={cellData} columnData={columnData} />);

--- a/packages/components/src/VirtualizedList/CellMappedData/MappedDataColumn.component.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/MappedDataColumn.component.js
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { defaultColumnConfiguration } from '../Content.component';
+
+import CellMappedData from './CellMappedData.component';
+
+export const cellType = 'mappedData';
+
+export const mappedDataColumnConfiguration = {
+	cellRenderer: props => <CellMappedData {...props} />,
+};
+
+function MappedDataColumn() {
+	return null;
+}
+
+MappedDataColumn.defaultProps = {
+	...defaultColumnConfiguration,
+	...mappedDataColumnConfiguration,
+};
+
+export default MappedDataColumn;

--- a/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
@@ -2,7 +2,7 @@
 
 exports[`CellMappedData should render checked mapped data cell for a collection of values 1`] = `
 <DefaultRenderer
-  cellData="not_mapped, Value 1"
+  cellData="2, not_mapped, One, Value 1"
   columnData={Object {}}
 />
 `;

--- a/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
@@ -7,6 +7,13 @@ exports[`CellMappedData should render checked mapped data cell for a collection 
 />
 `;
 
+exports[`CellMappedData should render checked mapped data cell for a collection of values 2`] = `
+<DefaultRenderer
+  cellData="Value 1 / Value 2"
+  columnData={Object {}}
+/>
+`;
+
 exports[`CellMappedData should render checked mapped data cell for a string value 1`] = `
 <DefaultRenderer
   cellData="Value 1"

--- a/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellMappedData/__snapshots__/CellMappedData.component.test.js.snap
@@ -1,0 +1,15 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellMappedData should render checked mapped data cell for a collection of values 1`] = `
+<DefaultRenderer
+  cellData="not_mapped, Value 1"
+  columnData={Object {}}
+/>
+`;
+
+exports[`CellMappedData should render checked mapped data cell for a string value 1`] = `
+<DefaultRenderer
+  cellData="Value 1"
+  columnData={Object {}}
+/>
+`;

--- a/packages/components/src/VirtualizedList/CellMappedData/index.js
+++ b/packages/components/src/VirtualizedList/CellMappedData/index.js
@@ -1,0 +1,4 @@
+import MappedDataColumn, { cellType, mappedDataColumnConfiguration } from './MappedDataColumn.component';
+
+export { cellType, MappedDataColumn };
+export default mappedDataColumnConfiguration;

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -302,7 +302,6 @@ for (let i = collection.length; i < 100; i += 1) {
 		modified: 1474495200,
 		description: 'Simple row with icon and actions',
 		author: 'Jean-Pierre DUPONT',
-		language: 'fr',
 		icon: 'talend-file-xls-o',
 		display: 'text',
 		className: 'item-0-class',

--- a/packages/components/src/VirtualizedList/VirtualizedList.stories.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.stories.js
@@ -210,6 +210,7 @@ const collection = [
 		modified: '2016-09-22',
 		description: 'Simple row with few actions',
 		author: 'Jean-Pierre DUPONT',
+		language: 'fr',
 		display: 'text',
 		className: 'item-0-class',
 		titleActions: fewTitleActions,
@@ -247,6 +248,7 @@ const collection = [
 		modified: '2016-09-22',
 		description: 'Simple row with icon and actions',
 		author: 'Jean-Pierre DUPONT',
+		language: ['de', 'en'],
 		display: 'text',
 		className: 'item-2-class',
 		persistentActions,
@@ -259,6 +261,7 @@ const collection = [
 		modified: '2016-09-22',
 		description: 'Simple row without icon',
 		author: '',
+		language: 'fr',
 		icon: 'talend-file-xls-o',
 		display: 'text',
 		className: 'item-3-class',
@@ -271,6 +274,7 @@ const collection = [
 		modified: '2016-09-22',
 		description: 'Simple row with title in edit mode',
 		author: 'Jean-Pierre DUPONT',
+		language: 'en',
 		icon: 'talend-file-json-o',
 		display: 'input',
 		className: 'item-4-class',
@@ -298,6 +302,7 @@ for (let i = collection.length; i < 100; i += 1) {
 		modified: 1474495200,
 		description: 'Simple row with icon and actions',
 		author: 'Jean-Pierre DUPONT',
+		language: 'fr',
 		icon: 'talend-file-xls-o',
 		display: 'text',
 		className: 'item-0-class',
@@ -451,6 +456,11 @@ storiesOf('Data/List/VirtualizedList', module)
 					<VirtualizedList.Badge label="Tag" dataKey="tag" columnData={{ selected: true }} />
 					<VirtualizedList.Text label="Description" dataKey="description" />
 					<VirtualizedList.Text label="Author" dataKey="author" />
+					<VirtualizedList.MappedData
+						label="Language"
+						dataKey="language"
+						columnData={{ valuesMap: { en: 'English', fr: 'French', de: 'German' } }}
+					/>
 					<VirtualizedList.Datetime
 						label="Created"
 						dataKey="created"

--- a/packages/components/src/VirtualizedList/index.js
+++ b/packages/components/src/VirtualizedList/index.js
@@ -12,6 +12,7 @@ import { BooleanColumn } from './CellBoolean';
 import { LabelColumn } from './CellLabel';
 import { IconTextColumn } from './CellIconText';
 import { QualityBarColumn } from './CellQualityBar';
+import { MappedDataColumn } from './CellMappedData';
 import HeaderResizable from './HeaderResizable';
 import RowCollapsiblePanel from './RowCollapsiblePanel';
 
@@ -32,6 +33,7 @@ VirtualizedList.Boolean = BooleanColumn;
 VirtualizedList.Label = LabelColumn;
 VirtualizedList.IconText = IconTextColumn;
 VirtualizedList.QualityBar = QualityBarColumn;
+VirtualizedList.MappedData = MappedDataColumn;
 VirtualizedList.RowCollapsiblePanel = RowCollapsiblePanel;
 VirtualizedList.HeaderResizable = HeaderResizable;
 VirtualizedList.cellDictionary = cellDictionary;

--- a/packages/components/src/VirtualizedList/utils/dictionary.js
+++ b/packages/components/src/VirtualizedList/utils/dictionary.js
@@ -8,6 +8,7 @@ import CellBadgeRenderer, { cellType as cellBadgeType } from '../CellBadge';
 import CellLabelRenderer, { cellType as cellLabelType } from '../CellLabel';
 import CellDatetimeRenderer, { cellType as cellDatetimeType } from '../CellDatetime';
 import CellTextIconRenderer, { cellType as cellTextType } from '../CellTextIcon';
+import CellMappedDataRenderer, { cellType as cellMappedDataType } from '../CellMappedData';
 import HeaderIconRenderer, { headerType as headerIconType } from '../HeaderIcon';
 import HeaderResizable, { headerType as headerResizableType } from '../HeaderResizable';
 
@@ -20,6 +21,7 @@ export const cellDictionary = {
 	[cellLabelType]: CellLabelRenderer,
 	[cellTextType]: CellTextIconRenderer,
 	[cellDatetimeType]: CellDatetimeRenderer,
+	[cellMappedDataType]: CellMappedDataRenderer,
 };
 
 /** Row renderers dictionary */


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When, in a VirtualizedList, we need to transform a field in the objects of a collection to a human-readable name, we currently have only 2 options:
- Iterate over the collection to transform the value in evey object to the HR name (inefficient)
- Define a custom cell renderer (which can be a bit cumbersome)

**What is the chosen solution to this problem?**
Create a new cell renderer `MappedCellData` (couldn't come up with something nicer, open to suggestions) that accepts a map of values in `columnData` so that value conversion is done at render time.
The cell also accepts arrays as values; in that case values are sorted.

**Please check if the PR fulfills these requirements**

* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
