### PR TITLE
fix(cmf): Export registry for Apps using noRender option

### DIFF
--- a/.changeset/flat-eggs-lie.md
+++ b/.changeset/flat-eggs-lie.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf': patch
+---
+
+Export registry for Apps using noRender option

--- a/packages/cmf/src/bootstrap.js
+++ b/packages/cmf/src/bootstrap.js
@@ -143,6 +143,7 @@ export default async function bootstrap(appOptions = {}) {
 		saga,
 		App,
 		cmfModule: options,
+		registry
 	};
 
 	if (options.render !== false) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Registry provider needs a registry value since https://github.com/Talend/ui/pull/3027
`<RegistryProvider value={props.registry}>`

**What is the chosen solution to this problem?**

export it when used with norender option

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
