### PR TITLE
feat(TDP-10570): Increaser Layout header z-index

### DIFF
--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -5,6 +5,8 @@
 
 /// Layout height of the header
 /// @type Number (Unit)
+
+// Need to be higher to typehead (1035)
 $tc-drawer-z-index: $zindex-navbar-fixed + 6 !default;
 $tc-layout-header-height: $navbar-height !default;
 $tc-layout-skip-links-z-index: $tc-drawer-z-index + 20 !default;

--- a/packages/components/src/Layout/Layout.scss
+++ b/packages/components/src/Layout/Layout.scss
@@ -5,7 +5,7 @@
 
 /// Layout height of the header
 /// @type Number (Unit)
-$tc-drawer-z-index: $drawer-z-index !default;
+$tc-drawer-z-index: $zindex-navbar-fixed + 6 !default;
 $tc-layout-header-height: $navbar-height !default;
 $tc-layout-skip-links-z-index: $tc-drawer-z-index + 20 !default;
 $tc-layout-header-z-index: $tc-drawer-z-index + 10 !default;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We have a complex z-index problem in Data Preparation: In some screens, we can't see dropdowns in header (App switcher, User profil).

Here is a screenshot of the problem:
![zindex](https://user-images.githubusercontent.com/52413026/145601606-5e68dda8-d67d-452c-9955-529240c15133.png)

This page have some specificity:

- A Layout with a stepper and a Drawer that contain a form with a Typeahead
- This Typeahead have a button that open another Drawer


To hide the typeahead opened popin, we need to have at least a `z-index` set to `1035`.
But with that, we hide the dropdown that have a `z-index` set to `110` (more additional infos at bottom)


With that in mind, we have a dilemma with our layout `z-index`:

- Be higher than `1035` to hide connection typehead
- Be smaller than `110` to show menu dropdown


**What is the chosen solution to this problem?**


The only solution that i see is this one:
- Increase header `z-index` to be at least `1036`
- Do not be higher than `1040` to prevent dialog conflict (https://github.com/Talend/ui/blob/master/packages/theme/src/theme/_guidelines.scss#L54)



Additional information:
In reality, header dropdown z-index is set to 1000 (class: .dropdown-menu). But one parent (header is set to 110). Because of stacking context feature, we can't have a child z-index higher that parent z-index (https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Positioning/Understanding_z_index/The_stacking_context)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
