### PR TITLE
fix(utils/date): convertToTimeZone function with specific timezone and summer time

### DIFF
--- a/.changeset/stale-hairs-give.md
+++ b/.changeset/stale-hairs-give.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': minor
+---
+
+return wrong date when calling “convertToTimeZone” function with specific timezone and summer time

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -204,7 +204,7 @@ describe('date', () => {
 			['Africa/Bamako', new Date('2022-01-25 08:32:12'), 0],
 			['Asia/Seoul', new Date('2022-06-14 08:32:12'), 540],
 			['Europe/Berlin', new Date('2022-01-25 08:32:12'), 60], // winter time
-			['Europe/Berlin', new Date('2022-06-1 08:32:12'), 120], //summer time
+			['Europe/Berlin', new Date('2022-06-1 08:32:12'), 120], // summer time
 		])(
 			'it should get %s timezone offset with specific date',
 			(timezone: string, date: Date, expectedOffset: number) => {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -110,7 +110,7 @@ describe('date', () => {
 	});
 
 	describe('formatToTimeZone', () => {
-		it('should format a locale date to a given timezone in a specifc format', () => {
+		it('should format a locale date to a given timezone in a specific format', () => {
 			// given
 			const dateObj = new Date('2020-05-13, 20:00');
 			const formatString = 'YYYY-MM-DD[T]HH:mm:ssZZ';
@@ -137,7 +137,7 @@ describe('date', () => {
 		});
 		it('should pass locale to datefns format method', () => {
 			// given
-			const mockLocal = { format: () => {}};
+			const mockLocal = { format: () => {} };
 			const dateObj = new Date('2020-12-20, 20:00');
 			const formatString = 'ddd YYYY-MM-DD HH:mm:ss';
 			const options = {
@@ -156,6 +156,27 @@ describe('date', () => {
 					locale: mockLocal,
 				}),
 			);
+		});
+		it('should be formatted to a correct winter time and summer time for specific timezone', () => {
+			// given
+			const formatString = 'ddd YYYY-MM-DD HH:mm:ss';
+			const timeZone = 'Europe/Berlin';
+			const winterTimestamp = 1643095932000; //  2022-01-25 08:32:12
+			const expectedWinterTime = 'Tue 2022-01-25 08:32:12';
+			const summerTimestamp = 1654068732000; // 2022-06-01 08:32:12
+			const expectedSummerTime = 'Wed 2022-06-01 09:32:12';
+
+			// when for winter time
+			const winterTime = formatToTimeZone(winterTimestamp, formatString, { timeZone });
+
+			// then
+			expect(winterTime).toEqual(expectedWinterTime);
+
+			// when for summer time
+			const summerTime = formatToTimeZone(summerTimestamp, formatString, { timeZone });
+
+			// then
+			expect(summerTime).toEqual(expectedSummerTime);
 		});
 	});
 
@@ -179,6 +200,17 @@ describe('date', () => {
 		])('it should get %s timezone offset', (timezone: string, expectedOffset: number) => {
 			expect(getUTCOffset(timezone)).toEqual(expectedOffset);
 		});
+		test.each([
+			['Africa/Bamako', new Date('2022-01-25 08:32:12'), 0],
+			['Asia/Seoul', new Date('2022-06-14 08:32:12'), 540],
+			['Europe/Berlin', new Date('2022-01-25 08:32:12'), 60], //winter time
+			['Europe/Berlin', new Date('2022-06-1 08:32:12'), 120], //summer time
+		])(
+			'it should get %s timezone offset with specific date',
+			(timezone: string, date: Date, expectedOffset: number) => {
+				expect(getUTCOffset(timezone, date)).toEqual(expectedOffset);
+			},
+		);
 	});
 
 	describe('timeZoneExists', () => {

--- a/packages/utils/src/date/date.test.ts
+++ b/packages/utils/src/date/date.test.ts
@@ -203,7 +203,7 @@ describe('date', () => {
 		test.each([
 			['Africa/Bamako', new Date('2022-01-25 08:32:12'), 0],
 			['Asia/Seoul', new Date('2022-06-14 08:32:12'), 540],
-			['Europe/Berlin', new Date('2022-01-25 08:32:12'), 60], //winter time
+			['Europe/Berlin', new Date('2022-01-25 08:32:12'), 60], // winter time
 			['Europe/Berlin', new Date('2022-06-1 08:32:12'), 120], //summer time
 		])(
 			'it should get %s timezone offset with specific date',

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -36,7 +36,7 @@ export function getUTCOffset(timeZone: string, date?: Date): number {
 	const timezoneFormat = new Intl.DateTimeFormat(locale, { ...formatOptions, timeZone });
 
 	// Create the same date in UTC timezone and the target timezone
-	const dateObj = date ? date : new Date();
+	const dateObj = date || new Date();
 	const utcDate = new Date(utcFormat.format(dateObj));
 	const timezoneDate = new Date(timezoneFormat.format(dateObj));
 

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -16,7 +16,7 @@ export interface DateFormatOptions {
 /**
  * Get the offset between a timezone and the UTC time (in minutes)
  * @param {string} timeZone Timezone IANA name
- * @param {Date} date (optional) When specified, will be stead of default current time
+ * @param {Date} date (optional) When specified, will be instead of default current time
  * @returns {Number}
  *
  * @see https://en.wikipedia.org/wiki/List_of_tz_database_time_zones


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When calling “convertToTimeZone” function with specific timezone (Europe/Berlin) and summer time, it returns a wrong date.
More details please check https://jira.talendforge.org/browse/TDOPS-1233

**What is the chosen solution to this problem?**

Pass an optional "date" object to "getUTCOffset" function instead of the default current time to get the right time offset.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
