### PR TITLE
chore(surge): teardown workflow without npm cache

### DIFF
--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -15,7 +15,6 @@ jobs:
         uses: actions/setup-node@v2
         with:
           node-version: 14
-          cache: 'npm'
 
       - name: Push to surge
         run: npx surge teardown ${{ github.event.pull_request.number }}.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
GH action to teardown surge at PR closing fails with 
```
Dependencies lock file is not found in /home/runner/work/ui/ui. Supported file patterns: package-lock.json,yarn.lock
```
This seems to be the npm cache configuration that fails, if we see [this post](https://github.community/t/github-ci-actions-for-nodejs-says-error-dependencies-lock-file-is-not-found/189354) or [this one](https://stackoverflow.com/questions/68527897/how-to-specifiy-path-for-actions-setup-node-in-github)

**What is the chosen solution to this problem?**
We don't need npm cache, we have npm just to use npx. Remove the cache config

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
