### PR TITLE
chore(design-system): visual testing on demand

### DIFF
--- a/.github/workflows/design-system-visual-testing.yml
+++ b/.github/workflows/design-system-visual-testing.yml
@@ -1,6 +1,14 @@
 name: Design System visual testing
 
 on:
+  workflow_dispatch:
+    inputs:
+      sha:
+        description: The SHA-1 hash referring to the commit to check.
+        required: true
+      ref:
+        description: The head branch associated with the pull request.
+        required: true
   pull_request:
     branches:
       - master


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Chromatic is now available through a GH application

**What is the chosen solution to this problem?**

Thanks to @gjou-tlnd, we can run visual testing gh action on demand

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
