### PR TITLE
fix(design-system/storybook): Broken Storybook on Windows

### DIFF
--- a/.changeset/flat-tables-prove.md
+++ b/.changeset/flat-tables-prove.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system/storybook): Broken Storybook on Windows

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -13,7 +13,7 @@
     "test": "echo Tests are managed by Cypress using yarn test:cy",
     "test:cy": "cypress run-ct",
     "test:demo": "npm run build-storybook",
-    "storybook": "npm run build:lib && BROWSER=none start-storybook -p 6006",
+    "storybook": "cross-env BROWSER=none npm run build:lib && start-storybook -p 6006",
     "build-storybook": "build-storybook --docs && node ./scripts/sitemap.js",
     "extract-i18n": "tsc --jsx preserve --outDir tmp && i18next-scanner --config i18next-scanner.config.js && rm -rf tmp",
     "lint:es": "talend-scripts lint:es"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook can't be started on Windows, `cross-env` is required to set environment variables.

**What is the chosen solution to this problem?**
Add it.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
