### PR TITLE
feat(TCCUI-221): Add tooltip for Status component

### DIFF
--- a/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
+++ b/packages/components/src/CollapsiblePanel/__snapshots__/CollapsiblePanel.snapshot.test.js.snap
@@ -17,7 +17,9 @@ exports[`CollapsiblePanel should render default with expanded key/value content 
                   <coral.icon name="fa fa-check">
                   </coral.icon>
                 </span>
-                <span class="theme-tc-status-label tc-status-label theme-info">
+                <span class="theme-tc-status-label tc-status-label theme-info"
+                      aria-describedby="42"
+                >
                   inProgress
                 </span>
                 <div class="tc-actions theme-tc-status-actions tc-status-actions btn-group">
@@ -125,7 +127,9 @@ exports[`CollapsiblePanel should render default with key/value content 1`] = `
                   <coral.icon name="fa fa-check">
                   </coral.icon>
                 </span>
-                <span class="theme-tc-status-label tc-status-label theme-info">
+                <span class="theme-tc-status-label tc-status-label theme-info"
+                      aria-describedby="42"
+                >
                   inProgress
                 </span>
                 <div class="tc-actions theme-tc-status-actions tc-status-actions btn-group">
@@ -230,7 +234,9 @@ exports[`CollapsiblePanel should render default without content 1`] = `
                   <coral.icon name="fa fa-check">
                   </coral.icon>
                 </span>
-                <span class="theme-tc-status-label tc-status-label theme-info">
+                <span class="theme-tc-status-label tc-status-label theme-info"
+                      aria-describedby="42"
+                >
                   inProgress
                 </span>
                 <div class="tc-actions theme-tc-status-actions tc-status-actions btn-group">

--- a/packages/components/src/Status/Status.component.js
+++ b/packages/components/src/Status/Status.component.js
@@ -6,6 +6,7 @@ import Actions from '../Actions/Actions.component';
 import CircularProgress from '../CircularProgress/CircularProgress.component';
 import Icon from '../Icon';
 import Skeleton from '../Skeleton';
+import TooltipTrigger from '../TooltipTrigger';
 
 import css from './Status.scss';
 
@@ -94,7 +95,7 @@ function renderLabel(status, label) {
 	return label;
 }
 
-export function Status({ status, label, icon, actions, progress }) {
+export function Status({ status, label, icon, actions, progress, tooltip }) {
 	const rootClassnames = classNames(css['tc-status'], 'tc-status', {
 		[css.action]: actions && actions.length,
 	});
@@ -110,11 +111,14 @@ export function Status({ status, label, icon, actions, progress }) {
 		'tc-status-label',
 		css[getbsStyleFromStatus(status)],
 	);
+	const labelText = renderLabel(status, label);
 
 	return (
 		<div role="status" className={rootClassnames}>
 			<span className={iconClassnames}>{renderIcon(status, icon, progress)}</span>
-			<span className={labelClassNames}>{renderLabel(status, label)}</span>
+			<TooltipTrigger label={tooltip || labelText} tooltipPlacement="top">
+				<span className={labelClassNames}>{labelText}</span>
+			</TooltipTrigger>
 			<Actions
 				actions={actions}
 				className={classNames(css['tc-status-actions'], 'tc-status-actions')}
@@ -138,6 +142,7 @@ Status.propTypes = {
 	icon: PropTypes.string,
 	actions: Actions.propTypes.actions,
 	progress: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+	tooltip: PropTypes.string,
 };
 
 Status.defaultProps = {

--- a/packages/components/src/Status/Status.stories.js
+++ b/packages/components/src/Status/Status.stories.js
@@ -76,6 +76,10 @@ storiesOf('Messaging & Communication/Status', module).add('default', () => (
 			icon=""
 			progress="50"
 		/>
+		<h3>
+			Status with <code>tooltip</code>
+		</h3>
+		<Status {...myStatus} actions={[]} tooltip='tooltip test' />
 		<br />
 	</div>
 ));

--- a/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
+++ b/packages/components/src/Status/__snapshots__/Status.snapshot.test.js.snap
@@ -11,7 +11,14 @@ exports[`Status should render a label 1`] = `
     
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-success"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     Successful
   </span>
@@ -67,7 +74,14 @@ exports[`Status should render a label with Icon 1`] = `
     />
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-success"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     Successful
   </span>
@@ -123,7 +137,14 @@ exports[`Status should render a label with Icon without actions 1`] = `
     />
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-success"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     Successful
   </span>
@@ -164,7 +185,14 @@ exports[`Status should render a label with a continuous circular progress 1`] = 
     </svg>
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-info"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     In Progress
   </span>
@@ -238,7 +266,14 @@ exports[`Status should render a label with a fixed circular progress 1`] = `
     </svg>
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-info"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     In Progress
   </span>
@@ -301,7 +336,14 @@ exports[`Status should render a label with a skeleton 1`] = `
     />
   </span>
   <span
+    aria-describedby="42"
     className="theme-tc-status-label tc-status-label theme-skeleton"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onKeyPress={[Function]}
+    onMouseOut={[Function]}
+    onMouseOver={[Function]}
   >
     <span
       aria-label="text (loading)"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Jira -> https://jira.talendforge.org/browse/TCCUI-221
This part is the sequel of that item https://jira.talendforge.org/browse/TDOPS-113

We need to have tooltips for all list parts. Status is the last missing part
https://talend365.sharepoint.com/:p:/g/departments/rd/EdHLTiIIiDhAvaKgIjrVE7ABrY_eX1U17uCSSE5PEEPHxQ?e=SfvRM6&nav=eyJzSWQiOjI5OCwiY0lkIjoyODE2NTM4MDgyfQ

**What is the chosen solution to this problem?**
Add custom tooltip for status column
**Please check if the PR fulfills these requirements**

* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
