### PR TITLE
chore(ARCH-432/CI): remove changeset from upgrade

### DIFF
--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -9,6 +9,7 @@ jobs:
   upgrade:
     name: Upgrade dependencies
     runs-on: ubuntu-latest
+    continue-on-error: true  # we want the PR to popup even if sth goes wrong
 
     steps:
       - name: Checkout

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -28,9 +28,7 @@ jobs:
           yarn talend-scripts upgrade:deps
           yarn talend-scripts upgrade:deps --scope=@talend --latest
           yarn talend-scripts upgrade:deps --latest --dry > dependencies-latest.txt
-          yarn talend-scripts upgrade:deps --changeset
           git add dependencies-latest.txt
-          git add .changeset
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

changesets on upgrade generates too much release without real changes.

**What is the chosen solution to this problem?**

unplug it at the moment

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
