### PR TITLE
chore(CI): minimum threshold for UMD size check

### DIFF
--- a/.github/workflows/lerna-ci.yml
+++ b/.github/workflows/lerna-ci.yml
@@ -37,3 +37,5 @@ jobs:
           pattern: './packages/*/dist/*.{js,css,json}'
           exclude: '{**/*.html,**/*.map,**/node_modules/**}'
           compression: 'none'
+          minimum-change-threshold: 100
+


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Without a minimum threshold, UMD size checks give "false positives" since you can have some changing bytes

**What is the chosen solution to this problem?**

According to https://github.com/preactjs/compressed-size-action#increasing-the-required-threshold
Let's  imagine that we want to be aware only if the diff is equal or greater than `100b`

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
