### PR TITLE
fix(ListTable): remove box-shadow on each item

### DIFF
--- a/.changeset/kind-olives-tease.md
+++ b/.changeset/kind-olives-tease.md
@@ -2,4 +2,4 @@
 '@talend/react-components': patch
 ---
 
-fix(ListTable): remove shaddow-box on each item
+fix(ListTable): remove box-shadow on each item

--- a/.changeset/kind-olives-tease.md
+++ b/.changeset/kind-olives-tease.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(ListTable): remove shaddow-box on each item

--- a/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
@@ -112,7 +112,7 @@ exports[`LazyLoadingList should render lazy loading list component 1`] = `
                       style={Object {}}
                     >
                       <div
-                        className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row"
+                        className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
                         role="row"
                         style={
                           Object {

--- a/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/LazyLoadingList/__snapshots__/LazyLoadingList.component.test.js.snap
@@ -112,7 +112,7 @@ exports[`LazyLoadingList should render lazy loading list component 1`] = `
                       style={Object {}}
                     >
                       <div
-                        className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
+                        className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row theme-tc-list-headerRow"
                         role="row"
                         style={
                           Object {

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -225,7 +225,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
                       role="row"
                       style={
                         Object {
@@ -1210,7 +1210,7 @@ exports[`List should render 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
                       role="row"
                       style={
                         Object {
@@ -2219,7 +2219,7 @@ exports[`List should render id if provided 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
                       role="row"
                       style={
                         Object {

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -225,7 +225,7 @@ exports[`List should not render the toolbar without toolbar props 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row theme-tc-list-headerRow"
                       role="row"
                       style={
                         Object {
@@ -1210,7 +1210,7 @@ exports[`List should render 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row theme-tc-list-headerRow"
                       role="row"
                       style={
                         Object {
@@ -2219,7 +2219,7 @@ exports[`List should render id if provided 1`] = `
                     style={Object {}}
                   >
                     <div
-                      className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
+                      className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row theme-tc-list-headerRow"
                       role="row"
                       style={
                         Object {

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
@@ -63,6 +63,15 @@ function ListTable(props) {
 
 	const onRowClickCallback = decorateRowClick(onRowClick);
 	const onRowDoubleClickCallback = decorateRowDoubleClick(onRowDoubleClick);
+	const headerRowRenderer = ({ className, columns, style }) => (
+		<div
+			className={classNames(...[className, theme['tc-list-headerRow']])}
+			role="row"
+			style={style}
+		>
+			{columns}
+		</div>
+	);
 
 	return (
 		<VirtualizedTable
@@ -73,11 +82,14 @@ function ListTable(props) {
 			onRowClick={onRowClickCallback}
 			onRowDoubleClick={onRowDoubleClickCallback}
 			rowClassName={({ index }) =>
-				classNames(...['tc-list-item', rowThemes, collection[index] && collection[index].className])
+				classNames(
+					...[theme['tc-list-item'], rowThemes, collection[index] && collection[index].className],
+				)
 			}
 			rowCount={rowCount || collection.length}
 			rowGetter={({ index }) => collection[index] || {}}
 			rowRenderer={RowTableRenderer}
+			headerRowRenderer={headerRowRenderer}
 			{...restProps}
 		/>
 	);

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
@@ -73,9 +73,7 @@ function ListTable(props) {
 			onRowClick={onRowClickCallback}
 			onRowDoubleClick={onRowDoubleClickCallback}
 			rowClassName={({ index }) =>
-				classNames(
-					...[theme['tc-list-item'], rowThemes, collection[index] && collection[index].className],
-				)
+				classNames(...['tc-list-item', rowThemes, collection[index] && collection[index].className])
 			}
 			rowCount={rowCount || collection.length}
 			rowGetter={({ index }) => collection[index] || {}}

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.scss
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.scss
@@ -23,7 +23,7 @@ $tc-list-table-border: 1px solid darken($concrete, 5%);
 		}
 	}
 
-	:global(.ReactVirtualized__Table__headerRow) {
+	.tc-list-headerRow {
 		box-shadow: $shadow-default;
 		.header {
 			color: $tc-list-table-header-color;

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.scss
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.scss
@@ -23,9 +23,8 @@ $tc-list-table-border: 1px solid darken($concrete, 5%);
 		}
 	}
 
-	.tc-list-item {
+	:global(.ReactVirtualized__Table__headerRow) {
 		box-shadow: $shadow-default;
-
 		.header {
 			color: $tc-list-table-header-color;
 			display: inline-flex;

--- a/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
@@ -46,7 +46,7 @@ exports[`ListGrid should render noRows 1`] = `
       style={Object {}}
     >
       <div
-        className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
+        className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row theme-tc-list-headerRow"
         role="row"
         style={
           Object {

--- a/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
+++ b/packages/components/src/VirtualizedList/ListTable/__snapshots__/ListTable.test.js.snap
@@ -46,7 +46,7 @@ exports[`ListGrid should render noRows 1`] = `
       style={Object {}}
     >
       <div
-        className="ReactVirtualized__Table__headerRow theme-tc-list-item theme-row theme-row"
+        className="ReactVirtualized__Table__headerRow tc-list-item theme-row theme-row"
         role="row"
         style={
           Object {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

A `box-shadow` css property was added to each list item, breaking list style. 

**What is the chosen solution to this problem?**

I get back old selector for header, in order to prevent `box-shadow` to apply.

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
