### PR TITLE
fix(components/List): add translation for CellDatetime

### DIFF
--- a/.changeset/light-walls-smash.md
+++ b/.changeset/light-walls-smash.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Translate date string displayed in CellDatetime.

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -41,7 +41,7 @@ export function computeValue(cellData, columnData, t) {
 	return cellData;
 }
 
-export function getTooltipLabel(cellData, columnData) {
+export function getTooltipLabel(cellData, columnData, t) {
 	if (typeof columnData.getTooltipLabel === 'function') {
 		return columnData.getTooltipLabel(cellData);
 	}
@@ -50,9 +50,10 @@ export function getTooltipLabel(cellData, columnData) {
 		if (columnData.timeZone) {
 			tooltipLabel = dateUtils.formatToTimeZone(cellData, columnData.pattern || DATE_TIME_FORMAT, {
 				timeZone: columnData.timeZone,
+				locale: getLocale(t),
 			});
 		} else {
-			tooltipLabel = format(cellData, columnData.pattern || DATE_TIME_FORMAT);
+			tooltipLabel = format(cellData, columnData.pattern || DATE_TIME_FORMAT, { locale: getLocale(t) });
 		}
 		return tooltipLabel;
 	}
@@ -74,7 +75,7 @@ export class CellDatetimeComponent extends React.Component {
 	render() {
 		const { cellData, columnData, t } = this.props;
 		const computedValue = computeValue(cellData, columnData, t);
-		const tooltipLabel = getTooltipLabel(cellData, columnData);
+		const tooltipLabel = getTooltipLabel(cellData, columnData, t);
 
 		const cell = (
 			<div className={classnames('cell-datetime-container', styles['cell-datetime-container'])}>

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -31,9 +31,10 @@ export function computeValue(cellData, columnData, t) {
 			if (columnData.timeZone) {
 				return dateUtils.formatToTimeZone(cellData, columnData.pattern || DATE_TIME_FORMAT, {
 					timeZone: columnData.timeZone,
+					locale: getLocale(t),
 				});
 			}
-			return format(cellData, columnData.pattern || DATE_TIME_FORMAT);
+			return format(cellData, columnData.pattern || DATE_TIME_FORMAT, { locale: getLocale(t) });
 		}
 	}
 
@@ -47,13 +48,9 @@ export function getTooltipLabel(cellData, columnData) {
 	if (columnData.mode === 'ago') {
 		let tooltipLabel = '';
 		if (columnData.timeZone) {
-			tooltipLabel = dateUtils.formatToTimeZone(
-				cellData,
-				columnData.pattern || DATE_TIME_FORMAT,
-				{
-					timeZone: columnData.timeZone,
-				},
-			);
+			tooltipLabel = dateUtils.formatToTimeZone(cellData, columnData.pattern || DATE_TIME_FORMAT, {
+				timeZone: columnData.timeZone,
+			});
 		} else {
 			tooltipLabel = format(cellData, columnData.pattern || DATE_TIME_FORMAT);
 		}

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -100,6 +100,7 @@ describe('CellDatetime', () => {
 
 	it('should format according to the pattern', () => {
 		// when
+		const t = jest.fn();
 		const columnData = {
 			mode: 'format',
 			pattern: 'YYYY-MM-DD HH:mm:ss',
@@ -112,10 +113,12 @@ describe('CellDatetime', () => {
 		const expectedStrDate = `2016-09-22 ${isOneDigitHours ? 0 : ''}${
 			11 + timezoneOffset / 60
 		}:00:00`;
-		const computedStrOffset = computeValue(cellDataWithOffset, columnData);
+		const computedStrOffset = computeValue(cellDataWithOffset, columnData, t);
 		// then
 		expect(computedStrOffset).toEqual(expectedStrDate);
-		expect(format).toHaveBeenCalledWith(cellDataWithOffset, columnData.pattern);
+		expect(format).toHaveBeenCalledWith(cellDataWithOffset, columnData.pattern, {
+			locale: getLocale(t),
+		});
 	});
 
 	it('should render CellDatetime with tooltip in ago mode', () => {
@@ -139,13 +142,15 @@ describe('CellDatetime', () => {
 			pattern: 'YYYY-MM-DD HH:mm:ss',
 			timeZone: 'Pacific/Niue',
 		};
+		const t = jest.fn();
 
 		const cellData = 1474495200000;
-		computeValue(cellData, columnData);
+		computeValue(cellData, columnData, t);
 
 		// then
 		expect(dateUtils.formatToTimeZone).toHaveBeenCalledWith(cellData, columnData.pattern, {
 			timeZone: columnData.timeZone,
+			locale: getLocale(t),
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Formatted date in CellDatetime is not translated.
![image](https://user-images.githubusercontent.com/3214228/144553552-9569188b-f7a3-4574-82c3-77b224b02b12.png)


**What is the chosen solution to this problem?**
Pass locale object to datefns format function

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
