### PR TITLE
chore(http): Drop lodash dependency

### DIFF
--- a/.changeset/good-years-rush.md
+++ b/.changeset/good-years-rush.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': patch
+---
+
+Drop lodash dependency

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -35,9 +35,6 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "dependencies": {
-    "lodash": "^4.17.4"
-  },
   "jest": {
     "collectCoverageFrom": [
       "src/**/*.{js,jsx}",

--- a/packages/http/src/config.js
+++ b/packages/http/src/config.js
@@ -1,5 +1,3 @@
-import get from 'lodash/get';
-
 /**
  * Storage point for the doc setup using `setDefaultConfig`
  */
@@ -43,7 +41,7 @@ export function getDefaultConfig() {
  * @param {String} language
  */
 export function setDefaultLanguage(language) {
-	if (get(HTTP, 'defaultConfig.headers')) {
+	if (HTTP.defaultConfig?.headers) {
 		HTTP.defaultConfig.headers['Accept-Language'] = language;
 	} else {
 		// eslint-disable-next-line no-console

--- a/packages/http/src/http.common.js
+++ b/packages/http/src/http.common.js
@@ -1,5 +1,3 @@
-import merge from 'lodash/merge';
-import get from 'lodash/get';
 import { mergeCSRFToken } from './csrfHandling';
 import { HTTP_STATUS, testHTTPCode } from './http.constants';
 import { HTTP } from './config';
@@ -43,7 +41,7 @@ export function encodePayload(headers, payload) {
 export async function handleBody(response) {
 	let methodBody = 'text';
 
-	const headers = get(response, 'headers', new Headers());
+	const headers = response?.headers || new Headers();
 	const contentType = headers.get('Content-Type');
 	if (contentType && contentType.includes('application/json')) {
 		methodBody = 'json';
@@ -104,15 +102,17 @@ export async function httpFetch(url, config, method, payload) {
 		delete defaultHeaders['Content-Type'];
 	}
 
-	const params = merge(
-		{
-			credentials: 'same-origin',
-			headers: defaultHeaders,
-			method,
+	const params = {
+		credentials: 'same-origin',
+		method,
+		...HTTP.defaultConfig,
+		...config,
+		headers: {
+			...defaultHeaders,
+			...HTTP.defaultConfig?.headers,
+			...config?.headers,
 		},
-		HTTP.defaultConfig,
-		config,
-	);
+	};
 
 	const response = await fetch(
 		url,

--- a/packages/http/src/http.constants.js
+++ b/packages/http/src/http.constants.js
@@ -1,6 +1,3 @@
-import find from 'lodash/find';
-import inRange from 'lodash/inRange';
-
 export const OPTIONS = 'OPTIONS';
 export const GET = 'GET';
 export const HEAD = 'HEAD';
@@ -86,7 +83,11 @@ export const HTTP_STATUS = {
  * match the status code with the HTTP_STATUS collection
  * @param {number} code
  */
-export const isHTTPStatus = code => find(HTTP_STATUS, value => value === code);
+export const isHTTPStatus = code => Object.values(HTTP_STATUS).find(value => value === code);
+
+function inRange(number, start, end) {
+	return +number >= start && +number < end;
+}
 
 /**
  * suite of test to see if status code match in the following categories of status

--- a/yarn.lock
+++ b/yarn.lock
@@ -11952,7 +11952,7 @@ lodash.unset@^4.1.0:
   resolved "https://registry.yarnpkg.com/lodash.unset/-/lodash.unset-4.5.2.tgz#370d1d3e85b72a7e1b0cdf2d272121306f23e4ed"
   integrity sha1-Nw0dPoW3Kn4bDN8tJyEhMG8j5O0=
 
-lodash@4.x, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.4:
+lodash@4.x, lodash@^4, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.7.0, lodash@~4.17.4:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Lodash can't be used in service worker due to current ui-scripts config: lodash is expected as an external but it's not there
![image](https://user-images.githubusercontent.com/58977230/132655518-7b381b1e-714d-4b51-99e0-3f3142a2c2da.png)

**What is the chosen solution to this problem?**

Config should be fixed but we can also remove lodash as it's not really needed

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
