### PR TITLE
fix(scripts): env var in npm scripts for windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:es": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:es",
     "lint:style": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:style",
     "build": "yarn workspaces run build",
-    "test": "cross-env EXECUTE_PARALLEL=true cross-env TZ=Europe/Paris node workspace-run.js test --silent",
+    "test": "cross-env EXECUTE_PARALLEL=true TZ=Europe/Paris node workspace-run.js test --silent",
     "test:update": "cross-env TZ=Europe/Paris yarn workspaces run test --silent -u",
     "test:cov": "cross-env TZ=Europe/Paris yarn workspaces run test:cov",
     "test:demo": "node workspace-run.js test:demo",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "i18next-scanner": "^3.1.0"
   },
   "scripts": {
-    "postinstall": "EXECUTE_PARALLEL=true node workspace-run.js build:lib",
+    "postinstall": "cross-env EXECUTE_PARALLEL=true node workspace-run.js build:lib",
     "pre-release": "node workspace-run.js pre-release",
     "start": "yarn workspace @talend/ui-playground run start",
     "info": "yarn workspaces --silent info > info.json",
@@ -15,7 +15,7 @@
     "lint:es": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:es",
     "lint:style": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:style",
     "build": "yarn workspaces run build",
-    "test": "EXECUTE_PARALLEL=true cross-env TZ=Europe/Paris node workspace-run.js test --silent",
+    "test": "cross-env EXECUTE_PARALLEL=true cross-env TZ=Europe/Paris node workspace-run.js test --silent",
     "test:update": "cross-env TZ=Europe/Paris yarn workspaces run test --silent -u",
     "test:cov": "cross-env TZ=Europe/Paris yarn workspaces run test:cov",
     "test:demo": "node workspace-run.js test:demo",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Using `yarn` on Windows fails at post install.
```
yarn
....
$ EXECUTE_PARALLEL=true node workspace-run.js build:lib
'EXECUTE_PARALLEL' n’est pas reconnu en tant que commande interne
ou externe, un programme exécutable ou un fichier de commandes.  
error Command failed with exit code 1.
```

**What is the chosen solution to this problem?**
Use `cross-env`.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
