### PR TITLE
doc(design-system): Updating template and guidelines

### DIFF
--- a/.github/workflows/design-system-visual-testing.yml
+++ b/.github/workflows/design-system-visual-testing.yml
@@ -11,7 +11,7 @@ on:
         required: true
   pull_request:
     # By default, a workflow only runs when a pull_request event's activity type is opened, synchronize, or reopened
-    types: [ labeled, synchronize, opened, reopened]
+    types: [labeled, synchronize, opened, reopened, ready_for_review]
     branches:
       - master
   push:

--- a/packages/design-system/CONTRIBUTING.md
+++ b/packages/design-system/CONTRIBUTING.md
@@ -1,4 +1,5 @@
 # Contributing
+
 Congratulations on becoming a contributor to the design system! You are pushing the whole company upwards.
 
 Here's what we expect our contributors to do when it comes to code.
@@ -6,6 +7,7 @@ Here's what we expect our contributors to do when it comes to code.
 We don't believe in giving you rigid steps to follow, we prefer guidance and a loose checklist. Always put people before processes.
 
 ## How do I know what I can do?
+
 We have a [self-service Jira board set-up for this](https://jira.talendforge.org/secure/RapidBoard.jspa?projectKey=TUX&rapidView=1030). All the tasks in the TODO column are up for grabs!
 
 Assign yourself to a ticket, it's all fair game.
@@ -13,10 +15,12 @@ Assign yourself to a ticket, it's all fair game.
 You can also simply ask on Slack, channel #ask-designsystem.
 
 ## TL;WR
+
 - Contribute to the design phase by offering browser-based know-how.
 - You may need to create the initial Storybook PR and help contributing designers write down specs (use the [provided template for the ComponentName.stories.mdx pages](DOCTEMPLATE.md)).
 - Get peer reviews on the [API of your component](#Designing-the-component's-API) before moving on to the implementation.
 - Follow the basic structure of a component/layout folder in the repository and use the [provided template for doc pages](DOCTEMPLATE.md).
+
 ```
 ├── Component.tsx          # Component
 ├── Component.spec.tsx     # Cypress tests
@@ -24,10 +28,14 @@ You can also simply ask on Slack, channel #ask-designsystem.
 ├── Component.stories.tsx  # Actual stories written explicitely in TSX
 ├── Component.module.scss  # Component styles (in BEM)
 ├── index.ts               # Clean component export
-└── private                # Internal composition elements
+└── primitive              # Internal composition elements
     ├── ComponentBrick.A.tsx
     └── ComponentBrick.B.tsx
+└── variants               # Standalone variants of the components
+    ├── ComponentVariantA.tsx
+    └── ComponentVariantB.tsx
 ```
+
 - Use design tokens with a burning passion.
 - Explicitness > Implicitness, always and in all things.
 - Don't let consumers easily override the styles or behaviours of the component.
@@ -71,7 +79,6 @@ Both can be done in one pull request, but ideally in very separate commits and s
 The goal is to outline the API, without necessarily coding the component itself.
 
 It can be something like that:
-
 
 ```tsx
 type Data = {
@@ -141,4 +148,3 @@ If not, reach out on Slack through a public channel (`#ak-ux` or `#ask-designsys
 The requirements are basically the same as they are for new implementations, but the required reviews are less strict. You need approval from a code owner and from the ticket's creator for most maintenance tasks.
 
 However, if your upgrade involves API changes or design changes, you'll still need approval from an outside developer and a product designer.
-

--- a/packages/design-system/DOCTEMPLATE.md
+++ b/packages/design-system/DOCTEMPLATE.md
@@ -4,7 +4,7 @@ Use the following template when creating a new `ComponentName.stories.mdx` page.
 
 ```markdown
 import { Meta, Story } from '@storybook/addon-docs';
-import { FigmaImage, FigmaLink, Use } from '../../docs';
+import { FigmaImage, FigmaLink, Use } from '~docs';
 
 <Meta
     title="Components/Title"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Doc was slightly out of date

**What is the chosen solution to this problem?**
I updated it

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
