### PR TITLE
fix(faceted-search): Quick search does not select correct facet when using filter

### DIFF
--- a/.changeset/shaggy-ravens-beg.md
+++ b/.changeset/shaggy-ravens-beg.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+Quick search does not select correct facet when using filter

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -190,7 +190,7 @@ BasicSearch.propTypes = {
 	customOperatorsDictionary: operatorsPropTypes,
 	initialFilterValue: PropTypes.string,
 	quickSearchPlaceholder: PropTypes.string,
-	/* Can be used to filter facets displayed when input changes; (term, facet) => boolean */
+	/* Can be used to filter facets displayed when input changes; (term, facets) => [facets] */
 	quickSearchFacetsFilter: PropTypes.func,
 	onSubmit: PropTypes.func.isRequired,
 	setBadgesFaceted: PropTypes.func,

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
@@ -1,8 +1,8 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import { mount } from 'enzyme';
-import cloneDeep from 'lodash/cloneDeep';
-import set from 'lodash/set';
 import React from 'react';
+import { mount } from 'enzyme';
+import set from 'lodash/set';
+import cloneDeep from 'lodash/cloneDeep';
 import { BasicSearch } from './BasicSearch.component';
 import { FacetedManager } from '../FacetedManager';
 import { USAGE_TRACKING_TAGS } from '../../constants';

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
@@ -1,12 +1,11 @@
 /* eslint-disable import/no-extraneous-dependencies */
-import React from 'react';
 import { mount } from 'enzyme';
-import set from 'lodash/set';
 import cloneDeep from 'lodash/cloneDeep';
+import set from 'lodash/set';
+import React from 'react';
 import { BasicSearch } from './BasicSearch.component';
 import { FacetedManager } from '../FacetedManager';
 import { USAGE_TRACKING_TAGS } from '../../constants';
-
 
 describe('BasicSearch', () => {
 	const badgeText = {
@@ -57,13 +56,15 @@ describe('BasicSearch', () => {
 
 	const badgesDefinitions = [badgeDefinitionName];
 
-	const badgesDefinitionsWithQuicksearch = [{
-		...badgeDefinitionName,
-		metadata: {
-			...badgeDefinitionName.metadata,
-			isAvailableForQuickSearch: true,
+	const badgesDefinitionsWithQuicksearch = [
+		{
+			...badgeDefinitionName,
+			metadata: {
+				...badgeDefinitionName.metadata,
+				isAvailableForQuickSearch: true,
+			},
 		},
-	}];
+	];
 
 	it('should render the default html output with no badges', () => {
 		// Given
@@ -101,11 +102,13 @@ describe('BasicSearch', () => {
 		// Given
 		const props = {
 			badgesDefinitions,
-			initialBadges: [{
-				attribute: 'name',
-				operator: '=',
-				value: 'hello'
-			}],
+			initialBadges: [
+				{
+					attribute: 'name',
+					operator: '=',
+					value: 'hello',
+				},
+			],
 			onSubmit: jest.fn(),
 		};
 		// When
@@ -146,25 +149,26 @@ describe('BasicSearch', () => {
 			<FacetedManager id="manager-id">
 				<BasicSearch
 					{...props}
-					quickSearchFacetsFilter={(term, facet) => facet.properties.label === term}
+					quickSearchFacetsFilter={(term, facets) =>
+						facets.filter(facet => facet.properties.label === term)
+					}
 				/>
 			</FacetedManager>,
 		);
 		// Then
 		wrapper.find('input[role="searchbox"]').simulate('change', {
 			target: {
-				value: 'Name'
-			}
+				value: 'Name',
+			},
 		});
 		expect(wrapper.find('[role="option"]')).toHaveLength(1);
 
 		wrapper.find('input[role="searchbox"]').simulate('change', {
 			target: {
-				value: 'NotName'
-			}
+				value: 'NotName',
+			},
 		});
 		expect(wrapper.find('[role="option"]')).toHaveLength(0);
-
 	});
 	it('should not trigger onSubmit when a badge is in creation', () => {
 		// given
@@ -231,12 +235,10 @@ describe('BasicSearch', () => {
 		);
 
 		// Then
-		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_ADD}"]`).length).toBe(
-			0,
+		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_ADD}"]`).length).toBe(0);
+		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_CLEAR}"]`).length).toBe(
+			1,
 		);
-		expect(
-			wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_CLEAR}"]`).length,
-		).toBe(1);
 	});
 
 	it('should not show remove all button when no badge can be removed', () => {
@@ -254,12 +256,10 @@ describe('BasicSearch', () => {
 		);
 
 		// Then
-		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_ADD}"]`).length).toBe(
-			1,
+		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_ADD}"]`).length).toBe(1);
+		expect(wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_CLEAR}"]`).length).toBe(
+			0,
 		);
-		expect(
-			wrapper.find(`button[data-feature="${USAGE_TRACKING_TAGS.BASIC_CLEAR}"]`).length,
-		).toBe(0);
 	});
 
 	it('should remove all badges on clear button click', () => {
@@ -278,10 +278,7 @@ describe('BasicSearch', () => {
 
 		// Then
 		expect(wrapper.find('.tc-badge').length).toBe(1);
-		wrapper
-			.find('.tc-basic-search-clear-button')
-			.at(0)
-			.simulate('click');
+		wrapper.find('.tc-basic-search-clear-button').at(0).simulate('click');
 		expect(wrapper.find('.tc-badge').length).toBe(0);
 	});
 });

--- a/packages/faceted-search/src/components/QuickSearchInput/QuickSearchInput.component.js
+++ b/packages/faceted-search/src/components/QuickSearchInput/QuickSearchInput.component.js
@@ -16,7 +16,7 @@ export const QuickSearchInput = ({
 	placeholder,
 	className,
 	onSelect = () => {},
-	facetsFilter = () => true,
+	facetsFilter,
 }) => {
 	const defaultFacet = useMemo(() => getDefaultFacet(facets), [facets]);
 	const [opened, setOpened] = useState(false);
@@ -26,11 +26,11 @@ export const QuickSearchInput = ({
 		return null;
 	}
 
+	const filteredFacets = facetsFilter ? facetsFilter(value, facets) : facets;
+
 	return (
 		<Typeahead
-			placeholder={
-				placeholder || t('QUICKSEARCH_PLACEHOLDER', 'Find in a column...')
-			}
+			placeholder={placeholder || t('QUICKSEARCH_PLACEHOLDER', 'Find in a column...')}
 			onFocus={() => setOpened(value.length >= MINIMUM_LENGTH)}
 			onBlur={() => {
 				setValue('');
@@ -43,7 +43,7 @@ export const QuickSearchInput = ({
 			}}
 			onSelect={(_, { itemIndex }) => {
 				if (value.length >= MINIMUM_LENGTH) {
-					onSelect(facets[itemIndex] || defaultFacet, value);
+					onSelect(filteredFacets[itemIndex] || defaultFacet, value);
 					setValue('');
 					setOpened(false);
 				}
@@ -58,9 +58,7 @@ export const QuickSearchInput = ({
 						title: t('QUICKSEARCH_ITEM_TOOLTIP', {
 							defaultValue: 'Search in',
 						}),
-						suggestions: facets
-							.filter(facet => facetsFilter(value, facet))
-							.map(a => get(a, ['properties', 'label'], null)),
+						suggestions: filteredFacets.map(a => get(a, ['properties', 'label'], null)),
 					},
 				]
 			}

--- a/packages/faceted-search/stories/facetedSearch.stories.js
+++ b/packages/faceted-search/stories/facetedSearch.stories.js
@@ -501,10 +501,10 @@ export const BasicSearchWithSliderPopin = {
 
 export const WithQuickSearchFilter = () => (
 	<FacetedSearch.Faceted id="my-faceted-search">
-		<p>Quick search will only suggest facets matching input (Connection name, author)</p>
+		<p>Quick search will only suggest facets matching input (Connection name, Author)</p>
 		<br />
 		<FacetedSearch.BasicSearch
-			quickSearchFacetsFilter={(term, facet) => facet.properties.label.includes(term)}
+			quickSearchFacetsFilter={(term, facets) => facets.filter(facet => facet.properties.label.includes(term))}
 			badgesDefinitions={[badgeAuthor, badgeName, badgeConnectionName]}
 			onSubmit={action('onSubmit')}
 			callbacks={callbacks}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

onSelect is using the unfiltered facets array, leading to incorrect selection

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
