### PR TITLE
fix(InlineEditing): enter key should not submit in multiline mode

### DIFF
--- a/.changeset/early-cooks-collect.md
+++ b/.changeset/early-cooks-collect.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(InlineEditing): enter key should not submit in multiline mode

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
@@ -51,7 +51,7 @@ context('<InlineEditing />', () => {
 	it('should not validate on Enter when multiline', () => {
 		cy.mount(<Textarea />);
 		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('ìnlineediting.textarea')
+		cy.getByTestId('inlineediting.textarea')
 			.focus()
 			.type('{selectall}{del}blah')
 			.should('have.value', 'blah')

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
@@ -10,52 +10,52 @@ const { Default, Textarea } = composeStories(Stories);
 context('<InlineEditing />', () => {
 	it('should go to edit mode when clicking on the button', () => {
 		cy.mount(<Default />);
-		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('ìnlineediting.input').should('exist').should('have.attr', 'type', 'text');
+		cy.getByTest('inlineediting.button.edit').click();
+		cy.getByTest('inlineediting.input').should('exist').should('have.attr', 'type', 'text');
 	});
 
 	it('should go to edit mode when double clicking on the span', () => {
 		cy.mount(<Default />);
-		cy.getByTestId('inlineediting').dblclick();
-		cy.getByTestId('ìnlineediting.input').should('exist').should('have.attr', 'type', 'text');
+		cy.getByTest('inlineediting').dblclick();
+		cy.getByTest('inlineediting.input').should('exist').should('have.attr', 'type', 'text');
 	});
 
 	it('should render Textarea', () => {
 		cy.mount(<Textarea />);
-		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('ìnlineediting.textarea').should('exist');
+		cy.getByTest('inlineediting.button.edit').click();
+		cy.getByTest('inlineediting.textarea').should('exist');
 	});
 
 	it('should restore value on Esc', () => {
 		cy.mount(<Default />);
-		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('ìnlineediting.input')
+		cy.getByTest('inlineediting.button.edit').click();
+		cy.getByTest('inlineediting.input')
 			.focus()
 			.type('{selectall}{del}blah')
 			.should('have.value', 'blah')
 			.type('{esc}');
-		cy.getByTestId('inlineediting').contains('Lorem ipsum dolor sit amet');
+		cy.getByTest('inlineediting').contains('Lorem ipsum dolor sit amet');
 	});
 
 	it('should validate on Enter', () => {
 		cy.mount(<Default />);
-		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('ìnlineediting.input')
+		cy.getByTest('inlineediting.button.edit').click();
+		cy.getByTest('inlineediting.input')
 			.focus()
 			.type('{selectall}{del}blah')
 			.should('have.value', 'blah')
 			.type('{enter}');
-		cy.getByTestId('inlineediting').contains('blah');
+		cy.getByTest('inlineediting').contains('blah');
 	});
 
 	it('should not validate on Enter when multiline', () => {
 		cy.mount(<Textarea />);
-		cy.getByTestId('inlineediting.button.edit').click();
-		cy.getByTestId('inlineediting.textarea')
+		cy.getByTest('inlineediting.button.edit').click();
+		cy.getByTest('inlineediting.textarea')
 			.focus()
 			.type('{selectall}{del}blah')
 			.should('have.value', 'blah')
 			.type('{enter}');
-		cy.getByTestId('inlineediting.textarea').should('exist');
+		cy.getByTest('inlineediting.textarea').should('exist');
 	});
 });

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
@@ -47,4 +47,15 @@ context('<InlineEditing />', () => {
 			.type('{enter}');
 		cy.getByTestId('inlineediting').contains('blah');
 	});
+
+	it('should not validate on Enter when multiline', () => {
+		cy.mount(<Textarea />);
+		cy.getByTestId('inlineediting.button.edit').click();
+		cy.getByTestId('ìnlineediting.textarea')
+			.focus()
+			.type('{selectall}{del}blah')
+			.should('have.value', 'blah')
+			.type('{enter}');
+		cy.getByTestId('ìnlineediting.textarea').should('exist');
+	});
 });

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.spec.tsx
@@ -56,6 +56,6 @@ context('<InlineEditing />', () => {
 			.type('{selectall}{del}blah')
 			.should('have.value', 'blah')
 			.type('{enter}');
-		cy.getByTestId('ìnlineediting.textarea').should('exist');
+		cy.getByTestId('inlineediting.textarea').should('exist');
 	});
 });

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
@@ -89,10 +89,10 @@ const InlineEditing = React.forwardRef(
 		);
 
 		const Input = mode === Mode.Multi ? Form.Textarea : Form.Text;
-		const testId = `ìnlineediting.${mode === Mode.Multi ? 'textarea' : 'input'}`;
+		const testId = `inlineediting.${mode === Mode.Multi ? 'textarea' : 'input'}`;
 
 		return (
-			<S.InlineEditing data-testid="inlineediting" {...rest} ref={ref}>
+			<S.InlineEditing data-test="inlineediting" {...rest} ref={ref}>
 				{isEditing ? (
 					<div className="c-inline-editing--editing">
 						<form>
@@ -107,20 +107,20 @@ const InlineEditing = React.forwardRef(
 										| React.ChangeEvent<HTMLInputElement>
 										| React.ChangeEvent<HTMLTextAreaElement>,
 								): void => setValue(event.target.value)}
-								data-testid={testId}
+								data-test={testId}
 							/>
 							<div className="c-inline-editing__actions">
 								<Button.Icon
 									onClick={handleCancel}
 									icon="talend-cross-circle"
-									data-testid="inlineediting.button.cancel"
+									data-test="inlineediting.button.cancel"
 								>
 									{t('INLINE_EDITING_CANCEL', 'Cancel')}
 								</Button.Icon>
 								<Button.Icon
 									onClick={handleSubmit}
 									icon="talend-check-circle"
-									data-testid="inlineediting.button.submit"
+									data-test="inlineediting.button.submit"
 								>
 									{t('INLINE_EDITING_SUBMIT', 'Submit')}
 								</Button.Icon>
@@ -143,7 +143,7 @@ const InlineEditing = React.forwardRef(
 							icon="talend-pencil"
 							onClick={() => setEditMode(true)}
 							disabled={loading}
-							data-testid="inlineediting.button.edit"
+							data-test="inlineediting.button.edit"
 						>
 							{t('INLINE_EDITING_EDIT', 'Edit')}
 						</Button.Icon>

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
@@ -80,7 +80,7 @@ const InlineEditing = React.forwardRef(
 		useKey(
 			'Enter',
 			(event: KeyboardEvent): void => {
-				if (mode !== 'multi') {
+				if (mode !== Mode.Multi) {
 					handleSubmit(event);
 				}
 			},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

enter key should not submit in multiline mode

**What is the chosen solution to this problem?**

a fix

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
