### PR TITLE
feat(WithDrawer): Support appear/exit animations

### DIFF
--- a/.changeset/young-beans-deny.md
+++ b/.changeset/young-beans-deny.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+WithDrawer: Support appear/exit animations

--- a/packages/components/src/WithDrawer/WithDrawer.component.js
+++ b/packages/components/src/WithDrawer/WithDrawer.component.js
@@ -23,11 +23,11 @@ body > div {
  * @example
  <Layout mode="TwoColumns" one={one} two={two}></Layout>
  */
-function WithDrawer({ drawers, children }) {
+function WithDrawer({ drawers, children, ...rest }) {
 	return (
 		<div className={theme['tc-with-drawer']}>
 			{children}
-			<TransitionGroup className={theme['tc-with-drawer-container']}>
+			<TransitionGroup className={theme['tc-with-drawer-container']} {...rest}>
 				{drawers &&
 					drawers.map((drawer, key) => (
 						<Drawer.Animation
@@ -54,6 +54,7 @@ WithDrawer.displayName = 'WithDrawer';
 WithDrawer.propTypes = {
 	drawers: PropTypes.arrayOf(PropTypes.element),
 	children: PropTypes.node,
+	...TransitionGroup.propTypes,
 };
 
 export default WithDrawer;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`WithDrawer` doesn't have animation when mounted with drawers
`<WithDrawer drawers={[<Drawer/>]}/>`
The `TransitionGroup` is overriding `Drawer.Animation`props with `undefined`

https://github.com/Talend/ui/blob/master/packages/components/src/Drawer/Drawer.component.js#L32
![Screenshot 2022-01-28 at 16 31 18](https://user-images.githubusercontent.com/58977230/151574924-3b9ecfc6-fbe5-4d39-9958-f01ce05dd323.png)


**What is the chosen solution to this problem?**

Forward appear props to the transition group

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
