### PR TITLE
chore: Use latest @talend/react-components everywhere

### DIFF
--- a/.changeset/curvy-eels-sip.md
+++ b/.changeset/curvy-eels-sip.md
@@ -1,0 +1,8 @@
+---
+'@talend/react-containers': patch
+'@talend/react-datagrid': patch
+'@talend/react-dataviz': patch
+'@talend/react-stepper': patch
+---
+
+chore: Use latest @talend/react-components everywhere

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -33,7 +33,7 @@
   },
   "dependencies": {
     "@talend/react-cmf": "^6.38.3",
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "@talend/react-forms": "^6.39.2",
     "classnames": "^2.2.5",
     "immutable": "^3.8.1",

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@talend/icons": "^6.36.2",
     "@talend/react-cmf": "^6.38.3",
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "ag-grid-community": "^25.1.0",
     "ag-grid-react": "^25.1.0",
     "classnames": "^2.3.1",
@@ -51,7 +51,7 @@
     "@talend/icons": "^6.36.2",
     "@talend/locales-tui": "^6.36.0",
     "@talend/react-cmf": "^6.38.3",
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "@talend/react-storybook-cmf": "^6.36.2",
     "@talend/scripts-core": "^11.0.1",
     "@talend/scripts-preset-react-lib": "^9.9.1",

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -36,7 +36,7 @@
     "url": "https://github.com/Talend/ui.git"
   },
   "dependencies": {
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "classnames": "^2.2.6",
     "d3": "^6.5.0",
     "date-fns": "^2.16.1",
@@ -55,7 +55,7 @@
     "@talend/icons": "^6.36.2",
     "@talend/locales-tui": "^6.36.0",
     "@talend/locales-tui-dataviz": "^0.4.4",
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "@talend/scripts-core": "^11.0.1",
     "@talend/scripts-preset-react-lib": "^9.9.1",
     "@types/classnames": "^2.2.11",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -33,7 +33,7 @@
     "url": "https://github.com/Talend/ui.git"
   },
   "dependencies": {
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "classnames": "^2.2.5",
     "invariant": "^2.2.2",
     "keycode": "^2.2.0",
@@ -45,7 +45,7 @@
     "@storybook/addons": "^6.3.7",
     "@storybook/react": "^6.3.7",
     "@talend/icons": "^6.36.2",
-    "@talend/react-components": "^6.39.2",
+    "@talend/react-components": "^6.39.4",
     "@talend/scripts-core": "^11.0.1",
     "@talend/scripts-preset-react-lib": "^9.9.1",
     "babel-loader": "^8.1.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When trying to use latest version of `@talend/react-components` and `@talend/react-forms` (for example) in a project, we end up with several versions of the same libs (`@talend/react-components`, `@talend/design-system` for example).
`@talend/react-forms` (and other packages) still reference a previous release of `@talend/react-components`.

**What is the chosen solution to this problem?**
Bump it everywhere

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
