### PR TITLE
fix(dynamic cdn): handle package without varName

### DIFF
--- a/.changeset/three-cups-taste.md
+++ b/.changeset/three-cups-taste.md
@@ -1,0 +1,5 @@
+---
+'@talend/dynamic-cdn-webpack-plugin': patch
+---
+
+fix: handle package without varName

--- a/fork/dynamic-cdn-webpack-plugin/src/index.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/index.js
@@ -276,7 +276,9 @@ class DynamicCdnWebpackPlugin {
 
 	async addModule(contextPath, modulePath, { env, isOptional = false }) {
 		const isModuleExcluded =
-			this.exclude.includes(modulePath) || (this.only && !this.only.includes(modulePath));
+			this.exclude.includes(modulePath) ||
+			(this.only && !this.only.includes(modulePath)) ||
+			modulePath.startsWith('@types/');
 		if (isModuleExcluded) {
 			return false;
 		}
@@ -316,7 +318,7 @@ class DynamicCdnWebpackPlugin {
 				if (!this.directDependencies[modulePath]) {
 					this.directDependencies[modulePath] = this.modulesFromCdn[modulePath];
 				}
-				return this.modulesFromCdn[modulePath].var;
+				return this.modulesFromCdn[modulePath].var || true;
 			}
 
 			this.log(
@@ -401,7 +403,7 @@ class DynamicCdnWebpackPlugin {
 		this.modulesFromCdn[modulePath] = cdnConfig;
 		this.directDependencies[modulePath] = cdnConfig;
 		this.debug('\n✅', modulePath, version, `will be served by ${cdnConfig.url}`);
-		return cdnConfig.var;
+		return cdnConfig.var || true;
 	}
 
 	applyWebpackCore(compiler) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When there is no varName in a package it can result with module added but considered as not added.
This is the case for design system in react components:

```
❌ @talend/design-system 2.3.0 couldn't be loaded because peer dependency is missing @talend/locales-design-system /Users/jmfrancois/github/talend/ui/packages/components/src/Icon
```

**What is the chosen solution to this problem?**

ensure addModule return at least true when there is no varName

```return cdnConfig.varName || true```

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
