### PR TITLE
fix(pre-release): remove display=none option

### DIFF
--- a/.changeset/sharp-spoons-rule.md
+++ b/.changeset/sharp-spoons-rule.md
@@ -1,0 +1,16 @@
+---
+'@talend/react-cmf': patch
+'@talend/react-cmf-cqrs': patch
+'@talend/react-cmf-router': patch
+'@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/react-datagrid': patch
+'@talend/react-forms': patch
+'@talend/http': patch
+'@talend/router-bridge': patch
+'@talend/react-sagas': patch
+'@talend/react-stepper': patch
+'@talend/bootstrap-theme': patch
+---
+
+Fix pre-release script: remove display=none option

--- a/.surge/index.html
+++ b/.surge/index.html
@@ -7,7 +7,7 @@
 		<meta name="description" content="" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-		<link rel="stylesheet" href="https://talend.surge.sh/theme/dist/bootstrap.css" />
+		<link rel="stylesheet" href="https://talend.surge.sh/theme/bootstrap.css" />
 		<style>
 			.layout {
 				position: relative;

--- a/.surge/index.html
+++ b/.surge/index.html
@@ -7,7 +7,7 @@
 		<meta name="description" content="" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-		<link rel="stylesheet" href="https://talend.surge.sh/theme/dist/bootstrap.css" />
+		<link rel="stylesheet" href="/theme/dist/bootstrap.css" />
 		<style>
 			.layout {
 				position: relative;

--- a/.surge/index.html
+++ b/.surge/index.html
@@ -7,7 +7,7 @@
 		<meta name="description" content="" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />
 
-		<link rel="stylesheet" href="https://talend.surge.sh/theme/bootstrap.css" />
+		<link rel="stylesheet" href="https://talend.surge.sh/theme/dist/bootstrap.css" />
 		<style>
 			.layout {
 				position: relative;

--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf-router/package.json
+++ b/packages/cmf-router/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test",
     "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "start-storybook -p 6007",
     "test": "talend-scripts test",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "start-storybook -p 6010",
     "test": "talend-scripts test --silent",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/http/package.json
+++ b/packages/http/package.json
@@ -19,7 +19,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/router-bridge/package.json
+++ b/packages/router-bridge/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "build": "talend-scripts build:lib",
     "test": "talend-scripts test",

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev --display=none && yarn build:prod --display=none",
+    "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test --silent",
     "test:noisy": "cross-env TZ=Europe/Paris talend-scripts test",

--- a/packages/theme/package.json
+++ b/packages/theme/package.json
@@ -5,7 +5,7 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
-    "pre-release": "rimraf ./dist && webpack --display=none",
+    "pre-release": "rimraf ./dist && webpack",
     "build:lib": "rimraf ./dist && webpack",
     "start": "webpack serve --mode=development",
     "test": "echo no test for @talend/bootstrap-theme",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
All packages fail to build with release scripts due to a unknown webpack option.

**What is the chosen solution to this problem?**
Remove the option.

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
