### PR TITLE
fix(faceted-search): input width in badge with slider popin

### DIFF
--- a/.changeset/mighty-melons-melt.md
+++ b/.changeset/mighty-melons-melt.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+fix(faceted-search): input width in badge with slider popin

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.scss
@@ -1,4 +1,5 @@
 // stylelint-disable property-no-vendor-prefix
+
 .tc-badge-slider-form {
 	:global(.tc-tooltip-body) {
 		margin: 0;
@@ -11,19 +12,23 @@
 
 		&-row {
 			display: flex;
-			gap: 1.4rem;
+			gap: 1.2rem;
 			justify-content: center;
 			align-items: center;
 			margin-top: 2rem;
 			margin-bottom: 1rem;
 
-			> div:not(:empty) {
+			.tc-badge-slider-form-body-row-icon,
+			.tc-badge-slider-form-body-row-value {
 				flex: 1;
 				display: flex;
+			}
+
+			.tc-badge-slider-form-body-row-icon {
 				justify-content: flex-end;
 			}
 
-			> div:empty ~ div {
+			.tc-badge-slider-form-body-row-value:only-child {
 				.tc-badge-value-unit,
 				input {
 					text-align: center;
@@ -45,7 +50,6 @@
 				border: none;
 				background: none;
 				padding: 0;
-				margin: 0px 2px;
 				text-align: start;
 			}
 

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.scss
@@ -11,18 +11,32 @@
 
 		&-row {
 			display: flex;
+			gap: 1.4rem;
 			justify-content: center;
 			align-items: center;
 			margin-top: 2rem;
 			margin-bottom: 1rem;
 
+			> div:not(:empty) {
+				flex: 1;
+				display: flex;
+				justify-content: flex-end;
+			}
+
+			> div:empty ~ div {
+				.tc-badge-value-unit,
+				input {
+					text-align: center;
+				}
+			}
+
 			svg {
 				width: 3.2rem;
 				height: 3.2rem;
-				margin-right: 1.4rem;
 			}
 
 			.tc-badge-value-unit {
+				flex: 1;
 				font-size: 3.2rem;
 				font-weight: $font-weight-semi-bold;
 				width: 5rem;
@@ -30,19 +44,21 @@
 				margin-bottom: 0;
 				border: none;
 				background: none;
-				padding: {
-					left: 0;
-					top: 0.2rem;
-				}
+				padding: 0;
+				margin: 0px 2px;
+				text-align: start;
 			}
 
 			input {
+				flex: 1;
 				font-size: 3.2rem;
 				font-weight: $font-weight-semi-bold;
-				width: 5rem;
+				width: 8rem;
 				color: $dove-gray;
 				box-shadow: none;
 				height: 4.7rem;
+				padding: 0;
+				margin: 0;
 
 				-moz-appearance: textfield;
 
@@ -51,10 +67,6 @@
 					-webkit-appearance: none;
 					margin: 0;
 				}
-			}
-
-			> div {
-				display: none;
 			}
 		}
 	}

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
@@ -76,41 +76,45 @@ const BadgeSliderForm = ({
 		<form className={theme('tc-badge-slider-form')} id={`${id}-slider`} onSubmit={onSubmit}>
 			<Rich.Layout.Body id={`${id}-badge-body`} className={theme('tc-badge-slider-form-body')}>
 				<div className={theme('tc-badge-slider-form-body-row')}>
-					{icon && <Icon name={icon.name} className={theme('tc-badge-icon', icon.class || icon.className)} />}
-					{editing ? (
-						<input
-							id={`${id}-input`}
-							autoFocus // eslint-disable-line jsx-a11y/no-autofocus
-							className="form-control"
-							min={min}
-							max={max}
-							step={step}
-							onChange={event => {
-								const v = event.target.value;
-								setInput(v);
-								setValue(!isErroneous(v) ? v : defaultValue);
-							}}
-							onBlur={() => {
-								setInput(value);
-								setValue(value);
-								setSlider(value);
-								setEditing(false);
-							}}
-							type="number"
-							value={input}
-						/>
-					) : (
-						<button
-							className={theme('tc-badge-value-unit')}
-							onClick={() => setEditing(true)}
-							title={t('FACETED_SEARCH_EDIT_DIRECTLY', {
-								defaultValue: 'Edit directly',
-							})}
-						>
-							{value}
-							{unit}
-						</button>
-					)}
+					<div>
+						{icon && <Icon name={icon.name} className={theme('tc-badge-icon', icon.class || icon.className)} />}
+					</div>
+					<div>
+						{editing ? (
+							<input
+								id={`${id}-input`}
+								autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+								className="form-control"
+								min={min}
+								max={max}
+								step={step}
+								onChange={event => {
+									const v = event.target.value;
+									setInput(v);
+									setValue(!isErroneous(v) ? v : defaultValue);
+								}}
+								onBlur={() => {
+									setInput(value);
+									setValue(value);
+									setSlider(value);
+									setEditing(false);
+								}}
+								type="number"
+								value={input}
+							/>
+						) : (
+							<button
+								className={theme('tc-badge-value-unit')}
+								onClick={() => setEditing(true)}
+								title={t('FACETED_SEARCH_EDIT_DIRECTLY', {
+									defaultValue: 'Edit directly',
+								})}
+							>
+								{value}
+								{unit}
+							</button>
+						)}
+					</div>
 				</div>
 				<Slider
 					value={slider}

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
@@ -73,15 +73,15 @@ const BadgeSliderForm = ({
 		<form className={theme('tc-badge-slider-form')} id={`${id}-slider`} onSubmit={onSubmit}>
 			<Rich.Layout.Body id={`${id}-badge-body`} className={theme('tc-badge-slider-form-body')}>
 				<div className={theme('tc-badge-slider-form-body-row')}>
-					<div>
-						{icon && (
+					{icon && (
+						<div className={theme('tc-badge-slider-form-body-row-icon')}>
 							<Icon
 								name={icon.name}
 								className={theme('tc-badge-icon', icon.class || icon.className)}
 							/>
-						)}
-					</div>
-					<div>
+						</div>
+					)}
+					<div className={theme('tc-badge-slider-form-body-row-value')}>
 						{editing ? (
 							<input
 								id={`${id}-input`}

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSliderForm.component.js
@@ -61,13 +61,10 @@ const BadgeSliderForm = ({
 	const [slider, setSlider] = useState(initialValue);
 	const [input, setInput] = useState(initialValue);
 	const [editing, setEditing] = useState(false);
-	const error = useMemo(() => getErrorMessage(t, decimal, min, max, input), [
-		t,
-		decimal,
-		min,
-		max,
-		input,
-	]);
+	const error = useMemo(
+		() => getErrorMessage(t, decimal, min, max, input),
+		[t, decimal, min, max, input],
+	);
 	const isErroneous = useMemo(() => getValidator(decimal, min, max), [decimal, min, max]);
 
 	useEffect(() => onChange(null, value), [onChange, value]);
@@ -77,7 +74,12 @@ const BadgeSliderForm = ({
 			<Rich.Layout.Body id={`${id}-badge-body`} className={theme('tc-badge-slider-form-body')}>
 				<div className={theme('tc-badge-slider-form-body-row')}>
 					<div>
-						{icon && <Icon name={icon.name} className={theme('tc-badge-icon', icon.class || icon.className)} />}
+						{icon && (
+							<Icon
+								name={icon.name}
+								className={theme('tc-badge-icon', icon.class || icon.className)}
+							/>
+						)}
 					</div>
 					<div>
 						{editing ? (

--- a/packages/faceted-search/stories/facetedSearch.stories.js
+++ b/packages/faceted-search/stories/facetedSearch.stories.js
@@ -439,3 +439,62 @@ export const BasicSearchWithAnEmptyLabelBadge = () => (
 		/>
 	</FacetedSearch.Faceted>
 );
+
+export const BasicSearchWithSliderPopin = {
+	render: ({ decimal, withIcon }) => {
+		const step = decimal ? 0.01 : 1;
+		const icon = withIcon ? badgeValid.properties.icon : undefined;
+
+		const overritenProperties = {
+			initialOperatorOpened: false,
+			initialValueOpened: true,
+			step,
+			decimal: true,
+			operator: {
+				label: 'Less than',
+				name: 'LessThan',
+				iconName: 'less-than',
+			},
+			icon,
+			operators: [
+				{
+					label: 'Less than',
+					name: 'LessThan',
+					iconName: 'less-than',
+				},
+				{
+					label: 'Less than or equal',
+					name: 'LessThanOrEquals',
+					iconName: 'less-than-equal',
+				},
+			],
+		};
+
+		const badgeFacetedCustom = {
+			badges: [
+				{
+					...badgeValid,
+					properties: {
+						...badgeValid.properties,
+						...overritenProperties,
+					},
+				},
+			],
+		};
+
+		return (
+			<FacetedSearch.Faceted id="my-faceted-search">
+				<FacetedSearch.BasicSearch
+					badgesDefinitions={badgesDefinitions}
+					badgesFaceted={badgeFacetedCustom}
+					callbacks={callbacks}
+					onSubmit={action('onSubmit')}
+				/>
+			</FacetedSearch.Faceted>
+		);
+	},
+	args: {
+		decimal: true,
+		withIcon: true,
+	},
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Context: [JIRA 6189](https://jira.talendforge.org/browse/TDC-6189)

It updates Layout of Badge with slider popin in order to fix input width.
It handles large intergers and decimals.
It also handles with or without icon.
You can play with these two parameters in added story `Basic Search With Slider Popin` (2 dedicated boolean controls `withIcon` and `decimals`).

## Before:
 
![Screenshot 2022-03-17 at 16 02 11](https://user-images.githubusercontent.com/6088236/158832687-eb830468-d279-433c-98cb-fa52628c1ab2.png)

## After: 

![Screenshot 2022-03-17 at 16 03 56](https://user-images.githubusercontent.com/6088236/158832541-b12bd34d-568d-493a-a1e8-83dd22391e61.png)

**What is the chosen solution to this problem?**

Splitting flex row in 2 when icon is present and adjust alignment.

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
