### PR TITLE
feat(DataGrid): Set focused column from props

### DIFF
--- a/.changeset/nasty-turkeys-flow.md
+++ b/.changeset/nasty-turkeys-flow.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': minor
+---
+
+feat(DataGrid): Set focused column from props"

--- a/.changeset/nasty-turkeys-flow.md
+++ b/.changeset/nasty-turkeys-flow.md
@@ -2,4 +2,4 @@
 '@talend/react-datagrid': minor
 ---
 
-feat(DataGrid): Set focused column from props"
+feat(DataGrid): Set focused column from props

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -108,10 +108,20 @@ export default class DataGrid extends React.Component {
 			console.warn('DEPRECATED: forceRedrawRows is deprecated');
 			this.gridAPI.redrawRows();
 		}
+
+		if (
+			this.props.focusedColumnId !== prevProps.focusedColumnId &&
+			this.props.focusedColumnId !== this.currentColId
+		) {
+			this.onFocusedColumn(this.props.focusedColumnId);
+		}
 	}
 
 	onGridReady({ api }) {
 		this.gridAPI = api;
+		if (this.props.focusedColumnId && this.props.focusedColumnId !== this.currentColId) {
+			this.onFocusedColumn(this.props.focusedColumnId);
+		}
 	}
 
 	onFocusedCell(props) {

--- a/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.proptypes.js
@@ -10,6 +10,7 @@ const DATAGRID_PROPTYPES = {
 	loading: PropTypes.bool,
 	enableColResize: PropTypes.bool,
 	columnMinWidth: PropTypes.number,
+	focusedColumnId: PropTypes.string,
 	forceRedrawRows: PropTypes.func, // deprecated
 	getComponent: PropTypes.func,
 	getPinnedColumnDefsFn: PropTypes.func,

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -175,7 +175,7 @@ describe('#DataGrid', () => {
 			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} loading />,
 		);
 
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
@@ -185,7 +185,7 @@ describe('#DataGrid', () => {
 			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} />,
 		);
 
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
@@ -201,7 +201,7 @@ describe('#DataGrid', () => {
 				redrawRows,
 			},
 		});
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 
 		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).toHaveBeenCalled();
@@ -219,7 +219,7 @@ describe('#DataGrid', () => {
 				redrawRows,
 			},
 		});
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 
 		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).not.toHaveBeenCalled();
@@ -265,7 +265,10 @@ describe('#AgGrid API', () => {
 		const api = {};
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		expect(wrapper.instance().gridAPI).toBe(api);
 	});
@@ -381,7 +384,10 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -408,7 +414,10 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -431,7 +440,10 @@ describe('#Datagrid method', () => {
 			rowIndex: 2,
 		};
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		const nextFocusedCell = wrapper.instance().handleKeyboard({
 			nextCellPosition,
@@ -440,6 +452,26 @@ describe('#Datagrid method', () => {
 
 		expect(nextFocusedCell).toBe(nextCellPosition);
 		expect(setSelected).not.toHaveBeenCalled();
+	});
+
+	it('should set the current selected column from props', () => {
+		const wrapper = shallow(<DataGrid getComponent={getComponent} focusedColumnId="field3" />);
+		wrapper.instance().onFocusedColumn = jest.fn();
+		wrapper.instance().onGridReady({ api: {} });
+
+		expect(wrapper.instance().onFocusedColumn).toHaveBeenCalledWith('field3');
+	});
+
+	it('should update current selected column from props', () => {
+		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
+		wrapper.instance().onFocusedColumn = jest.fn();
+		wrapper.instance().onGridReady({ api: {} });
+
+		wrapper.setProps({
+			focusedColumnId: 'field2',
+		});
+
+		expect(wrapper.instance().onFocusedColumn).toHaveBeenCalledWith('field2');
 	});
 
 	it('should focus a column', () => {
@@ -460,7 +492,10 @@ describe('#Datagrid method', () => {
 		instance.removeFocusColumn = jest.fn();
 		instance.updateStyleFocusColumn = jest.fn();
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		instance.onFocusedColumn(currentColId);
 
@@ -605,7 +640,10 @@ describe('#Datagrid method', () => {
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 		const instance = wrapper.instance();
 
-		wrapper.find('AgGridReact').props().onGridReady({ api });
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({ api });
 
 		instance.onKeyDownHeaderColumn(
 			{
@@ -627,10 +665,13 @@ describe('#Datagrid method', () => {
 		const wrapper = shallow(<DataGrid getComponent={getComponent} />);
 		const instance = wrapper.instance();
 
-		wrapper.find('AgGridReact').props().onGridReady({
-			setFocusedCell,
-			ensureIndexVisible,
-		});
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({
+				setFocusedCell,
+				ensureIndexVisible,
+			});
 
 		instance.onKeyDownHeaderColumn(
 			{
@@ -660,9 +701,12 @@ describe('#Datagrid method', () => {
 		);
 		const instance = wrapper.instance();
 
-		wrapper.find('AgGridReact').props().onGridReady({
-			api,
-		});
+		wrapper
+			.find('AgGridReact')
+			.props()
+			.onGridReady({
+				api,
+			});
 
 		instance.onBodyScroll(event);
 
@@ -729,7 +773,7 @@ describe('#forceRedraw', () => {
 			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} loading />,
 		);
 
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
@@ -739,7 +783,7 @@ describe('#forceRedraw', () => {
 			<DataGrid getComponent={getComponent} forceRedrawRows={forceRedrawRows} />,
 		);
 
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 		expect(forceRedrawRows).not.toHaveBeenCalled();
 	});
 
@@ -755,7 +799,7 @@ describe('#forceRedraw', () => {
 				redrawRows,
 			},
 		});
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 
 		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).toHaveBeenCalled();
@@ -773,7 +817,7 @@ describe('#forceRedraw', () => {
 				redrawRows,
 			},
 		});
-		wrapper.instance().componentDidUpdate();
+		wrapper.instance().componentDidUpdate({});
 
 		expect(forceRedrawRows).toHaveBeenCalled();
 		expect(redrawRows).not.toHaveBeenCalled();

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-console */
 
-import React from 'react';
+import React, { useState } from 'react';
 import { storiesOf } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import { IconsProvider } from '@talend/react-components';
@@ -209,4 +209,21 @@ storiesOf('Data/Datagrid/Datagrid', module)
 			<FasterDatagrid />
 		</div>
 	))
-	.add('datagrid with immutable data', () => <ImmutableDataGrid />);
+	.add('datagrid with immutable data', () => <ImmutableDataGrid />)
+	.add('datagrid with controlled focused column', () => {
+		const [focusedColumnId, setFocusedColumnId] = useState('data.field2');
+		return (
+			<div style={{ height: '200px' }}>
+				<input type="button" value="Set Column" onClick={() => setFocusedColumnId('data.field3')} />
+				<DataGrid
+					data={sample}
+					getComponent={getComponent}
+					focusedColumnId={focusedColumnId}
+					onFocusedCell={cell => setFocusedColumnId(cell.column.colId)}
+					onFocusedColumn={col => setFocusedColumnId(col.colId)}
+					onVerticalScroll={event => console.log(event)}
+					rowSelection="multiple"
+				/>
+			</div>
+		);
+	});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

 Datagrid focused column can't be set from outside the grid.

**What is the chosen solution to this problem?**

Add a `focusedColumnId` prop

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
