### PR TITLE
fix(TDOPS-1135/components) - label for displaying total columns

### DIFF
--- a/.changeset/great-squids-dress.md
+++ b/.changeset/great-squids-dress.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix Column chooser label for displaying total columns

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.js
@@ -13,7 +13,8 @@ const Default = () => {
 	const { columns, t } = useColumnChooserContext();
 	const selectedColumns = t('SELECT_COLUMNS', {
 		count: columns.filter(isVisible).length,
-		defaultValue: `{{count}}/${columns.length} selected`,
+		total: columns.length,
+		defaultValue: '{{count}}/{{total}} selected',
 	});
 	return (
 		<div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Total of column is missing on column chooser
https://jira.talendforge.org/browse/TDOPS-1135

**What is the chosen solution to this problem?**
Fix label for displaying total columns

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
