### PR TITLE
chore(design-system): deploy gh action

### DIFF
--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -24,6 +24,7 @@ jobs:
 
       - name: Build Storybook
         run: |
+          yarn
           yarn build-storybook
 
       - name: Deploy to Netlify production

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -6,7 +6,7 @@ on:
 #      - 'packages/design-system/**'
 
 jobs:
-  cypress-run:
+  deploy:
     runs-on: ubuntu-latest
     defaults:
       run:

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -2,8 +2,8 @@ name: Deploy design.talend.com
 
 on:
   push:
-    paths:
-      - 'packages/design-system/**'
+#    paths:
+#      - 'packages/design-system/**'
 
 jobs:
   cypress-run:
@@ -31,7 +31,7 @@ jobs:
 #        if: github.ref == 'refs/heads/master'
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dry --dir=packages/design-system/storybook-static
+          args: deploy --dir=packages/design-system/storybook-static
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -2,6 +2,8 @@ name: Deploy design.talend.com
 
 on:
   push:
+    branches:
+      - master
     paths:
       - 'packages/design-system/**'
 
@@ -29,7 +31,6 @@ jobs:
           yarn build-storybook
 
       - name: Deploy to Netlify production
-        if: github.ref == 'refs/heads/master'
         uses: netlify/actions/cli@master
         with:
           args: deploy --prod --dir=packages/design-system/storybook-static

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -1,0 +1,36 @@
+name: Deploy design.talend.com
+
+on:
+  push:
+    paths:
+      - 'packages/design-system/**'
+
+jobs:
+  cypress-run:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/design-system
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
+          registry-url: "https://registry.npmjs.org/"
+          scope: "@talend"
+          cache: "yarn"
+
+      - name: Build Storybook
+        run: |
+          yarn build-storybook
+
+      - name: Deploy to Netlify production
+#        if: github.ref == 'refs/heads/master'
+        uses: netlify/actions/cli@master
+        with:
+          args: deploy --dry --dir=packages/design-system/storybook-static
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -2,13 +2,13 @@ name: Deploy design.talend.com
 
 on:
   push:
-#    paths:
-#      - 'packages/design-system/**'
+    paths:
+      - 'packages/design-system/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: pull_request_unsafe
+    environment: main
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -29,7 +29,7 @@ jobs:
           yarn build-storybook
 
       - name: Deploy to Netlify production
-#        if: github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         uses: netlify/actions/cli@master
         with:
           args: deploy --prod --dir=packages/design-system/storybook-static

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -32,7 +32,7 @@ jobs:
 #        if: github.ref == 'refs/heads/master'
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=packages/design-system/storybook-static
+          args: deploy --prod --dir=packages/design-system/storybook-static
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -27,7 +27,7 @@ jobs:
 
       - name: Build Storybook
         run: |
-          yarn
+          yarn install --frozen-lockfile
           yarn build-storybook
 
       - name: Deploy to Netlify production

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pull_request_unsafe
     defaults:
       run:
         working-directory: ./packages/design-system

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -5,9 +5,9 @@
 <hr />
 
 <div style="text-align:center">
-  <img src="https://api.netlify.com/api/v1/badges/d6d66424-7754-4257-bb5e-cc6de2f9d9aa/deploy-status" alt="Netlify" />
-  <img src="https://github.com/Talend/design-system/workflows/Chromatic/badge.svg" alt="Chromatic"/> 
-  <img src="https://github.com/Talend/design-system/workflows/Upload%20to%20CDN/badge.svg" alt="S3 deploy" />
+  <a href="https://app.netlify.com/sites/gifted-tesla-96fe2e/deploys">
+    <img src="https://api.netlify.com/api/v1/badges/d6d66424-7754-4257-bb5e-cc6de2f9d9aa/deploy-status" alt="Netlify Status" />
+  </a>
 </div>
 
 <hr />
@@ -50,7 +50,7 @@ Use styled-components format.
 
 ### Variations
 
-Variations should extend of the basic components in separated files. 
+Variations should extend of the basic components in separated files.
 Limit changes to styled-components scope.
 
 ### End-to-End tests

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -4,6 +4,10 @@
 
 <hr />
 
+[![netlify](https://github.com/Talend/ui/actions/workflows/design-system-deploy.yml/badge.svg)](https://github.com/Talend/ui/actions/workflows/design-system-deploy.yml)
+
+<hr />
+
 Coral is the design system used to build accessible, consistent, customizable and high quality customer experiences at Talend.
 
 ## Getting Started

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -4,11 +4,7 @@
 
 <hr />
 
-<div style="text-align:center">
-  <a href="https://app.netlify.com/sites/gifted-tesla-96fe2e/deploys">
-    <img src="https://api.netlify.com/api/v1/badges/d6d66424-7754-4257-bb5e-cc6de2f9d9aa/deploy-status" alt="Netlify Status" />
-  </a>
-</div>
+[![Netlify Status](https://api.netlify.com/api/v1/badges/d6d66424-7754-4257-bb5e-cc6de2f9d9aa/deploy-status)](https://app.netlify.com/sites/gifted-tesla-96fe2e/deploys)
 
 <hr />
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -4,10 +4,6 @@
 
 <hr />
 
-[![Netlify Status](https://api.netlify.com/api/v1/badges/d6d66424-7754-4257-bb5e-cc6de2f9d9aa/deploy-status)](https://app.netlify.com/sites/gifted-tesla-96fe2e/deploys)
-
-<hr />
-
 Coral is the design system used to build accessible, consistent, customizable and high quality customer experiences at Talend.
 
 ## Getting Started


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We can't rely on Surge to deploy design.talend.com for some HA and SSL reasons.
We have to keep using Netlify for that.

**What is the chosen solution to this problem?**

Each commit on master where the design system has changed must deploy a new version of the documentation on Netlify.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
