### PR TITLE
fix(multiselect): add height when no option

### DIFF
--- a/.changeset/wise-beers-wonder.md
+++ b/.changeset/wise-beers-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(MultiSelect): add height for the dropdown if there is no option available

--- a/packages/components/src/MultiSelect/MultiSelect.container.js
+++ b/packages/components/src/MultiSelect/MultiSelect.container.js
@@ -250,9 +250,12 @@ class MultiSelect extends React.Component {
 
 	render() {
 		const items = this.getListItems();
+		// If we don't have item to display, we show the message that tell there is no items
+		const itemsDisplayed = Math.min(items.length, 6) || 1;
+
 		const height = this.props.isLoading
 			? 120
-			: this.props.itemOptionRender.rowHeight * Math.min(items.length, 6);
+			: this.props.itemOptionRender.rowHeight * itemsDisplayed;
 
 		const nbSelected = this.getSelectedMap().size;
 		const viewHeight = this.props.itemViewRender.rowHeight * Math.min(6, nbSelected + 1);
@@ -282,6 +285,7 @@ class MultiSelect extends React.Component {
 				)}
 				<input
 					type="text"
+					// eslint-disable-next-line
 					role="search"
 					className="form-control"
 					name={this.props.name}
@@ -290,6 +294,7 @@ class MultiSelect extends React.Component {
 					onFocus={this.onInputFocus}
 					onKeyDown={this.onInputKeyDown}
 					disabled={this.props.disabled}
+					// eslint-disable-next-line
 					autoFocus={this.props.autoFocus}
 					placeholder={this.props.placeholder}
 					readOnly={this.props.readOnly}

--- a/packages/components/src/MultiSelect/MultiSelect.stories.js
+++ b/packages/components/src/MultiSelect/MultiSelect.stories.js
@@ -39,6 +39,24 @@ class Photos extends React.Component {
 						/>
 					</div>
 					<div className="form-group">
+						<label className="control-label" htmlFor="storybook">
+							Empty
+						</label>
+						<MultiSelect id="storybook" options={[]} isLoading={this.state.loading} withCreateNew />
+					</div>
+					<div className="form-group">
+						<label className="control-label" htmlFor="storybook">
+							2 items
+						</label>
+						<MultiSelect
+							id="storybook"
+							options={this.state.photos?.splice(0, 2)}
+							isLoading={this.state.loading}
+							withCreateNew
+						/>
+					</div>
+
+					<div className="form-group">
 						{/* eslint-disable-next-line jsx-a11y/label-has-associated-control */}
 						<label className="control-label" htmlFor="useless">
 							another


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We don't see the message that display there is no record to show
![CleanShot 2022-04-13 at 11 17 18@2x](https://user-images.githubusercontent.com/2909671/163143532-87de65c2-43ad-4bcf-b076-5d552ac310b8.png)

**What is the chosen solution to this problem?**
<img width="950" alt="CleanShot 2022-04-13 at 11 16 13@2x" src="https://user-images.githubusercontent.com/2909671/163143338-1686b318-f6bb-4b49-9899-e3ea18fa8213.png">


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
