### PR TITLE
fix(WithDrawer): Drawer is rendering below Switcher buttons

### DIFF
--- a/.changeset/eleven-steaks-promise.md
+++ b/.changeset/eleven-steaks-promise.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+WithDrawer: Drawer is rendering below Switcher buttons

--- a/packages/components/src/WithDrawer/withDrawer.scss
+++ b/packages/components/src/WithDrawer/withDrawer.scss
@@ -4,7 +4,8 @@
 	overflow: hidden;
 	display: flex;
 	flex-direction: column;
-	z-index: 2;
+	// Need to go above the Switcher buttons https://github.com/Talend/ui/blob/master/packages/design-system/src/components/Switch/Switch.style.ts#L12
+	z-index: 3;
 }
 
 .tc-with-drawer-container {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Switcher button text is rendered above drawer

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
