### PR TITLE
chore(design-tokens): deploy on Netlify

### DIFF
--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -11,11 +11,12 @@ on:
 #      - master
 #    paths:
 #      - 'packages/design-system/**'
+#      - 'packages/design-tokens/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: main
+    environment: pull_request_unsafe
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -37,12 +38,11 @@ jobs:
         run: |
           cd ../design-tokens
           yarn build-storybook
-          cd -
 
       - name: Build using Netlify
         uses: netlify/actions/cli@master
         with:
-          args: build 
+          args: build
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -3,20 +3,15 @@ name: Deploy design.talend.com
 on:
   push:
     branches:
-      - frassinier/chore/design-tokens/netlify_deploy
-#
-#  /!\ commented for test purpose
-#
-#    branches:
-#      - master
-#    paths:
-#      - 'packages/design-system/**'
-#      - 'packages/design-tokens/**'
+      - master
+    paths:
+      - 'packages/design-system/**'
+      - 'packages/design-tokens/**'
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: pull_request_unsafe
+    environment: main
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -52,7 +47,7 @@ jobs:
       - name: Deploy to Netlify production
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dir=storybook-static
+          args: deploy --prod --dir=packages/design-system/storybook-static
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -48,7 +48,7 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Copy design tokens Storybook into design system output
-        run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens/
+        run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens
 
       - name: Deploy to Netlify production
         uses: netlify/actions/cli@master

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -2,6 +2,8 @@ name: Deploy design.talend.com
 
 on:
   push:
+    branches:
+      - frassinier/chore/design-tokens/netlify_deploy
 #
 #  /!\ commented for test purpose
 #

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -39,22 +39,12 @@ jobs:
         run: |
           cd ../design-tokens
           yarn build-storybook
+          cd -
 
-      - name: Link repository to Netlify
-        uses: netlify/actions/cli@master
-        with:
-          args: link
+      - name: Build Storybook of the design system
+        run: yarn build-storybook
         env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
-
-      - name: Build using Netlify
-        uses: netlify/actions/cli@master
-        with:
-          args: build
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          STORYBOOK_FIGMA_ACCESS_TOKEN: ${{ STORYBOOK_FIGMA_ACCESS_TOKEN }}
 
       - name: Copy design tokens Storybook into design system output
         run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -2,10 +2,13 @@ name: Deploy design.talend.com
 
 on:
   push:
-    branches:
-      - master
-    paths:
-      - 'packages/design-system/**'
+#
+#  /!\ commented for test purpose
+#
+#    branches:
+#      - master
+#    paths:
+#      - 'packages/design-system/**'
 
 jobs:
   deploy:
@@ -25,15 +28,30 @@ jobs:
           scope: "@talend"
           cache: "yarn"
 
-      - name: Build Storybook
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Build Storybook of the design tokens
         run: |
-          yarn install --frozen-lockfile
+          cd ../design-tokens
           yarn build-storybook
+          cd -
+
+      - name: Build using Netlify
+        uses: netlify/actions/cli@master
+        with:
+          args: build 
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+
+      - name: Copy design tokens Storybook into design system output
+        run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens/
 
       - name: Deploy to Netlify production
         uses: netlify/actions/cli@master
         with:
-          args: deploy --prod --dir=packages/design-system/storybook-static
+          args: deploy --dry --dir=storybook-static
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -27,25 +27,28 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+          registry-url: 'https://registry.npmjs.org/'
+          scope: '@talend'
+          cache: 'yarn'
 
       - name: Install dependencies
-        run: yarn install --frozen-lockfile
+        run: |
+          yarn install --frozen-lockfile
 
       - name: Build Storybook of the design tokens
         run: |
           cd ../design-tokens
           yarn build-storybook
 
+      - name: Link repository to Netlify
+        uses: netlify/actions/cli@master
+        with:
+          args: link --id=${{ secrets.NETLIFY_SITE_ID }}
+
       - name: Build using Netlify
         uses: netlify/actions/cli@master
         with:
           args: build
-        env:
-          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
-          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Copy design tokens Storybook into design system output
         run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -43,12 +43,18 @@ jobs:
       - name: Link repository to Netlify
         uses: netlify/actions/cli@master
         with:
-          args: link --id=${{ secrets.NETLIFY_SITE_ID }}
+          args: link
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Build using Netlify
         uses: netlify/actions/cli@master
         with:
           args: build
+        env:
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
 
       - name: Copy design tokens Storybook into design system output
         run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens
@@ -56,7 +62,7 @@ jobs:
       - name: Deploy to Netlify production
         uses: netlify/actions/cli@master
         with:
-          args: deploy --dry --dir=storybook-static
+          args: deploy --dir=storybook-static
         env:
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Build Storybook of the design system
         run: yarn build-storybook
         env:
-          STORYBOOK_FIGMA_ACCESS_TOKEN: ${{ STORYBOOK_FIGMA_ACCESS_TOKEN }}
+          STORYBOOK_FIGMA_ACCESS_TOKEN: ${{ secrets.STORYBOOK_FIGMA_ACCESS_TOKEN }}
 
       - name: Copy design tokens Storybook into design system output
         run: cp -Rf ../design-tokens/storybook-static ./storybook-static/design-tokens


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Design tokens related Storybook must be included into design.talend.com

**What is the chosen solution to this problem?**

Deploy  Design tokens' Storybook on Netlify, in addition of the Design System documentation.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
