### PR TITLE
chore(cypress): github action

### DIFF
--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -32,7 +32,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn --frozen-lock
+          yarn --frozen-lock --ignore-scripts
+          yarn install cypress
 
       - name: Build @talend/design-tokens
         run: |

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          yarn --frozen-lock --ignore-scripts
+          yarn --frozen-lock
 
       - name: Build @talend/design-tokens
         run: |

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           yarn --frozen-lock --ignore-scripts
-          yarn install cypress
+          yarn cypress install
 
       - name: Build @talend/design-tokens
         run: |


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Cypress bin was not installed anymore since we hit `yarn --ignore-scripts`

**What is the chosen solution to this problem?**

Force at least Cy installation with `yarn cypress install` addition

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
