### PR TITLE
qchore(ci): Broken github action

### DIFF
--- a/.github/workflows/design-system-visual-testing.yml
+++ b/.github/workflows/design-system-visual-testing.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       (github.ref == 'refs/heads/master') ||
-      contains(github.event.pull_request.labels.*.name, 'need visual approval'))
+      contains(github.event.pull_request.labels.*.name, 'need visual approval')
     environment: pull_request_unsafe
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
