### PR TITLE
chore: restore security scan cron

### DIFF
--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -1,7 +1,6 @@
 name: Security scan
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 0 * * 0' # https://crontab.guru/every-week "At 00:00 on Sunday."
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Making it able to trigger the GH action manually cancelled the cron somehow.

**What is the chosen solution to this problem?**
Let's restore the cron by removing the manual trigger.

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
