### PR TITLE
chore(design-system): browser matrix for Cypress

### DIFF
--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        browser: [ 'chrome', 'firefox', 'edge' ]
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -33,8 +36,9 @@ jobs:
           yarn build:lib
 
       - name: Cypress Component Testing
-        run: |
-          npx cypress run-ct
+        uses: cypress-io/github-action@v2
+        with:
+          browser: ${{ matrix.browser }}
 
       - name: Cypress artifacts upload
         uses: actions/upload-artifact@v2

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -48,11 +48,11 @@ jobs:
         if: failure()
         with:
           name: cypress-component-testing-${{ matrix.browser }}-screenshots
-          path: cypress/screenshots/components/**/*
+          path: packages/design-system/cypress/screenshots/**/*
 
       - name: Cypress videos upload
         uses: actions/upload-artifact@v2
         if: always()
         with:
           name: cypress-component-testing-${{ matrix.browser }}-videos
-          path: cypress/videos/components/**/*
+          path: packages/design-system/cypress/videos/**/*

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -2,9 +2,9 @@ name: Design System component testing
 
 on:
   push:
-#    paths:
-#      - 'packages/design-tokens/**'
-#      - 'packages/design-system/**'
+    paths:
+      - 'packages/design-tokens/**'
+      - 'packages/design-system/**'
 
 jobs:
   cypress-run:
@@ -47,12 +47,12 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: cypress-component-testing-screenshots
+          name: cypress-component-testing-${{ matrix.browser }}-screenshots
           path: cypress/screenshots/components/**/*
 
       - name: Cypress videos upload
         uses: actions/upload-artifact@v2
         if: always()
         with:
-          name: cypress-component-testing-videos
+          name: cypress-component-testing-${{ matrix.browser }}-videos
           path: cypress/videos/components/**/*

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -2,16 +2,17 @@ name: Design System component testing
 
 on:
   push:
-    paths:
-      - 'packages/design-tokens/**'
-      - 'packages/design-system/**'
+#    paths:
+#      - 'packages/design-tokens/**'
+#      - 'packages/design-system/**'
 
 jobs:
   cypress-run:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        browser: [ 'chrome', 'firefox', 'edge' ]
+        browser: ['chrome', 'firefox', 'edge']
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -22,9 +23,9 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '14'
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+          registry-url: 'https://registry.npmjs.org/'
+          scope: '@talend'
+          cache: 'yarn'
 
       - name: Install dependencies
         run: |
@@ -38,12 +39,19 @@ jobs:
       - name: Cypress Component Testing
         uses: cypress-io/github-action@v2
         with:
-          working-directory: packages/design-system
           browser: ${{ matrix.browser }}
+          working-directory: packages/design-system
 
-      - name: Cypress artifacts upload
+      - name: Cypress screenshots upload
         uses: actions/upload-artifact@v2
-        if: ${{ always() }}
+        if: failure()
+        with:
+          name: cypress-component-testing-screenshots
+          path: cypress/screenshots/components/**/*
+
+      - name: Cypress videos upload
+        uses: actions/upload-artifact@v2
+        if: always()
         with:
           name: cypress-component-testing-videos
           path: cypress/videos/components/**/*

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Cypress Component Testing
         uses: cypress-io/github-action@v2
         with:
+          working-directory: packages/design-system
           browser: ${{ matrix.browser }}
 
       - name: Cypress artifacts upload

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -37,7 +37,7 @@ jobs:
           yarn build:lib
 
       - name: Cypress Component Testing
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v3
         with:
           browser: ${{ matrix.browser }}
           working-directory: packages/design-system

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        browser: ['chrome', 'firefox', 'edge']
+        browser: ['chrome', 'firefox']
     defaults:
       run:
         working-directory: ./packages/design-system
@@ -40,6 +40,7 @@ jobs:
         uses: cypress-io/github-action@v3
         with:
           browser: ${{ matrix.browser }}
+          command: yarn test:cy
           working-directory: packages/design-system
 
       - name: Cypress screenshots upload

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -60,7 +60,8 @@ Limit changes to styled-components scope.
 
 ### End-to-End tests
 
-Prior to end-to-end tests using Cypress if you want to test interactions in real browsers.
+Simple renders will be covered by Chromatic.
+Prior to end-to-end tests, using Cypress, if you have to test interactions in real browsers.
 
 ## License
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -60,7 +60,7 @@ Limit changes to styled-components scope.
 
 ### End-to-End tests
 
-Prior to end-to-end tests if you want to test interactions in real browsers.
+Prior to end-to-end tests using Cypress if you want to test interactions in real browsers.
 
 ## License
 

--- a/packages/design-system/README.md
+++ b/packages/design-system/README.md
@@ -60,8 +60,8 @@ Limit changes to styled-components scope.
 
 ### End-to-End tests
 
-Simple renders will be covered by Chromatic.
-Prior to end-to-end tests, using Cypress, if you have to test interactions in real browsers.
+Snapshot testing will be covered by Chromatic.
+Use Cypress if you have to perform interaction tests, in real browsers.
 
 ## License
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Cypress executes tests using Electron, that's sad since it's designed to be run through real web browsers!

**What is the chosen solution to this problem?**

Run E2E tests on Chrome and Firefox in parallel 💯 

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
