### PR TITLE
fix(design-system): Missing design tokens

### DIFF
--- a/.changeset/afraid-keys-mate.md
+++ b/.changeset/afraid-keys-mate.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Bump @talend/design-token to get missing tokens

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -33,7 +33,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@talend/design-tokens": "^1.1.0",
+    "@talend/design-tokens": "^1.2.0",
     "classnames": "^2.3.1",
     "modern-css-reset": "^1.4.0",
     "polished": "^4.1.4",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

@talend/design-token dependency doesn't contain tokens required by `ButtonIcon`

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
