### PR TITLE
feat(storybook-preset): Support apps

### DIFF
--- a/.changeset/cyan-kiwis-relax.md
+++ b/.changeset/cyan-kiwis-relax.md
@@ -2,4 +2,4 @@
 '@talend/scripts-config-storybook-lib': minor
 ---
 
-Support apps & @talend/design-tokens
+Support apps

--- a/.changeset/cyan-kiwis-relax.md
+++ b/.changeset/cyan-kiwis-relax.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+Support apps & @talend/design-tokens

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -75,12 +75,6 @@ const defaultMain = {
 						return rule;
 					}),
 					...talendWebpackConfig.module.rules,
-					// Not sure this will stay here, but we need it for now
-					{
-						test: /\.css$/,
-						use: ['style-loader', 'css-loader'],
-						include: /design-tokens/,
-					}
 				],
 			},
 			plugins: [

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -25,7 +25,7 @@ function getStoriesFolders() {
 const excludedPlugins = [
 	CDNPlugin, // will be overrided without @talend modules
 	DuplicatesPlugin, // slow
-	HtmlWebpackPlugin, //  use SB index.html, not app's
+	HtmlWebpackPlugin, // use SB index.html, not app's
 ]
 
 const defaultMain = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Storybook preset can't be used on apps as it's loading app's index.html 

**What is the chosen solution to this problem?**

- remove conflicting plugins 

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
