### PR TITLE
chore(design-system): deprecate Button.Icon and Toggle

### DIFF
--- a/.changeset/poor-windows-fetch.md
+++ b/.changeset/poor-windows-fetch.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+doc(design-tokens): Button.Icon and Toggle usage is now discouraged

--- a/packages/design-system/.storybook/docs/Badge.tsx
+++ b/packages/design-system/.storybook/docs/Badge.tsx
@@ -29,6 +29,17 @@ export const renderStatus = (status?: Status) => {
 					{status}
 				</span>
 			);
+		case Status.DEPRECATED:
+			return (
+				<span
+					style={{
+						color: tokens.coralColorWarningTextWeak,
+						background: tokens.coralColorWarningBackgroundStrong,
+					}}
+				>
+					{status}
+				</span>
+			);
 		case Status.KO:
 			return (
 				<span

--- a/packages/design-system/.storybook/docs/BadgeStorybook.tsx
+++ b/packages/design-system/.storybook/docs/BadgeStorybook.tsx
@@ -5,7 +5,7 @@ import Badge from './Badge';
 const StorybookStatus = (props: React.FunctionComponent) => {
 	return (
 		<Badge {...props} icon="storybook">
-			Documentation
+			Storybook
 		</Badge>
 	);
 };

--- a/packages/design-system/.storybook/docs/StatusTable.tsx
+++ b/packages/design-system/.storybook/docs/StatusTable.tsx
@@ -10,6 +10,7 @@ export enum Status {
 	OK = 'ok',
 	KO = 'ko',
 	WIP = 'wip',
+	DEPRECATED = 'deprecated',
 	NA = 'na',
 	UNKNOWN = '❔', // This one is the default value, not designed to be used
 }

--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -33,7 +33,7 @@ module.exports = {
 	refs: {
 		'design-tokens': {
 			title: 'Design Tokens',
-			url: '/design-tokens',
+			url: 'https://design.talend.com/design-tokens',
 		},
 	},
 	stories: [

--- a/packages/design-system/src/components/Button/docs/Button.stories.mdx
+++ b/packages/design-system/src/components/Button/docs/Button.stories.mdx
@@ -95,7 +95,7 @@ Icon buttons can be used as dropdown but without the caret icon.
 
 <InlineMessage.Warning
 	withBackground
-	description="This component will be replaced in the next major version."
+	description="This component's API will be reworked in the next major version."
 />
 
 <Canvas>

--- a/packages/design-system/src/components/Button/docs/Button.stories.mdx
+++ b/packages/design-system/src/components/Button/docs/Button.stories.mdx
@@ -3,6 +3,7 @@ import { FigmaIframe, FigmaImage, Use } from '~docs';
 import Button from '../';
 import * as Stories from '../Button.stories';
 import { IconsProvider } from '../../IconsProvider';
+import InlineMessage from '../../InlineMessage';
 
 <Meta
 	title="Components/Button"
@@ -91,6 +92,11 @@ Icon buttons can be used as dropdown but without the caret icon.
 </Canvas>
 
 #### Icon button
+
+<InlineMessage.Warning
+	withBackground
+	description="This component will be replaced in the next major version."
+/>
 
 <Canvas>
 	<Story story={Stories.Icon} />

--- a/packages/design-system/src/components/Toggle/docs/Toggle.stories.mdx
+++ b/packages/design-system/src/components/Toggle/docs/Toggle.stories.mdx
@@ -8,7 +8,7 @@ import Toggle from '../';
 	title="Components/Toggle"
 	component={Toggle}
 	parameters={{
-		status: { figma: 'ok', storybook: 'ok', react: 'ok', i18n: 'na' },
+		status: { figma: 'deprecated', storybook: 'deprecated', react: 'deprecated', i18n: 'na' },
 		figmaLink: 'https://www.figma.com/file/uA0kGVh0USLFEg6bhU8YZR/Toggle',
 	}}
 />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Toggle and Button.Icon will be merged into ButtonIcon in the next release

**What is the chosen solution to this problem?**

Deprecated them from our single source of truth right now

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
