### PR TITLE
fix(AboutModal): Unnecessary div in markup

### DIFF
--- a/.changeset/tame-beds-promise.md
+++ b/.changeset/tame-beds-promise.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+AboutDialog: Unnecessary div in markup

--- a/packages/components/src/AboutDialog/AboutDialog.component.js
+++ b/packages/components/src/AboutDialog/AboutDialog.component.js
@@ -1,15 +1,13 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
-
 import Dialog from '../Dialog';
-import Skeleton from '../Skeleton';
 import Icon from '../Icon';
+import Skeleton from '../Skeleton';
+import I18N_DOMAIN_COMPONENTS from '../constants';
 import getDefaultT from '../translate';
 import theme from './AboutDialog.scss';
-
-import I18N_DOMAIN_COMPONENTS from '../constants';
 import { AboutDialogTable, Text } from './AboutDialogTable.component';
 
 function AboutDialog({
@@ -57,27 +55,31 @@ function AboutDialog({
 				/>
 				<div className={classNames(theme['about-excerpt'], 'about-excerpt')}>
 					{version && (
+						<div>
+							<Text
+								text={t('ABOUT_VERSION_NAME', {
+									defaultValue: 'Version: {{version}}',
+									version,
+									interpolation: { escapeValue: false },
+								})}
+								size={Skeleton.SIZES.xlarge}
+								loading={loading}
+							/>
+						</div>
+					)}
+					<div>
 						<Text
-							text={t('ABOUT_VERSION_NAME', {
-								defaultValue: 'Version: {{version}}',
-								version,
-								interpolation: { escapeValue: false },
-							})}
-							size={Skeleton.SIZES.xlarge}
+							text={
+								copyrights ||
+								t('ABOUT_COPYRIGHTS', {
+									defaultValue: '© {{year}} Talend. All Rights Reserved',
+									year: new Date().getFullYear(),
+								})
+							}
+							size={Skeleton.SIZES.large}
 							loading={loading}
 						/>
-					)}
-					<Text
-						text={
-							copyrights ||
-							t('ABOUT_COPYRIGHTS', {
-								defaultValue: '© {{year}} Talend. All Rights Reserved',
-								year: new Date().getFullYear(),
-							})
-						}
-						size={Skeleton.SIZES.large}
-						loading={loading}
-					/>
+					</div>
 				</div>
 				{expanded && (
 					<AboutDialogTable t={t} loading={loading} services={services} definition={definition} />

--- a/packages/components/src/AboutDialog/AboutDialogTable.component.js
+++ b/packages/components/src/AboutDialog/AboutDialogTable.component.js
@@ -1,10 +1,8 @@
+import classNames from 'classnames';
 import PropTypes from 'prop-types';
 import React from 'react';
-import classNames from 'classnames';
-
-import { getI18nInstance } from '../translate';
 import Skeleton from '../Skeleton';
-
+import { getI18nInstance } from '../translate';
 import theme from './AboutDialog.scss';
 
 const i18n = getI18nInstance();
@@ -16,7 +14,7 @@ export const getColumnHeaders = () => ({
 });
 
 export function Text({ text, loading, size = Skeleton.SIZES.medium }) {
-	return <div>{loading ? <Skeleton type={Skeleton.TYPES.text} size={size} /> : text}</div>;
+	return loading ? <Skeleton type={Skeleton.TYPES.text} size={size} /> : text;
 }
 
 export function AboutDialogTable({


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Modal table is full of useless `<div>` cluttering snapshots

**What is the chosen solution to this problem?**

Removing the div when rendering a text

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
