### PR TITLE
fix(IconToggle/Drawer/Slider/ObjectViewer): calc with sass vars

### DIFF
--- a/.changeset/gold-ghosts-laugh.md
+++ b/.changeset/gold-ghosts-laugh.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(IconToggle): calc with sass vars

--- a/.changeset/gold-ghosts-laugh.md
+++ b/.changeset/gold-ghosts-laugh.md
@@ -2,4 +2,4 @@
 '@talend/react-components': patch
 ---
 
-fix(IconToggle): calc with sass vars
+fix(IconToggle/Drawer/Slider/ObjectViewer): calc with sass vars

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.scss
@@ -7,7 +7,7 @@ $tc-icon-toggle-tick-border: 1px solid $white;
 @mixin tc-icon-toggle($btn-size: $tc-icon-toggle-size, $icon-size: $tc-icon-toggle-icon-size) {
 	height: $btn-size;
 	width: $btn-size;
-	border-radius: calc($btn-size / 2);
+	border-radius: calc(#{$btn-size} / 2);
 
 	svg {
 		height: $icon-size;
@@ -80,7 +80,7 @@ $tc-icon-toggle-tick-border: 1px solid $white;
 		position: absolute;
 		width: $tc-icon-toggle-tick-size;
 		height: $tc-icon-toggle-tick-size;
-		border-radius: calc($tc-icon-toggle-tick-size / 2);
+		border-radius: calc(#{$tc-icon-toggle-tick-size} / 2);
 		right: -0.4rem;
 		top: -0.4rem;
 		background: $scooter;

--- a/packages/components/src/Drawer/Drawer.scss
+++ b/packages/components/src/Drawer/Drawer.scss
@@ -118,7 +118,7 @@ $tc-drawer-z-index: $drawer-z-index !default;
 		.drawer-close-action-tooltip {
 			position: absolute;
 			right: 0;
-			bottom: calc($tc-drawer-padding / 2);
+			bottom: calc(#{$tc-drawer-padding} / 2);
 		}
 
 		> .tc-editable-text {

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.scss
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.scss
@@ -138,7 +138,7 @@
 			background-color: rgba($brand-primary, 0.3);
 			color: $brand-primary;
 			font-size: 1rem;
-			padding: calc($padding-smaller / 2) $padding-smaller;
+			padding: calc(#{$padding-smaller} / 2) $padding-smaller;
 			display: inline-table;
 		}
 	}

--- a/packages/components/src/Slider/Slider.scss
+++ b/packages/components/src/Slider/Slider.scss
@@ -20,7 +20,7 @@ $tc-slider-line-height: 24px;
 }
 
 .tc-slider {
-	padding: 0 calc($tc-slider-line-height / 2);
+	padding: 0 calc(#{$tc-slider-line-height} / 2);
 
 	:global(.rc-slider-disabled) {
 		background-color: transparent;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With the switch from division to calc, there are some sass variables not interpreted.
It results in css output like `calc($btn-size / 2)` which is invalid css.

**What is the chosen solution to this problem?**
Interpret the var to output the value in resulting css

**Please check if the PR fulfills these requirements**

* [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
