### PR TITLE
chore: retrigger release

### DIFF
--- a/.changeset/spicy-papayas-battle.md
+++ b/.changeset/spicy-papayas-battle.md
@@ -2,4 +2,4 @@
 '@talend/dynamic-cdn-webpack-plugin': major
 ---
 
-10.x.x already exists from last year so bump to 11
+10.x.x already exists from last year so let's bump to 11

--- a/.changeset/spicy-papayas-battle.md
+++ b/.changeset/spicy-papayas-battle.md
@@ -1,0 +1,5 @@
+---
+'@talend/dynamic-cdn-webpack-plugin': major
+---
+
+10.x.x already exists from last year so bump to 11


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

changeset didn't push the release with the given fix of 10.0.1

https://www.npmjs.com/package/@talend/dynamic-cdn-webpack-plugin

**What is the chosen solution to this problem?**

re-trigger the release

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
