### PR TITLE
fix(components/ObjectViewer): i18n - add translation for colon

### DIFF
--- a/.changeset/khaki-clocks-cry.md
+++ b/.changeset/khaki-clocks-cry.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+i18n - add translation for colon

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -201,6 +201,7 @@ LineItem.propTypes = {
 	type: PropTypes.string,
 	value: PropTypes.node,
 	isValueOverflown: PropTypes.bool,
+	t: PropTypes.func,
 };
 
 /**

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -81,7 +81,7 @@ export function getJSONPath(key, prefix, type) {
 	return `${prefix}['${key}']`;
 }
 
-function getName(name, t) {
+export function getName(name, t) {
 	if (!name) {
 		return null;
 	}

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -492,6 +492,7 @@ export function Item(props) {
 }
 
 Item.propTypes = {
+	opened: PropTypes.arrayOf(PropTypes.string),
 	data: PropTypes.oneOfType([
 		PropTypes.bool,
 		PropTypes.number,

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.component.js
@@ -81,13 +81,14 @@ export function getJSONPath(key, prefix, type) {
 	return `${prefix}['${key}']`;
 }
 
-function getName(name) {
+function getName(name, t) {
 	if (!name) {
 		return null;
 	}
 	return (
 		<span key="name" className={theme.key}>
-			{name}:
+			{name}
+			{t('COLON', { defaultValue: ':' })}
 		</span>
 	);
 }
@@ -129,6 +130,7 @@ export class LineItem extends React.Component {
 			type,
 			value,
 			isValueOverflown,
+			t,
 		} = this.props;
 		const isSelectedLine = this.isSelected();
 
@@ -162,7 +164,7 @@ export class LineItem extends React.Component {
 							[theme['shrink-value']]: isValueOverflown,
 						})}
 					>
-						{getName(name)}
+						{getName(name, t)}
 						{value}
 						{type && (
 							<div key="type" className={`tc-object-viewer-line-type ${theme.type}`}>

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
@@ -220,7 +220,9 @@ describe('JSONLike', () => {
 						edited={[]}
 						info={{}}
 					/>
-					<button type="submit" onClick={mockOnSubmitClick} />
+					<button type="submit" onClick={mockOnSubmitClick}>
+						Submit
+					</button>
 				</form>,
 			);
 

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.test.js
@@ -7,6 +7,7 @@ import Component, {
 	getDataAbstract,
 	getDataInfo,
 	ComplexItem,
+	getName,
 } from './JSONLike.component';
 
 const callbacksProps = {
@@ -259,6 +260,19 @@ describe('JSONLike', () => {
 			// expect
 			expect(event.stopPropagation).toBeCalled();
 			expect(mockOnSelect).toBeCalled();
+		});
+	});
+
+	describe('getName', () => {
+		const t = jest.fn((_, { defaultValue }) => ` ${defaultValue}`);
+		it('should return null when name is empty', () => {
+			const name = getName(null, t);
+			expect(name).toBe(null);
+		});
+		it('should use colon translation in name label', () => {
+			const name = shallow(getName('spiderman', t));
+			expect(t).toHaveBeenCalledWith('COLON', { defaultValue: ':' });
+			expect(name.text()).toBe('spiderman :');
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in french, there sould be a space before colon, but we can't do that because it's hard-coded now instead translation.
**What is the chosen solution to this problem?**
add translation for colon
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
