### PR TITLE
fix(VirtualizedList): Checkbox should not be wrapped in a form

### DIFF
--- a/.changeset/violet-bikes-approve.md
+++ b/.changeset/violet-bikes-approve.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+List checkbox should not be wrapped in a form

--- a/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.component.js
+++ b/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.component.js
@@ -25,7 +25,7 @@ class CellCheckbox extends React.Component {
 		const type = selectionMode === SELECTION_MODE.SINGLE ? 'radio' : 'checkbox';
 
 		return (
-			<form className={classnames('tc-list-checkbox', theme['tc-list-checkbox'])}>
+			<div className={classnames('tc-list-checkbox', theme['tc-list-checkbox'])}>
 				<div className="checkbox">
 					<label htmlFor={id && `${id}-${rowIndex}-check`}>
 						<input
@@ -42,7 +42,7 @@ class CellCheckbox extends React.Component {
 						</span>
 					</label>
 				</div>
-			</form>
+			</div>
 		);
 	}
 }

--- a/packages/components/src/VirtualizedList/CellCheckbox/__snapshots__/CellCheckbox.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellCheckbox/__snapshots__/CellCheckbox.test.js.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`CellActions should render checked checkbox 1`] = `
-<form
+<div
   className="tc-list-checkbox theme-tc-list-checkbox"
 >
   <div
@@ -28,11 +28,11 @@ exports[`CellActions should render checked checkbox 1`] = `
       </span>
     </label>
   </div>
-</form>
+</div>
 `;
 
 exports[`CellActions should render radio button 1`] = `
-<form
+<div
   className="tc-list-checkbox theme-tc-list-checkbox"
 >
   <div
@@ -59,11 +59,11 @@ exports[`CellActions should render radio button 1`] = `
       </span>
     </label>
   </div>
-</form>
+</div>
 `;
 
 exports[`CellActions should render unchecked checkbox 1`] = `
-<form
+<div
   className="tc-list-checkbox theme-tc-list-checkbox"
 >
   <div
@@ -90,5 +90,5 @@ exports[`CellActions should render unchecked checkbox 1`] = `
       </span>
     </label>
   </div>
-</form>
+</div>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Each line has its own form which doesn't make sense. E mbedding a list in an outer form is generating an invalid markup (forms can' be nested)

![image](https://user-images.githubusercontent.com/58977230/138674670-cdee47f2-d5f9-4803-bb00-8fe88ce77b83.png)

**What is the chosen solution to this problem?**

List should be nested in an outer form, and lines should not render forms.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
