### PR TITLE
chore: fix test:demo script

### DIFF
--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -28,7 +28,7 @@ jobs:
           yarn global add surge
           echo "$(yarn global bin)" >> $GITHUB_PATH
           yarn prepublishOnly
-          yarn test:demo
+          yarn test:demo --quiet
           ./.github/workflows/before-surge.sh
 
       - name: deploy if master

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -28,7 +28,7 @@ jobs:
           yarn global add surge
           echo "$(yarn global bin)" >> $GITHUB_PATH
           yarn prepublishOnly
-          yarn test:demo --quiet
+          yarn test:demo
           ./.github/workflows/before-surge.sh
 
       - name: deploy if master

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -29,8 +29,6 @@ jobs:
           echo "$(yarn global bin)" >> $GITHUB_PATH
           yarn prepublishOnly
           yarn test:demo --quiet
-          cd packages/cmf-router && yarn install && yarn prepublishOnly && cd ../..
-          cd packages/dataviz && yarn install && yarn test:demo --quiet && cd ../..
           ./.github/workflows/before-surge.sh
 
       - name: deploy if master

--- a/workspace-run.js
+++ b/workspace-run.js
@@ -54,7 +54,8 @@ function run(cmd, opts = {}) {
 		});
 	});
 }
-const script = process.argv.slice(2);
+const script = process.argv[2];
+const scriptArgs = process.argv.slice(3);
 
 function consume(cmds) {
 	if (cmds.length > 0) {
@@ -79,7 +80,7 @@ run({ name: 'yarn', args: ['workspaces', '--silent', 'info'] })
 		const commands = Object.keys(info).reduce((acc, pkg) => {
 			const packageJson = require(`./${info[pkg].location}/package.json`);
 			if (packageJson.scripts[script]) {
-				acc.push({ name: 'yarn', args: ['workspace', '--silent', pkg, 'run', script] });
+				acc.push({ name: 'yarn', args: ['workspace', '--silent', pkg, 'run', script].concat(scriptArgs) });
 			}
 			return acc;
 		}, []);

--- a/workspace-run.js
+++ b/workspace-run.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-dynamic-require */
 /* eslint-disable global-require */
 /* eslint-disable no-console */
-const { exec } = require('child_process');
+const { spawn } = require('child_process');
 
 let exitCode = 0;
 
@@ -16,31 +16,40 @@ let exitCode = 0;
  */
 function run(cmd, opts = {}) {
 	if (opts.verbose) {
-		console.log(`#### RUNNER: ${cmd}`);
+		console.log(`#### RUNNER: ${cmd.name} ${cmd.args.join(' ')}`);
 	}
 	return new Promise((resolve, reject) => {
-		const out = exec(cmd, (error, stdout, stderr) => {
-			if (error) {
-				console.error(error);
-				exitCode += 1;
-				return reject(error);
-			}
-			if (stderr) {
-				if (opts.verbose) {
-					console.error(`RUNNER: Child Process STDERR: ${stderr}`);
-				}
-			}
-			if (stdout) {
-				if (opts.verbose) {
-					console.log(`RUNNER: Child Process STDOUT: ${stdout}`);
-				}
-				return resolve(stdout);
-			}
-			return reject(stderr);
+		const out = spawn(cmd.name, cmd.args);
+		let stdout = '';
+		let stderr = '';
+		out.on('error', error => {
+			console.error(error);
+			exitCode += 1;
+			reject(error);
 		});
-		out.on('exit', code => {
-			if (opts.verbose) {
-				console.log(`RUNNER: Child process exited with exit code ${code}`);
+		out.on('close', () => {
+			resolve(stdout);
+		});
+		out.on('exit', () => {
+			if (opts.verbose && stderr) {
+				console.error(`RUNNER: Child Process STDERR: ${stderr}`);
+			}
+			if (opts.verbose && stdout) {
+				console.error(`RUNNER: Child Process STDOUT: ${stdout}`);
+			}
+			resolve(stdout);
+		});
+		out.stdout.on('data', data => {
+			const datastr = data.toString();
+			if (data && datastr) {
+				stdout += datastr;
+			}
+		});
+
+		out.stderr.on('data', data => {
+			const datastr = data.toString();
+			if (data && datastr) {
+				stderr += data.toString();
 			}
 		});
 	});
@@ -58,7 +67,7 @@ function consume(cmds) {
 	}
 }
 
-run('yarn workspaces --silent info')
+run({ name: 'yarn', args: ['workspaces', '--silent', 'info'] })
 	.then(infoOutput => {
 		let info = {};
 		try {
@@ -70,7 +79,7 @@ run('yarn workspaces --silent info')
 		const commands = Object.keys(info).reduce((acc, pkg) => {
 			const packageJson = require(`./${info[pkg].location}/package.json`);
 			if (packageJson.scripts[script]) {
-				acc.push(`yarn workspace --silent ${pkg} run ${script}`);
+				acc.push({ name: 'yarn', args: ['workspace', '--silent', pkg, 'run', script] });
 			}
 			return acc;
 		}, []);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we suffer from buffer exceed error on test:demo script (because of the deprecation warning from sass).
So we do not have anymore surge demos.

**What is the chosen solution to this problem?**

switch to spawn which do not buffer reponse.
bonus: fix github action workflow which build dataviz and cmf-router twice.

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
