### PR TITLE
feat(theme/modals): Remove modal max height

### DIFF
--- a/.changeset/slimy-pears-cross.md
+++ b/.changeset/slimy-pears-cross.md
@@ -1,0 +1,5 @@
+---
+'@talend/bootstrap-theme': minor
+---
+
+feat(theme/modals): Remove modal max height

--- a/packages/theme/src/theme/_modals.scss
+++ b/packages/theme/src/theme/_modals.scss
@@ -1,5 +1,4 @@
 .modal-dialog {
-	max-height: 80vh;
 	display: flex;
 	flex-direction: row;
 	flex-wrap: nowrap;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Modals heights are limited to 80% of the viewport's height. This is problematic when modal content overflows, the content container gets a scrollbar.

**What is the chosen solution to this problem?**
Remove limitation.

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
