### PR TITLE
fix(design-system): add tsconfig rootDir

### DIFF
--- a/.changeset/violet-icons-rule.md
+++ b/.changeset/violet-icons-rule.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: tsconfig to have index.d.ts at root

--- a/packages/design-system/tsconfig.json
+++ b/packages/design-system/tsconfig.json
@@ -1,9 +1,10 @@
 {
   "extends": "@talend/scripts-config-typescript/tsconfig.json",
-  "include": [".storybook/docs", "src/*", "custom.d.ts"],
+  "include": ["../.storybook/docs/*", "src/*", "custom.d.ts"],
   "exclude": ["**/*.spec.tsx"],
   "files": [],
   "compilerOptions": {
+    "rootDir": "src",
     "declaration": true,
     "baseUrl": ".",
     "paths": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

last two releases 1.13 and 1.14 do not have index.d.ts which makes ts projects fails to compile.

**What is the chosen solution to this problem?**

add [rootDir](https://www.typescriptlang.org/tsconfig#rootDir) config to tsconfig

source: https://stackoverflow.com/a/58941798

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
