### PR TITLE
chore(forms): Storybook layout related stories

### DIFF
--- a/packages/forms/.storybook/config.js
+++ b/packages/forms/.storybook/config.js
@@ -20,7 +20,7 @@ function withIconsProvider(story) {
 }
 
 const withFormLayout = (story, options) => {
-	if (options.kind === 'Layout') {
+	if (options.kind.includes('Layout')) {
 		return story();
 	}
 	return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Since Storybook upgrade,  the way we  filter per story names has changed

**What is the chosen solution to this problem?**
To apply a decorator except to certain stories, fix the filter fn

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
