### PR TITLE
chore(design-tokens): exclude Storybook stuff from NPM package

### DIFF
--- a/.changeset/short-cheetahs-drive.md
+++ b/.changeset/short-cheetahs-drive.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-tokens': minor
+---
+
+chore(design-tokens): exclude storybook assets from npm package

--- a/packages/design-tokens/.npmignore
+++ b/packages/design-tokens/.npmignore
@@ -3,3 +3,5 @@ dependencies.json
 talend-scripts.json
 tsconfig.json
 webpack.config.js
+.storybook
+**/*.stories.mdx


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Storybook config and stories are embedded into the NPM package

**What is the chosen solution to this problem?**

Exclude them all

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
