### PR TITLE
fix(module-to-cdn): cdn build folder for @sentry/browser changed... again

### DIFF
--- a/.changeset/neat-pans-compare.md
+++ b/.changeset/neat-pans-compare.md
@@ -1,0 +1,5 @@
+---
+'@talend/module-to-cdn': patch
+---
+
+fix(module-to-cdn): cdn build folder for @sentry/browser changed... again

--- a/fork/module-to-cdn/modules.json
+++ b/fork/module-to-cdn/modules.json
@@ -145,11 +145,11 @@
   "@sentry/browser": {
     "var": "Sentry",
     "versions": {
-      ">= 4.0.0 < 6.19.0": {
+      ">= 4.0.0 < 6.19.0 || >= 6.19.5": {
         "development": "/build/bundle.js",
         "production": "/build/bundle.min.js"
       },
-      ">= 6.19.0": {
+      ">= 6.19.0 < 6.19.5": {
         "development": "/bundles/bundle.js",
         "production": "/bundles/bundle.min.js"
       }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
@sentry/browser umd folder changed again 🤦 

**What is the chosen solution to this problem?**
Impact module-to-cdn config

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
