### PR TITLE
fix(theme): resolve font url

### DIFF
--- a/.changeset/khaki-pets-know.md
+++ b/.changeset/khaki-pets-know.md
@@ -1,0 +1,5 @@
+---
+'@talend/bootstrap-theme': patch
+---
+
+fix(theme): resolve font url

--- a/packages/theme/webpack.config.js
+++ b/packages/theme/webpack.config.js
@@ -26,10 +26,11 @@ module.exports = (env, argv) => {
 						{
 							loader: 'file-loader',
 							options: {
-							  outputPath: 'fonts',
-							  name: '[name].[ext]',
+								outputPath: 'fonts',
+								name: '[name].[ext]',
+								esModule: false,
 							},
-						  },
+						},
 					],
 				},
 				{
@@ -49,9 +50,7 @@ module.exports = (env, argv) => {
 							loader: 'postcss-loader',
 							options: {
 								ident: 'postcss',
-								plugins: [
-									postcssPresetEnv({ browsers: 'last 2 versions' })
-								],
+								plugins: [postcssPresetEnv({ browsers: 'last 2 versions' })],
 							},
 						},
 						{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Theme doesn't resolve font url during build because file-loader consider any require() as esmodule. So the result is an object with default as expected value.
In the compiled css, we end up with `url([object Module])`

**What is the chosen solution to this problem?**
Set the theme file-loader option `esModule` to false

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
