### PR TITLE
fix(cmf): test in node 16

### DIFF
--- a/.changeset/eight-mugs-obey.md
+++ b/.changeset/eight-mugs-obey.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf': patch
+---
+
+fix(cmf): catch uncaught error in http error handling

--- a/packages/cmf/__tests__/middlewares/http.test.js
+++ b/packages/cmf/__tests__/middlewares/http.test.js
@@ -23,10 +23,12 @@ describe('CMF http middleware', () => {
 	it('should be available from middlewares/http', () => {
 		expect(http).toBe(httpMiddleware);
 	});
+
 	it('should DEFAULT_HTTP_HEADERS be json', () => {
 		expect(DEFAULT_HTTP_HEADERS.Accept).toBe('application/json');
 		expect(DEFAULT_HTTP_HEADERS['Content-Type']).toBe('application/json');
 	});
+
 	it('should isHTTPRequest check action type', () => {
 		const action = {
 			type: HTTP_METHODS.POST,
@@ -38,6 +40,7 @@ describe('CMF http middleware', () => {
 		action.type = 'HTTP/POST';
 		expect(isHTTPRequest(action)).toBe(false);
 	});
+
 	it('should isHTTPRequest check action.cmf.http', () => {
 		const action = {
 			type: 'WHAT_EVER_YOU_WANT',
@@ -47,6 +50,7 @@ describe('CMF http middleware', () => {
 		};
 		expect(isHTTPRequest(action)).toBe(true);
 	});
+
 	it('should getMethod find HTTP method in action type', () => {
 		expect(getMethod({ type: HTTP_METHODS.POST })).toBe('POST');
 		expect(getMethod({ type: HTTP_METHODS.OPTIONS })).toBe('OPTIONS');
@@ -326,7 +330,7 @@ describe('CMF http middleware', () => {
 				type: 'basic',
 				url: '//foo/bar',
 				clone: () => ({
-					text: () => new Promise(resolve => resolve('invalid json')),
+					text: () => Promise.resolve('invalid json'),
 				}),
 			},
 		};
@@ -404,6 +408,7 @@ describe('status function', () => {
 			expect(JSON.parse(JSON.stringify(err))).toMatchSnapshot();
 		});
 	});
+
 	it('should resolve if status >= HTTP_STATUS.OK & < 300', () => {
 		const response = {
 			status: HTTP_STATUS.NO_CONTENT,
@@ -423,6 +428,7 @@ describe('json function', () => {
 			expect(JSON.parse(JSON.stringify(err))).toMatchSnapshot();
 		});
 	});
+
 	it('should resolve if attr json is on response', () => {
 		const response = {
 			status: HTTP_STATUS.OK,
@@ -435,6 +441,7 @@ describe('json function', () => {
 			expect(r).toMatchSnapshot();
 		});
 	});
+
 	it('should resolve status HTTP_STATUS.NO_CONTENT but without json function', () => {
 		const response = {
 			status: HTTP_STATUS.NO_CONTENT,
@@ -589,6 +596,7 @@ describe('httpMiddleware configuration', () => {
 			done();
 		});
 	});
+
 	it('should call interceptor at every levels', done => {
 		// given
 		const response = { foo: 'bar' };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
cmf tests fail in node 16 because of un unhandled promise rejection.
This is due to http error with a text that is not in json. Cmf tries to parse it as json.

**What is the chosen solution to this problem?**
Catch the error, and doesn't take care of it as the response is already set as raw response.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
