### PR TITLE
fix(ds): remove icons from config

### DIFF
--- a/packages/design-system/talend-scripts.json
+++ b/packages/design-system/talend-scripts.json
@@ -1,9 +1,6 @@
 {
   "preset": "@talend/scripts-preset-react-lib",
-  "copy": [
-    { "from": "src/icons", "to": "icons" },
-    { "from": "src/images", "to": "images" }
-  ],
+  "copy": [{ "from": "src/images", "to": "images" }],
   "webpack": {
     "config": {
       "development": "./webpack.config.js",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
pre-release script exit in error.

```
 #### RUNNER: yarn workspace --silent @talend/design-system run pre-release exit code 1
```

which cause demo to be broken.

The error is 

```
ERROR in unable to locate '/Users/jmfrancois/github/talend/ui/packages/design-system/src/icons' glob
```



**What is the chosen solution to this problem?**

Remove icons from copy config

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
