### PR TITLE
typings(http): allow empty PUT payload

### DIFF
--- a/.changeset/clean-forks-juggle.md
+++ b/.changeset/clean-forks-juggle.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': patch
+---
+
+types: allow empty PUT payload

--- a/.changeset/clean-forks-juggle.md
+++ b/.changeset/clean-forks-juggle.md
@@ -2,4 +2,4 @@
 '@talend/http': patch
 ---
 
-types: allow empty PUT payload
+typings: allow empty PUT payload

--- a/packages/http/src/async.ts
+++ b/packages/http/src/async.ts
@@ -50,7 +50,7 @@ export async function httpPatch<T>(
  */
 export async function httpPut<T>(
 	url: string,
-	payload: any,
+	payload?: any,
 	config?: TalendRequestInit,
 ): Promise<TalendHttpResponse<T>> {
 	return httpFetch<T>(url, config, HTTP_METHODS.PUT, payload);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

PUT calls can have empty payloads

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
