### PR TITLE
chore(design-system): gh actions naming convention

### DIFF
--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -1,4 +1,4 @@
-name: Components testing
+name: Design System component testing
 
 on:
   push:
@@ -8,6 +8,9 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./packages/design-system
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
@@ -21,8 +24,7 @@ jobs:
 
       - name: Cypress Component Testing
         run: |
-          cd packages/design-system
-          yarn
+          yarn --frozen-lock
           npx cypress run-ct
 
       - name: Cypress artifacts upload

--- a/.github/workflows/desing-system-visual-testing.yml
+++ b/.github/workflows/desing-system-visual-testing.yml
@@ -1,4 +1,4 @@
-name: Chromatic on packages/design-system
+name: Design System visual testing
 
 on:
   pull_request:
@@ -9,30 +9,33 @@ on:
   push:
     branches:
       - master
-  workflow_dispatch:
+    paths:
+      - 'packages/design-system/**'
 
 jobs:
   build:
-    environment: pull_request_unsafe
+    runs-on: ubuntu-latest
     if: |
       (github.ref == 'refs/heads/master') ||
       (github.event.label.name == 'need visual approval')
-    runs-on: ubuntu-latest
+    environment: pull_request_unsafe
+    defaults:
+      run:
+        working-directory: ./packages/design-system
     steps:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
 
-      - name: Use Node.js 14
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          node-version: 14
+          node-version: '14'
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"
 
       - name: Install dependencies
-        run: yarn
+        run: yarn --frozen-lock
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -4,6 +4,8 @@
 
 <hr />
 
+[![cypress](https://github.com/Talend/ui/actions/workflows/design-system-component-testing.yml/badge.svg)](https://github.com/Talend/ui/actions/workflows/design-system-component-testing.yml)
+[![chromatic](https://github.com/Talend/ui/actions/workflows/design-system-visual-testing.yml/badge.svg)](https://github.com/Talend/ui/actions/workflows/design-system-visual-testing.yml)
 [![netlify](https://github.com/Talend/ui/actions/workflows/design-system-deploy.yml/badge.svg)](https://github.com/Talend/ui/actions/workflows/design-system-deploy.yml)
 
 <hr />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

DS GitHub Actions must respect a naming convention to not be generalized

**What is the chosen solution to this problem?**

Adapt existing workflows and add badges on README to get a clear status

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
