### PR TITLE
doc(design-system): Updating Copy story with static default value

### DIFF
--- a/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
+++ b/packages/design-system/src/components/Form/docs/Input.copy.stories.mdx
@@ -116,7 +116,7 @@ When using Rhf, if you want the confirmation message to disappear in case of inp
 					<Form.Row>
 						<Form.Copy
 							label={'Key'}
-							defaultValue={watch('apiKey', getUUID())}
+							defaultValue="10ca0868-1010-4b4a-a2cc-ff737527a7b5"
 							description={'This information is displayed only once.'}
 							{...register('apiKey')}
 						/>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Input Copy story used a random default value that fails on Chromatic each new commit.

**What is the chosen solution to this problem?**
Default value is now static.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
