### PR TITLE
fix(GeoChart): remove the use of ?? which break karma

### DIFF
--- a/.changeset/hot-terms-buy.md
+++ b/.changeset/hot-terms-buy.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+fix(GeoChart): ?? operator is breaking angular tests

--- a/packages/dataviz/src/components/GeoChart/GeoChart.component.tsx
+++ b/packages/dataviz/src/components/GeoChart/GeoChart.component.tsx
@@ -261,8 +261,8 @@ function GeoChart({ data, columnName, onSelection, chartConfig }: GeoChartProps)
 					ref={tooltipRef}
 					style={{
 						position: 'fixed',
-						top: `${tooltip.position.y - (tooltipRef.current?.offsetHeight ?? 0)}px`,
-						left: `${tooltip.position.x - ((tooltipRef.current?.offsetWidth ?? 0) / 2)}px`,
+						top: `${tooltip.position.y - (tooltipRef.current?.offsetHeight || 0)}px`,
+						left: `${tooltip.position.x - ((tooltipRef.current?.offsetWidth || 0) / 2)}px`,
 						pointerEvents: 'none',
 					}}
 				>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`??` operator is breaking AngularJS tests when updating to latest version of the dataviz lib

**What is the chosen solution to this problem?**

Replace `??` by `||` while we don't officially support it by a babel config.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
