### PR TITLE
feat(router-bridge): share saga router

### DIFF
--- a/.changeset/late-deers-rule.md
+++ b/.changeset/late-deers-rule.md
@@ -1,0 +1,5 @@
+---
+'@talend/router-bridge': major
+---
+
+feat: add saga router compatible with react-router v5

--- a/packages/router-bridge/package.json
+++ b/packages/router-bridge/package.json
@@ -4,11 +4,8 @@
   "description": "Bridge on top of cmf-router or react-router v5 + connected-react-router",
   "main": "lib/index.js",
   "scripts": {
-    "build:dev": "talend-scripts build:lib:umd --dev",
-    "build:prod": "talend-scripts build:lib:umd --prod",
-    "pre-release": "yarn build:dev && yarn build:prod",
-    "build:lib": "talend-scripts build:lib",
-    "build": "talend-scripts build:lib",
+    "pre-release": "yarn build",
+    "build": "talend-scripts build:ts:lib",
     "test": "talend-scripts test",
     "test:demo": "echo nothing to do"
   },
@@ -20,16 +17,26 @@
   "license": "ISC",
   "homepage": "https://github.com/ui/tree/master/packages/router-bridge#readme",
   "devDependencies": {
-    "@talend/scripts-core": "^11.2.0",
+    "@types/lodash": "^4.14.176",
+    "@types/react": "^16.14.20",
+    "@types/react-router-dom": "^5.3.2",
+    "@talend/react-cmf": "^6.38.4",
+    "@talend/scripts-core": "^11.3.0",
     "@talend/scripts-preset-react-lib": "^9.9.3",
     "connected-react-router": "^6.9.1",
     "history": "^5.1.0",
+    "lodash": "^4.17.21",
     "react": "^16.14.0",
+    "redux-saga": "^0.15.6",
     "react-router-dom": "^5.3.0"
   },
   "peerDependencies": {
+    "@talend/react-cmf": ">= 6.38.4",
     "connected-react-router": "^6.9.1",
-    "react-router-dom": "^5.2.0"
+    "lodash": "^4.17.21",
+    "react": "^16.14.0",
+    "react-router-dom": "^5.2.0",
+    "redux-saga": "^0.15.6"
   },
   "peerDependenciesMeta": {
     "connected-react-router": {

--- a/packages/router-bridge/src/index.js
+++ b/packages/router-bridge/src/index.js
@@ -1,5 +1,6 @@
 import { history, Switch, Route, Router, Link, Redirect, useParams, useRouteMatch } from './router';
 import { push, replace } from './redux';
+import { getSagaRouterModule } from './sagaRouter';
 
 export {
 	// react router v5 only, otherwise those are empty functions or components
@@ -14,4 +15,6 @@ export {
 	// bridge to connected-react-router or cmf-router
 	push,
 	replace,
+	// Saga router
+	getSagaRouterModule,
 };

--- a/packages/router-bridge/src/sagaRouter/index.ts
+++ b/packages/router-bridge/src/sagaRouter/index.ts
@@ -1,0 +1,1 @@
+export { getSagaRouterModule } from './module';

--- a/packages/router-bridge/src/sagaRouter/module.tsx
+++ b/packages/router-bridge/src/sagaRouter/module.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { Router } from 'react-router-dom';
+
+import { connectRouter, routerMiddleware, ConnectedRouter } from 'connected-react-router';
+import { fork, takeLatest } from 'redux-saga/effects';
+
+import cmf from '@talend/react-cmf';
+import { sagaRouter, SAGA_ROUTER_HISTORY_CHANGE } from './sagaRouter';
+
+const { history }: { history: any } = require('../router');
+
+const mergeConfig = {
+	history: cmf.module.merge.getUnique,
+	sagaRouterConfig: cmf.module.merge.mergeObjects,
+	titleRouterConfig: cmf.module.merge.mergeObjects,
+	routerFunctions: cmf.module.merge.mergeObjects,
+	startOnAction: cmf.module.merge.getUnique,
+};
+
+function mergeRouterConfig(...configs: any[]) {
+	// eslint-disable-next-line @typescript-eslint/no-unsafe-return
+	return configs.reduce(cmf.module.merge.getReduceConfig(mergeConfig), {});
+}
+
+export const getSagaRouterModule = (...args: any[]): any => {
+	const options = mergeRouterConfig(...args);
+	function* saga() {
+		let routerStarted = false;
+		if (options.sagaRouterConfig) {
+			if (options.startOnAction) {
+				yield takeLatest(options.startOnAction, function* startRouter() {
+					if (!routerStarted) {
+						yield fork(sagaRouter, history, options.sagaRouterConfig);
+						routerStarted = true;
+					}
+				});
+			} else {
+				yield fork(sagaRouter, history, options.sagaRouterConfig);
+			}
+		}
+	}
+
+	return {
+		id: 'react-router-saga-bridge',
+		reducer: {
+			router: connectRouter(history),
+		},
+		saga,
+		storeCallback: (store: { dispatch: (action: any) => void }) => {
+			history.listen(() => store.dispatch({ type: SAGA_ROUTER_HISTORY_CHANGE }));
+		},
+		middlewares: [routerMiddleware(history)],
+		RootComponent: (props: any) => (
+			<ConnectedRouter history={history}>
+				<Router {...props} history={history} />
+			</ConnectedRouter>
+		),
+	};
+};

--- a/packages/router-bridge/src/sagaRouter/sagaRouter.test.ts
+++ b/packages/router-bridge/src/sagaRouter/sagaRouter.test.ts
@@ -1,0 +1,270 @@
+import { spawn, take, cancel } from 'redux-saga/effects';
+import { createMockTask } from 'redux-saga/utils';
+
+import { sagaRouter, SAGA_ROUTER_HISTORY_CHANGE } from './sagaRouter';
+
+describe('sagaRouter RouteChange', () => {
+	it(`start the configured saga if route equals current location, additionnaly add a second param
+	to the started saga set to 'true'`, () => {
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute',
+			},
+		};
+		const routes: any = {
+			'/matchingroute': function* matchingSaga(_: any, isExact: boolean) {
+				if (isExact) {
+					yield take('SOMETHING');
+				}
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(spawn(routes['/matchingroute'], {}, true));
+		expect(gen.next().value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+	});
+
+	it(`start the configured  saga if route is a fragment of current location additionnaly add a second param
+		to the started saga set to 'false'`, () => {
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute/childroute',
+			},
+		};
+		const routes: any = {
+			'/matchingroute': function* matchingSaga(notused: any, isExact: boolean) {
+				if (isExact) {
+					yield take('NOT_DISPATCHED');
+				}
+				yield take('SOMETHING');
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(spawn(routes['/matchingroute'], {}, false));
+	});
+
+	it('keep running a saga if its route is a fragment of the new route', () => {
+		const mockTask = createMockTask();
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute',
+			},
+		};
+		const routes: any = {
+			'/matchingroute': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(spawn(routes['/matchingroute'], {}, true));
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		// since the saga should be kept running the router to be able to handle a new route change
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(
+			take(SAGA_ROUTER_HISTORY_CHANGE),
+		);
+	});
+
+	it("stop the saga if its route don't match the current location", () => {
+		const mockTask = createMockTask();
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute',
+			},
+		};
+		const routes: any = {
+			'/matchingroute': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(spawn(routes['/matchingroute'], {}, true));
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		mockHistory.location.pathname = '/noMatching';
+		const expectedCancelYield = cancel(mockTask);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(expectedCancelYield);
+	});
+
+	it('stop unmatched saga before spawning new ones, no matter the declaration order', () => {
+		const mockTask = createMockTask();
+
+		const mockHistory: any = {
+			location: {
+				pathname: '/toCancelFirst',
+			},
+		};
+
+		// mockHistory.location.pathname = '/toStartAfter';
+
+		const routes: any = {
+			'/toStartAfter': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+			'/toCancelFirst': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(spawn(routes['/toCancelFirst'], {}, true));
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		mockHistory.location.pathname = '/toStartAfter';
+		const expectedCancelYield = cancel(mockTask);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(expectedCancelYield);
+
+		const alternateRoutes: any = {
+			'/toCancelFirst': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+			'/toStartAfter': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		mockHistory.location.pathname = '/toCancelFirst';
+
+		const anotherGen = sagaRouter(mockHistory, alternateRoutes);
+		expect(anotherGen.next().value).toEqual(spawn(alternateRoutes['/toCancelFirst'], {}, true));
+		expect(anotherGen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		const anotherExpectedCancelYield = cancel(mockTask);
+		mockHistory.location.pathname = '/toStartAfter';
+		expect(anotherGen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(
+			anotherExpectedCancelYield,
+		);
+	});
+
+	it('stop a saga with "runOnExactMatch" parameter if its route is a fragment of the new route', () => {
+		// GIVEN
+		const mockTask = createMockTask();
+		const routes: any = {
+			'/resources': {
+				runOnExactMatch: true,
+				saga: function* resourcesSaga(params: any, isExact: boolean) {
+					if (isExact) {
+						yield take('SOMETHING');
+					}
+				},
+			},
+			'/resources/action': function* resourcesActionSaga() {
+				yield take('SOMETHING');
+			},
+		};
+
+		const mockHistory: any = {
+			location: {
+				pathname: '/resources',
+			},
+		};
+
+		// WHEN
+		const gen = sagaRouter(mockHistory, routes);
+		// EXPECT
+		expect(gen.next().value).toEqual(spawn(routes['/resources'].saga, {}, true));
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		mockHistory.location.pathname = '/resources/action';
+		const expectedCancelYield = cancel(mockTask);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(expectedCancelYield);
+	});
+
+	it(`does not start the configured saga with 'runOnExactMatch' parameter,
+		if route is a fragment of current location`, () => {
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute/childroute',
+			},
+		};
+		const routes: any = {
+			'/matchingroute': {
+				runOnExactMatch: true,
+				saga: function* matchingSaga(notused: any, isExact: boolean) {
+					if (isExact) {
+						yield take('NOT_DISPATCHED');
+					}
+					yield take('SOMETHING');
+				},
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next().value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(
+			take(SAGA_ROUTER_HISTORY_CHANGE),
+		);
+	});
+
+	it('restart a saga with `restartOnRouteChange` parameter if the route it was matched on is now a subset of another location', () => {
+		// GIVEN
+		const mockTask = createMockTask();
+		const routes: any = {
+			'/resources': {
+				restartOnRouteChange: true,
+				saga: function* resourcesSaga(params: any, isExact: boolean) {
+					if (isExact) {
+						yield take('SOMETHING');
+					}
+				},
+			},
+			'/resources/action': function* resourcesActionSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		const mockHistory: any = {
+			location: {
+				pathname: '/resources',
+			},
+		};
+
+		// WHEN
+		const gen = sagaRouter(mockHistory, routes);
+		// EXPECT
+		expect(gen.next().value).toEqual(spawn(routes['/resources'].saga, {}, true));
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		// if saga restarted, it will cancel it first and then start it.
+		mockHistory.location.pathname = '/resources/action';
+		const expectedCancelYield = cancel(mockTask);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(expectedCancelYield);
+		expect(gen.next().value).toEqual(spawn(routes['/resources'].saga, {}, false));
+	});
+
+	describe('sagaRouter route and route params', () => {
+		it('route params should be given to target saga as object', () => {
+			const mockHistory: any = {
+				location: {
+					pathname: '/matchingroute/anId',
+				},
+			};
+
+			const routes: any = {
+				'/matchingroute/:id': function* matchingSaga() {
+					yield take('SOMETHING');
+				},
+			};
+			const gen = sagaRouter(mockHistory, routes);
+
+			expect(gen.next().value).toEqual(spawn(routes['/matchingroute/:id'], { id: 'anId' }, true));
+			expect(gen.next().value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		});
+	});
+
+	it('if route params change, then matchings sagas should be cancel and restarted', () => {
+		const mockTask = createMockTask();
+
+		const mockHistory: any = {
+			location: {
+				pathname: '/matchingroute/anId',
+			},
+		};
+
+		const routes: any = {
+			'/matchingroute/:id': function* matchingSaga() {
+				yield take('SOMETHING');
+			},
+		};
+		const gen = sagaRouter(mockHistory, routes);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(
+			spawn(routes['/matchingroute/:id'], { id: 'anId' }, true),
+		);
+		expect(gen.next(mockTask).value).toEqual(take(SAGA_ROUTER_HISTORY_CHANGE));
+		mockHistory.location.pathname = '/matchingroute/anotherId';
+		const expectedCancelYield = cancel(mockTask);
+		expect(gen.next({ type: SAGA_ROUTER_HISTORY_CHANGE }).value).toEqual(expectedCancelYield);
+		expect(gen.next().value).toEqual(
+			spawn(routes['/matchingroute/:id'], { id: 'anotherId' }, true),
+		);
+	});
+});

--- a/packages/router-bridge/src/sagaRouter/sagaRouter.ts
+++ b/packages/router-bridge/src/sagaRouter/sagaRouter.ts
@@ -1,0 +1,174 @@
+/**
+ * @module react-cmf/lib/sagaRouter
+ * @example
+ *	import { sagaRouter } from '@talend/react-cmf';
+ *	import { browserHistory as history } from 'react-router';
+
+ *	const CANCEL_ACTION = 'CANCEL_ACTION';
+ *	// route configuration, a url fragment match with a generator
+ *	const routes = {
+ *		"/datasets/add": function* addDataset() {
+ *			yield take(CANCEL_ACTION);
+ *			yield put({
+ *				type: REDIRECT_ADD_DATASET_CANCEL,
+ *				cmf: {
+ *					routerReplace: "/datasets"
+ *				}
+ *			});
+ *		},
+ *		"/connections/:datastoreId/edit/add-dataset": function* addDataset({
+ *			datastoreId
+ *		}) {
+ *			yield take(CANCEL_ACTION);
+ *			yield put({
+ *				type: REDIRECT_CONNECTION_ADD_DATASET_CANCEL,
+ *				cmf: {
+ *					routerReplace: `/connections/${datastoreId}/edit`
+ *				}
+ *			});
+ *		}
+ *	};
+ *	// router saga is spawned and given router history, and route configuration
+ *	yield spawn(routerSaga, history, routes);
+ */
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { History } from 'history';
+import isEqual from 'lodash/isEqual';
+import { Task } from 'redux-saga';
+import { spawn, take, cancel } from 'redux-saga/effects';
+
+import cmf from '@talend/react-cmf';
+
+export interface Location {
+	pathname: string;
+}
+
+export interface RunningTasks {
+	[key: string]: MaybeSaga;
+}
+
+export interface RouteParams {
+	[key: string]: number;
+}
+
+export interface Match {
+	path: string;
+	url: string;
+	isExact: boolean;
+	params: RouteParams;
+}
+
+export interface MaybeSaga {
+	saga: Task;
+	match: Match;
+}
+
+export interface RouteSaga {
+	saga: MaybeSaga;
+	params: RouteParams;
+	runOnExactMatch: boolean;
+	restartOnRouteChange: boolean;
+}
+
+export interface RoutesConfig {
+	[key: string]: RouteSaga;
+}
+
+/**
+ * Determine if a saga should be restarted with the following rules :
+ */
+function shouldStartSaga(maybeSaga: MaybeSaga, match: Match, routeSaga: RouteSaga) {
+	if (match) {
+		if (!maybeSaga || (maybeSaga && maybeSaga.saga && !maybeSaga.saga.isRunning())) {
+			if (routeSaga.runOnExactMatch === true) {
+				return match.isExact;
+			}
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Determine if a saga should be canceled with the following rules :
+ */
+function shouldCancelSaga(maybeSaga: MaybeSaga, match: Match, routeSaga: RouteSaga) {
+	if (maybeSaga && maybeSaga.saga.isRunning()) {
+		if (!match || routeSaga.runOnExactMatch === true) {
+			return true;
+		}
+	}
+	return false;
+}
+
+/**
+ * Determine if a saga should be restarted with the following rules:
+ */
+function shouldRestartSaga(maybeSaga: MaybeSaga, match: Match, routeSaga: RouteSaga) {
+	if (match) {
+		if (maybeSaga) {
+			if (
+				routeSaga.restartOnRouteChange === true ||
+				!isEqual(maybeSaga.match.params, match.params)
+			) {
+				return true;
+			}
+		}
+	}
+	return false;
+}
+
+/**
+ * for a route a list of running saga and current location return a
+ * match object and a saga
+ */
+function parseSagaState(routeFragment: string, sagas: RunningTasks, currentLocation: Location) {
+	return {
+		match: cmf.router.matchPath(currentLocation.pathname, { path: routeFragment }),
+		maybeSaga: sagas[routeFragment],
+	};
+}
+
+export const SAGA_ROUTER_HISTORY_CHANGE = 'SAGA_ROUTER_HISTORY_CHANGE';
+/**
+ * responsible to start and cancel saga based on application current url,
+ * restart saga if necessary
+ * @param {object} history - react router history
+ * @param {RoutesConfig} routes
+ */
+export function* sagaRouter(history: History, routes: RoutesConfig): any {
+	const sagas: RunningTasks = {};
+	const routeFragments = Object.keys(routes);
+	while (true) {
+		const shouldStart = [];
+		const currentLocation = history.location;
+		for (let index = 0; index < routeFragments.length; ) {
+			const routeFragment = routeFragments[index];
+			const routeSaga = routes[routeFragment];
+			const { match, maybeSaga } = parseSagaState(routeFragment, sagas, currentLocation);
+			if (shouldCancelSaga(maybeSaga, match, routeSaga)) {
+				yield cancel(maybeSaga.saga);
+			} else if (shouldRestartSaga(maybeSaga, match, routeSaga)) {
+				yield cancel(maybeSaga.saga);
+				shouldStart.push({ routeFragment, match });
+			} else if (shouldStartSaga(maybeSaga, match, routeSaga)) {
+				shouldStart.push({ routeFragment, match });
+			}
+			index += 1;
+		}
+		for (let index = 0; index < shouldStart.length; ) {
+			const { routeFragment, match } = shouldStart[index];
+			let routeSaga: RouteSaga | MaybeSaga = routes[routeFragment];
+			if (typeof routes[routeFragment] === 'object') {
+				routeSaga = routes[routeFragment].saga;
+			}
+			sagas[routeFragment] = {
+				saga: yield spawn(routeSaga as any, match.params, match?.isExact),
+				match,
+			} as MaybeSaga;
+			index += 1;
+		}
+
+		yield take(SAGA_ROUTER_HISTORY_CHANGE);
+	}
+}

--- a/packages/router-bridge/src/talend.d.ts
+++ b/packages/router-bridge/src/talend.d.ts
@@ -1,0 +1,1 @@
+declare module '@talend/react-cmf';

--- a/packages/router-bridge/tsconfig.json
+++ b/packages/router-bridge/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../node_modules/@talend/scripts-config-typescript/tsconfig.json",
+  "include": ["src"],
+  "exclude": ["dist", "node_modules"],
+  "compilerOptions": {}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2972,27 +2972,7 @@
   resolved "https://registry.yarnpkg.com/@talend/scripts-config-typescript/-/scripts-config-typescript-9.11.1.tgz#3311d212bb386ca1b4cf957756559a8262534279"
   integrity sha512-MJm2pLV9ZbFKnpT7wrs+rAqTedfhxjyB3EHzsDvVfoF1MnZgZuEWM0NBYfEBlAOYF5f9lDKsO3KyQ3VzPSQajA==
 
-"@talend/scripts-core@^11.2.0":
-  version "11.2.0"
-  resolved "https://registry.yarnpkg.com/@talend/scripts-core/-/scripts-core-11.2.0.tgz#3a96f33e137a3dbe8b2d923e66f3a898db8822af"
-  integrity sha512-CKMQ1EOM0m2YFrNyBBtlLtWzHAPOhs1LX2MKfcSqXaDcTwc9YobvqRZqfbyg70BBSbcb62jClH4+ho1fSKBm7A==
-  dependencies:
-    "@babel/cli" "^7.14.8"
-    "@babel/core" "^7.15.0"
-    "@talend/upgrade-deps" "^1.1.0"
-    cpx2 "^3.0.2"
-    cross-spawn "^7.0.3"
-    lodash.get "^4.4.2"
-    lodash.template "^4.5.0"
-    rimraf "^3.0.2"
-    typescript "^4.4.2"
-    webpack-cli "^4.8.0"
-    webpack-dev-server "^4.2.0"
-    webpack-merge "^4.2.2"
-    which "^2.0.2"
-    yargs "^15.4.1"
-
-"@talend/scripts-core@^11.3.0":
+"@talend/scripts-core@^11.2.0", "@talend/scripts-core@^11.3.0":
   version "11.3.0"
   resolved "https://registry.yarnpkg.com/@talend/scripts-core/-/scripts-core-11.3.0.tgz#4098d9db20f69cfd668b41e7b94954b938eda185"
   integrity sha512-JbluWijNvMk3uV7agD4Qkx0PouYt1rXELM4rgfWg2VMSbymcQAui770+E3ueDeIWD9sV/56P7oUwkU542hG4Ow==
@@ -3040,17 +3020,7 @@
     "@talend/scripts-config-stylelint" "^1.0.1"
     "@talend/scripts-config-typescript" "^9.11.1"
 
-"@talend/upgrade-deps@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@talend/upgrade-deps/-/upgrade-deps-1.1.0.tgz#06ec4aef60530ae22e3d84827779d7a1bdb9dc44"
-  integrity sha512-oJx70efBuXgPUVvHLc4VbiqErVfYe6jEH+lfGTkxAuWFCVbOX9ivYowGAyRQVPyQQhLQs6ywXAj4sCH9EF8nIA==
-  dependencies:
-    "@yarnpkg/lockfile" "^1.1.0"
-    colors "^1.4.0"
-    semver "^7.3.5"
-    yarn-deduplicate "^3.1.0"
-
-"@talend/upgrade-deps@^1.2.0":
+"@talend/upgrade-deps@^1.1.0", "@talend/upgrade-deps@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@talend/upgrade-deps/-/upgrade-deps-1.2.0.tgz#5adf7a8783fa3e52a668616ee17e2d20640ac8cb"
   integrity sha512-mzubeFvgCJJ1YrAIVxBYfJkoSJV059fGVHJAS0Q7P38OgWhHJ/tjy/nmonEFn2lZBM06XWwd8pJjM8V8jnO3/g==

--- a/yarn.lock
+++ b/yarn.lock
@@ -2992,6 +2992,26 @@
     which "^2.0.2"
     yargs "^15.4.1"
 
+"@talend/scripts-core@^11.3.0":
+  version "11.3.0"
+  resolved "https://registry.yarnpkg.com/@talend/scripts-core/-/scripts-core-11.3.0.tgz#4098d9db20f69cfd668b41e7b94954b938eda185"
+  integrity sha512-JbluWijNvMk3uV7agD4Qkx0PouYt1rXELM4rgfWg2VMSbymcQAui770+E3ueDeIWD9sV/56P7oUwkU542hG4Ow==
+  dependencies:
+    "@babel/cli" "^7.14.8"
+    "@babel/core" "^7.15.0"
+    "@talend/upgrade-deps" "^1.2.0"
+    cpx2 "^3.0.2"
+    cross-spawn "^7.0.3"
+    lodash.get "^4.4.2"
+    lodash.template "^4.5.0"
+    rimraf "^3.0.2"
+    typescript "^4.4.2"
+    webpack-cli "^4.8.0"
+    webpack-dev-server "^4.2.0"
+    webpack-merge "^4.2.2"
+    which "^2.0.2"
+    yargs "^15.4.1"
+
 "@talend/scripts-preset-react-lib@^9.9.3":
   version "9.9.3"
   resolved "https://registry.yarnpkg.com/@talend/scripts-preset-react-lib/-/scripts-preset-react-lib-9.9.3.tgz#15be5518c1790ede65ed19721cf6d74524025dc8"
@@ -3028,6 +3048,17 @@
     "@yarnpkg/lockfile" "^1.1.0"
     colors "^1.4.0"
     semver "^7.3.5"
+    yarn-deduplicate "^3.1.0"
+
+"@talend/upgrade-deps@^1.2.0":
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/@talend/upgrade-deps/-/upgrade-deps-1.2.0.tgz#5adf7a8783fa3e52a668616ee17e2d20640ac8cb"
+  integrity sha512-mzubeFvgCJJ1YrAIVxBYfJkoSJV059fGVHJAS0Q7P38OgWhHJ/tjy/nmonEFn2lZBM06XWwd8pJjM8V8jnO3/g==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    colors "^1.4.0"
+    semver "^7.3.5"
+    strip-ansi "^6.0.0"
     yarn-deduplicate "^3.1.0"
 
 "@tootallnate/once@1":
@@ -3386,6 +3417,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/history@*":
+  version "4.7.9"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.9.tgz#1cfb6d60ef3822c589f18e70f8b12f9a28ce8724"
+  integrity sha512-MUc6zSmU3tEVnkQ78q0peeEjKWPUADMlC/t++2bI8WnAG2tvYRPIgHG8lWkXwqc8MsUF6Z2MOf+Mh5sazOmhiQ==
+
 "@types/html-minifier-terser@^5.0.0":
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/@types/html-minifier-terser/-/html-minifier-terser-5.1.2.tgz#693b316ad323ea97eed6b38ed1a3cc02b1672b57"
@@ -3583,6 +3619,23 @@
   dependencies:
     "@types/react" "*"
     redux "^3.6.0"
+
+"@types/react-router-dom@^5.3.2":
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.2.tgz#ebd8e145cf056db5c66eb1dac63c72f52e8542ee"
+  integrity sha512-ELEYRUie2czuJzaZ5+ziIp9Hhw+juEw8b7C11YNA4QdLCVbQ3qLi2l4aq8XnlqM7V31LZX8dxUuFUCrzHm6sqQ==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.17"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.17.tgz#087091006213b11042f39570e5cd414863693968"
+  integrity sha512-RNSXOyb3VyRs/EOGmjBhhGKTbnN6fHWvy5FNLzWfOWOGjgVUKqJZXfpKzLmgoU8h6Hj8mpALj/mbXQASOb92wQ==
+  dependencies:
+    "@types/history" "*"
+    "@types/react" "*"
 
 "@types/react-syntax-highlighter@11.0.5":
   version "11.0.5"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The current saga-router is only compatible with react-cmf-router and with the react-router v3.

**What is the chosen solution to this problem?**
For the projects that want to move on react-router v5, it would be nice to have a common one instead of copying pasting it in each project

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
