### PR TITLE
feat(utils/date): format date in specified locale

### DIFF
--- a/.changeset/mighty-colts-clap.md
+++ b/.changeset/mighty-colts-clap.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': minor
+---
+
+format date in specified locale

--- a/.changeset/mighty-colts-clap.md
+++ b/.changeset/mighty-colts-clap.md
@@ -2,4 +2,4 @@
 '@talend/utils': minor
 ---
 
-format date in specified locale
+feat(utils/date): format date in specified locale

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -1,3 +1,4 @@
+import dateFnsFormat from 'date-fns/format';
 import {
 	convertToLocalTime,
 	convertToTimeZone,
@@ -10,7 +11,18 @@ import {
 	timeZoneExists,
 } from './index';
 
+jest.mock('date-fns/format', () => {
+	const actualFormat = jest.requireActual('date-fns/format');
+	return {
+		__esModule: true,
+		default: jest.fn().mockImplementation(actualFormat),
+	};
+});
+
 describe('date', () => {
+	afterAll(() => {
+		jest.unmock('date-fns/format');
+	});
 	// "Locale date" here means Europe/Paris, according to the test command described in package.json
 
 	const timeZones = {
@@ -88,18 +100,13 @@ describe('date', () => {
 	});
 
 	describe('formatReadableUTCOffset', () => {
-		test.each(
-			[
-				[0, '+00:00'],
-				[540, '+09:00'],
-				[-360, '-06:00'],
-			]
-		)(
-			'it should format a %s minutes offset',
-			(offset: number, expectedOffset: string) => {
-				expect(formatReadableUTCOffset(offset)).toEqual(expectedOffset);
-			}
-		);
+		test.each([
+			[0, '+00:00'],
+			[540, '+09:00'],
+			[-360, '-06:00'],
+		])('it should format a %s minutes offset', (offset: number, expectedOffset: string) => {
+			expect(formatReadableUTCOffset(offset)).toEqual(expectedOffset);
+		});
 	});
 
 	describe('formatToTimeZone', () => {
@@ -128,6 +135,28 @@ describe('date', () => {
 			// then
 			expect(localDate).toEqual('2020-05-13T23:00:00Z');
 		});
+		it('should pass locale to datefns format method', () => {
+			// given
+			const mockLocal = jest.fn();
+			const dateObj = new Date('2020-12-20, 20:00');
+			const formatString = 'ddd YYYY-MM-DD HH:mm:ss';
+			const options = {
+				timeZone: timeZones['UTC+5'],
+				locale: mockLocal,
+			};
+
+			// when
+			formatToTimeZone(dateObj, formatString, options);
+
+			// then
+			expect(dateFnsFormat).toHaveBeenCalledWith(
+				expect.anything(),
+				expect.anything(),
+				expect.objectContaining({
+					locale: mockLocal,
+				}),
+			);
+		});
 	});
 
 	describe('convertToUTC', () => {
@@ -143,18 +172,13 @@ describe('date', () => {
 	});
 
 	describe('getUTCOffset', () => {
-		test.each(
-			[
-				['Africa/Bamako', 0],
-				['Asia/Seoul', 540],
-				['America/Swift_Current', -360],
-			]
-		)(
-			'it should get %s timezone offset',
-			(timezone: string, expectedOffset: number) => {
-				expect(getUTCOffset(timezone)).toEqual(expectedOffset);
-			}
-		);
+		test.each([
+			['Africa/Bamako', 0],
+			['Asia/Seoul', 540],
+			['America/Swift_Current', -360],
+		])('it should get %s timezone offset', (timezone: string, expectedOffset: number) => {
+			expect(getUTCOffset(timezone)).toEqual(expectedOffset);
+		});
 	});
 
 	describe('timeZoneExists', () => {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -20,8 +20,8 @@ jest.mock('date-fns/format', () => {
 });
 
 describe('date', () => {
-	afterAll(() => {
-		jest.unmock('date-fns/format');
+	afterEach(() => {
+		jest.clearAllMocks();
 	});
 	// "Locale date" here means Europe/Paris, according to the test command described in package.json
 
@@ -137,7 +137,7 @@ describe('date', () => {
 		});
 		it('should pass locale to datefns format method', () => {
 			// given
-			const mockLocal = jest.fn();
+			const mockLocal = { format: () => {}};
 			const dateObj = new Date('2020-12-20, 20:00');
 			const formatString = 'ddd YYYY-MM-DD HH:mm:ss';
 			const options = {

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -6,6 +6,7 @@ type DateFnsFormatInput = Date | number | string;
 interface ConversionOptions {
 	timeZone: string,
 	sourceTimeZone?: string,
+	locale?: Object,
 }
 
 export interface DateFormatOptions {
@@ -142,7 +143,9 @@ export function formatToTimeZone(date: DateFnsFormatInput, formatString: string,
 	// Replace timezone token(s) in the string format with timezone values, since format() will use local timezone
 	const dateFnsFormatWithTimeZoneValue = formatTimeZoneTokens(formatString, options.timeZone);
 
-	return dateFnsFormat(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue);
+	return dateFnsFormat(dateConvertedToTimezone, dateFnsFormatWithTimeZoneValue, {
+		locale: options.locale,
+	});
 }
 
 /**


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In `CellDatetime`, date strings are not translated.
**What is the chosen solution to this problem?**
Enrich `formatToTimeZone` function of utils package, so it can format date in specified locale.
Pass locale in options when calling date-fns' format
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
