### PR TITLE
fix(ARCH-402/playground): add ds in copyconfig

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env BASENAME='/playground' talend-scripts build",
     "test": "echo nothing to test in playground",
     "test:demo": "cross-env BASENAME='/playground' INITIATOR_URL='/playground/inject.js' talend-scripts build --prod",
-    "start": "cross-env BASENAME='/playground' talend-scripts start --open http://localhost:3000/playground/#/",
+    "start": "cross-env BASENAME='/playground' INITIATOR_URL='/playground/inject.js' talend-scripts start --open http://localhost:3000/playground/#/",
     "start-dist": "talend-scripts build && node serve-dist"
   },
   "repository": {

--- a/packages/playground/src/assets/inject.js
+++ b/packages/playground/src/assets/inject.js
@@ -1,20 +1,17 @@
 // custom inject to UMD from surge and the others from unpkg
 
 (function () {
+	const CDN_URL_REGEX = /^(\/?.*\/cdn)\//;
+
 	function prepareUrl(url) {
 		let newUrl;
-		if (url.startsWith('/cdn')) {
-			if (url.startsWith('/cdn/@talend') && !url.startsWith('/cdn/@talend/design-system')) {
-				// code specific target to surge
-				newUrl = url.split('/');
-				newUrl.splice(4, 1); // remove version
-				newUrl = newUrl.join('/').replace('/cdn', '');
-			} else {
-				newUrl = url.replace('/cdn', 'https://statics.cloud.talend.com');
+		const m = CDN_URL_REGEX.exec(url);
+		if (m !== null) {
+			//	return base ? url.slice(1) : url;
+
+			if (!url.includes('/cdn/@talend')) {
+				newUrl = url.replace(m[1], 'https://statics.cloud.talend.com');
 			}
-		} else if (url.startsWith('/')) {
-			// basename is added by ui-scripts
-			newUrl = url.replace('/', `${window.basename}/`);
 		}
 		if (newUrl) {
 			// eslint-disable-next-line no-console

--- a/packages/playground/webpack.config.dev.js
+++ b/packages/playground/webpack.config.dev.js
@@ -27,6 +27,7 @@ function getVersion(pkg) {
 }
 
 const PKGS = [
+	'@talend/design-system',
 	'@talend/react-components',
 	'@talend/react-containers',
 	'@talend/react-cmf',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we have imported DS into talend/ui 
playground do not take it from the node_modules so we are not able to see the impact.

**What is the chosen solution to this problem?**

* fix inject.js so it do not exclude the ds
* fix inject.js to support basename
* add it to copy config


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
