### PR TITLE
 test(ARCH-349): add faceted search playground

### DIFF
--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -37,6 +37,7 @@
     "@talend/react-containers": "^7.0.1",
     "@talend/react-datagrid": "^7.0.3",
     "@talend/react-dataviz": "^1.0.4",
+    "@talend/react-faceted-search": "^3.5.5",
     "@talend/react-forms": "^7.0.1",
     "history": "^3.3.0",
     "i18next": "^20.6.1",

--- a/packages/playground/src/app/components/FacetedSearch.js
+++ b/packages/playground/src/app/components/FacetedSearch.js
@@ -1,0 +1,70 @@
+import FacetedSearch from '@talend/react-faceted-search';
+import Layout from '@talend/react-components/lib/Layout';
+import SidePanel from '@talend/react-containers/lib/SidePanel';
+import HeaderBar from '@talend/react-containers/lib/HeaderBar';
+import * as badges from '@talend/react-faceted-search/stories/badgesDefinitions';
+
+function action(msg) {
+	return (...args) => console.log(msg, ...args);
+}
+
+const badgesDefinitions = Object.values(badges);
+console.log(badgesDefinitions);
+// [
+// 	badgeAll,
+// 	badgeName,
+// 	badgeConnectionName,
+// 	badgeAuthor,
+// 	badgeConnectionType,
+// 	badgeTags,
+// 	badgePrice,
+// 	badgeValid,
+// 	badgeEmpty,
+// 	badgeInvalid,
+// 	badgeCreationDate,
+// ];
+
+const callbacks = {
+	getTags: () =>
+		new Promise(resolve =>
+			setTimeout(resolve, 2000, [
+				'clean',
+				'production',
+				'last chunk',
+				'salesforce',
+				'outdated',
+				'extracted',
+				'security',
+				'in processing',
+				'deep learning',
+				'sql',
+				'cluster',
+				'visualization',
+				'analytics',
+				'users',
+				'warehouse',
+				'api',
+			]),
+		),
+};
+
+export function FacetedSearchPlayground() {
+	return (
+		<Layout mode="TwoColumns" one={<SidePanel />} header={<HeaderBar />}>
+			<FacetedSearch.Faceted>
+				{currentFacetedMode =>
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.ADVANCED && (
+						<FacetedSearch.AdvancedSearch onSubmit={action('onSubmit')} />
+					)) ||
+					(currentFacetedMode === FacetedSearch.constants.FACETED_MODE.BASIC && (
+						<FacetedSearch.BasicSearch
+							badgesDefinitions={badgesDefinitions}
+							callbacks={callbacks}
+							onSubmit={action('onSubmit')}
+						/>
+					))
+				}
+			</FacetedSearch.Faceted>
+		</Layout>
+	);
+}

--- a/packages/playground/src/app/components/FacetedSearch.js
+++ b/packages/playground/src/app/components/FacetedSearch.js
@@ -9,20 +9,6 @@ function action(msg) {
 }
 
 const badgesDefinitions = Object.values(badges);
-console.log(badgesDefinitions);
-// [
-// 	badgeAll,
-// 	badgeName,
-// 	badgeConnectionName,
-// 	badgeAuthor,
-// 	badgeConnectionType,
-// 	badgeTags,
-// 	badgePrice,
-// 	badgeValid,
-// 	badgeEmpty,
-// 	badgeInvalid,
-// 	badgeCreationDate,
-// ];
 
 const callbacks = {
 	getTags: () =>

--- a/packages/playground/src/app/index.js
+++ b/packages/playground/src/app/index.js
@@ -13,6 +13,7 @@ import ComponentForm from '@talend/react-containers/lib/ComponentForm';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
 import ComponentFormSandbox from './components/ComponentFormSandbox';
+import { FacetedSearchPlayground } from './components/FacetedSearch';
 
 import { LeaguesList } from './components/List';
 import { Dataviz } from './components/Dataviz';
@@ -45,7 +46,14 @@ function IconsProvider() {
 }
 
 const app = {
-	components: { ComponentForm, ComponentFormSandbox, LeaguesList, IconsProvider, Dataviz },
+	components: {
+		ComponentForm,
+		ComponentFormSandbox,
+		FacetedSearch: FacetedSearchPlayground,
+		LeaguesList,
+		IconsProvider,
+		Dataviz,
+	},
 	settingsURL: `${basename || ''}/settings.json`,
 	actionCreators: actions,
 	middlewares: [],

--- a/packages/playground/src/assets/settings.json
+++ b/packages/playground/src/assets/settings.json
@@ -29,6 +29,16 @@
           "routerPush": "/Dataviz"
         }
       }
+    },
+    "menu:FacetedSearch": {
+      "icon": "talend-search",
+      "label": "Faceted Search",
+      "onClickDispatch": {
+        "type": "MENU_LIST_CLICKED",
+        "cmf": {
+          "routerPush": "/FacetedSearch"
+        }
+      }
     }
   },
   "props": {
@@ -76,7 +86,7 @@
       "productsUrl": "/api/mock/header-bar/products-list"
     },
     "SidePanel#default": {
-      "actionIds": ["menu:ComponentForm", "menu:List", "menu:Dataviz"]
+      "actionIds": ["menu:ComponentForm", "menu:List", "menu:Dataviz", "menu:FacetedSearch"]
     },
     "Layout#default": {
       "mode": "TwoColumns",
@@ -109,6 +119,10 @@
       {
         "path": "Dataviz",
         "component": "Dataviz"
+      },
+      {
+        "path": "FacetedSearch",
+        "component": "FacetedSearch"
       },
       {
         "path": "*",

--- a/packages/playground/webpack.config.dev.js
+++ b/packages/playground/webpack.config.dev.js
@@ -33,6 +33,7 @@ const PKGS = [
 	'@talend/react-cmf',
 	'@talend/react-cmf-router',
 	'@talend/react-dataviz',
+	'@talend/react-faceted-search',
 	'@talend/react-forms',
 	'@talend/bootstrap-theme',
 	'@talend/icons',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In the context of CDN API I want to check all UMDs and make it easy to smoke tests all our Talend/ui libs

**What is the chosen solution to this problem?**

Add faceted search playground

![Screenshot 2022-02-10 at 10 09 39](https://user-images.githubusercontent.com/19857479/153374557-fbcef7fd-e8f1-4179-9d9b-62198941cdcb.png)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
