### PR TITLE
fix(forms/Fieldset): Some widgets are no longer rendered

### DIFF
--- a/.changeset/rotten-donkeys-ring.md
+++ b/.changeset/rotten-donkeys-ring.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+Missing fieldset widgets

--- a/packages/forms/src/UIForm/fieldsets/Fieldset/Fieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Fieldset/Fieldset.component.js
@@ -9,7 +9,7 @@ export default function Fieldset(props) {
 	const { title, items, options } = schema;
 
 	const widgets = items
-		.filter((itemSchema, index) => shouldRender(itemSchema.condition, itemSchema.properties, index))
+		.filter((itemSchema, index) => shouldRender(itemSchema.condition, props.properties, index))
 		.map((itemSchema, index) => <Widget {...restProps} key={index} schema={itemSchema} />);
 
 	return widgets.length ? (
@@ -31,5 +31,6 @@ if (process.env.NODE_ENV !== 'production') {
 				hideTitle: PropTypes.bool,
 			}),
 		}).isRequired,
+		properties: PropTypes.object,
 	};
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Form properties are not provided to `shouldRender` function => conditions are not correctly evaluated

![image](https://user-images.githubusercontent.com/58977230/139080555-2e52a628-ad7d-4629-8eb4-277b6e437054.png)


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
