### PR TITLE
fix(forms/NestedListView): Component should now detect props change

### DIFF
--- a/.changeset/quick-colts-join.md
+++ b/.changeset/quick-colts-join.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': minor
+---
+
+fix(forms/NestedListView): component should now detect props change

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
@@ -1,16 +1,15 @@
+import ListView from '@talend/react-components/lib/ListView';
+import keycode from 'keycode';
+import isEqual from 'lodash/isEqual';
 import PropTypes from 'prop-types';
 import React from 'react';
-import keycode from 'keycode';
-import ListView from '@talend/react-components/lib/ListView';
 import { withTranslation } from 'react-i18next';
-
 import { I18N_DOMAIN_FORMS } from '../../../constants';
 import getDefaultT from '../../../translate';
-import { getDisplayedItems, prepareItemsFromSchema } from './NestedListView.utils';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
 import FieldTemplate from '../FieldTemplate';
-
 import theme from './NestedListView.scss';
+import { getDisplayedItems, prepareItemsFromSchema } from './NestedListView.utils';
 
 const DISPLAY_MODE_DEFAULT = 'DISPLAY_MODE_DEFAULT';
 const DISPLAY_MODE_SEARCH = 'DISPLAY_MODE_SEARCH';
@@ -58,6 +57,19 @@ class NestedListViewWidget extends React.Component {
 			searchCriteria: null,
 			displayedItems: getDisplayedItems(this.items, this.value),
 		};
+	}
+
+	/**
+	 * Detect changes of props
+	 * @param { Object } prevProps The new props
+	 */
+	componentDidUpdate(prevProps) {
+		// If props.value if different from previous prop and this.value, refresh the displayed items
+		if (!isEqual(prevProps.value, this.props.value) && !isEqual(this.value, this.props.value)) {
+			this.value = this.props.value;
+			// eslint-disable-next-line react/no-did-update-set-state
+			this.setState({ displayedItems: getDisplayedItems(this.items, this.value) });
+		}
 	}
 
 	/**

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
@@ -82,10 +82,10 @@ describe('NestedListView component', () => {
 			});
 
 			// when : trigger a props update
-			const allValues = {};
-			props.schema.items.forEach(({ key, titleMap }) => {
-				allValues[key] = titleMap.map(titleMapItem => titleMapItem.value);
-			});
+			const allValues = props.schema.items.reduce((acc, item) => {
+				acc[item.key] = item.titleMap.map(titleMapItem => titleMapItem.value);
+				return acc;
+			}, {});
 			ReactDOM.render(<NestedListViewWidget {...props} value={allValues} />, node);
 
 			// then

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
@@ -1,9 +1,9 @@
-import React from 'react';
 import { shallow } from 'enzyme';
 import keycode from 'keycode';
-
+import React from 'react';
+import ReactDOM from 'react-dom';
 import { NestedListViewWidget } from './NestedListView.component';
-import { prepareItemsFromSchema, getDisplayedItems } from './NestedListView.utils';
+import { getDisplayedItems, prepareItemsFromSchema } from './NestedListView.utils';
 
 jest.useFakeTimers();
 
@@ -66,6 +66,36 @@ describe('NestedListView component', () => {
 
 		// then
 		expect(wrapper.getElement()).toMatchSnapshot();
+	});
+
+	describe('componentDidUpdate', () => {
+		it('should update items on props.value change', () => {
+			// given
+			const node = document.createElement('div');
+			// eslint-disable-next-line react/no-render-return-value
+			const instance = ReactDOM.render(<NestedListViewWidget {...props} value={{}} />, node);
+			const previousItems = instance.state.displayedItems;
+			expect(previousItems.length).toBe(2);
+			previousItems.forEach(({ checked, children }) => {
+				expect(checked).toBe(false);
+				children.forEach(childrenItem => expect(childrenItem.checked).toBe(false));
+			});
+
+			// when : trigger a props update
+			const allValues = {};
+			props.schema.items.forEach(({ key, titleMap }) => {
+				allValues[key] = titleMap.map(titleMapItem => titleMapItem.value);
+			});
+			ReactDOM.render(<NestedListViewWidget {...props} value={allValues} />, node);
+
+			// then
+			const nextItems = instance.state.displayedItems;
+			expect(nextItems.length).toBe(2);
+			nextItems.forEach(({ checked, children }) => {
+				expect(checked).toBe(true);
+				children.forEach(childrenItem => expect(childrenItem.checked).toBe(true));
+			});
+		});
 	});
 
 	describe('onExpandToggle', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When using a NestedListView component in a form, if we change the values passed as a prop outside of a user interaction, the component won't take it into account.

**What is the chosen solution to this problem?**
Add to the component _componentDidUpdate_ lifecycle a condition to check if the props have been changed and does not match the internal values

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
