### PR TITLE
chore(ARCH-482/ComponentForm): remove deprecated lifecycle

### DIFF
--- a/.changeset/twelve-nails-exercise.md
+++ b/.changeset/twelve-nails-exercise.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': patch
+---
+
+chore(ARCH-482/ComponentForm): remove deprecated lifecycle

--- a/packages/containers/.storybook/preview.js
+++ b/packages/containers/.storybook/preview.js
@@ -4,6 +4,7 @@ import { namespaces as containersNamespaces } from '@talend/locales-tui-containe
 import { namespaces as dsNamespaces } from '@talend/locales-design-system/namespaces';
 
 import cmfModule, { settings } from './cmfModule';
+import { ThemeProvider } from '@talend/design-system';
 
 export const i18n = {
 	namespaces: [
@@ -21,6 +22,14 @@ export const i18n = {
 		'design-system': 'https://unpkg.com/@talend/locales-design-system/locales/{{lng}}/{{ns}}.json',
 	},
 };
+
+export const decorators = [
+	(Story, context) => (
+		<ThemeProvider>
+			<Story {...context} />
+		</ThemeProvider>
+	),
+];
 
 export const cmf = {
 	modules: [cmfModule],

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -101,15 +101,12 @@ export class TCompForm extends React.Component {
 		this.getMemoizedInitialState = memoizeOne(toJS);
 	}
 
-	componentWillReceiveProps(nextProps) {
-		const nextProperties = nextProps.state.get('properties', Map());
-
-		if (this.props.state.get('properties') !== nextProperties) {
+	componentDidUpdate(prevProps) {
+		const nextProperties = this.props.state.get('properties', Map());
+		if (prevProps.state.get('properties') !== nextProperties) {
 			this.setState({ properties: nextProperties.toJS() });
 		}
-	}
 
-	componentDidUpdate(prevProps) {
 		if (
 			prevProps.triggerURL !== this.props.triggerURL ||
 			prevProps.customTriggers !== this.props.customTriggers

--- a/packages/containers/src/Form/Form.stories.js
+++ b/packages/containers/src/Form/Form.stories.js
@@ -26,7 +26,7 @@ const SCHEMA = `{
 	  { "key": "bio", "title": "Bio", "widget": "textarea" },
 	  { "key": "password", "title": "Password", "type": "password", "description": "Hint: Make it strong!" }
 	],
-	"properties": {
+	"data": {
 	  "firstName": "Chuck",
 	  "lastName": "Norris",
 	  "age": 75,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Deprecated lifecycle in ComponentForm

**What is the chosen solution to this problem?**
Remove deprecated lifecycle

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
