### PR TITLE
fix(Checkbox): Data-feature should be on label

### DIFF
--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
@@ -100,6 +100,7 @@ export const SCheckbox = styled(InlineStyle)<{
 
 export type CheckboxProps = InputProps & {
 	checked?: boolean | 'indeterminate' | (string | number)[];
+        'data-feature'?: string;
 };
 
 const Checkbox = React.forwardRef(
@@ -114,6 +115,7 @@ const Checkbox = React.forwardRef(
 			disabled,
 			required,
 			children,
+			'data-feature': dataFeature
 			...rest
 		}: CheckboxProps,
 		ref: React.Ref<HTMLInputElement>,
@@ -127,7 +129,7 @@ const Checkbox = React.forwardRef(
 		});
 
 		return (
-			<SCheckbox readOnly={!!readOnly} checked={!!checkbox.state} disabled={!!disabled}>
+			<SCheckbox readOnly={!!readOnly} checked={!!checkbox.state} disabled={!!disabled} data-feature={dataFeature}>
 				<label htmlFor={checkboxId} style={readOnly ? { pointerEvents: 'none' } : {}}>
 					{/*
 					// ReakitCheckbox is not based on HTMLInputElement despite working like one


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The data-feature attribute on the input, which has a 0px width.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
