### PR TITLE
chore(design-system): components testing gh action

### DIFF
--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -1,0 +1,42 @@
+name: Components testing
+
+on:
+  push:
+    paths:
+      - 'package/design-system/**'
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+
+      - name: Yarn cache directory
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Cypress Component Testing
+        run: |
+          yarn
+          npx cypress run-ct
+
+      - name: Cypress artifacts upload
+        uses: actions/upload-artifact@v2
+        if: ${{ always() }}
+        with:
+          name: cypress-component-testing-videos
+          path: cypress/videos/components/**/*

--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -3,7 +3,7 @@ name: Components testing
 on:
   push:
     paths:
-      - 'package/design-system/**'
+      - 'packages/design-system/**'
 
 jobs:
   cypress-run:

--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -15,19 +15,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-
-      - name: Yarn cache directory
-        id: yarn-cache-dir-path
-        run: echo "::set-output name=dir::$(yarn cache dir)"
-
-      - name: Yarn cache
-        uses: actions/cache@v2
-        id: yarn-cache
-        with:
-          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-yarn-
+          registry-url: "https://registry.npmjs.org/"
+          scope: "@talend"
+          cache: "yarn"
 
       - name: Cypress Component Testing
         run: |


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

After migration, Cypress components testing on PR was not run anymore

**What is the chosen solution to this problem?**

Re-enable it

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
