### PR TITLE
fix(component): typehead icon is not aligned

### DIFF
--- a/.changeset/blue-phones-hide.md
+++ b/.changeset/blue-phones-hide.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: remove margin on typehead

--- a/packages/components/src/Typeahead/Typeahead.scss
+++ b/packages/components/src/Typeahead/Typeahead.scss
@@ -10,7 +10,7 @@ $tc-typeahead-section-border-color: $gray75 !default;
 
 $tc-typeahead-icon-color: $gray !default;
 $tc-typeahead-only-icon-color: $gray200 !default;
-$tc-typeahead-section-header-color: #63AEBD !default;
+$tc-typeahead-section-header-color: #63aebd !default;
 
 $tc-typeahead-items-box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.4) !default;
 $tc-typeahead-items-border-radius: $border-radius-base !default;
@@ -78,6 +78,7 @@ $tc-typeahead-item-description-height: 1.6rem !default;
 	&-icon {
 		[type='text'].typeahead-input {
 			padding-left: 2.5em;
+			margin-bottom: 0;
 		}
 
 		.icon-cls {

--- a/size.json
+++ b/size.json
@@ -43,7 +43,7 @@
   "packages/design-tokens/dist/TalendDesignTokens.min.js.dependencies.json": 2,
   "packages/faceted-search/dist/TalendReactFacetedSearch.css": 10508,
   "packages/faceted-search/dist/TalendReactFacetedSearch.js": 367004,
-  "packages/faceted-search/dist/TalendReactFacetedSearch.js.dependencies.json": 995,
+  "packages/faceted-search/dist/TalendReactFacetedSearch.js.dependencies.json": 1251,
   "packages/faceted-search/dist/TalendReactFacetedSearch.min.js": 92300,
   "packages/faceted-search/dist/TalendReactFacetedSearch.min.js.dependencies.json": 1025,
   "packages/flow-designer/dist/ReactFlowDesigner.min.js": 91151,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Search icon is not aligned, it's because there is a margin bottom. I don't see usage of this margin (it's coming from bootstrap)

<img width="284" alt="CleanShot 2021-12-30 at 14 39 07@2x" src="https://user-images.githubusercontent.com/2909671/147757039-34b06497-6616-42ac-8af2-9a363c865a0c.png">

**What is the chosen solution to this problem?**
<img width="282" alt="CleanShot 2021-12-30 at 14 39 21@2x" src="https://user-images.githubusercontent.com/2909671/147757045-c8a0b80a-1841-4c04-80ea-0036affcef9b.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
