### PR TITLE
chore(build): order packages on pre-release hook

### DIFF
--- a/.changeset/quiet-crews-sit.md
+++ b/.changeset/quiet-crews-sit.md
@@ -1,0 +1,25 @@
+---
+'@talend/bootstrap-sass': patch
+'@talend/react-cmf': patch
+'@talend/react-cmf-cqrs': patch
+'@talend/react-cmf-router': patch
+'@talend/react-cmf-webpack-plugin': patch
+'@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/react-datagrid': patch
+'@talend/react-dataviz': patch
+'@talend/eslint-config': patch
+'@talend/react-forms': patch
+'@talend/http': patch
+'@talend/icons': patch
+'@talend/json-schema-form-core': patch
+'@talend/local-libs-webpack-plugin': patch
+'@talend/router-bridge': patch
+'@talend/react-sagas': patch
+'@talend/react-stepper': patch
+'@talend/react-storybook-cmf': patch
+'@talend/bootstrap-theme': patch
+'@talend/utils': patch
+---
+
+chore(build): order packages on pre-release hook


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UMD Builds depends on inner deps `*.dependencies.json` for `@talend` deps.
But those `*.dependencies.json` are generated during the build. It means the inner deps mus be built before.

The run-workspace script doesn't control the build order.

**What is the chosen solution to this problem?**
Sort the packages by dependencies to ensure that the `*.dependencies.json` files are generated before they are needed.

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
