### PR TITLE
fix(ARCH-465/design-tokens): umd are not well defined

### DIFF
--- a/.changeset/sixty-mirrors-chew.md
+++ b/.changeset/sixty-mirrors-chew.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-tokens': patch
+---
+
+fix: umd distribution

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -6,11 +6,12 @@
   "types": "lib/index.d.ts",
   "mainSrc": "src/index.ts",
   "scripts": {
-    "pre-release": "yarn build:lib && yarn build:umd:dev && yarn build:umd:prod",
+    "pre-release": "yarn build:lib && yarn build:umd:dev && yarn build:umd:prod && yarn test:umd",
     "build:umd:dev": "talend-scripts build:lib:umd --dev",
     "build:umd:prod": "talend-scripts build:lib:umd",
     "build:lib": "talend-scripts build:ts:lib",
     "test": "echo no test for @talend/design-tokens",
+    "test:umd": "jest scripts/umd.test.js",
     "test:cov": "echo no test for @talend/design-tokens",
     "test:demo": "yarn build-storybook",
     "start": "yarn storybook",

--- a/packages/design-tokens/package.json
+++ b/packages/design-tokens/package.json
@@ -11,9 +11,9 @@
     "build:umd:prod": "talend-scripts build:lib:umd",
     "build:lib": "talend-scripts build:ts:lib",
     "test": "echo no test for @talend/design-tokens",
-    "test:umd": "jest scripts/umd.test.js",
     "test:cov": "echo no test for @talend/design-tokens",
     "test:demo": "yarn build-storybook",
+    "test:umd": "jest scripts/umd.test.js",
     "start": "yarn storybook",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook --docs"

--- a/packages/design-tokens/scripts/umd.test.js
+++ b/packages/design-tokens/scripts/umd.test.js
@@ -21,4 +21,10 @@ describe('umd', () => {
 		expect(min.default.coralColorNeutralText).toBeDefined();
 		expect(dev.default.coralColorNeutralText).toBeDefined();
 	});
+	it('should expose dark and light css properties in css', () => {
+		const content = fs.readFileSync(cssDev).toString();
+		expect(content).toContain('[data-theme=light]');
+		expect(content).toContain('[data-theme=dark]');
+		expect(content).toContain('--coral-color-neutral-text');
+	});
 });

--- a/packages/design-tokens/scripts/umd.test.js
+++ b/packages/design-tokens/scripts/umd.test.js
@@ -1,0 +1,24 @@
+/* eslint-disable global-require */
+/* eslint-disable import/no-dynamic-require */
+const fs = require('fs');
+const path = require('path');
+
+const umdMinified = path.join(__dirname, '..', './dist/TalendDesignTokens.min.js');
+const umdDev = path.join(__dirname, '..', './dist/TalendDesignTokens.js');
+const cssDev = path.join(__dirname, '..', './dist/TalendDesignTokens.css');
+
+describe('umd', () => {
+	it('should exists', () => {
+		expect(fs.existsSync(umdMinified)).toBeTruthy();
+		expect(fs.existsSync(umdDev)).toBeTruthy();
+		expect(fs.existsSync(cssDev)).toBeTruthy();
+	});
+	it('should expose default and values', () => {
+		const min = require(umdMinified);
+		const dev = require(umdDev);
+		expect(min.default).toBeDefined();
+		expect(dev.default).toBeDefined();
+		expect(min.default.coralColorNeutralText).toBeDefined();
+		expect(dev.default.coralColorNeutralText).toBeDefined();
+	});
+});

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,3 +1,4 @@
 import tokens from './light';
+import './light/_index.scss';
 
 export default tokens;

--- a/packages/design-tokens/src/index.ts
+++ b/packages/design-tokens/src/index.ts
@@ -1,4 +1,3 @@
 import tokens from './light';
-import './light/_index.scss';
 
 export default tokens;

--- a/packages/design-tokens/src/index.umd.ts
+++ b/packages/design-tokens/src/index.umd.ts
@@ -1,5 +1,4 @@
-import './light/_index.scss';
-import './dark/_index.scss';
+import './index.scss';
 import tokens from '.';
 
 export default tokens;

--- a/packages/design-tokens/src/index.umd.ts
+++ b/packages/design-tokens/src/index.umd.ts
@@ -1,0 +1,5 @@
+import './light/_index.scss';
+import './dark/_index.scss';
+import tokens from '.';
+
+export default tokens;

--- a/packages/design-tokens/webpack.config.js
+++ b/packages/design-tokens/webpack.config.js
@@ -1,5 +1,6 @@
 module.exports = {
-	entry: {
-		TalendDesignTokens: ['./src/index.ts', './src/index.scss'],
-	},
+	// entry: {
+	// 	TalendDesignTokens: './src/index.ts',
+	// TalendDesignTokensCss: './src/index.scss',
+	// },
 };

--- a/packages/design-tokens/webpack.config.js
+++ b/packages/design-tokens/webpack.config.js
@@ -1,6 +1,3 @@
 module.exports = {
-	// entry: {
-	// 	TalendDesignTokens: './src/index.ts',
-	// TalendDesignTokensCss: './src/index.scss',
-	// },
+	entry: './src/index.umd.ts',
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current playground is broken.
UMD of design-tokens was not used before DS 2.0 (with Input field)
The current UMD reprensent two modules (index.js + index.scss) which is not supported by UMD.

**What is the chosen solution to this problem?**

fix design-token umd by using a single entry.
add css import to obtain the good output.
UMD mean one global variable which reprensent the src/index.js
add tests to not repeat this in the future

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
