### PR TITLE
feat(Inject): Support components as props when not cmfConnected

### DIFF
--- a/.changeset/empty-seals-work.md
+++ b/.changeset/empty-seals-work.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(Inject): Support components as props when not cmfConnected

--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -77,10 +77,13 @@ Inject.all = function injectAll(getComponent, components, CustomInject = Inject)
 /**
  * used to inject a component with componentID & fallback on a component given if not available
  * @param {function} getComponent the method used to resolve the component
- * @param {string} componentId the id to fetch with getComponent method
+ * @param {string|function} componentId the id to fetch with getComponent method or the component to render
  * @param {object} DefaultComponent The component to fallback to
  */
 Inject.get = function injectGet(getComponent, componentId, DefaultComponent) {
+	if (!getComponent && typeof componentId === 'function') {
+		return componentId;
+	}
 	if (!getComponent || componentId == null) {
 		return DefaultComponent;
 	}

--- a/packages/components/src/Inject/Inject.component.js
+++ b/packages/components/src/Inject/Inject.component.js
@@ -81,7 +81,7 @@ Inject.all = function injectAll(getComponent, components, CustomInject = Inject)
  * @param {object} DefaultComponent The component to fallback to
  */
 Inject.get = function injectGet(getComponent, componentId, DefaultComponent) {
-	if (!getComponent && typeof componentId === 'function') {
+	if (typeof componentId === 'function') {
 		return componentId;
 	}
 	if (!getComponent || componentId == null) {

--- a/packages/components/src/Inject/Inject.test.js
+++ b/packages/components/src/Inject/Inject.test.js
@@ -192,9 +192,10 @@ describe('Inject.get', () => {
 	it('should return null', () => {
 		expect(Inject.get(null, null, null)).toEqual(null);
 	});
-	it('should return given component', () => {
+	it('should return provided component', () => {
+		const getComponent = jest.fn();
 		const comp = () => null;
-		expect(Inject.get(null, comp, null)).toEqual(comp);
+		expect(Inject.get(getComponent, comp, null)).toEqual(comp);
 	});
 });
 

--- a/packages/components/src/Inject/Inject.test.js
+++ b/packages/components/src/Inject/Inject.test.js
@@ -192,6 +192,10 @@ describe('Inject.get', () => {
 	it('should return null', () => {
 		expect(Inject.get(null, null, null)).toEqual(null);
 	});
+	it('should return given component', () => {
+		const comp = () => null;
+		expect(Inject.get(null, comp, null)).toEqual(comp);
+	});
 });
 
 describe('Inject.getAll', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Some components are cmf connected only to get renderers from the registry
Example: 
```
        import DataGrid from '@talend/react-datagrid/containers';
	<DataGrid     
		headerRenderer="DataGridHeaderRenderer" // name of the component in the registry
        />
```

Would be nice to be able to use the component like this
```
        import DataGrid from '@talend/react-datagrid/components'; 
	<DataGrid     
		headerRenderer={DataGridHeaderRenderer} // actual component
        />
```

**What is the chosen solution to this problem?**

Update`Inject` to return the prop if it's a composant and look for the componentId in the registry otherwise

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
