### PR TITLE
fix(design-system/Link): fix title related to target attribute

### DIFF
--- a/.changeset/wet-elephants-fetch.md
+++ b/.changeset/wet-elephants-fetch.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+fix(design-system/Link): The title "open in a new tab" should be related to the target attribute and not the detection of external link

--- a/.changeset/wet-elephants-fetch.md
+++ b/.changeset/wet-elephants-fetch.md
@@ -1,5 +1,5 @@
 ---
-'@talend/design-system': minor
+'@talend/design-system': patch
 ---
 
 fix(design-system/Link): The title "open in a new tab" should be related to the target attribute and not the detection of external link

--- a/packages/design-system/src/components/Link/Link.spec.tsx
+++ b/packages/design-system/src/components/Link/Link.spec.tsx
@@ -27,6 +27,7 @@ context('<Link />', () => {
 		cy.mount(<TargetBlank />);
 		cy.get('.link')
 			.should('have.attr', 'title', 'Open in a new tab')
-			.should('have.attr', 'target', '_blank');
+			.should('have.attr', 'target', '_blank')
+			.should('have.attr', 'rel', 'noopener noreferrer');
 	});
 });

--- a/packages/design-system/src/components/Link/Link.spec.tsx
+++ b/packages/design-system/src/components/Link/Link.spec.tsx
@@ -1,11 +1,10 @@
 /// <reference types="cypress" />
 
-import React from 'react';
 import { composeStories } from '@storybook/testing-react';
-
+import React from 'react';
 import * as Stories from './Link.stories';
 
