### PR TITLE
fix(Datalist): keep suggestions when clicking inside the suggestion box

### DIFF
--- a/.changeset/tall-bags-boil.md
+++ b/.changeset/tall-bags-boil.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(Datalist): keep suggestions when clicking inside the suggestion box

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -383,7 +383,7 @@ function Datalist(props) {
 
 	const icon = getSelectedIcon();
 	return (
-		<FocusManager onFocusOut={hideSuggestions} className={theme['tc-datalist-item']}>
+		<FocusManager onFocusOut={onBlur} className={theme['tc-datalist-item']} key="focus-manager">
 			{icon && <Icon className={theme['tc-datalist-item-icon']} {...icon} />}
 			<Typeahead
 				{...omit(props, PROPS_TO_OMIT)}
@@ -391,7 +391,6 @@ function Datalist(props) {
 				focusedItemIndex={selection.focusedItemIndex}
 				focusedSectionIndex={selection.focusedSectionIndex}
 				items={suggestions}
-				onBlur={onBlur}
 				onChange={onFilterChange}
 				onFocus={onFocus}
 				onClick={onClick}

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -164,6 +164,7 @@ describe('Datalist component', () => {
 
 	it('should close suggestions on blur', () => {
 		// given
+		jest.useFakeTimers();
 		render(<Datalist id="my-datalist" onChange={jest.fn()} {...props} />);
 		const input = screen.getByRole('textbox');
 		fireEvent.click(input);
@@ -172,6 +173,7 @@ describe('Datalist component', () => {
 
 		// when
 		fireEvent.blur(input);
+		jest.runAllTimers(); // focus manager
 
 		// then
 		expect(screen.queryByRole('listbox')).not.toBeInTheDocument();
@@ -210,6 +212,7 @@ describe('Datalist component', () => {
 
 	it('should clear input', () => {
 		// given
+		jest.useFakeTimers();
 		const onChange = jest.fn();
 		render(<Datalist id="my-datalist" onChange={onChange} {...props} value="foo" />);
 
@@ -217,6 +220,7 @@ describe('Datalist component', () => {
 		const input = screen.getByRole('textbox');
 		userEvent.clear(input);
 		fireEvent.blur(input);
+		jest.runAllTimers(); // focus manager
 
 		// then
 		expect(onChange).toBeCalledWith(expect.anything(), { value: '' });
@@ -268,6 +272,7 @@ describe('Datalist component', () => {
 	describe('non restricted mode (default)', () => {
 		it('should persist known value on blur', () => {
 			// given
+			jest.useFakeTimers();
 			const onChange = jest.fn();
 			render(<Datalist id="my-datalist" onChange={onChange} {...props} />);
 			expect(onChange).not.toBeCalled();
@@ -276,6 +281,7 @@ describe('Datalist component', () => {
 			const input = screen.getByRole('textbox');
 			userEvent.type(input, 'foo');
 			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
 
 			// then
 			expect(onChange).toBeCalledWith(expect.anything(), { value: 'foo' });
@@ -283,6 +289,7 @@ describe('Datalist component', () => {
 
 		it('should persist unknown value on blur', () => {
 			// given
+			jest.useFakeTimers();
 			const onChange = jest.fn();
 			render(<Datalist id="my-datalist" onChange={onChange} {...props} />);
 
@@ -290,6 +297,7 @@ describe('Datalist component', () => {
 			const input = screen.getByRole('textbox');
 			userEvent.type(input, 'not a known value');
 			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
 
 			// then
 			expect(onChange).toBeCalledWith(expect.anything(), { value: 'not a known value' });
@@ -326,6 +334,7 @@ describe('Datalist component', () => {
 	describe('restricted mode', () => {
 		it('should persist known value on blur', () => {
 			// given
+			jest.useFakeTimers();
 			const onChange = jest.fn();
 			render(<Datalist id="my-datalist" onChange={onChange} restricted {...props} />);
 			expect(onChange).not.toBeCalled();
@@ -334,6 +343,7 @@ describe('Datalist component', () => {
 			// when
 			userEvent.type(input, 'foo');
 			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
 
 			// then
 			expect(onChange).toBeCalledWith(expect.anything(), { value: 'foo' });
@@ -341,6 +351,7 @@ describe('Datalist component', () => {
 
 		it('should reset unknown value on blur', () => {
 			// given
+			jest.useFakeTimers();
 			const onChange = jest.fn();
 			render(<Datalist id="my-datalist" onChange={onChange} {...props} restricted value="foo" />);
 
@@ -348,6 +359,7 @@ describe('Datalist component', () => {
 			const input = screen.getByRole('textbox');
 			userEvent.type(input, 'not a known value');
 			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
 
 			// then
 			expect(onChange).not.toBeCalled();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In datalist, when we have other elements in the suggestions box like categories title or custom children, we should not close the suggestions box when we click on them as they are inside the box.

This is due to a double blur management:
- onBlur is passed to react-autowhatever, which hides the box on input blur
- focus manager that delays the blur event callback in case we focus on anotherpart of the box

The first one prevent the second one to do the job.

**What is the chosen solution to this problem?**
Remove onBlur callback passed to react-autowhatever

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
