### PR TITLE
fix(Switch): Animation is broken

### DIFF
--- a/.changeset/funny-pandas-swim.md
+++ b/.changeset/funny-pandas-swim.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Switch: Animation is broken

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -32,11 +32,6 @@ const Switch = ({
 
 	const containerRef = useRef<React.PropsWithChildren<any>>();
 	const switchIndicator = useRef<React.PropsWithChildren<any>>();
-	const radioWidths = useRef<number[]>();
-
-	if (!radioWidths.current) {
-		radioWidths.current = radio.items.map(item => item.ref.current?.scrollWidth || 0);
-	}
 
 	useLayoutEffect(() => {
 		const radioGroup = containerRef?.current;
@@ -53,12 +48,13 @@ const Switch = ({
 		const switchIndicatorRef = switchIndicator?.current;
 		if (switchIndicatorRef) {
 			switchIndicatorRef.style.width = `${checkedRadioSpanWidth}px`;
-			switchIndicatorRef.style.transform = `translateX(${radioWidths.current
+			const radioWidths = radio.items.map(item => item.ref.current?.scrollWidth || 0);
+			switchIndicatorRef.style.transform = `translateX(${radioWidths
 				?.slice(0, checkedRadioIndex)
 				.reduce((accumulator, currentValue) => accumulator + currentValue, 0)}px)`;
 			switchIndicatorRef.dataset.animated = true;
 		}
-	}, [radio, defaultValue]);
+	}, [radio, defaultValue, radio.items]);
 
 	return (
 		<S.Switch readOnly={readOnly} disabled={disabled}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The "blue bubble" is no longer correctly positioned when selecting a value
https://design.talend.com/?path=/docs/components-switch--default-story&globals=theme:light
Regression from: https://github.com/Talend/ui/pull/3605

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
