### PR TITLE
fix(design-system/buttons): default cursor for busy buttons

### DIFF
--- a/.changeset/green-swans-lick.md
+++ b/.changeset/green-swans-lick.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(buttons): busy buttons should have a regular cursor

--- a/packages/design-system/src/components/Button/variations/Button.base.tsx
+++ b/packages/design-system/src/components/Button/variations/Button.base.tsx
@@ -29,10 +29,6 @@ const ButtonBase: React.FC<ButtonProps> = button`
 		opacity: ${tokens.opacity.disabled};
 	}
 
-	&[aria-busy='true'] {
-		cursor: progress;
-	}
-
 	&[aria-disabled='true'] {
 		cursor: not-allowed;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

busy buttons have a `progress` cursor

**What is the chosen solution to this problem?**

busy buttons should have default cursor

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
