### PR TITLE
fix: update withDrawer z-index

### DIFF
--- a/.changeset/kind-pigs-brush.md
+++ b/.changeset/kind-pigs-brush.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: update withDrawer z-index

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -59,9 +59,9 @@ export function WithDrawer({ drawers, children }) {
 				{drawers &&
 					drawers.map((drawer, key) => (
 						<Animation key={key}>
-							{({ style }) => (
+							{({ style, ...props }) => (
 								<div className="tc-with-drawer-wrapper" style={style}>
-									{drawer}
+									{React.cloneElement(drawer, props)}
 								</div>
 							)}
 						</Animation>

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -1,39 +1,11 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { TransitionGroup, Transition } from 'react-transition-group';
+import { TransitionGroup } from 'react-transition-group';
+import get from 'lodash/get';
+
+import Drawer from '../Drawer';
 
 import theme from './withDrawer.scss';
-
-const STYLES = {
-	entering: { transform: 'translateX(0%)' },
-	entered: { transform: 'translateX(0%)' },
-	exiting: { transform: 'translateX(100%)' },
-	exited: { transform: 'translateX(100%)' },
-};
-
-function Animation(props) {
-	const { children, ...rest } = props;
-
-	return (
-		<Transition in appear timeout={500} {...rest}>
-			{transitionState => {
-				const style = {
-					transition: 'transform 350ms ease-in-out',
-					...STYLES[transitionState],
-				};
-				return children({
-					style,
-					transitioned: transitionState === 'entered',
-					transitionState,
-				});
-			}}
-		</Transition>
-	);
-}
-
-Animation.propTypes = {
-	children: PropTypes.node,
-};
 
 /**
  * The Layout component is a container
@@ -51,20 +23,26 @@ body > div {
  * @example
  <Layout mode="TwoColumns" one={one} two={two}></Layout>
  */
-export function WithDrawer({ drawers, children }) {
+function WithDrawer({ drawers, children }) {
 	return (
 		<div className={theme['tc-with-drawer']}>
 			{children}
 			<TransitionGroup className={theme['tc-with-drawer-container']}>
 				{drawers &&
 					drawers.map((drawer, key) => (
-						<Animation key={key}>
+						<Drawer.Animation
+							withTransition={
+								get(drawer, 'props.withTransition', true) &&
+								get(drawer, 'props.route.state.withTransition')
+							}
+							key={get(drawer, 'props.route.path', key)}
+						>
 							{({ style, ...props }) => (
 								<div className="tc-with-drawer-wrapper" style={style}>
 									{React.cloneElement(drawer, props)}
 								</div>
 							)}
-						</Animation>
+						</Drawer.Animation>
 					))}
 			</TransitionGroup>
 		</div>

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -1,11 +1,39 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import { TransitionGroup } from 'react-transition-group';
-import get from 'lodash/get';
-
-import Drawer from '../Drawer';
+import { TransitionGroup, Transition } from 'react-transition-group';
 
 import theme from './withDrawer.scss';
+
+const STYLES = {
+	entering: { transform: 'translateX(0%)' },
+	entered: { transform: 'translateX(0%)' },
+	exiting: { transform: 'translateX(100%)' },
+	exited: { transform: 'translateX(100%)' },
+};
+
+function Animation(props) {
+	const { children, ...rest } = props;
+
+	return (
+		<Transition in appear timeout={500} {...rest}>
+			{transitionState => {
+				const style = {
+					transition: 'transform 350ms ease-in-out',
+					...STYLES[transitionState],
+				};
+				return children({
+					style,
+					transitioned: transitionState === 'entered',
+					transitionState,
+				});
+			}}
+		</Transition>
+	);
+}
+
+Animation.propTypes = {
+	children: PropTypes.node,
+};
 
 /**
  * The Layout component is a container
@@ -23,26 +51,20 @@ body > div {
  * @example
  <Layout mode="TwoColumns" one={one} two={two}></Layout>
  */
-function WithDrawer({ drawers, children }) {
+export function WithDrawer({ drawers, children }) {
 	return (
 		<div className={theme['tc-with-drawer']}>
 			{children}
 			<TransitionGroup className={theme['tc-with-drawer-container']}>
 				{drawers &&
 					drawers.map((drawer, key) => (
-						<Drawer.Animation
-							withTransition={
-								get(drawer, 'props.withTransition', true) &&
-								get(drawer, 'props.route.state.withTransition')
-							}
-							key={get(drawer, 'props.route.path', key)}
-						>
-							{({ style, ...props }) => (
+						<Animation key={key}>
+							{({ style }) => (
 								<div className="tc-with-drawer-wrapper" style={style}>
-									{React.cloneElement(drawer, props)}
+									{drawer}
 								</div>
 							)}
-						</Drawer.Animation>
+						</Animation>
 					))}
 			</TransitionGroup>
 		</div>

--- a/packages/components/src/WithDrawer/withDrawer.scss
+++ b/packages/components/src/WithDrawer/withDrawer.scss
@@ -4,6 +4,7 @@
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
+	z-index: 2;
 }
 
 .tc-with-drawer-container {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
With this z-index, some elements behind the drawer can still be renderer above it

**What is the chosen solution to this problem?**
Add a z-index

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
