### PR TITLE
test(ARCH-349): add datagrid playground

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -35,6 +35,7 @@
     "@talend/react-cmf-router": "^4.0.1",
     "@talend/react-components": "^6.44.0",
     "@talend/react-containers": "^7.0.1",
+    "@talend/react-datagrid": "^7.0.3",
     "@talend/react-dataviz": "^1.0.4",
     "@talend/react-forms": "^7.0.1",
     "history": "^3.3.0",

--- a/packages/playground/src/app/components/DataGrid.js
+++ b/packages/playground/src/app/components/DataGrid.js
@@ -1,0 +1,15 @@
+import data from '@talend/react-datagrid/stories/sample.json';
+import DataGrid from '@talend/react-datagrid';
+import Layout from '@talend/react-components/lib/Layout';
+import SidePanel from '@talend/react-containers/lib/SidePanel';
+import HeaderBar from '@talend/react-containers/lib/HeaderBar';
+
+export function DataGridPlayground() {
+	return (
+		<Layout mode="TwoColumns" one={<SidePanel />} header={<HeaderBar />}>
+			<div style={{ height: '100%' }}>
+				<DataGrid data={data} />
+			</div>
+		</Layout>
+	);
+}

--- a/packages/playground/src/app/index.js
+++ b/packages/playground/src/app/index.js
@@ -13,6 +13,7 @@ import ComponentForm from '@talend/react-containers/lib/ComponentForm';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import ComponentFormSandbox from './components/ComponentFormSandbox';
+import { DataGridPlayground } from './components/DataGrid';
 
 import { LeaguesList } from './components/List';
 import { Dataviz } from './components/Dataviz';
@@ -45,7 +46,14 @@ function IconsProvider() {
 }
 
 const app = {
-	components: { ComponentForm, ComponentFormSandbox, LeaguesList, IconsProvider, Dataviz },
+	components: {
+		ComponentForm,
+		ComponentFormSandbox,
+		DataGrid: DataGridPlayground,
+		LeaguesList,
+		IconsProvider,
+		Dataviz,
+	},
 	settingsURL: `${basename || ''}/settings.json`,
 	actionCreators: actions,
 	middlewares: [],

--- a/packages/playground/src/assets/settings.json
+++ b/packages/playground/src/assets/settings.json
@@ -1,7 +1,7 @@
 {
   "actions": {
     "menu:ComponentForm": {
-      "icon": "talend-burger",
+      "icon": "talend-text",
       "label": "ComponentForm",
       "onClickDispatch": {
         "type": "MENU_COMPONENT_FORM_CLICKED",
@@ -11,7 +11,7 @@
       }
     },
     "menu:List": {
-      "icon": "talend-burger",
+      "icon": "talend-table",
       "label": "List",
       "onClickDispatch": {
         "type": "MENU_LIST_CLICKED",
@@ -21,12 +21,22 @@
       }
     },
     "menu:Dataviz": {
-      "icon": "talend-burger",
+      "icon": "talend-charts",
       "label": "Dataviz",
       "onClickDispatch": {
         "type": "MENU_LIST_CLICKED",
         "cmf": {
           "routerPush": "/Dataviz"
+        }
+      }
+    },
+    "menu:DataGrid": {
+      "icon": "talend-datagrid",
+      "label": "DataGrid",
+      "onClickDispatch": {
+        "type": "MENU_LIST_CLICKED",
+        "cmf": {
+          "routerPush": "/DataGrid"
         }
       }
     }
@@ -76,7 +86,7 @@
       "productsUrl": "/api/mock/header-bar/products-list"
     },
     "SidePanel#default": {
-      "actionIds": ["menu:ComponentForm", "menu:List", "menu:Dataviz"]
+      "actionIds": ["menu:ComponentForm", "menu:List", "menu:Dataviz", "menu:DataGrid"]
     },
     "Layout#default": {
       "mode": "TwoColumns",
@@ -109,6 +119,10 @@
       {
         "path": "Dataviz",
         "component": "Dataviz"
+      },
+      {
+        "path": "DataGrid",
+        "component": "DataGrid"
       },
       {
         "path": "*",

--- a/packages/playground/webpack.config.dev.js
+++ b/packages/playground/webpack.config.dev.js
@@ -33,6 +33,7 @@ const PKGS = [
 	'@talend/react-cmf',
 	'@talend/react-cmf-router',
 	'@talend/react-dataviz',
+	'@talend/react-datagrid',
 	'@talend/react-forms',
 	'@talend/bootstrap-theme',
 	'@talend/icons',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In the context of the CDN api I need to enforce testing.


**What is the chosen solution to this problem?**

Let's add a datagrid playground.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
