### PR TITLE
feat(Step): Add tooltip support

### DIFF
--- a/.changeset/rare-waves-promise.md
+++ b/.changeset/rare-waves-promise.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Step: Add tooltip support

--- a/packages/design-system/src/components/Stepper/Step/Step.spec.tsx
+++ b/packages/design-system/src/components/Stepper/Step/Step.spec.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import Step from './index';
+
+context('<Step />', () => {
+	describe('default', () => {
+		it('should show a tooltip', () => {
+			cy.mount(<Step.Disabled tooltip="Here is why" title="Step label" data-testid="step" />);
+
+			cy.getByTestId('step').trigger('mouseover');
+
+			cy.getByRole('tooltip').should('be.visible').should('have.text', 'Here is why');
+		});
+	});
+});

--- a/packages/design-system/src/components/Stepper/Step/Step.tsx
+++ b/packages/design-system/src/components/Stepper/Step/Step.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 import { IconName } from '@talend/icons';
 import { Icon } from '../../Icon/Icon';
-
 import * as S from './Step.style';
+import Tooltip from '../../Tooltip';
 
 export type StepProps = React.PropsWithRef<any> & {
 	/** The title of the step */
 	title: string;
+	/** The title of the step */
+	tooltip?: string;
 	/** The optional class name */
 	className?: string;
 	/** The icon element to display */
@@ -17,8 +19,8 @@ export type StepProps = React.PropsWithRef<any> & {
  * Steps are the main elements for the stepper.
  */
 const Step: React.FC<StepProps> = React.forwardRef(
-	({ icon, title, className = '', children, ...rest }: StepProps, ref) => {
-		return (
+	({ icon, title, className = '', tooltip, children, ...rest }: StepProps, ref) => {
+		const step = (
 			<S.Step ref={ref} {...rest} className={`step ${className || ''}`}>
 				<span className="step__title">{children || title}</span>
 				<span className="step__icon" aria-hidden>
@@ -26,6 +28,7 @@ const Step: React.FC<StepProps> = React.forwardRef(
 				</span>
 			</S.Step>
 		);
+		return tooltip ? <Tooltip title={tooltip}>{step}</Tooltip> : step;
 	},
 );
 

--- a/packages/design-system/src/components/Stepper/docs/Stepper.step.stories.mdx
+++ b/packages/design-system/src/components/Stepper/docs/Stepper.step.stories.mdx
@@ -79,6 +79,22 @@ The max-width for a step is 20rem, if the label is longer we display an ellipsis
 	</Story>
 </Canvas>
 
+**Disabled**
+
+<Canvas>
+	<Story name="Disabled">
+		<Step.Disabled data-index={3} title="Lorem Ipsum" />
+	</Story>
+</Canvas>
+
+**With tooltip**
+
+<Canvas>
+	<Story name="With tooltip">
+		<Step.Disabled tooltip="Here is why" data-index={3} title="Lorem Ipsum" />
+	</Story>
+</Canvas>
+
 <!--
 <FigmaImage
 	src="https://www.figma.com/file/WUVKJmcDHfR7K1q1lYhaHk/Stepper?node-id=1%3A424"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

It's not possible to display tooltip on (disabled) steps.

**What is the chosen solution to this problem?**

Add an optional `tooltip` prop

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
