### PR TITLE
fix(containers/forms): multiselect in readonly mode

### DIFF
--- a/.changeset/friendly-cougars-yawn.md
+++ b/.changeset/friendly-cougars-yawn.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-containers': patch
+'@talend/react-forms': patch
+---
+
+fix: MultiSelect in text mode

--- a/packages/containers/src/ComponentForm/fields/MultiSelect/displayMode/TextMode.component.js
+++ b/packages/containers/src/ComponentForm/fields/MultiSelect/displayMode/TextMode.component.js
@@ -21,10 +21,10 @@ export default function MultiSelectTextMode(props) {
 		name: names[index],
 		value: nextVal,
 	}));
-	const FieldTemplate = Form.UIForm.FieldTemplate.TextModeTemplate;
+	const TextModeTemplate = Form.UIForm.TextModeTemplate;
 
 	return (
-		<FieldTemplate id={props.id} label={props.schema.title}>
+		<TextModeTemplate id={props.id} label={props.schema.title}>
 			<div style={{ height: 300 }}>
 				<VirtualizedList
 					type="tc-multiselect"
@@ -33,7 +33,7 @@ export default function MultiSelectTextMode(props) {
 					collection={titleMap}
 				/>
 			</div>
-		</FieldTemplate>
+		</TextModeTemplate>
 	);
 }
 

--- a/packages/containers/src/ComponentForm/fields/index.js
+++ b/packages/containers/src/ComponentForm/fields/index.js
@@ -3,10 +3,8 @@ import Form from '@talend/react-forms';
 import MultiSelect, { MultiSelectTextMode } from './MultiSelect';
 import withNameResolver from './NameResolver';
 
-const {
-	multiSelectTag: MultiSelectTagWidget,
-	datalist: DatalistWidget,
-} = Form.UIForm.utils.widgets;
+const { multiSelectTag: MultiSelectTagWidget, datalist: DatalistWidget } =
+	Form.UIForm.utils.widgets;
 
 export default {
 	datalist: withNameResolver(DatalistWidget),

--- a/packages/forms/src/UIForm/fields/index.js
+++ b/packages/forms/src/UIForm/fields/index.js
@@ -5,7 +5,7 @@ import Comparator from './Comparator';
 import Datalist from './Datalist';
 import * as Date from './Date';
 import Enumeration from './Enumeration';
-import FieldTemplate from './FieldTemplate';
+import FieldTemplate, { TextModeTemplate } from './FieldTemplate';
 import File from './File';
 import KeyValue from './KeyValue';
 import ListView from './ListView';
@@ -40,6 +40,7 @@ export default {
 	Select,
 	Text,
 	TextArea,
+	TextModeTemplate,
 	TimezoneList,
 	Toggle,
 };

--- a/packages/forms/src/UIForm/index.js
+++ b/packages/forms/src/UIForm/index.js
@@ -1,5 +1,5 @@
 import * as FormTemplate from './FormTemplate';
-import FieldTemplate from './fields/FieldTemplate';
+import FieldTemplate, { TextModeTemplate } from './fields/FieldTemplate';
 import Message from './Message';
 import callTrigger from './trigger';
 import utils from './utils';
@@ -16,6 +16,7 @@ import * as triggers from './utils/triggers';
 export { UIForm, triggers };
 
 UIForm.FormTemplate = FormTemplate;
+UIForm.TextModeTemplate = TextModeTemplate;
 UIForm.FieldTemplate = FieldTemplate;
 UIForm.Message = Message;
 UIForm.callTrigger = callTrigger;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TextModeTemplate is not extracted by Form (and used in @talend/react-containers)

<img width="1370" alt="CleanShot 2022-03-02 at 16 17 14@2x" src="https://user-images.githubusercontent.com/2909671/156390562-62c23ee8-2b07-4717-ba9b-d7ff878ac014.png">


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
