### PR TITLE
chore(security): Add .semgrepignore file

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,51 @@
+# Items added to this file will be ignored by Semgrep.
+#
+# This file uses .gitignore syntax:
+#
+# To ignore a file anywhere it occurs in your project, enter a
+# glob pattern here. E.g. "*.min.js".
+#
+# To ignore a directory anywhere it occurs in your project, add
+# a trailing slash to the file name. E.g. "dist/".
+#
+# To ignore a file or directory only relative to the project root,
+# include a slash anywhere except the last character. E.g.
+# "/dist/", or "src/generated".
+#
+# Some parts of .gitignore syntax are not supported, and patterns
+# using this syntax will be dropped from the ignore list:
+# - Explicit "include syntax", e.g. "!kept/".
+# - Multi-character expansion syntax, e.g. "*.py[cod]"
+#
+# To include ignore patterns from another file, start a line
+# with ':include', followed by the path of the file. E.g.
+# ":include path/to/other/ignore/file".
+#
+# To ignore a file with a literal ':' character, escape it with
+# a backslash, e.g. "\:foo".
+
+# Ignore git items
+.gitignore
+.git/
+:include .gitignore
+semgrep-core/tests/
+
+# submodule, generated code
+semgrep-core/tree-sitter-lang/
+
+pfff/
+semgrep/tests/e2e/targets/
+semgrep/tests/performance/targets/
+semgrep/tests/e2e/snapshots/
+
+# rules being tested for performance
+perf/rules/
+perf/r2c-rules/
+
+# END OF DEFAULT SEMGREPIGNORE FILE
+
+# TALEND SEMGREPIGNORE
+
+*.test.js
+*.test.tsx
+*.stories.js


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Tests are not in a /test folder and semgrep does not ignore these .js / .tsx files by default
This is to prevent false positives in scans

**What is the chosen solution to this problem?**
This is to prevent the CI scans from flagging lots of tests and unrelated code
https://semgrep.dev/docs/semgrep-ci/overview/#ignoring-files
**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
