### PR TITLE
fix(DS): Update i18next version to match other packages

### DIFF
--- a/.changeset/silent-hornets-collect.md
+++ b/.changeset/silent-hornets-collect.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Update i18next version to match other packages

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -106,7 +106,7 @@
     "@talend/icons": "^6.36.3",
     "@talend/locales-design-system": "^1.4.0",
     "focus-outline-manager": "^1.0.2",
-    "i18next": "^21.2.0",
+    "i18next": "^20.1.0",
     "react": "^16.14.0",
     "react-dom": "^16.14.0",
     "react-i18next": "^11.8.13",

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.component.test.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.component.test.js
@@ -4,7 +4,7 @@ import { shallow } from 'enzyme';
 import TimezoneList from './TimezoneList.component';
 
 jest.mock('../Datalist', () => {
-	return function DataList() { };
+	return function DataList() {};
 });
 
 describe('TimezoneList component', () => {
@@ -28,8 +28,7 @@ describe('TimezoneList component', () => {
 										Freetown: { exemplarCity: 'Freetown' },
 									},
 									Europe: {
-										Paris: { exemplarCity: 'Paris' },
-										Kiev: { exemplarCity: 'Kiev' },
+										Istanbul: { exemplarCity: 'Istanbul' },
 									},
 								},
 							},

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
@@ -13,8 +13,7 @@ describe('getTimezones', () => {
 									Freetown: { exemplarCity: '[EN] Freetown' },
 								},
 								Europe: {
-									Paris: { exemplarCity: '[EN] Paris' },
-									Kiev: { exemplarCity: '[EN] Kiev' },
+									Istanbul: { exemplarCity: '[EN] Istanbul' },
 								},
 							},
 						},
@@ -33,8 +32,7 @@ describe('getTimezones', () => {
 									Freetown: { exemplarCity: '[FR] Freetown' },
 								},
 								Europe: {
-									Paris: { exemplarCity: '[FR] Paris' },
-									Kiev: { exemplarCity: '[FR] Kiev' },
+									Istanbul: { exemplarCity: '[FR] Istanbul' },
 								},
 							},
 						},
@@ -50,10 +48,24 @@ describe('getTimezones', () => {
 
 		// then
 		expect(timezones).toEqual([
-			{ name: '(UTC +00:00) [FR] Abidjan', timezoneName: '[FR] Abidjan', offset: 0, value: 'Africa/Abidjan' },
-			{ name: '(UTC +00:00) [FR] Freetown', timezoneName: '[FR] Freetown', offset: 0, value: 'Africa/Freetown' },
-			{ name: '(UTC +01:00) [FR] Paris', timezoneName: '[FR] Paris', offset: 60, value: 'Europe/Paris' },
-			{ name: '(UTC +02:00) [FR] Kiev', timezoneName: '[FR] Kiev', offset: 120, value: 'Europe/Kiev' },
+			{
+				name: '(UTC +00:00) [FR] Abidjan',
+				timezoneName: '[FR] Abidjan',
+				offset: 0,
+				value: 'Africa/Abidjan',
+			},
+			{
+				name: '(UTC +00:00) [FR] Freetown',
+				timezoneName: '[FR] Freetown',
+				offset: 0,
+				value: 'Africa/Freetown',
+			},
+			{
+				name: '(UTC +03:00) [FR] Istanbul',
+				timezoneName: '[FR] Istanbul',
+				offset: 180,
+				value: 'Europe/Istanbul',
+			},
 		]);
 	});
 
@@ -63,10 +75,24 @@ describe('getTimezones', () => {
 
 		// then
 		expect(timezones).toEqual([
-			{ name: '(UTC +00:00) [EN] Abidjan', timezoneName: '[EN] Abidjan', offset: 0, value: 'Africa/Abidjan' },
-			{ name: '(UTC +00:00) [EN] Freetown', timezoneName: '[EN] Freetown', offset: 0, value: 'Africa/Freetown' },
-			{ name: '(UTC +01:00) [EN] Paris', timezoneName: '[EN] Paris', offset: 60, value: 'Europe/Paris' },
-			{ name: '(UTC +02:00) [EN] Kiev', timezoneName: '[EN] Kiev', offset: 120, value: 'Europe/Kiev' },
+			{
+				name: '(UTC +00:00) [EN] Abidjan',
+				timezoneName: '[EN] Abidjan',
+				offset: 0,
+				value: 'Africa/Abidjan',
+			},
+			{
+				name: '(UTC +00:00) [EN] Freetown',
+				timezoneName: '[EN] Freetown',
+				offset: 0,
+				value: 'Africa/Freetown',
+			},
+			{
+				name: '(UTC +03:00) [EN] Istanbul',
+				timezoneName: '[EN] Istanbul',
+				offset: 180,
+				value: 'Europe/Istanbul',
+			},
 		]);
 	});
 

--- a/packages/forms/src/UIForm/fields/TimezoneList/__snapshots__/TimezoneList.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/TimezoneList/__snapshots__/TimezoneList.component.test.js.snap
@@ -20,11 +20,8 @@ exports[`TimezoneList component should render the timezone dropdown widget 1`] =
                       },
                     },
                     "Europe": Object {
-                      "Kiev": Object {
-                        "exemplarCity": "Kiev",
-                      },
-                      "Paris": Object {
-                        "exemplarCity": "Paris",
+                      "Istanbul": Object {
+                        "exemplarCity": "Istanbul",
                       },
                     },
                   },
@@ -50,16 +47,10 @@ exports[`TimezoneList component should render the timezone dropdown widget 1`] =
             "value": "Africa/Freetown",
           },
           Object {
-            "name": "(UTC +01:00) Paris",
-            "offset": 60,
-            "timezoneName": "Paris",
-            "value": "Europe/Paris",
-          },
-          Object {
-            "name": "(UTC +02:00) Kiev",
-            "offset": 120,
-            "timezoneName": "Kiev",
-            "value": "Europe/Kiev",
+            "name": "(UTC +03:00) Istanbul",
+            "offset": 180,
+            "timezoneName": "Istanbul",
+            "value": "Europe/Istanbul",
           },
         ],
       },
@@ -78,16 +69,10 @@ exports[`TimezoneList component should render the timezone dropdown widget 1`] =
           "value": "Africa/Freetown",
         },
         Object {
-          "name": "(UTC +01:00) Paris",
-          "offset": 60,
-          "timezoneName": "Paris",
-          "value": "Europe/Paris",
-        },
-        Object {
-          "name": "(UTC +02:00) Kiev",
-          "offset": 120,
-          "timezoneName": "Kiev",
-          "value": "Europe/Kiev",
+          "name": "(UTC +03:00) Istanbul",
+          "offset": 180,
+          "timezoneName": "Istanbul",
+          "value": "Europe/Istanbul",
         },
       ],
     }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

i18next peer deps doesn't match
- DS dev dep (https://github.com/Talend/ui/blob/master/packages/design-system/package.json#L88)
- other TUI packages peer/dev deps

(also, fixing unit tests failing beacuse of DST)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
