### PR TITLE
chore(cmf): change spawn saga to fork

### DIFF
--- a/.changeset/small-buckets-grin.md
+++ b/.changeset/small-buckets-grin.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf': minor
+---
+
+chore: change spawn saga to fork

--- a/packages/cmf/src/bootstrap.js
+++ b/packages/cmf/src/bootstrap.js
@@ -2,7 +2,7 @@ import React from 'react';
 import { render } from 'react-dom';
 import createSagaMiddleware from 'redux-saga';
 import { batchedSubscribe } from 'redux-batched-subscribe';
-import { spawn } from 'redux-saga/effects';
+import { fork } from 'redux-saga/effects';
 import compose from 'redux';
 
 import App from './App';
@@ -51,10 +51,10 @@ export function bootstrapRegistry(options) {
 export function bootstrapSaga(options) {
 	assertTypeOf(options, 'saga', 'function');
 	function* cmfSaga() {
-		yield spawn(handleSagaComponent);
-		yield spawn(sagas.component.handle);
+		yield fork(handleSagaComponent);
+		yield fork(sagas.component.handle);
 		if (typeof options.saga === 'function') {
-			yield spawn(options.saga);
+			yield fork(options.saga);
 		}
 	}
 	// https://chrome.google.com/webstore/detail/redux-saga-dev-tools/kclmpmjofefcpjlommdpokoccidafnbi

--- a/packages/cmf/src/cmfModule.merge.js
+++ b/packages/cmf/src/cmfModule.merge.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { spawn } from 'redux-saga/effects';
+import { fork } from 'redux-saga/effects';
 import _merge from 'lodash/merge';
 import { assertValueTypeOf } from './assert';
 
@@ -73,8 +73,8 @@ function mergeSaga(saga, newSaga) {
 
 	if (saga && newSaga) {
 		return function* mergedSaga() {
-			yield spawn(saga);
-			yield spawn(newSaga);
+			yield fork(saga);
+			yield fork(newSaga);
 		};
 	}
 	if (newSaga) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we get the result of the runMiddleware saga, all sagas that bootstrap the main cmf saga are not attached to the main one.
That does not allow us to cancel the saga (in the talend storybook configuration)

**What is the chosen solution to this problem?**
Switch spawn to fork to keep attached to the main thread
https://redux-saga.js.org/docs/api#forkfn-args

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
