### PR TITLE
doc(design-system): remove remark plugin

### DIFF
--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -1,26 +1,26 @@
 const path = require('path');
-const visit = require('unist-util-visit');
+// const visit = require('unist-util-visit');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
-const tokens = require('../lib/tokens').default;
+// const tokens = require('../lib/tokens').default;
 
-const getValue = (path, obj) => path.split('.').reduce((acc, c) => acc && acc[c], obj);
-const getTokenValue = path => getValue(path, tokens);
-const designTokensPlugin = () => tree =>
-	visit(tree, 'text', node => {
-		const regex = /\$([\w+\.]+\w+)/g;
-		const nodeValue = node.value;
-		let results;
-		while ((results = regex.exec(nodeValue)) !== null) {
-			if (getTokenValue(results[1])) {
-				node.type = 'html';
-				node.value = node.value.replace(
-					results[0],
-					`<abbr title="${getTokenValue(results[1])}">${results[0]}</abbr>`,
-				);
-			}
-		}
-	});
+// const getValue = (path, obj) => path.split('.').reduce((acc, c) => acc && acc[c], obj);
+// const getTokenValue = path => getValue(path, tokens);
+// const designTokensPlugin = () => tree =>
+// 	visit(tree, 'text', node => {
+//		const regex = /\$([\w+\.]+\w+)/g;
+//		const nodeValue = node.value;
+//		let results;
+//		while ((results = regex.exec(nodeValue)) !== null) {
+//			if (getTokenValue(results[1])) {
+//				node.type = 'html';
+//				node.value = node.value.replace(
+//					results[0],
+//					`<abbr title="${getTokenValue(results[1])}">${results[0]}</abbr>`,
+//				);
+//			}
+//		}
+//	});
 
 module.exports = {
 	features: {
@@ -90,17 +90,17 @@ module.exports = {
 	},
 	webpackFinal: async config => {
 		config.entry.unshift('core-js');
-		config.module.rules.map(rule => {
-			if (rule.use && rule.use.some(use => use.loader && use.loader.includes('@mdx-js'))) {
-				return rule.use.map(use => {
-					if (use.options && use.options.remarkPlugins) {
-						use.options.remarkPlugins.push(designTokensPlugin);
-					}
-					return use;
-				});
-			}
-			return rule;
-		});
+		//config.module.rules.map(rule => {
+		//	if (rule.use && rule.use.some(use => use.loader && use.loader.includes('@mdx-js'))) {
+		//		return rule.use.map(use => {
+		//			if (use.options && use.options.remarkPlugins) {
+		//				use.options.remarkPlugins.push(designTokensPlugin);
+		//			}
+		//			return use;
+		//		});
+		//	}
+		//	return rule;
+		//});
 
 		config.plugins.push(
 			new BrowserSyncPlugin({

--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -1,26 +1,5 @@
 const path = require('path');
-// const visit = require('unist-util-visit');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
-
-// const tokens = require('../lib/tokens').default;
-
-// const getValue = (path, obj) => path.split('.').reduce((acc, c) => acc && acc[c], obj);
-// const getTokenValue = path => getValue(path, tokens);
-// const designTokensPlugin = () => tree =>
-// 	visit(tree, 'text', node => {
-//		const regex = /\$([\w+\.]+\w+)/g;
-//		const nodeValue = node.value;
-//		let results;
-//		while ((results = regex.exec(nodeValue)) !== null) {
-//			if (getTokenValue(results[1])) {
-//				node.type = 'html';
-//				node.value = node.value.replace(
-//					results[0],
-//					`<abbr title="${getTokenValue(results[1])}">${results[0]}</abbr>`,
-//				);
-//			}
-//		}
-//	});
 
 module.exports = {
 	features: {
@@ -90,18 +69,6 @@ module.exports = {
 	},
 	webpackFinal: async config => {
 		config.entry.unshift('core-js');
-		//config.module.rules.map(rule => {
-		//	if (rule.use && rule.use.some(use => use.loader && use.loader.includes('@mdx-js'))) {
-		//		return rule.use.map(use => {
-		//			if (use.options && use.options.remarkPlugins) {
-		//				use.options.remarkPlugins.push(designTokensPlugin);
-		//			}
-		//			return use;
-		//		});
-		//	}
-		//	return rule;
-		//});
-
 		config.plugins.push(
 			new BrowserSyncPlugin({
 				host: 'localhost',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

The remark plugin is used to provide the default value of a design token if its name is found in the documentation. 

**What is the chosen solution to this problem?**

It leans on previous values of the design tokens.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
