### PR TITLE
fix(TDOPS-1135/components) - default value on title remains unchanged

### DIFF
--- a/.changeset/rude-bees-notice.md
+++ b/.changeset/rude-bees-notice.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Fix column chooser default label for displaying selected columns

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.js
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserHeader/ColumnChooserHeader.component.js
@@ -12,9 +12,9 @@ const isVisible = column => column.visible;
 const Default = () => {
 	const { columns, t } = useColumnChooserContext();
 	const selectedColumns = t('SELECT_COLUMNS', {
-		count: columns.filter(isVisible).length,
+		checked: columns.filter(isVisible).length,
 		total: columns.length,
-		defaultValue: '{{count}}/{{total}} selected',
+		defaultValue: '{{checked}}/{{total}} selected',
 	});
 	return (
 		<div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Default value text is not picked up by the xtm

https://github.com/Talend/ui/pull/3487/files#diff-870ec3f1edfbb98610e8665f4681069464fde29407901ae1b09d963535235d67R17

https://jira.talendforge.org/browse/TDOPS-1135

**What is the chosen solution to this problem?**
Change default value text and attributes

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
