### PR TITLE
fix(ComponentForm): infinite rendering because of new Map ref everytime

### DIFF
--- a/.changeset/small-bugs-melt.md
+++ b/.changeset/small-bugs-melt.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': patch
+---
+
+fix(ComponentForm): infinite rendering because of new Map ref everytime

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -9,6 +9,8 @@ import memoizeOne from 'memoize-one';
 import kit from './kit';
 import tcompFieldsWidgets from './fields';
 
+const emptyMap = Map();
+
 const TO_OMIT = [
 	'definitionURL',
 	'uiSpecPath',
@@ -102,7 +104,7 @@ export class TCompForm extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		const nextProperties = this.props.state.get('properties', Map());
+		const nextProperties = this.props.state.get('properties', emptyMap);
 		if (prevProps.state.get('properties') !== nextProperties) {
 			this.setState({ properties: nextProperties.toJS() });
 		}

--- a/packages/containers/src/ComponentForm/ComponentForm.component.js
+++ b/packages/containers/src/ComponentForm/ComponentForm.component.js
@@ -9,8 +9,6 @@ import memoizeOne from 'memoize-one';
 import kit from './kit';
 import tcompFieldsWidgets from './fields';
 
-const emptyMap = Map();
-
 const TO_OMIT = [
 	'definitionURL',
 	'uiSpecPath',
@@ -104,9 +102,9 @@ export class TCompForm extends React.Component {
 	}
 
 	componentDidUpdate(prevProps) {
-		const nextProperties = this.props.state.get('properties', emptyMap);
+		const nextProperties = this.props.state.get('properties');
 		if (prevProps.state.get('properties') !== nextProperties) {
-			this.setState({ properties: nextProperties.toJS() });
+			this.setState({ properties: nextProperties?.toJS() || {} });
 		}
 
 		if (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
componentDidUpdate set states when properties have changed. But the comparison is ko when there is no properties passed, as it takes a new Map by default.

**What is the chosen solution to this problem?**
Compare the properties properly without default values to check if they have changed

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
