### PR TITLE
fix(TDOPS-1376/components/dataviz): recharts path in dependencies.json

### DIFF
--- a/.changeset/healthy-carrots-stare.md
+++ b/.changeset/healthy-carrots-stare.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-components': patch
+'@talend/react-dataviz': patch
+---
+
+fix(components/dataviz): recharts path in dependencies.json

--- a/yarn.lock
+++ b/yarn.lock
@@ -3163,9 +3163,9 @@
   integrity sha512-pW1kVv6atGEy5qIfp2VVpdFAtJrwpYpIIiE576W5IDw0q8U7yAafEb+vhk9jVHElyrAkYJSYjxjit8gYX/CJxw==
 
 "@talend/module-to-cdn@^9.7.3":
-  version "9.7.3"
-  resolved "https://registry.yarnpkg.com/@talend/module-to-cdn/-/module-to-cdn-9.7.3.tgz#6663ba95f25cf1e318f3d627efb83c8e79b0763d"
-  integrity sha512-OREjZdX9aEVcBLZ5Z2ec+AO0sGSpi71VUdJ352zYiuuyS3I2Yt2tabtUSkYgHNmXh3BVEgX6vZAbyjIBO4aYiA==
+  version "9.7.4"
+  resolved "https://registry.yarnpkg.com/@talend/module-to-cdn/-/module-to-cdn-9.7.4.tgz#4b12ae2caee3574f826143fdd25e4641531d970f"
+  integrity sha512-c3JOB27qJJGO/Wefyrs7MhagrPJzDwrURB467bBSSaz687HRY16UlpSltx9TTZzTmQffBDtzrduKU+FNQ+QhmA==
   dependencies:
     execa "^4.1.0"
     mkdirp "^1.0.4"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is a issue in version 9.7.3 of `@talend/module-to-cdn`: the recharts path for prod version is wrong.
The releases of react-components and react-dataviz have the wrong path in their prod dependencies.json.

**What is the chosen solution to this problem?**
Upgrade `@talend/module-to-cdn` and release fix versions

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
