### PR TITLE
fix(APIC-751): add a prefix parameter to the copy component

### DIFF
--- a/.changeset/three-starfishes-count.md
+++ b/.changeset/three-starfishes-count.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+fix(APIC-751): add a prefix parameter to the copy component

--- a/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
@@ -8,7 +8,7 @@ import { InputProps } from './Input';
 
 const InputCopy = React.forwardRef(
 	(
-		{ label, disabled, readOnly, value, defaultValue, ...rest }: InputProps,
+		{ label, disabled, readOnly, value, defaultValue, prefix, ...rest }: InputProps,
 		ref: React.Ref<HTMLInputElement | null>,
 	) => {
 		const [{ value: copiedValue, error: copyError }, copyToClipboard] = useCopyToClipboard();
@@ -30,6 +30,7 @@ const InputCopy = React.forwardRef(
 		return (
 			<FieldGroup
 				label={label}
+				prefix={prefix}
 				suffix={
 					!readOnly ? (
 						<Button.Icon

--- a/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
@@ -35,6 +35,14 @@ It's used to let the user copy a generated text to clipboard.
 	</Story>
 </Canvas>
 
+### Prefix
+
+<Canvas>
+	<Story name="prefix">
+		<Form.Copy label="Copy" prefix="URL" value="https://exemple.com" />
+	</Story>
+</Canvas>
+
 ### Hover
 
 <Canvas withSource="none">

--- a/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
@@ -38,7 +38,7 @@ It's used to let the user copy a generated text to clipboard.
 ### Prefix
 
 <Canvas>
-	<Story name="prefix">
+	<Story name="With prefix">
 		<Form.Copy label="Copy" prefix="URL" value="https://exemple.com" />
 	</Story>
 </Canvas>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In a new screen for API sharing, we need a prefix parameter on the Copy component.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
