### PR TITLE
fix(Datagrid): Support empty selection in controlled mode

### DIFF
--- a/.changeset/wet-carrots-relax.md
+++ b/.changeset/wet-carrots-relax.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Support empty selection in controlled mode

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -91,6 +91,7 @@ export default class DataGrid extends React.Component {
 		this.setCurrentFocusedColumn = this.setCurrentFocusedColumn.bind(this);
 		this.updateStyleFocusColumn = this.updateStyleFocusColumn.bind(this);
 		this.onKeyDownHeaderColumn = this.onKeyDownHeaderColumn.bind(this);
+		this.currentColId = null;
 	}
 
 	/**

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.js
@@ -483,7 +483,7 @@ describe('#Datagrid method', () => {
 	});
 
 	it('should not update local state on click when in controlled mode', () => {
-		const wrapper = shallow(<DataGrid getComponent={getComponent} focusedColumnId="field3" />);
+		const wrapper = shallow(<DataGrid getComponent={getComponent} focusedColumnId={null} />);
 		const deselectAll = jest.fn();
 		const clearFocusedCell = jest.fn();
 		const api = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Contolled mode doesn't work when initially rendered with an empty selection

**What is the chosen solution to this problem?**

Set the initial state to `null` instead of `undefined` to better handle props changes:
- `focusedColumnId = null`: force empty controlled selection, user can't click on a cell
- `focusedColumnId = undefined`: empty uncontrolled selection, user can click on a cell

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
