### PR TITLE
chore(husky): enforce prettier@^2.5.0 and remove eslint on mdx

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "cross-env": "^7.0.3",
     "cross-spawn": "^7.0.3",
     "husky": "^7.0.0",
-    "i18next-scanner": "^3.1.0"
+    "i18next-scanner": "^3.1.0",
+    "prettier": "^2.5.1"
   },
   "scripts": {
     "postinstall": "node workspace-run.js build:lib",
@@ -41,7 +42,7 @@
     "fork/*"
   ],
   "lint-staged": {
-    "*.{js,ts,tsx,jsx,mdx}": [
+    "*.{js,ts,tsx,jsx}": [
       "eslint --quiet --fix"
     ],
     "*.{json,md,mdx,html,js,jsx,ts,tsx}": [

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -88,7 +88,6 @@
     "i18next": "^20.6.1",
     "i18next-scanner": "^3.1.0",
     "mdx-embed": "^0.0.22",
-    "prettier": "2.3.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-helmet": "^6.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15916,6 +15916,11 @@ prettier@^1.19.1:
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
   integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
+prettier@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.5.1.tgz#fff75fa9d519c54cf0fce328c1017d94546bc56a"
+  integrity sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==
+
 pretty-bytes@^5.6.0:
   version "5.6.0"
   resolved "https://registry.yarnpkg.com/pretty-bytes/-/pretty-bytes-5.6.0.tgz#356256f643804773c82f64723fe78c92c62beaeb"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Husky executes prettier and eslint in mdx.
But 
- the bin of prettier is not the right version, instead of v2, it ttakes v1 that comes with changeset
- current eslint doesn't support mdx, need to add that in talend/scripts

**What is the chosen solution to this problem?**
- enforce prettier v2 by installing it at workspace level
- remove eslint on mdx for now

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
