### PR TITLE
chore: remove build warning

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2810,9 +2810,9 @@
     typeface-source-sans-pro "^1.1.13"
 
 "@talend/dynamic-cdn-webpack-plugin@^9.7.7":
-  version "9.7.9"
-  resolved "https://registry.yarnpkg.com/@talend/dynamic-cdn-webpack-plugin/-/dynamic-cdn-webpack-plugin-9.7.9.tgz#8b495372ee2aecb17cee8274522370ea9f3da62a"
-  integrity sha512-83q/SvglnmV+zmzHxFFcbWB7PyYyiA9/DfjkR9VohuWAm82YecEB8NKH8Qb6t/TghLXKZrtdJP0fy2gy9+dyfg==
+  version "9.7.11"
+  resolved "https://registry.yarnpkg.com/@talend/dynamic-cdn-webpack-plugin/-/dynamic-cdn-webpack-plugin-9.7.11.tgz#18a55b5bd88076b9eac1009be7aea42c049e0fad"
+  integrity sha512-beSq/3TBW2ClGsvtelNKDXaAIINKlSn8bFhFtK5HZTac84y/M+H0Qp7xtO/ov3Pm1YGu3d2momdrNz/logMokA==
   dependencies:
     "@talend/module-to-cdn" "^9.7.1"
     read-pkg-up "^7.0.1"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Lots of those warnings
```
WARNING in Conflict: Multiple assets emit different content to the same filename xxx.dependencies.json
```

**What is the chosen solution to this problem?**
Upgrade `@talend/dynamic-cdn-webpack-plugin` that fixed the issue

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
