### PR TITLE
fix(ARCH-432/router-bridge): set visibility to public

### DIFF
--- a/.changeset/weak-mails-poke.md
+++ b/.changeset/weak-mails-poke.md
@@ -1,0 +1,5 @@
+---
+'@talend/router-bridge': patch
+---
+
+fix: set package visility to public

--- a/packages/router-bridge/package.json
+++ b/packages/router-bridge/package.json
@@ -16,7 +16,7 @@
     "url": "git+https://ithub.com/Talend/ui.git"
   },
   "author": "",
-  "license": "ISC",
+  "license": "Apache-2.0",
   "homepage": "https://github.com/ui/tree/master/packages/router-bridge#readme",
   "devDependencies": {
     "@talend/scripts-core": "^11.5.1",
@@ -37,5 +37,8 @@
     "react-router-dom": {
       "optional": true
     }
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

ui is a public repository.
but https://unpkg.com/@talend/router-bridge is 404.

**What is the chosen solution to this problem?**

* set visilibility to public.
* update license to Apache-2.0 as the other packages

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