-const { Default, WithIcon, External } = composeStories(Stories);
+const { Default, WithIcon, External, TargetBlank } = composeStories(Stories);
 
 context('<Link />', () => {
 	it('should render', () => {
@@ -20,6 +19,11 @@ context('<Link />', () => {
 
 	it('should render external', () => {
 		cy.mount(<External />);
+		cy.get('.link .link__icon').should('have.attr', 'name', 'talend-link');
+	});
+
+	it('should render target blank', () => {
+		cy.mount(<TargetBlank />);
 		cy.get('.link')
 			.should('have.attr', 'title', 'Open in a new tab')
 			.should('have.attr', 'target', '_blank');

--- a/packages/design-system/src/components/Link/Link.spec.tsx
+++ b/packages/design-system/src/components/Link/Link.spec.tsx
@@ -1,7 +1,8 @@
 /// <reference types="cypress" />
 
-import { composeStories } from '@storybook/testing-react';
 import React from 'react';
+import { composeStories } from '@storybook/testing-react';
+
 import * as Stories from './Link.stories';
 
 const { Default, WithIcon, External, TargetBlank } = composeStories(Stories);

--- a/packages/design-system/src/components/Link/Link.stories.tsx
+++ b/packages/design-system/src/components/Link/Link.stories.tsx
@@ -1,7 +1,7 @@
-import React from 'react';
 import { Story } from '@storybook/react';
-import { WithSelector } from '../../docs';
+import React from 'react';
 import Link from '.';
+import { WithSelector } from '../../docs';
 
 export default {
 	component: Link,
@@ -57,8 +57,14 @@ export const External = {
 	args: {
 		...defaultProps,
 		href: 'https://www.talend.com',
-		target: '_blank',
 		children: 'talend.com',
+	},
+};
+
+export const TargetBlank = {
+	args: {
+		...defaultProps,
+		target: '_blank',
 	},
 };
 

--- a/packages/design-system/src/components/Link/Link.test.js
+++ b/packages/design-system/src/components/Link/Link.test.js
@@ -1,6 +1,6 @@
 import React from 'react';
-import { render } from '../../../test-utils';
 import Link from '.';
+import { render } from '../../../test-utils';
 
 describe('Link', () => {
 	test('default', () => {
@@ -49,6 +49,16 @@ describe('Link', () => {
 		expect(
 			link.querySelector('.link__icon').classList.contains('link__icon--external'),
 		).toBeTruthy();
+	});
+
+	test('target blank', () => {
+		const { getByTestId } = render(
+			<Link data-testid="my.link" target="_blank">
+				Link
+			</Link>,
+		);
+		const link = getByTestId('my.link');
+		expect(link.getAttribute('title')).toBe('Open in a new tab');
 	});
 
 	test('data-feature', () => {

--- a/packages/design-system/src/components/Link/Link.test.js
+++ b/packages/design-system/src/components/Link/Link.test.js
@@ -59,6 +59,29 @@ describe('Link', () => {
 		);
 		const link = getByTestId('my.link');
 		expect(link.getAttribute('title')).toBe('Open in a new tab');
+		expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+	});
+
+	test('target unknown', () => {
+		const { getByTestId } = render(
+			<Link data-testid="my.link" target="unknown">
+				Link
+			</Link>,
+		);
+		const link = getByTestId('my.link');
+		expect(link.getAttribute('title')).toBe('Open in a new tab');
+		expect(link.getAttribute('rel')).toBe('noopener noreferrer');
+	});
+
+	test('target self', () => {
+		const { getByTestId } = render(
+			<Link data-testid="my.link" target="_self">
+				Link
+			</Link>,
+		);
+		const link = getByTestId('my.link');
+		expect(link.getAttribute('title')).toBeNull();
+		expect(link.getAttribute('rel')).toBeNull();
 	});
 
 	test('data-feature', () => {

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -38,7 +38,10 @@ const Link = React.forwardRef(
 		ref: React.Ref<any>,
 	) => {
 		const { t } = useTranslation();
-		const isBlank: boolean = React.useMemo(() => target?.toLowerCase() === '_blank', [target]);
+		const isBlank: boolean = React.useMemo(
+			() => !!target && !['_self', '_parent', '_top'].includes(target.toLowerCase()),
+			[target],
+		);
 		const isExternal = React.useMemo(() => {
 			if (!href) {
 				return false;

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -1,9 +1,7 @@
+import { IconName } from '@talend/icons';
 import React from 'react';
 import { useTranslation } from 'react-i18next';
-import { IconName } from '@talend/icons';
-
 import { Icon } from '../Icon/Icon';
-
 import * as S from './Link.style';
 
 export type LinkProps = React.AnchorHTMLAttributes<any> & {
@@ -60,13 +58,13 @@ const Link = React.forwardRef(
 					defaultValue: 'This link is disabled',
 				});
 			}
-			if (isExternal && isBlank && title) {
+			if (isBlank && title) {
 				return t('LINK_EXTERNAL_TITLE', {
 					title,
 					defaultValue: '{{title}} (open in a new tab)',
 				});
 			}
-			if (isExternal && isBlank) {
+			if (isBlank) {
 				return t('LINK_EXTERNAL', {
 					defaultValue: 'Open in a new tab',
 				});

--- a/packages/design-system/src/components/Link/docs/Link.stories.mdx
+++ b/packages/design-system/src/components/Link/docs/Link.stories.mdx
@@ -62,7 +62,6 @@ When the link targets a new domain, we add an external-link icon right after.
 	<Story story={Stories.External} />
 </Canvas>
 
-### Target blank
 
 Even if it's the same domain, when the link opens in a new window or tab, the title `open in a new tab` is added or appended to an existing title.
 

--- a/packages/design-system/src/components/Link/docs/Link.stories.mdx
+++ b/packages/design-system/src/components/Link/docs/Link.stories.mdx
@@ -64,7 +64,7 @@ When the link targets a new domain, we add an external-link icon right after.
 
 ### Target blank
 
-When the link opens in a new window or tab, the title `open in a new tab` is added or appended to an existing title.
+Even if it's the same domain, when the link opens in a new window or tab, the title `open in a new tab` is added or appended to an existing title.
 
 <Canvas>
 	<Story story={Stories.TargetBlank} />

--- a/packages/design-system/src/components/Link/docs/Link.stories.mdx
+++ b/packages/design-system/src/components/Link/docs/Link.stories.mdx
@@ -62,6 +62,14 @@ When the link targets a new domain, we add an external-link icon right after.
 	<Story story={Stories.External} />
 </Canvas>
 
+### Target blank
+
+When the link opens in a new window or tab, the title `open in a new tab` is added or appended to an existing title.
+
+<Canvas>
+	<Story story={Stories.TargetBlank} />
+</Canvas>
+
 The attribute `rel="noopener noreferrer"` is added if its target is `_blank`.
 
 ### As a button


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The title "open in a new tab" should be related to the target attribute and not the detection of external link

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
