### PR TITLE
test(components): avoid tests over timezone with DST

### DIFF
--- a/.changeset/proud-games-dream.md
+++ b/.changeset/proud-games-dream.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Unit tests must not rely on timezones with DST

--- a/.changeset/proud-games-dream.md
+++ b/.changeset/proud-games-dream.md
@@ -1,5 +1,0 @@
----
-'@talend/react-components': patch
----
-
-Unit tests must not rely on timezones with DST

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
@@ -274,16 +274,16 @@ describe('Date extraction', () => {
 			// given
 			const payload = {
 				date: new Date(2019, 9, 11),
-				textInput: '2019-10-11',
+				textInput: '11.10.2019',
 			};
 			const time = '12:30';
-			const options = { dateFormat: 'YYYY-MM-DD', timezone: 'America/New_York' };
+			const options = { dateFormat: 'DD.MM.YYYY', timezone: 'America/Argentina/Buenos_Aires' };
 			// when
 			const parts = updatePartsOnDateChange(payload, time, options);
 			// then
-			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 17, 30)));
+			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 15, 30)));
 			expect(parts.date).toEqual(new Date(2019, 9, 11));
-			expect(parts.textInput).toEqual('2019-10-11 12:30');
+			expect(parts.textInput).toEqual('11.10.2019 12:30');
 			expect(parts.errors).toEqual([]);
 			expect(parts.errorMessage).toBeNull();
 		});
@@ -350,13 +350,13 @@ describe('Date extraction', () => {
 				textInput: '09:32',
 			};
 			const date = new Date(2019, 9, 11);
-			const options = { dateFormat: 'YYYY-MM-DD', timezone: 'America/New_York' };
+			const options = { dateFormat: 'DD.MM.YYYY', timezone: 'America/Argentina/Buenos_Aires' };
 			// when
 			const parts = updatePartsOnTimeChange(payload, date, options);
 			// then
-			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 14, 32)));
+			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 12, 32)));
 			expect(parts.time).toEqual({ hours: '09', minutes: '32', seconds: '00' });
-			expect(parts.textInput).toEqual('2019-10-11 09:32');
+			expect(parts.textInput).toEqual('11.10.2019 09:32');
 			expect(parts.errors).toEqual([]);
 			expect(parts.errorMessage).toBeNull();
 		});

--- a/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
+++ b/packages/components/src/DateTimePickers/DateTime/datetime-extraction.test.js
@@ -274,16 +274,16 @@ describe('Date extraction', () => {
 			// given
 			const payload = {
 				date: new Date(2019, 9, 11),
-				textInput: '11.10.2019',
+				textInput: '11/10/2019',
 			};
 			const time = '12:30';
-			const options = { dateFormat: 'DD.MM.YYYY', timezone: 'America/Argentina/Buenos_Aires' };
+			const options = { dateFormat: 'DD/MM/YYYY', timezone: 'America/Caracas' };
 			// when
 			const parts = updatePartsOnDateChange(payload, time, options);
 			// then
-			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 15, 30)));
+			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 16, 30)));
 			expect(parts.date).toEqual(new Date(2019, 9, 11));
-			expect(parts.textInput).toEqual('11.10.2019 12:30');
+			expect(parts.textInput).toEqual('11/10/2019 12:30');
 			expect(parts.errors).toEqual([]);
 			expect(parts.errorMessage).toBeNull();
 		});
@@ -350,13 +350,13 @@ describe('Date extraction', () => {
 				textInput: '09:32',
 			};
 			const date = new Date(2019, 9, 11);
-			const options = { dateFormat: 'DD.MM.YYYY', timezone: 'America/Argentina/Buenos_Aires' };
+			const options = { dateFormat: 'DD/MM/YYYY', timezone: 'America/Caracas' };
 			// when
 			const parts = updatePartsOnTimeChange(payload, date, options);
 			// then
-			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 12, 32)));
+			expect(parts.datetime).toEqual(new Date(Date.UTC(2019, 9, 11, 13, 32)));
 			expect(parts.time).toEqual({ hours: '09', minutes: '32', seconds: '00' });
-			expect(parts.textInput).toEqual('11.10.2019 09:32');
+			expect(parts.textInput).toEqual('11/10/2019 09:32');
 			expect(parts.errors).toEqual([]);
 			expect(parts.errorMessage).toBeNull();
 		});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Two unit tests rely on one of the USA's timezone since they change their time twice a year, known as DST.
https://www.timeanddate.com/time/change/usa

**What is the chosen solution to this problem?**

I've modified these tests to now rely on Caracas' timezone, Venezuela is one of the countries which never changes.
http://www.webexhibits.org/daylightsaving/g.html
https://symbolhunt.com/venezuela/date-format/

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
