### PR TITLE
chore: remove prepublishOnly script

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -25,7 +25,7 @@ jobs:
           cache: 'yarn'
 
       - name: Install Dependencies
-        run: yarn
+        run: yarn && yarn pre-release
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/.github/workflows/lerna-ci.yml
+++ b/.github/workflows/lerna-ci.yml
@@ -33,6 +33,6 @@ jobs:
         if: github.ref != 'refs/heads/master'
         with:
           repo-token: '${{ secrets.GITHUB_TOKEN }}'
-          build-script: 'prepublishOnly'
+          build-script: 'pre-release'
           pattern: './packages/*/dist/*.{js,css,json}'
           exclude: '{**/*.html,**/*.map,**/node_modules/**}'

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -27,7 +27,7 @@ jobs:
           yarn install --frozen-lockfile
           yarn global add surge
           echo "$(yarn global bin)" >> $GITHUB_PATH
-          yarn prepublishOnly
+          yarn pre-release
           yarn test:demo --quiet
           ./.github/workflows/before-surge.sh
 

--- a/package.json
+++ b/package.json
@@ -6,12 +6,12 @@
     "i18next-scanner": "^3.0.0"
   },
   "scripts": {
-    "prepare": " yarn workspaces run prepare",
-    "prepublishOnly": "yarn workspaces run prepublishOnly",
+    "prepare": "yarn workspaces run prepare",
+    "pre-release": "node workspace-run.js pre-release",
     "info": "yarn workspaces --silent info > info.json",
     "release": "yarn changeset publish",
-    "lint:es": "node workspace-run.js lint:es",
-    "lint:style": "node workspace-run.js lint:style",
+    "lint:es": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:es",
+    "lint:style": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:style",
     "build": "yarn workspaces run build",
     "test": "cross-env TZ=Europe/Paris yarn workspaces run test --silent",
     "test:update": "cross-env TZ=Europe/Paris yarn workspaces run test --silent -u",

--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf-router/package.json
+++ b/packages/cmf-router/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf-webpack-plugin/package.json
+++ b/packages/cmf-webpack-plugin/package.json
@@ -4,7 +4,6 @@
   "main": "lib/index.js",
   "mainSrc": "src/index.js",
   "scripts": {
-    "prepublishOnly": "echo nothing to prepublishOnly",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "echo nothing to test yet in @talend/react-cmf-webpack-plugin",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test",
     "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6007",
     "test": "talend-scripts test",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "start-storybook -p 6010",
     "test": "talend-scripts test --silent",

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -7,7 +7,7 @@
   "types": "./lib/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "yarn build:umd:dev && yarn build:umd:prod",
+    "pre-release": "yarn build:umd:dev && yarn build:umd:prod",
     "build:umd:dev": "talend-scripts build:lib:umd --dev",
     "build:umd:prod": "talend-scripts build:lib:umd",
     "build": "talend-scripts build:ts:lib",

--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -6,7 +6,6 @@
   "main": "index.js",
   "scripts": {
     "prepare": "echo nothing to prepare",
-    "prepublishOnly": "echo nothing to prepublishOnly",
     "test": "echo nothing to test",
     "test:demo": "echo nothing to do"
   },

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -6,7 +6,7 @@
   "style": "build/octicons.css",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "node ./scripts/typescript.js",
+    "pre-release": "node ./scripts/typescript.js",
     "build-umd": "webpack --config webpack.umd.js && webpack --config webpack.umd.js --env.production",
     "build-react": "node scripts/react.js",
     "build-webfont": "webpack",

--- a/packages/jsfc/package.json
+++ b/packages/jsfc/package.json
@@ -5,7 +5,6 @@
   "main": "dist/index.js",
   "mainSrc": "src/index.js",
   "scripts": {
-    "prepublishOnly": "echo nothing to prepublish",
     "prepare": "rimraf dist && talend-scripts build:lib:umd",
     "watch": "webpack --watch",
     "dist-untested": "webpack --config webpack.config.dist.js",

--- a/packages/local-libs-webpack-plugin/package.json
+++ b/packages/local-libs-webpack-plugin/package.json
@@ -6,7 +6,6 @@
   "license": "Apache-2.0",
   "scripts": {
     "prepare": "echo nothing to prepare",
-    "prepublishOnly": "echo nothing to prepublishOnly",
     "test": "jest",
     "test:demo": "echo nothing to do",
     "lint": "eslint lib/**"

--- a/packages/router-bridge/package.json
+++ b/packages/router-bridge/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "build": "talend-scripts build:lib",
     "test": "talend-scripts test",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "prepublishOnly": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
     "prepare": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
     "test:noisy": "cross-env TZ=Europe/Paris talend-scripts test",

--- a/packages/storybook-cmf/package.json
+++ b/packages/storybook-cmf/package.json
@@ -17,7 +17,6 @@
     "addon"
   ],
   "scripts": {
-    "prepublishOnly": "echo nothing to prepublishOnly",
     "prepare": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:demo": "echo nothing to demo",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "prepublishOnly": "rimraf ./dist && webpack --display=none",
+    "pre-release": "rimraf ./dist && webpack --display=none",
     "prepare": "rimraf ./dist && webpack",
     "start": "webpack serve --mode=development",
     "test": "echo no test for @talend/bootstrap-theme",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
   "scripts": {
     "build": "talend-scripts build:ts:lib",
     "lint:es": "talend-scripts lint:es --format json -o eslint-report.json",
-    "prepublishOnly": "npm run test",
+    "pre-release": "npm run test",
     "prepare": "npm run build",
     "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
     "test:demo": "echo nothing to do",

--- a/workspace-run.js
+++ b/workspace-run.js
@@ -62,7 +62,13 @@ function consume(cmds) {
 		const cmd = cmds.pop();
 		run(cmd, { verbose: true })
 			.then(() => consume(cmds))
-			.catch(() => consume(cmds));
+			.catch(() => {
+				if (process.env.WORKSPACE_RUN_FAIL === 'no-bail') {
+					consume(cmds);
+				} else {
+					process.exit(exitCode);
+				}
+			});
 	} else {
 		process.exit(exitCode);
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

changeset ci fails because of prepublishOnly npm script.
`npm publish --json` is execute which execute prepublishOnly script with --json option.
Webpack output change and become a json payload, but changeset want the json payload from npm publish so it fails.

**What is the chosen solution to this problem?**

move prepublishOnly into a new pre-release script which is not known by npm.
trigger it from the CI


**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
