### PR TITLE
feat(Checkbox): Support data-feature attribute

### DIFF
--- a/.changeset/clean-cows-agree.md
+++ b/.changeset/clean-cows-agree.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+feat(Checkbox): Support data-feature attribute

--- a/packages/design-system/cypress/support/index.js
+++ b/packages/design-system/cypress/support/index.js
@@ -24,3 +24,7 @@ Cypress.Commands.add('getByTest', (selector, ...args) => {
 Cypress.Commands.add('getByRole', (selector, ...args) => {
 	return cy.get(`[role="${selector}"]`, ...args);
 });
+
+Cypress.Commands.add('getByFeature', (selector, ...args) => {
+	return cy.get(`[data-feature="${selector}"]`, ...args);
+});

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.spec.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.spec.tsx
@@ -6,7 +6,7 @@ import * as Stories from './Input.Checkbox.stories';
 const { DataFeature } = composeStories(Stories);
 
 describe('Checkbox', () => {
-	it('Should set data-feature label', () => {
+	it('Should set data-feature on label', () => {
 		cy.mount(<DataFeature />);
 
 		cy.getByFeature('my.prefix.enable').click();

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.spec.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.spec.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { composeStories } from '@storybook/testing-react';
+import Checkbox from './Input.Checkbox';
+import * as Stories from './Input.Checkbox.stories';
+
+const { DataFeature } = composeStories(Stories);
+
+describe('Checkbox', () => {
+	it('Should set data-feature label', () => {
+		cy.mount(<DataFeature />);
+
+		cy.getByFeature('my.prefix.enable').click();
+		cy.getByFeature('my.prefix.enable').should('not.exist');
+
+		cy.getByFeature('my.prefix.disable').click();
+		cy.getByFeature('my.prefix.disable').should('not.exist');
+	});
+});

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.stories.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.stories.tsx
@@ -1,0 +1,14 @@
+import Checkbox from './Input.Checkbox';
+
+export default {
+	component: Checkbox,
+	args: {
+		label: 'Checkbox',
+	},
+};
+
+export const DataFeature = {
+	args: {
+		'data-feature': 'my.prefix',
+	},
+};

--- a/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Checkbox.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { Checkbox as ReakitCheckbox, unstable_useId as useId } from 'reakit';
 import styled from 'styled-components';
 
@@ -100,6 +100,7 @@ export const SCheckbox = styled(InlineStyle)<{
 
 export type CheckboxProps = InputProps & {
 	checked?: boolean | 'indeterminate' | (string | number)[];
+	'data-feature'?: string;
 };
 
 const Checkbox = React.forwardRef(
@@ -114,6 +115,7 @@ const Checkbox = React.forwardRef(
 			disabled,
 			required,
 			children,
+			'data-feature': dataFeature,
 			...rest
 		}: CheckboxProps,
 		ref: React.Ref<HTMLInputElement>,
@@ -128,7 +130,13 @@ const Checkbox = React.forwardRef(
 
 		return (
 			<SCheckbox readOnly={!!readOnly} checked={!!checkbox.state} disabled={!!disabled}>
-				<label htmlFor={checkboxId} style={readOnly ? { pointerEvents: 'none' } : {}}>
+				<label
+					htmlFor={checkboxId}
+					style={readOnly ? { pointerEvents: 'none' } : {}}
+					data-feature={
+						dataFeature ? `${dataFeature}.${checkbox.state ? 'disable' : 'enable'}` : null
+					}
+				>
 					{/*
 					// ReakitCheckbox is not based on HTMLInputElement despite working like one
 					// @ts-ignore */}

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -6,6 +6,9 @@
     "declaration": true,
     "jsx": "react",
     "target": "ES5",
-    "module": "CommonJs"
+    "module": "CommonJs",
+    "types": [
+      "cypress"
+    ]
   }
 }

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -6,9 +6,6 @@
     "declaration": true,
     "jsx": "react",
     "target": "ES5",
-    "module": "CommonJs",
-    "types": [
-      "cypress"
-    ]
+    "module": "CommonJs"
   }
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

1. The data-feature attribute on the input, which has a 0px width.
2. data-feature should be suffixed by the action name

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
