### PR TITLE
fix(design-system): remove hardcoded string in the input file component

### DIFF
--- a/.changeset/brown-impalas-attack.md
+++ b/.changeset/brown-impalas-attack.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+fix(design-system): remove hardcoded string in the input file component

--- a/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
@@ -3,6 +3,7 @@ import { shade, tint } from 'polished';
 import styled from 'styled-components';
 import { unstable_useId as useId } from 'reakit';
 import { Trans, useTranslation } from 'react-i18next';
+import { TFunction } from 'i18next';
 import Button from '../../../Button';
 import Link from '../../../Link';
 import { Icon } from '../../../Icon';
@@ -124,13 +125,13 @@ const FileField = styled.div`
 	}
 `;
 
-function getFileSize(size: number) {
+function getFileSize(size: number, t: TFunction) {
 	if (size < 1024) {
-		return `${size}bytes`;
+		return t('INPUT_FILE_BYTES', '{{size}}bytes', size.toString());
 	} else if (size > 1024 && size < 1048576) {
-		return `${(size / 1024).toFixed(1)}KB`;
+		return t('INPUT_FILE_KB', '{{size}}KB', (size / 1024).toFixed(1));
 	} else if (size > 1048576) {
-		return `${(size / 1048576).toFixed(1)}MB`;
+		return t('INPUT_FILE_MB', '{{size}}MB', (size / 1048576).toFixed(1));
 	}
 	return '';
 }
@@ -205,7 +206,7 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 						files
 							? Array.from(files)
 									.map((file: File | string) =>
-										typeof file === 'string' ? file : `${file.name} (${getFileSize(file.size)})`,
+										typeof file === 'string' ? file : `${file.name} (${getFileSize(file.size, t)})`,
 									)
 									.join(';')
 							: ''
@@ -240,7 +241,7 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 								{files &&
 									Array.from(files).map((file: File | string, index: React.Key) => (
 										<li key={index} className="preview__list-item">
-											{typeof file === 'string' ? file : `${file.name} (${getFileSize(file.size)})`}
+											{typeof file === 'string' ? file : `${file.name} (${getFileSize(file.size, t)})`}
 										</li>
 									))}
 							</ol>

--- a/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
@@ -127,11 +127,11 @@ const FileField = styled.div`
 
 function getFileSize(size: number, t: TFunction) {
 	if (size < 1024) {
-		return t('INPUT_FILE_BYTES', '{{size}}bytes', size.toString());
+		return t('INPUT_FILE_BYTES', '{{size}}bytes', { size });
 	} else if (size > 1024 && size < 1048576) {
-		return t('INPUT_FILE_KB', '{{size}}KB', (size / 1024).toFixed(1));
+		return t('INPUT_FILE_KB', '{{size}}KB', { size: (size / 1024).toFixed(1) });
 	} else if (size > 1048576) {
-		return t('INPUT_FILE_MB', '{{size}}MB', (size / 1048576).toFixed(1));
+		return t('INPUT_FILE_MB', '{{size}}MB', { size: (size / 1048576).toFixed(1) });
 	}
 	return '';
 }
@@ -241,7 +241,9 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 								{files &&
 									Array.from(files).map((file: File | string, index: React.Key) => (
 										<li key={index} className="preview__list-item">
-											{typeof file === 'string' ? file : `${file.name} (${getFileSize(file.size, t)})`}
+											{typeof file === 'string'
+												? file
+												: `${file.name} (${getFileSize(file.size, t)})`}
 										</li>
 									))}
 							</ol>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There was hardcoded string left in the `getFileSize` function.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
