### PR TITLE
fix(WithDrawer): Drawer is rendering below the Typeahead icon

### DIFF
--- a/.changeset/nervous-tips-do.md
+++ b/.changeset/nervous-tips-do.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(WithDrawer): Drawer is rendering below the Typeahead icon

--- a/packages/components/src/WithDrawer/withDrawer.scss
+++ b/packages/components/src/WithDrawer/withDrawer.scss
@@ -12,6 +12,8 @@
 	width: 100%;
 	top: 0;
 	right: 0;
+	// Need to go above the Typeahead icon https://github.com/Talend/ui/blob/f5bc529001c63cad7a6921e1284751efd750a579/packages/components/src/Typeahead/Typeahead.scss#L92
+	z-index: 2;
 }
 
 .tc-with-drawer-container > div {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Drawer is rendering below the Typeahead icon

**What is the chosen solution to this problem?**

Fix z-index

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
