### PR TITLE
fix(workspace-run): package run order

### DIFF
--- a/.changeset/clever-poems-tan.md
+++ b/.changeset/clever-poems-tan.md
@@ -1,0 +1,25 @@
+---
+'@talend/bootstrap-sass': patch
+'@talend/react-cmf': patch
+'@talend/react-cmf-cqrs': patch
+'@talend/react-cmf-router': patch
+'@talend/react-cmf-webpack-plugin': patch
+'@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/react-datagrid': patch
+'@talend/react-dataviz': patch
+'@talend/eslint-config': patch
+'@talend/react-forms': patch
+'@talend/http': patch
+'@talend/icons': patch
+'@talend/json-schema-form-core': patch
+'@talend/local-libs-webpack-plugin': patch
+'@talend/router-bridge': patch
+'@talend/react-sagas': patch
+'@talend/react-stepper': patch
+'@talend/react-storybook-cmf': patch
+'@talend/bootstrap-theme': patch
+'@talend/utils': patch
+---
+
+fix(workspace-run): package run order

--- a/workspace-run.js
+++ b/workspace-run.js
@@ -59,7 +59,7 @@ const scriptArgs = process.argv.slice(3);
 
 function consume(cmds) {
 	if (cmds.length > 0) {
-		const cmd = cmds.pop();
+		const cmd = cmds.shift();
 		run(cmd, { verbose: true })
 			.then(() => consume(cmds))
 			.catch(() => {
@@ -94,9 +94,7 @@ run({ name: 'yarn', args: ['workspaces', '--silent', 'info'] })
 					// to do that, we find the dependencies index, and put the command after the last dependency (max index)
 					let packagePlace = 0;
 					if (workspaceDependencies.length) {
-						const depsIndexes = workspaceDependencies.map(dep =>
-							Math.max(packages.indexOf(dep), 0),
-						);
+						const depsIndexes = workspaceDependencies.map(dep => packages.indexOf(dep));
 						packagePlace = Math.max(...depsIndexes) + 1;
 					}
 
@@ -108,6 +106,7 @@ run({ name: 'yarn', args: ['workspaces', '--silent', 'info'] })
 			},
 			{ commands: [], packages: [] },
 		);
+		console.log(orderedWorkspaceInfo);
 		consume(orderedWorkspaceInfo.commands);
 	})
 	.catch(e => {

--- a/workspace-run.js
+++ b/workspace-run.js
@@ -106,7 +106,6 @@ run({ name: 'yarn', args: ['workspaces', '--silent', 'info'] })
 			},
 			{ commands: [], packages: [] },
 		);
-		console.log(orderedWorkspaceInfo);
 		consume(orderedWorkspaceInfo.commands);
 	})
 	.catch(e => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`workspace-run.js` oder the commands depending on the packages workspace dependencies.
But the run takes them from the last to first.

**What is the chosen solution to this problem?**
Fix the order, run the first command first.

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
