### PR TITLE
chore: use Node 16 for github actions

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -18,10 +18,10 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js 14.x
+      - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14.x
+          node-version: 16
           registry-url: 'https://registry.npmjs.org/'
           scope: '@talend'
           cache: 'yarn'

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
           registry-url: 'https://registry.npmjs.org/'
           scope: '@talend'
           cache: 'yarn'

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
           registry-url: 'https://registry.npmjs.org/'
           scope: '@talend'
           cache: 'yarn'

--- a/.github/workflows/design-system-visual-testing.yml
+++ b/.github/workflows/design-system-visual-testing.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: '14'
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"

--- a/.github/workflows/design-tokens.yml
+++ b/.github/workflows/design-tokens.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -15,10 +15,10 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"

--- a/.github/workflows/pr-playground.yml
+++ b/.github/workflows/pr-playground.yml
@@ -18,10 +18,10 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Checkout sources
         uses: actions/checkout@v2
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           check-latest: true
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"

--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -11,10 +11,10 @@ jobs:
     environment: pull_request_unsafe
 
     steps:
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
 
       - name: Push to surge
         run: npx surge teardown ${{ github.event.pull_request.number }}.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/yarn-deduplicate.yml
+++ b/.github/workflows/yarn-deduplicate.yml
@@ -18,10 +18,10 @@ jobs:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal token
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
-      - name: Use Node.js 14
+      - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 14
+          node-version: 16
           registry-url: "https://registry.npmjs.org/"
           scope: "@talend"
           cache: "yarn"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Node 14 is used but LTS is Node 16

*Use Node 16*What is the chosen solution to this problem?**
`
**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
