### PR TITLE
fix(design-system): default outline still displayed on Firefox using kbd

### DIFF
--- a/.changeset/ten-cups-drive.md
+++ b/.changeset/ten-cups-drive.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Fix: Firefox default outline is displayed when taking focus in an input with tab.

--- a/packages/design-system/src/components/Form/Field/Field.style.ts
+++ b/packages/design-system/src/components/Form/Field/Field.style.ts
@@ -37,6 +37,7 @@ export const FieldControl = styled.input`
 	&:focus {
 		border-width: 2px;
 		border-color: ${({ theme }) => theme.colors.inputFocusBorderColor};
+		outline:none;
 	}
 
 	&:disabled {
@@ -251,7 +252,7 @@ export const FieldGroup = styled.div<{ after: React.ReactNode }>`
   }`
 			: ''}
 
-	svg, 
+	svg,
   button {
 		position: absolute;
 		padding: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When an input get focus with tab, there is the default outline and our border focus indicator shown.

**What is the chosen solution to this problem?**
As Safari [doesn't respect border-radius](https://bugs.webkit.org/show_bug.cgi?id=20807) on outline property for now, we need to keep the border implementation for now.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
