### PR TITLE
fix(cmf): doc

### DIFF
--- a/packages/cmf/website/package.json
+++ b/packages/cmf/website/package.json
@@ -7,9 +7,8 @@
     "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
-    "examples": "docusaurus-examples",
     "start": "cross-env NODE_ENV=development docusaurus-start",
-    "build": "docusaurus-build",
+    "prepare": "docusaurus-build",
     "publish-gh-pages": "docusaurus-publish",
     "write-translations": "docusaurus-write-translations",
     "version": "docusaurus-version",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current surge is 404: https://talend.surge.sh/cmf
because the test:demo npm script of cmf do not trigger the website build

**What is the chosen solution to this problem?**

use prepare npm script in website folder so the yarn command trigger the build
fixed http://3484.talend.surge.sh/cmf/

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
