### PR TITLE
fix(theme): Fix chevron rotation on firefox

### DIFF
--- a/.changeset/great-panthers-wink.md
+++ b/.changeset/great-panthers-wink.md
@@ -1,0 +1,5 @@
+---
+'@talend/bootstrap-theme': minor
+---
+
+fix(theme): Fix chevron rotation on firefox

--- a/packages/theme/src/theme/_forms.switch-nested.scss
+++ b/packages/theme/src/theme/_forms.switch-nested.scss
@@ -14,7 +14,7 @@
 			}
 		}
 		&.expanded {
-			svg {
+			.tc-svg-icon {
 				transform: rotate(180deg);
 			}
 		}

--- a/packages/theme/src/theme/_forms.switch-nested.scss
+++ b/packages/theme/src/theme/_forms.switch-nested.scss
@@ -5,20 +5,24 @@
 		top: 0;
 		display: flex;
 		justify-content: flex-end;
+
 		.btn.btn-link {
 			line-height: 20px;
 			min-height: auto;
+
 			svg {
 				width: 10px;
 				height: 10px;
 			}
 		}
+
 		&.expanded {
 			.tc-svg-icon {
 				transform: rotate(180deg);
 			}
 		}
 	}
+
 	&.checkbox > label {
 		input[type='checkbox'] {
 			position: absolute;
@@ -34,10 +38,10 @@
 				color: tint($black, 50);
 			}
 
-			+ *:before,
-			+ *:after,
-			&:checked + *:before,
-			&:checked + *:after {
+			+ *::before,
+			+ *::after,
+			&:checked + *::before,
+			&:checked + *::after {
 				position: absolute;
 				content: '';
 				top: 0;
@@ -46,8 +50,8 @@
 				border-radius: 13rem;
 			}
 
-			+ *:before,
-			&:checked + *:before {
+			+ *::before,
+			&:checked + *::before {
 				width: 2.7rem;
 				height: 0.6rem;
 				margin-top: 0.5rem;
@@ -57,8 +61,8 @@
 				transform: rotate(0deg);
 			}
 
-			+ *:after,
-			&:checked + *:after {
+			+ *::after,
+			&:checked + *::after {
 				width: 1.5rem;
 				height: 1.5rem;
 				background-color: $wild-sand;
@@ -72,41 +76,41 @@
 					color: $text-color;
 				}
 
-				+ *:before {
+				+ *::before {
 					background-color: $scooter;
 				}
 
-				+ *:after {
+				+ *::after {
 					transform: translate(1.2rem, 0);
 				}
 			}
 
 			&:hover,
 			&:focus {
-				+ *:after {
+				+ *::after {
 					background-color: $white;
 					box-shadow: $switch-thumb-shadow-focused;
 				}
 			}
 
 			&:disabled {
-				+ *:before {
+				+ *::before {
 					background-color: tint($gallery, 70);
 					box-shadow: $switch-track-shadow-disabled;
 				}
 
-				+ *:after {
+				+ *::after {
 					background-color: $wild-sand;
 					border: $switch-thumb-border-disabled;
 					box-shadow: $switch-thumb-shadow;
 				}
 
 				&:checked {
-					+ *:before {
+					+ *::before {
 						background-color: tint($scooter, 70);
 					}
 
-					+ *:after {
+					+ *::after {
 						background-color: $wild-sand;
 						border: $switch-thumb-border-disabled;
 					}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On firefox , the chevron used in Forms/NestedListView is disappearing when using css rotation on it
![Screen Shot 2021-09-03 at 15 58 05](https://user-images.githubusercontent.com/16574861/132186222-572e70df-f643-4786-bc60-72f7e87d31ff.png)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
