### PR TITLE
feat(components): update semantic awareness display

### DIFF
--- a/.changeset/healthy-cats-cover.md
+++ b/.changeset/healthy-cats-cover.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(components/ModelViewer): update on semantic awareness

--- a/packages/components/src/DataViewer/DataViewer.stories.js
+++ b/packages/components/src/DataViewer/DataViewer.stories.js
@@ -77,6 +77,47 @@ stories
 			</div>
 		);
 	})
+	.add('DataTree without semantic awareness', () => {
+		const [jsonPathSelection, setJsonPathSelection] = useState("$['category']");
+		const layoutCn = classNames(theme['tc-twoviewers-layout'], 'tc-twoviewers-layout');
+
+		const highlighted = [buildRegExpJsonpath(jsonPathSelection)];
+		const onSelect = (_, jsonpath) => setJsonPathSelection(jsonpath);
+		const isUnion = item => Array.isArray(item.type);
+		const getDisplayValue = item => (typeof item === 'string' ? item : get(item, 'doc', item.name));
+
+		return (
+			<div className={layoutCn}>
+				<div
+					className={classNames(theme['tc-twoviewers-layout-left'], 'tc-twoviewers-layout-left')}
+				>
+					<ModelViewer
+						componentId="ModelViewer"
+						highlighted={highlighted}
+						jsonPathSelection={jsonPathSelection}
+						onSelect={onSelect}
+						sample={hierarchicSample}
+						renderLeafOptions={() => {}}
+						getDisplayValue={getDisplayValue}
+						isUnion={isUnion}
+						hasSemanticAwareness={false}
+					/>
+				</div>
+				<div
+					className={classNames(theme['tc-twoviewers-layout-right'], 'tc-twoviewers-layout-right')}
+				>
+					<RecordsViewer
+						componentId="RecordsViewer"
+						highlighted={highlighted}
+						onVerticalScroll={() => {}}
+						sample={hierarchicSample}
+						renderLeafAdditionalValue={() => {}}
+						renderBranchAdditionalValue={() => {}}
+					/>
+				</div>
+			</div>
+		);
+	})
 	.add('DataTree with type display on records', () => {
 		return (
 			<div style={{ height: '100%' }}>

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/ModelViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/ModelViewerLeaf.component.js
@@ -44,8 +44,10 @@ export function ModelViewerLeaf({
 	const ariaLabelButton = t('MODEL_VIEWER_LEAF_BUTTON_ARIA_LABEL_SELECT', {
 		defaultValue: 'Select',
 	});
-	const formattedKey = getDisplayValue(value);
-	const formattedValue = hasSemanticAwareness ? `${getDisplayKey(value)}${isOptional(value)}` : '';
+	const formattedKey = hasSemanticAwareness
+		? `${getDisplayValue(value)}${isOptional(value)}`
+		: getDisplayValue(value);
+	const formattedValue = hasSemanticAwareness ? `${getDisplayKey(value)}` : '';
 	const separator = ' ';
 
 	return (

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/ModelViewerLeaf.component.js
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/ModelViewerLeaf.component.js
@@ -44,9 +44,9 @@ export function ModelViewerLeaf({
 	const ariaLabelButton = t('MODEL_VIEWER_LEAF_BUTTON_ARIA_LABEL_SELECT', {
 		defaultValue: 'Select',
 	});
-	const formattedKey = hasSemanticAwareness
-		? `${getDisplayValue(value)}${isOptional(value)}`
-		: getDisplayValue(value);
+	const displayValue = getDisplayValue(value);
+	const formattedKey =
+		displayValue && hasSemanticAwareness ? `${displayValue}${isOptional(value)}` : displayValue;
 	const formattedValue = hasSemanticAwareness ? `${getDisplayKey(value)}` : '';
 	const separator = ' ';
 

--- a/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
+++ b/packages/components/src/DataViewer/ModelViewer/Leaf/__snapshots__/ModelViewerLeaf.test.js.snap
@@ -31,13 +31,13 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf highlighted 1`] = `
     aria-label="Select myDataKey ($)"
     className="theme-tc-model-leaf-button-highlighted tc-model-leaf-button-highlighted theme-tc-model-leaf-button tc-model-leaf-button"
     onClick={[Function]}
-    title=" (typeSem)*"
+    title=" (typeSem)"
   />
   <SimpleTextKeyValue
     displayTypes={false}
     separator=" "
     typesRenderer={[Function]}
-    value="(typeSem)*"
+    value="(typeSem)"
   />
   <span
     className="theme-tc-model-leaf-options tc-model-leaf-options"
@@ -53,13 +53,13 @@ exports[`ModelViewerLeaf should render ModelViewerLeaf with additional data 1`] 
     aria-label="Select myDataKey ($)"
     className="theme-tc-model-leaf-button-highlighted tc-model-leaf-button-highlighted theme-tc-model-leaf-button tc-model-leaf-button"
     onClick={[Function]}
-    title=" (typeSem)*"
+    title=" (typeSem)"
   />
   <SimpleTextKeyValue
     displayTypes={false}
     separator=" "
     typesRenderer={[Function]}
-    value="(typeSem)*"
+    value="(typeSem)"
   />
   <span
     className="theme-tc-model-leaf-options tc-model-leaf-options"

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.component.js
@@ -147,7 +147,12 @@ const SimpleTextKeyValue = React.forwardRef(function SimpleTextKeyValue(
 			style={style}
 		>
 			{!isNull(formattedKey) && (
-				<span className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key')}>
+				<span
+					className={classNames(theme['tc-simple-text-key'], 'tc-simple-text-key', {
+						[theme['tc-simple-text-key-with-value']]: value,
+						'tc-simple-text-key-with-value': value,
+					})}
+				>
 					{get(schema, 'talend.component.label', formattedKey)}
 					{separator}
 					{types}

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
@@ -7,6 +7,7 @@
 	:global(.td-default-cell) {
 		font-weight: 400;
 	}
+
 	&-key {
 		margin-right: $padding-smaller;
 		white-space: nowrap;
@@ -20,11 +21,12 @@
 	}
 
 	&-value {
+		text-transform: lowercase;
+		white-space: nowrap;
+
 		&::first-letter {
 			text-transform: uppercase;
 		}
-		text-transform: lowercase;
-		white-space: nowrap;
 
 		&.shrink-value {
 			overflow: hidden;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.scss
@@ -15,7 +15,7 @@
 		vertical-align: top;
 	}
 
-	&-key::after {
+	&-key-with-value::after {
 		content: ':';
 	}
 

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/SimpleTextKeyValue.test.js.snap
@@ -17,7 +17,7 @@ exports[`SimpleTextKeyValue should render only the value 1`] = `
   className="theme-tc-simple-text tc-simple-text"
 >
   <span
-    className="theme-tc-simple-text-key tc-simple-text-key"
+    className="theme-tc-simple-text-key tc-simple-text-key theme-tc-simple-text-key-with-value tc-simple-text-key-with-value"
   />
   <span
     className="theme-tc-simple-text-value tc-simple-text-value"
@@ -37,7 +37,7 @@ exports[`SimpleTextKeyValue should render the key and the value 1`] = `
   }
 >
   <span
-    className="theme-tc-simple-text-key tc-simple-text-key"
+    className="theme-tc-simple-text-key tc-simple-text-key theme-tc-simple-text-key-with-value tc-simple-text-key-with-value"
   >
     myKey
      : 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
To be homogeneous with other renders, we got to show the asterisk for the not null field aside the type and not the semantic type.

**What is the chosen solution to this problem?**
(i like to) Move it move it 🎶 
<img width="335" alt="CleanShot 2021-09-01 at 09 09 26@2x" src="https://user-images.githubusercontent.com/2909671/131627827-19144e08-3258-402f-aae7-d9ff62731de9.png">


**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [x] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
