### PR TITLE
feat(components): add custom xpath props support

### DIFF
--- a/.changeset/spicy-weeks-flash.md
+++ b/.changeset/spicy-weeks-flash.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-components': minor
+'@talend/react-forms': minor
+---
+
+Add custom xpath props support for listView, MultiselectTag, Bage components

--- a/packages/components/src/Badge/Badge.component.js
+++ b/packages/components/src/Badge/Badge.component.js
@@ -83,6 +83,7 @@ function Badge({
 	white,
 	type,
 	dropdown,
+	dataTest,
 }) {
 	const displayClass =
 		display === SIZES.small ? 'tc-badge-display-small' : 'tc-badge-display-large';
@@ -106,7 +107,7 @@ function Badge({
 	};
 
 	return (
-		<div className={containerClasses} style={style}>
+		<div className={containerClasses} style={style} data-test={dataTest}>
 			<BadgeType {...badgeProps} disabled={disabled} onSelect={onSelect}>
 				{!children ? (
 					<DefaultBadge
@@ -144,6 +145,7 @@ Badge.propTypes = {
 	white: PropTypes.bool,
 	type: PropTypes.oneOf(Object.values(TYPES)),
 	dropdown: PropTypes.object,
+	dataTest: PropTypes.string,
 };
 Badge.displayName = 'Badge';
 Badge.SIZES = SIZES;

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -79,10 +79,13 @@ class Item extends Component {
 						</>
 					}
 					aria-label={ariaLabel}
-					data-test={`${dataTest}.checkbox`}
+					data-test={dataTest && `${dataTest}.checkbox`}
 				/>
 				{children && (
-					<div className={classNames('checkbox-nested-expand', { expanded: item.expanded })} data-test={`${dataTest}.checkbox-nested-expand`}>
+					<div
+						className={classNames('checkbox-nested-expand', { expanded: item.expanded })}
+						data-test={dataTest && `${dataTest}.checkbox-nested-expand`}
+					>
 						<Action
 							bsStyle="link"
 							icon="talend-caret-down"

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -21,7 +21,7 @@ class Item extends Component {
 	}
 
 	render() {
-		const { id, item, parentItem, isSwitchBox, searchCriteria, children, t } = this.props;
+		const { id, item, parentItem, isSwitchBox, searchCriteria, children, dataTest, t } = this.props;
 
 		/**
 		 * This function allow to get component rendering based on searchCriteria
@@ -53,7 +53,6 @@ class Item extends Component {
 				? t('TC_LISTVIEW_COLLAPSE', { defaultValue: 'Collapse {{ value }}', value: item.label })
 				: t('TC_LISTVIEW_EXPAND', { defaultValue: 'Expand {{ value }}', value: item.label });
 		}
-
 		return (
 			<div
 				id={id}
@@ -61,6 +60,7 @@ class Item extends Component {
 				key={item.index}
 				role="option"
 				aria-selected={item.checked}
+				data-test={dataTest}
 			>
 				<Checkbox
 					id={itemId}
@@ -79,9 +79,10 @@ class Item extends Component {
 						</>
 					}
 					aria-label={ariaLabel}
+					data-test={`${dataTest}.checkbox`}
 				/>
 				{children && (
-					<div className={classNames('checkbox-nested-expand', { expanded: item.expanded })}>
+					<div className={classNames('checkbox-nested-expand', { expanded: item.expanded })} data-test={`${dataTest}.checkbox-nested-expand`}>
 						<Action
 							bsStyle="link"
 							icon="talend-caret-down"

--- a/packages/components/src/ListView/Items/Item/Item.propTypes.js
+++ b/packages/components/src/ListView/Items/Item/Item.propTypes.js
@@ -8,4 +8,5 @@ export default {
 	onChange: PropTypes.func,
 	measure: PropTypes.func,
 	icon: PropTypes.shape(Icon.propTypes),
+	dataTest: PropTypes.string,
 };

--- a/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
+++ b/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
@@ -4,6 +4,7 @@ exports[`Item should display a selected item 1`] = `
 <div
   aria-selected={true}
   className="checkbox"
+  data-test="item"
   id="0-item"
   role="option"
 >
@@ -17,7 +18,7 @@ exports[`Item should display a selected item 1`] = `
         aria-label="Deselect toto"
         checked={true}
         data-checked={2}
-        data-test="undefined.checkbox"
+        data-test="item.checkbox"
         id="checkbox-0-item"
         onChange={[Function]}
         type="checkbox"

--- a/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
+++ b/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
@@ -17,6 +17,7 @@ exports[`Item should display a selected item 1`] = `
         aria-label="Deselect toto"
         checked={true}
         data-checked={2}
+        data-test="undefined.checkbox"
         id="checkbox-0-item"
         onChange={[Function]}
         type="checkbox"

--- a/packages/components/src/ListView/Items/Item/item.snapshot.test.js
+++ b/packages/components/src/ListView/Items/Item/item.snapshot.test.js
@@ -13,7 +13,7 @@ describe('Item', () => {
 		const props = {
 			id: '0-item',
 			item: selectedItem,
-			dataTest:'item',
+			dataTest: 'item',
 		};
 
 		// when

--- a/packages/components/src/ListView/Items/Item/item.snapshot.test.js
+++ b/packages/components/src/ListView/Items/Item/item.snapshot.test.js
@@ -13,6 +13,7 @@ describe('Item', () => {
 		const props = {
 			id: '0-item',
 			item: selectedItem,
+			dataTest:'item',
 		};
 
 		// when

--- a/packages/components/src/ListView/Items/Items.component.js
+++ b/packages/components/src/ListView/Items/Items.component.js
@@ -182,6 +182,7 @@ export class ItemsComponent extends React.PureComponent {
 				item={item}
 				isSwitchBox={this.props.isSwitchBox && !item.children}
 				searchCriteria={this.props.searchCriteria}
+				dataTest={`${this.props.dataTest}-${index}`}
 			>
 				{item.children &&
 					item.children.map((nestedItem, nestedIndex) => (
@@ -191,6 +192,7 @@ export class ItemsComponent extends React.PureComponent {
 							item={nestedItem}
 							parentItem={item}
 							searchCriteria={this.props.searchCriteria}
+							dataTest={`${this.props.dataTest}.nested-${nestedIndex}`}
 						/>
 					))}
 			</Item>
@@ -247,6 +249,7 @@ ItemsComponent.propTypes = {
 	toggleAllChecked: PropTypes.bool,
 	showToggleAll: PropTypes.bool,
 	onToggleAll: PropTypes.func,
+	dataTest: PropTypes.string,
 	t: PropTypes.func,
 };
 

--- a/packages/components/src/ListView/Items/Items.component.js
+++ b/packages/components/src/ListView/Items/Items.component.js
@@ -168,6 +168,7 @@ export class ItemsComponent extends React.PureComponent {
 	}
 
 	renderItem(item, index, measure) {
+		const { dataTest } = this.props;
 		let computedId;
 		if (this.props.id) {
 			const computedIndex = this.hasToggleAll ? index + 1 : index;
@@ -182,7 +183,7 @@ export class ItemsComponent extends React.PureComponent {
 				item={item}
 				isSwitchBox={this.props.isSwitchBox && !item.children}
 				searchCriteria={this.props.searchCriteria}
-				dataTest={`${this.props.dataTest}-${index}`}
+				dataTest={dataTest && `${dataTest}-${index}`}
 			>
 				{item.children &&
 					item.children.map((nestedItem, nestedIndex) => (
@@ -192,7 +193,7 @@ export class ItemsComponent extends React.PureComponent {
 							item={nestedItem}
 							parentItem={item}
 							searchCriteria={this.props.searchCriteria}
-							dataTest={`${this.props.dataTest}.nested-${nestedIndex}`}
+							dataTest={dataTest && `${dataTest}.nested-${nestedIndex}`}
 						/>
 					))}
 			</Item>

--- a/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
+++ b/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`Items should render 1`] = `
 <withI18nextTranslation(ItemsComponent)
+  dataTest="item"
   getItemHeight={[Function]}
   isSwitchBox={false}
   items={
@@ -273,7 +274,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-0"
+                      dataTest="item-0"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -285,12 +286,12 @@ exports[`Items should render 1`] = `
                     >
                       <div
                         className="checkbox"
-                        data-test="undefined-0"
+                        data-test="item-0"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
-                          data-test="undefined-0.checkbox"
+                          data-test="item-0.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 0
@@ -305,7 +306,7 @@ exports[`Items should render 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 0"
                                 data-checked={0}
-                                data-test="undefined-0.checkbox"
+                                data-test="item-0.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -372,7 +373,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-1"
+                      dataTest="item-1"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -386,13 +387,13 @@ exports[`Items should render 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox"
-                        data-test="undefined-1"
+                        data-test="item-1"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
-                          data-test="undefined-1.checkbox"
+                          data-test="item-1.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 1
@@ -408,7 +409,7 @@ exports[`Items should render 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor sit amet 1"
                                 checked={true}
                                 data-checked={2}
-                                data-test="undefined-1.checkbox"
+                                data-test="item-1.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -475,7 +476,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-2"
+                      dataTest="item-2"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -487,12 +488,12 @@ exports[`Items should render 1`] = `
                     >
                       <div
                         className="checkbox"
-                        data-test="undefined-2"
+                        data-test="item-2"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
-                          data-test="undefined-2.checkbox"
+                          data-test="item-2.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 2
@@ -507,7 +508,7 @@ exports[`Items should render 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 2"
                                 data-checked={0}
-                                data-test="undefined-2.checkbox"
+                                data-test="item-2.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -533,6 +534,7 @@ exports[`Items should render 1`] = `
 
 exports[`Items should render with nested items 1`] = `
 <withI18nextTranslation(ItemsComponent)
+  dataTest="item"
   getItemHeight={[Function]}
   isSwitchBox={false}
   items={
@@ -825,7 +827,7 @@ exports[`Items should render with nested items 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-0"
+                      dataTest="item-0"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -837,12 +839,12 @@ exports[`Items should render with nested items 1`] = `
                     >
                       <div
                         className="checkbox"
-                        data-test="undefined-0"
+                        data-test="item-0"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor default"
-                          data-test="undefined-0.checkbox"
+                          data-test="item-0.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor default
@@ -857,7 +859,7 @@ exports[`Items should render with nested items 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor default"
                                 data-checked={0}
-                                data-test="undefined-0.checkbox"
+                                data-test="item-0.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -921,7 +923,7 @@ exports[`Items should render with nested items 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-1"
+                      dataTest="item-1"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -947,13 +949,13 @@ exports[`Items should render with nested items 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox switch-nested"
-                        data-test="undefined-1"
+                        data-test="item-1"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor Parent"
                           checked={true}
-                          data-test="undefined-1.checkbox"
+                          data-test="item-1.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor Parent
@@ -969,7 +971,7 @@ exports[`Items should render with nested items 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor Parent"
                                 checked={true}
                                 data-checked={2}
-                                data-test="undefined-1.checkbox"
+                                data-test="item-1.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -981,7 +983,7 @@ exports[`Items should render with nested items 1`] = `
                         </Checkbox>
                         <div
                           className="checkbox-nested-expand"
-                          data-test="undefined-1.checkbox-nested-expand"
+                          data-test="item-1.checkbox-nested-expand"
                         >
                           <Action
                             bsStyle="link"
@@ -1071,6 +1073,7 @@ exports[`Items should render with nested items 1`] = `
 
 exports[`Items should render with provided id 1`] = `
 <withI18nextTranslation(ItemsComponent)
+  dataTest="item"
   getItemHeight={[Function]}
   id="my-widget"
   isSwitchBox={false}
@@ -1343,7 +1346,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-0"
+                      dataTest="item-0"
                       id="my-widget-1-item"
                       isSwitchBox={false}
                       item={
@@ -1357,13 +1360,13 @@ exports[`Items should render with provided id 1`] = `
                     >
                       <div
                         className="checkbox"
-                        data-test="undefined-0"
+                        data-test="item-0"
                         id="my-widget-1-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
-                          data-test="undefined-0.checkbox"
+                          data-test="item-0.checkbox"
                           id="checkbox-my-widget-1-item"
                           label={
                             <React.Fragment>
@@ -1381,7 +1384,7 @@ exports[`Items should render with provided id 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 0"
                                 data-checked={0}
-                                data-test="undefined-0.checkbox"
+                                data-test="item-0.checkbox"
                                 id="checkbox-my-widget-1-item"
                                 onChange={[Function]}
                                 type="checkbox"
@@ -1449,7 +1452,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-1"
+                      dataTest="item-1"
                       id="my-widget-2-item"
                       isSwitchBox={false}
                       item={
@@ -1465,14 +1468,14 @@ exports[`Items should render with provided id 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox"
-                        data-test="undefined-1"
+                        data-test="item-1"
                         id="my-widget-2-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
-                          data-test="undefined-1.checkbox"
+                          data-test="item-1.checkbox"
                           id="checkbox-my-widget-2-item"
                           label={
                             <React.Fragment>
@@ -1491,7 +1494,7 @@ exports[`Items should render with provided id 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor sit amet 1"
                                 checked={true}
                                 data-checked={2}
-                                data-test="undefined-1.checkbox"
+                                data-test="item-1.checkbox"
                                 id="checkbox-my-widget-2-item"
                                 onChange={[Function]}
                                 type="checkbox"
@@ -1559,7 +1562,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
-                      dataTest="undefined-2"
+                      dataTest="item-2"
                       id="my-widget-3-item"
                       isSwitchBox={false}
                       item={
@@ -1573,13 +1576,13 @@ exports[`Items should render with provided id 1`] = `
                     >
                       <div
                         className="checkbox"
-                        data-test="undefined-2"
+                        data-test="item-2"
                         id="my-widget-3-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
-                          data-test="undefined-2.checkbox"
+                          data-test="item-2.checkbox"
                           id="checkbox-my-widget-3-item"
                           label={
                             <React.Fragment>
@@ -1597,7 +1600,7 @@ exports[`Items should render with provided id 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 2"
                                 data-checked={0}
-                                data-test="undefined-2.checkbox"
+                                data-test="item-2.checkbox"
                                 id="checkbox-my-widget-3-item"
                                 onChange={[Function]}
                                 type="checkbox"

--- a/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
+++ b/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
@@ -273,6 +273,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-0"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -284,10 +285,12 @@ exports[`Items should render 1`] = `
                     >
                       <div
                         className="checkbox"
+                        data-test="undefined-0"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
+                          data-test="undefined-0.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 0
@@ -302,6 +305,7 @@ exports[`Items should render 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 0"
                                 data-checked={0}
+                                data-test="undefined-0.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -368,6 +372,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-1"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -381,11 +386,13 @@ exports[`Items should render 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox"
+                        data-test="undefined-1"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
+                          data-test="undefined-1.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 1
@@ -401,6 +408,7 @@ exports[`Items should render 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor sit amet 1"
                                 checked={true}
                                 data-checked={2}
+                                data-test="undefined-1.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -467,6 +475,7 @@ exports[`Items should render 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-2"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -478,10 +487,12 @@ exports[`Items should render 1`] = `
                     >
                       <div
                         className="checkbox"
+                        data-test="undefined-2"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
+                          data-test="undefined-2.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor sit amet 2
@@ -496,6 +507,7 @@ exports[`Items should render 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 2"
                                 data-checked={0}
+                                data-test="undefined-2.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -813,6 +825,7 @@ exports[`Items should render with nested items 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-0"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -824,10 +837,12 @@ exports[`Items should render with nested items 1`] = `
                     >
                       <div
                         className="checkbox"
+                        data-test="undefined-0"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor default"
+                          data-test="undefined-0.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor default
@@ -842,6 +857,7 @@ exports[`Items should render with nested items 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor default"
                                 data-checked={0}
+                                data-test="undefined-0.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -905,6 +921,7 @@ exports[`Items should render with nested items 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-1"
                       isSwitchBox={false}
                       item={
                         Object {
@@ -930,11 +947,13 @@ exports[`Items should render with nested items 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox switch-nested"
+                        data-test="undefined-1"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor Parent"
                           checked={true}
+                          data-test="undefined-1.checkbox"
                           label={
                             <React.Fragment>
                               Lorem ipsum dolor Parent
@@ -950,6 +969,7 @@ exports[`Items should render with nested items 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor Parent"
                                 checked={true}
                                 data-checked={2}
+                                data-test="undefined-1.checkbox"
                                 onChange={[Function]}
                                 type="checkbox"
                               />
@@ -961,6 +981,7 @@ exports[`Items should render with nested items 1`] = `
                         </Checkbox>
                         <div
                           className="checkbox-nested-expand"
+                          data-test="undefined-1.checkbox-nested-expand"
                         >
                           <Action
                             bsStyle="link"
@@ -1322,6 +1343,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-0"
                       id="my-widget-1-item"
                       isSwitchBox={false}
                       item={
@@ -1335,11 +1357,13 @@ exports[`Items should render with provided id 1`] = `
                     >
                       <div
                         className="checkbox"
+                        data-test="undefined-0"
                         id="my-widget-1-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 0"
+                          data-test="undefined-0.checkbox"
                           id="checkbox-my-widget-1-item"
                           label={
                             <React.Fragment>
@@ -1357,6 +1381,7 @@ exports[`Items should render with provided id 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 0"
                                 data-checked={0}
+                                data-test="undefined-0.checkbox"
                                 id="checkbox-my-widget-1-item"
                                 onChange={[Function]}
                                 type="checkbox"
@@ -1424,6 +1449,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-1"
                       id="my-widget-2-item"
                       isSwitchBox={false}
                       item={
@@ -1439,12 +1465,14 @@ exports[`Items should render with provided id 1`] = `
                       <div
                         aria-selected={true}
                         className="checkbox"
+                        data-test="undefined-1"
                         id="my-widget-2-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Deselect Lorem ipsum dolor sit amet 1"
                           checked={true}
+                          data-test="undefined-1.checkbox"
                           id="checkbox-my-widget-2-item"
                           label={
                             <React.Fragment>
@@ -1463,6 +1491,7 @@ exports[`Items should render with provided id 1`] = `
                                 aria-label="Deselect Lorem ipsum dolor sit amet 1"
                                 checked={true}
                                 data-checked={2}
+                                data-test="undefined-1.checkbox"
                                 id="checkbox-my-widget-2-item"
                                 onChange={[Function]}
                                 type="checkbox"
@@ -1530,6 +1559,7 @@ exports[`Items should render with provided id 1`] = `
                     }
                   >
                     <withI18nextTranslation(Item)
+                      dataTest="undefined-2"
                       id="my-widget-3-item"
                       isSwitchBox={false}
                       item={
@@ -1543,11 +1573,13 @@ exports[`Items should render with provided id 1`] = `
                     >
                       <div
                         className="checkbox"
+                        data-test="undefined-2"
                         id="my-widget-3-item"
                         role="option"
                       >
                         <Checkbox
                           aria-label="Select Lorem ipsum dolor sit amet 2"
+                          data-test="undefined-2.checkbox"
                           id="checkbox-my-widget-3-item"
                           label={
                             <React.Fragment>
@@ -1565,6 +1597,7 @@ exports[`Items should render with provided id 1`] = `
                               <input
                                 aria-label="Select Lorem ipsum dolor sit amet 2"
                                 data-checked={0}
+                                data-test="undefined-2.checkbox"
                                 id="checkbox-my-widget-3-item"
                                 onChange={[Function]}
                                 type="checkbox"

--- a/packages/components/src/ListView/Items/items.test.js
+++ b/packages/components/src/ListView/Items/items.test.js
@@ -15,6 +15,7 @@ describe('Items', () => {
 			{ label: 'Lorem ipsum dolor sit amet 1', checked: true },
 			{ label: 'Lorem ipsum dolor sit amet 2' },
 		],
+		dataTest:'item',
 		getItemHeight: () => 42,
 	};
 
@@ -23,6 +24,7 @@ describe('Items', () => {
 			{ label: 'Lorem ipsum dolor default' },
 			{ label: 'Lorem ipsum dolor Parent', checked: true, children: props.items },
 		],
+		dataTest:'item',
 		getItemHeight: () => 42,
 	};
 

--- a/packages/components/src/ListView/ListView.component.js
+++ b/packages/components/src/ListView/ListView.component.js
@@ -93,6 +93,7 @@ HeaderListView.propTypes = {
 	headerDefault: PropTypes.arrayOf(PropTypes.object),
 	headerInput: PropTypes.arrayOf(PropTypes.object),
 	headerLabel: PropTypes.string,
+	labelProps: PropTypes.object,
 	items: ListView.propTypes.items,
 	onInputChange: PropTypes.func,
 	onAddKeyDown: PropTypes.func,

--- a/packages/components/src/ListView/ListView.stories.js
+++ b/packages/components/src/ListView/ListView.stories.js
@@ -24,6 +24,7 @@ const props = {
 	headerLabel: 'Choose wisely',
 	toggleAllChecked: false,
 	onToggleAll: action('onToggleAll'),
+	dataTest: 'item',
 };
 
 const searchProps = {
@@ -110,6 +111,7 @@ const withNestedItems = {
 	toggleAllChecked: false,
 	onToggleAll: action('onToggleAll'),
 	showToggleAll: false,
+	dataTest: 'item',
 };
 
 const withIconProps = {

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -28,7 +28,7 @@ class Photos extends React.Component {
 			<section style={{ margin: 20 }}>
 				<form className="form">
 					<div className="form-group">
-						{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}}
+						{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
 						<label className="control-label" htmlFor="storybook">
 							photos
 						</label>
@@ -40,7 +40,7 @@ class Photos extends React.Component {
 						/>
 					</div>
 					<div className="form-group">
-						{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}}
+						{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
 						<label className="control-label" htmlFor="useless">
 							another
 						</label>

--- a/packages/forms/src/UIForm/fields/ListView/ListView.component.js
+++ b/packages/forms/src/UIForm/fields/ListView/ListView.component.js
@@ -195,6 +195,7 @@ class ListViewWidget extends React.Component {
 					items={this.state.displayedItems}
 					t={this.props.t}
 					containerProps={{ 'aria-describedby': `${descriptionId} ${errorId}` }}
+					dataTest={this.props.schema.dataTest}
 				/>
 			</FieldTemplate>
 		);
@@ -219,6 +220,7 @@ if (process.env.NODE_ENV !== 'production') {
 			required: PropTypes.bool,
 			title: PropTypes.string,
 			labelProps: PropTypes.object,
+			dataTest: PropTypes.string,
 			titleMap: PropTypes.arrayOf(
 				PropTypes.shape({
 					name: PropTypes.string.isRequired,

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -244,7 +244,7 @@ export default class MultiSelectTag extends React.Component {
 				<div className={`${theme.wrapper} form-control`}>
 					{this.props.value.map((val, index) => {
 						const label = getLabel(this.getTitleMap(), val, names[index]);
-						const badgeProps = { label, key: index, dataTest: `${schema.dataTest || 'multiselectTag'}.${index}` };
+						const badgeProps = { label, key: index, dataTest: schema.dataTest && `${schema.dataTest}.${index}`};
 						if (!schema.readOnly && !schema.disabled) {
 							badgeProps.onDelete = event => this.onRemoveTag(event, index);
 						}

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -244,7 +244,7 @@ export default class MultiSelectTag extends React.Component {
 				<div className={`${theme.wrapper} form-control`}>
 					{this.props.value.map((val, index) => {
 						const label = getLabel(this.getTitleMap(), val, names[index]);
-						const badgeProps = { label, key: index, dataTest: `${this.schema.dataTest}.${index}` };
+						const badgeProps = { label, key: index, dataTest: `${schema.dataTest}.${index}` };
 						if (!schema.readOnly && !schema.disabled) {
 							badgeProps.onDelete = event => this.onRemoveTag(event, index);
 						}
@@ -305,6 +305,7 @@ if (process.env.NODE_ENV !== 'production') {
 			restricted: PropTypes.bool,
 			title: PropTypes.string,
 			labelProps: PropTypes.object,
+			dataTest: PropTypes.string,
 			titleMap: PropTypes.arrayOf(
 				PropTypes.shape({
 					name: PropTypes.string.isRequired,

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -244,7 +244,7 @@ export default class MultiSelectTag extends React.Component {
 				<div className={`${theme.wrapper} form-control`}>
 					{this.props.value.map((val, index) => {
 						const label = getLabel(this.getTitleMap(), val, names[index]);
-						const badgeProps = { label, key: index, dataTest: `${schema.dataTest}.${index}` };
+						const badgeProps = { label, key: index, dataTest: `${schema.dataTest || 'multiselectTag'}.${index}` };
 						if (!schema.readOnly && !schema.disabled) {
 							badgeProps.onDelete = event => this.onRemoveTag(event, index);
 						}

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.js
@@ -244,7 +244,7 @@ export default class MultiSelectTag extends React.Component {
 				<div className={`${theme.wrapper} form-control`}>
 					{this.props.value.map((val, index) => {
 						const label = getLabel(this.getTitleMap(), val, names[index]);
-						const badgeProps = { label, key: index };
+						const badgeProps = { label, key: index, dataTest: `${this.schema.dataTest}.${index}` };
 						if (!schema.readOnly && !schema.disabled) {
 							badgeProps.onDelete = event => this.onRemoveTag(event, index);
 						}

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.component.test.js
@@ -29,6 +29,7 @@ describe('MultiSelectTag field', () => {
 				{ name: 'toto', value: 'titi' },
 				{ name: 'tata', value: 'tutu' },
 			],
+			dataTest: 'item',
 		},
 		value: ['aze', 'tutu'],
 	};

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/__snapshots__/MultiSelectTag.component.test.js.snap
@@ -15,10 +15,12 @@ exports[`MultiSelectTag field should render MultiSelectTag 1`] = `
     className="theme-wrapper form-control"
   >
     <Badge
+      dataTest="item.0"
       label="aze"
       onDelete={[Function]}
     />
     <Badge
+      dataTest="item.1"
       label="tata"
       onDelete={[Function]}
     />

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
@@ -230,6 +230,8 @@ class NestedListViewWidget extends React.Component {
 						labelProps={schema.labelProps}
 						required={schema.required}
 						searchPlaceholder={schema.placeholder}
+						dataTest={schema.dataTest}
+						dataTestNested={schema.dataTestNested}
 						showToggleAll={false}
 					/>
 				</FieldTemplate>
@@ -258,6 +260,8 @@ if (process.env.NODE_ENV !== 'production') {
 			required: PropTypes.bool,
 			title: PropTypes.string,
 			labelProps: PropTypes.object,
+			dataTest: PropTypes.string,
+			dataTestNested: PropTypes.string,
 			autosize: PropTypes.bool,
 		}),
 		value: PropTypes.object,

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
@@ -230,7 +230,7 @@ class NestedListViewWidget extends React.Component {
 						labelProps={schema.labelProps}
 						required={schema.required}
 						searchPlaceholder={schema.placeholder}
-						dataTest={schema.dataTest || 'listView'}
+						dataTest={schema.dataTest}
 						showToggleAll={false}
 					/>
 				</FieldTemplate>

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
@@ -230,7 +230,7 @@ class NestedListViewWidget extends React.Component {
 						labelProps={schema.labelProps}
 						required={schema.required}
 						searchPlaceholder={schema.placeholder}
-						dataTest={schema.dataTest}
+						dataTest={schema.dataTest || 'listView'}
 						showToggleAll={false}
 					/>
 				</FieldTemplate>

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.component.js
@@ -231,7 +231,6 @@ class NestedListViewWidget extends React.Component {
 						required={schema.required}
 						searchPlaceholder={schema.placeholder}
 						dataTest={schema.dataTest}
-						dataTestNested={schema.dataTestNested}
 						showToggleAll={false}
 					/>
 				</FieldTemplate>
@@ -261,7 +260,6 @@ if (process.env.NODE_ENV !== 'production') {
 			title: PropTypes.string,
 			labelProps: PropTypes.object,
 			dataTest: PropTypes.string,
-			dataTestNested: PropTypes.string,
 			autosize: PropTypes.bool,
 		}),
 		value: PropTypes.object,

--- a/packages/forms/src/UIForm/fields/NestedListView/__snapshots__/NestedListView.test.js.snap
+++ b/packages/forms/src/UIForm/fields/NestedListView/__snapshots__/NestedListView.test.js.snap
@@ -11,7 +11,6 @@ exports[`NestedListView component should render component 1`] = `
     isValid={true}
   >
     <ListView
-      dataTest="listView"
       displayedItems={
         Array [
           Object {

--- a/packages/forms/src/UIForm/fields/NestedListView/__snapshots__/NestedListView.test.js.snap
+++ b/packages/forms/src/UIForm/fields/NestedListView/__snapshots__/NestedListView.test.js.snap
@@ -11,6 +11,7 @@ exports[`NestedListView component should render component 1`] = `
     isValid={true}
   >
     <ListView
+      dataTest="listView"
       displayedItems={
         Array [
           Object {

--- a/packages/forms/stories-core/json/fields/core-multiSelectTag.json
+++ b/packages/forms/stories-core/json/fields/core-multiSelectTag.json
@@ -100,6 +100,7 @@
       "restricted": true,
       "title": "Select your favorite movies from the list",
       "widget": "multiSelectTag",
+      "dataTest": "item",
       "titleMap": [
         {
           "name": "The Dark Knight",

--- a/packages/forms/stories-core/json/fields/core-nestedListView.json
+++ b/packages/forms/stories-core/json/fields/core-nestedListView.json
@@ -40,6 +40,7 @@
 			"title": "Food",
 			"widget": "nestedListView",
 			"autosize": true,
+			"dataTest": "item",
 			"items": [
 				{
 					"key": "food.fruits",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add custom xpath props support for listView, MultiselectTag, Bage components
https://jira.talendforge.org/browse/TDOPS-659

**What is the chosen solution to this problem?**
Add a new property -  dataTest

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
