### PR TITLE
chore(design-system): Chromatic GH Action

### DIFF
--- a/.github/workflows/design-system-visual-testing.yml
+++ b/.github/workflows/design-system-visual-testing.yml
@@ -10,6 +10,7 @@ on:
     branches:
       - master
     paths:
+      - 'packages/design-tokens/**'
       - 'packages/design-system/**'
 
 jobs:
@@ -36,6 +37,11 @@ jobs:
 
       - name: Install dependencies
         run: yarn --frozen-lock
+
+      - name: Build @talend/design-tokens
+        run: |
+          cd ../design-tokens
+          yarn build:lib
 
       - name: Publish to Chromatic
         uses: chromaui/action@v1


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Chromatic GH Action needs to build design-tokens at first because it's owned by the monorepo.

**What is the chosen solution to this problem?**

Build the package  before publishing it to Chromatic

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
