### PR TITLE
fix(Dataviz): Remove useless z-index on zoom buttons

### DIFF
--- a/.changeset/nine-cheetahs-wonder.md
+++ b/.changeset/nine-cheetahs-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+GeoChart: Useless zoom buttons z-index

--- a/packages/dataviz/src/components/GeoChart/GeoChart.scss
+++ b/packages/dataviz/src/components/GeoChart/GeoChart.scss
@@ -30,7 +30,6 @@
 		position: absolute;
 		bottom: 15px;
 		left: 10px;
-		z-index: 3;
 	}
 
 	&__zoom-button {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

z-index doesn't seem to me needed and I can't remenber why I added it
http://talend.surge.sh/dataviz/?path=/story/dataviz-geochart--continent

**What is the chosen solution to this problem?**


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
