### PR TITLE
feat(design-system/Checkbox): Support controlled checked state

### DIFF
--- a/.changeset/perfect-pens-boil.md
+++ b/.changeset/perfect-pens-boil.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Checkbox: Support controlled checked state

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
@@ -99,7 +99,7 @@ export const SCheckbox = styled(InlineStyle)<{
 `;
 
 export type CheckboxProps = InputProps & {
-	checked: boolean | 'indeterminate' | (string | number)[];
+	checked?: boolean | 'indeterminate' | (string | number)[];
 };
 
 const Checkbox = React.forwardRef(

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
@@ -126,10 +126,6 @@ const Checkbox = React.forwardRef(
 			readOnly,
 		});
 
-		useEffect(() => {
-			checkbox.setState(state);
-		}, [state]);
-
 		return (
 			<SCheckbox readOnly={!!readOnly} checked={!!checkbox.state} disabled={!!disabled}>
 				<label htmlFor={checkboxId} style={readOnly ? { pointerEvents: 'none' } : {}}>

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { Checkbox as ReakitCheckbox, unstable_useId as useId } from 'reakit';
 import styled from 'styled-components';
 
@@ -120,10 +120,15 @@ const Checkbox = React.forwardRef(
 	) => {
 		const { id: reakitId } = useId();
 		const checkboxId = id || `checkbox--${reakitId}`;
+		const state = (indeterminate && 'indeterminate') || defaultChecked || checked;
 		const checkbox = useCheckboxState({
-			state: (indeterminate && 'indeterminate') || defaultChecked || checked,
+			state,
 			readOnly,
 		});
+
+		useEffect(() => {
+			checkbox.setState(state);
+		}, [state]);
 
 		return (
 			<SCheckbox readOnly={!!readOnly} checked={!!checkbox.state} disabled={!!disabled}>

--- a/packages/design-system/src/components/Form/Field/Input/Input.Switch.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Switch.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components';
-import { shade } from 'polished';
 import { unstable_useId as useId, Checkbox as ReakitCheckbox } from 'reakit';
 
 import useCheckboxState from './hooks/useCheckboxState';

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
@@ -3,19 +3,19 @@ import Reakit, { useCheckboxState as useReakitCheckboxState } from 'reakit';
 
 import useReadOnly from './useReadOnly';
 
-type InitialChoiceState = Reakit.CheckboxInitialState & {
+type ChoiceState = Reakit.CheckboxInitialState & {
 	readOnly?: boolean;
 };
 
-export default function useCheckboxState({ readOnly, ...initialState }: InitialChoiceState) {
-	const checkboxState = useReakitCheckboxState(initialState);
-	const readOnlyState = useReadOnly(initialState.state);
+export default function useCheckboxState({ readOnly, ...choiceState }: ChoiceState) {
+	const checkboxState = useReakitCheckboxState(choiceState);
+	const readOnlyState = useReadOnly(choiceState.state);
 
 	useEffect(() => {
-		if (initialState.state) {
-			checkboxState.setState(initialState.state);
+		if (choiceState.state) {
+			checkboxState.setState(choiceState.state);
 		}
-	}, [initialState.state]);
+	}, [checkboxState.setState, choiceState.state]);
 
 	if (readOnly) {
 		return { ...checkboxState, ...readOnlyState, setState: () => {} };

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
@@ -12,7 +12,9 @@ export default function useCheckboxState({ readOnly, ...initialState }: InitialC
 	const readOnlyState = useReadOnly(initialState.state);
 
 	useEffect(() => {
-		checkboxState.setState(initialState.state);
+		if (initialState.state) {
+			checkboxState.setState(initialState.state);
+		}
 	}, [initialState.state]);
 
 	if (readOnly) {

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from 'react';
 import Reakit, { useCheckboxState as useReakitCheckboxState } from 'reakit';
 
 import useReadOnly from './useReadOnly';
@@ -9,6 +10,10 @@ type InitialChoiceState = Reakit.CheckboxInitialState & {
 export default function useCheckboxState({ readOnly, ...initialState }: InitialChoiceState) {
 	const checkboxState = useReakitCheckboxState(initialState);
 	const readOnlyState = useReadOnly(initialState.state);
+
+	useEffect(() => {
+		checkboxState.setState(initialState.state);
+	}, [initialState.state]);
 
 	if (readOnly) {
 		return { ...checkboxState, ...readOnlyState, setState: () => {} };

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useCheckboxState.tsx
@@ -12,7 +12,7 @@ export default function useCheckboxState({ readOnly, ...choiceState }: ChoiceSta
 	const readOnlyState = useReadOnly(choiceState.state);
 
 	useEffect(() => {
-		if (choiceState.state) {
+		if (choiceState.state !== undefined) {
 			checkboxState.setState(choiceState.state);
 		}
 	}, [checkboxState.setState, choiceState.state]);

--- a/packages/design-system/src/components/Form/docs/Input.checkbox.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.checkbox.stories.mdx
@@ -121,6 +121,30 @@ Use a checkbox when you want to give your recipients the opportunity to select m
 	</Story>
 </Canvas>
 
+### Controlled checkbox
+
+<Canvas>
+	<Story name="controlled">
+		{() => {
+			const { register, handleSubmit, watch } = useForm();
+			const [formData, setFormData] = React.useState();
+			const optionA = watch('option-a');
+			return (
+				<Form onSubmit={handleSubmit(setFormData)}>
+					<Form.Fieldset legend="Control checkbox state" required>
+						<Form.Checkbox label="Controller checkbox" {...register('option-a')} />
+						<Form.Checkbox label="Controlled checkbox" checked={optionA} />
+					</Form.Fieldset>
+					<Form.Buttons>
+						<Button.Primary type="submit">Submit</Button.Primary>
+					</Form.Buttons>
+				</Form>
+			);
+		}}
+	</Story>
+</Canvas>
+
+
 ## Content
 
 Checkboxes appear as a list on UI so it's important to make their labels as parallel as possible without twisting the language too much. It’s important to have parallelism, but not at the expense of comprehension.

--- a/packages/design-system/src/components/Form/docs/Input.checkbox.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.checkbox.stories.mdx
@@ -132,7 +132,7 @@ Use a checkbox when you want to give your recipients the opportunity to select m
 			return (
 				<Form onSubmit={handleSubmit(setFormData)}>
 					<Form.Fieldset legend="Control checkbox state" required>
-						<Form.Checkbox label="Controller checkbox" {...register('option-a')} />
+						<Form.Checkbox label="Toggle all" {...register('option-a')} />
 						<Form.Checkbox label="Controlled checkbox" checked={optionA} />
 					</Form.Fieldset>
 					<Form.Buttons>

--- a/packages/design-system/src/components/Form/docs/Input.switch.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.switch.stories.mdx
@@ -82,6 +82,29 @@ Use switches to change the state of system functionalities and preferences on or
 
 - The label must always be clickable to enable or disable.
 
+### Controlled switch
+
+<Canvas>
+    <Story name="controlled">
+        {() => {
+            const { register, handleSubmit, watch } = useForm();
+            const [formData, setFormData] = React.useState();
+            const optionA = watch('option-a');
+            return (
+                <Form onSubmit={handleSubmit(setFormData)}>
+                    <Form.Fieldset legend="Control switch state" required>
+                        <Form.Switch label="Toggle all" {...register('option-a')} />
+                        <Form.Switch label="Controlled switch" checked={optionA} />
+                    </Form.Fieldset>
+                    <Form.Buttons>
+                        <Button.Primary type="submit">Submit</Button.Primary>
+                    </Form.Buttons>
+                </Form>
+            );
+        }}
+    </Story>
+</Canvas>
+
 ## Usage
 
 <Canvas>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Changes to `checked` prop are not taken into account

**What is the chosen solution to this problem?**

This feels like a dirty fix and I guess we'll have the same issue in other components using the `useCheckboxState`... 
We could put the `useEffect` in `useCheckboxState` but it would break the "`useXXState` first param is a default state" convention

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
