### PR TITLE
chore: adapt i18n workflow to independant packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,11 +44,10 @@ hs_err_pid*
 
 # Talend web apps build directory
 build/
-/i18n/
+/packages/*/i18n/
 tmp/
 lib/
 storybook-static/
 dist/
-i18n-extract/
 eslint-report.json
 stylelint-report.json

--- a/package.json
+++ b/package.json
@@ -23,13 +23,7 @@
     "start-stepper": "yarn workspace  @talend/react-stepper run start",
     "start-forms": "yarn workspace  @talend/react-forms run start",
     "start-theme": "yarn workspace @talend/bootstrap-theme run start",
-    "changelog": "git log --pretty=\"format:%C(bold green)%ad%C(reset) %s\" --date=short --color",
-    "extract-i18n": "npm run extract-i18n-components && npm run extract-i18n-forms && npm run extract-i18n-containers && npm run extract-i18n-datagrid",
-    "extract-i18n-components": "i18next-scanner --config packages/components/i18next-scanner.config.js 'packages/components/src/**/*.js' '!packages/components/src/**/*.stories.js'",
-    "extract-i18n-forms": "i18next-scanner --config packages/forms/i18next-scanner.config.js 'packages/forms/src/**/*.js' '!packages/forms/src/**/*.stories.js'",
-    "extract-i18n-containers": "i18next-scanner --config packages/containers/i18next-scanner.config.js 'packages/containers/src/**/*.js' '!packages/containers/src/**/*.stories.js'",
-    "extract-i18n-datagrid": "i18next-scanner --config packages/datagrid/i18next-scanner.config.js 'packages/datagrid/src/**/*.js' '!packages/datagrid/src/**/*.stories.js'",
-    "extract-i18n-stepper": "i18next-scanner --config packages/stepper/i18next-scanner.config.js 'packages/stepper/src/**/*.js' '!packages/stepper/src/**/*.stories.js'"
+    "changelog": "git log --pretty=\"format:%C(bold green)%ad%C(reset) %s\" --date=short --color"
   },
   "repository": {
     "type": "git",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -16,7 +16,8 @@
     "lint:style": "talend-scripts lint:style -f json -o stylelint-report.json",
     "lint:es": "talend-scripts lint:es --format json -o eslint-report.json",
     "lint": "yarn lint:es && yarn lint:style",
-    "start": "start-storybook -p 6006"
+    "start": "start-storybook -p 6006",
+    "extract-i18n": "i18next-scanner --config i18next-scanner.config.js 'src/**/*.js' '!src/**/*.stories.js'"
   },
   "keywords": [
     "react",

--- a/packages/components/talend-i18n.json
+++ b/packages/components/talend-i18n.json
@@ -1,0 +1,17 @@
+{
+  "extract": {
+    "method": "yarn",
+    "script": "extract-i18n",
+    "target": "./i18n"
+  },
+  "load": {
+    "project": "TUI-components",
+    "template": "TUI"
+  },
+  "github": {
+    "url": "https://github.com/Talend/i18n-product.git"
+  },
+  "module": {
+    "type": "npm"
+  }
+}

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -14,7 +14,8 @@
     "test:watch": "talend-scripts test --watch",
     "test:cov": "talend-scripts test --coverage",
     "test:demo": "build-storybook",
-    "lint:es": "talend-scripts lint:es --format json -o eslint-report.json"
+    "lint:es": "talend-scripts lint:es --format json -o eslint-report.json",
+    "extract-i18n": "i18next-scanner --config i18next-scanner.config.js 'src/**/*.js' '!src/**/*.stories.js'"
   },
   "keywords": [
     "react",

--- a/packages/containers/talend-i18n.json
+++ b/packages/containers/talend-i18n.json
@@ -5,7 +5,8 @@
     "target": "./i18n"
   },
   "load": {
-    "project": "TUI"
+    "project": "TUI-containers",
+    "template": "TUI"
   },
   "github": {
     "url": "https://github.com/Talend/i18n-product.git"

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -17,7 +17,8 @@
     "test:demo": "build-storybook",
     "lint": "yarn lint:es && yarn lint:style",
     "lint:es": "talend-scripts lint:es --format json -o eslint-report.json",
-    "lint:style": "talend-scripts lint:style -f json -o stylelint-report.json"
+    "lint:style": "talend-scripts lint:style -f json -o stylelint-report.json",
+    "extract-i18n": "i18next-scanner --config i18next-scanner.config.js 'src/**/*.js' '!src/**/*.stories.js'"
   },
   "keywords": [
     "react",

--- a/packages/datagrid/talend-i18n.json
+++ b/packages/datagrid/talend-i18n.json
@@ -1,0 +1,17 @@
+{
+  "extract": {
+    "method": "yarn",
+    "script": "extract-i18n",
+    "target": "./i18n"
+  },
+  "load": {
+    "project": "TUI-datagrid",
+    "template": "TUI"
+  },
+  "github": {
+    "url": "https://github.com/Talend/i18n-product.git"
+  },
+  "module": {
+    "type": "npm"
+  }
+}

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -16,7 +16,8 @@
     "lint:es": "talend-scripts lint:es --format json -o eslint-report.json --ignore-pattern deprecated",
     "lint:style": "talend-scripts lint:style -f json -o stylelint-report.json",
     "lint": "yarn run lint:es && yarn run lint:style",
-    "start": "start-storybook -p 6008"
+    "start": "start-storybook -p 6008",
+    "extract-i18n": "i18next-scanner --config i18next-scanner.config.js 'src/**/*.js' '!src/**/*.stories.js'"
   },
   "keywords": [
     "react",

--- a/packages/forms/talend-i18n.json
+++ b/packages/forms/talend-i18n.json
@@ -1,0 +1,17 @@
+{
+  "extract": {
+    "method": "yarn",
+    "script": "extract-i18n",
+    "target": "./i18n"
+  },
+  "load": {
+    "project": "TUI-forms",
+    "template": "TUI"
+  },
+  "github": {
+    "url": "https://github.com/Talend/i18n-product.git"
+  },
+  "module": {
+    "type": "npm"
+  }
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TUI i18n handles 4 packages that are now independants.

**What is the chosen solution to this problem?*
Split the TUI workflow into 4 parts.

**Please check if the PR fulfills these requirements**

* [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
* [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
* [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
* [ ] Docs have been added / updated (for bug fixes / features)
* [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
