### PR TITLE
chore(CI): fix cypress error

### DIFF
--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -21,6 +21,7 @@ jobs:
 
       - name: Cypress Component Testing
         run: |
+          cd packages/design-system
           yarn
           npx cypress run-ct
 

--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Cypress Component Testing
         run: |
-          yarn
           cd packages/design-system
+          yarn
           npx cypress run-ct
 
       - name: Cypress artifacts upload

--- a/.github/workflows/components-testing.yml
+++ b/.github/workflows/components-testing.yml
@@ -21,8 +21,8 @@ jobs:
 
       - name: Cypress Component Testing
         run: |
-          cd packages/design-system
           yarn
+          cd packages/design-system
           npx cypress run-ct
 
       - name: Cypress artifacts upload

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.stories.mdx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.stories.mdx
@@ -73,7 +73,7 @@ The edit mode can be triggered by clicking on the pencil icon, or by double-clic
 
 Non-regression testing can be performed using:
 
-| data-testid                                       | description                                                                   |
+| data-test                                         | description                                                                   |
 | ------------------------------------------------- | ----------------------------------------------------------------------------- |
 | `inlineediting`                                   | Container containing value and actions                                        |
 | `inlineediting.button.edit`                       | Edit button to pass into "editing" mode                                       |


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Cypress CT does not run on DS

**What is the chosen solution to this problem?**

Limit the GH Action to the DS package

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
