### PR TITLE
fix(design-system): build with design tokens

### DIFF
--- a/.changeset/light-insects-boil.md
+++ b/.changeset/light-insects-boil.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): build using design tokens

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -12,7 +12,7 @@
     "start": "npm run storybook",
     "test": "talend-scripts test",
     "test:cy": "cypress run-ct",
-    "test:demo": "build-storybook --docs && node ./scripts/sitemap.js",
+    "test:demo": "npm run build-storybook",
     "storybook": "npm run build:lib && BROWSER=none start-storybook -p 6006",
     "build-storybook": "npm run build:lib && build-storybook --docs && node ./scripts/sitemap.js",
     "extract-i18n": "i18next-scanner --config i18next-scanner.config.js",

--- a/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
+++ b/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
@@ -59,7 +59,7 @@ function Block({ width }: { width: string }) {
 				height: tokens.coralSizeL,
 				borderRadius: tokens.coralRadiusM,
 				background: tokens.coralColorAccentBackground,
-				border: `${tokens.coralBorderDashedS} ${tokens.coralColorAccentBorder}`,
+				border: `${tokens.coralBorderSDashed} ${tokens.coralColorAccentBorder}`,
 			}}
 		/>
 	);

--- a/packages/design-system/src/components/Stack/StackVertical.stories.tsx
+++ b/packages/design-system/src/components/Stack/StackVertical.stories.tsx
@@ -22,7 +22,7 @@ function Block({ width }: { width: string }) {
 				height: tokens.coralSizeL,
 				borderRadius: tokens.coralRadiusM,
 				background: tokens.coralColorAccentBackground,
-				border: `${tokens.coralBorderDashedS} ${tokens.coralColorAccentBorder}`,
+				border: `${tokens.coralBorderSDashed} ${tokens.coralColorAccentBorder}`,
 			}}
 		/>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

DS uses Design Tokens with the monorepo's workspace, so it depends on the build you've done before

**What is the chosen solution to this problem?**

DS will now rely on the real tokens

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
