### PR TITLE
fix(ARCH-421/design-system): ts config

### DIFF
--- a/.changeset/seven-crews-warn.md
+++ b/.changeset/seven-crews-warn.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+adjust ts config to generate index.d.ts

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@talend/scripts-config-typescript/tsconfig.json",
-  "include": ["src/**/*", "custom.d.ts"],
+  "include": ["src/*", "custom.d.ts"],
   "exclude": ["**/*.spec.tsx"],
   "compilerOptions": {
     "declaration": true,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current DS package do not have index.d.ts file 
https://unpkg.com/browse/@talend/design-system@1.12.1/lib/

Last release with it was https://unpkg.com/browse/@talend/design-system@1.11.3/lib/

**What is the chosen solution to this problem?**

Adjust tsconfig.json seems to fix the issue.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
