### PR TITLE
chore(design-system): Usage story was not rendering

### DIFF
--- a/packages/design-system/src/components/InlineMessage/InlineMessage.stories.tsx
+++ b/packages/design-system/src/components/InlineMessage/InlineMessage.stories.tsx
@@ -4,7 +4,7 @@ import Link from '../Link';
 
 export default { component: InlineMessage };
 
-const render = ({ variant, ...rest }: { variant: keyof typeof InlineMessage }) => {
+const render = ({ variant, ...rest }: { variant?: keyof typeof InlineMessage }) => {
 	switch (variant) {
 		case 'Information':
 			return <InlineMessage.Information {...rest} />;
@@ -15,7 +15,7 @@ const render = ({ variant, ...rest }: { variant: keyof typeof InlineMessage }) =
 		case 'Destructive':
 			return <InlineMessage.Destructive {...rest} />;
 		default:
-			return null;
+			return <InlineMessage {...rest} />;
 	}
 };
 
@@ -26,6 +26,7 @@ const defaultProps = {
 	link: <Link href="#">See more</Link>,
 };
 
+export const Default = { args: { ...defaultProps }, render };
 export const Information = {
 	args: {
 		...defaultProps,

--- a/packages/design-system/src/components/InlineMessage/docs/InlineMessage.stories.mdx
+++ b/packages/design-system/src/components/InlineMessage/docs/InlineMessage.stories.mdx
@@ -162,7 +162,7 @@ Error messages should tell why there was a problem and what could be done to res
 			},
 		}}
 	>
-		{Stories.Information.render.bind({})}
+		{Stories.Default.render.bind({})}
 	</Story>
 </Canvas>
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

No variant in demo means return nothing and Chromatic failed

**What is the chosen solution to this problem?**

Return the primitive of InlineMessage instead

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
