### PR TITLE
fix(playground): inject.js manage integrity

### DIFF
--- a/packages/playground/src/assets/inject.js
+++ b/packages/playground/src/assets/inject.js
@@ -1,7 +1,16 @@
 // custom inject to UMD from surge and the others from unpkg
 
+// eslint-disable-next-line func-names
 (function () {
 	const CDN_URL_REGEX = /^(\/?.*\/cdn)\//;
+
+	function removeIntegrity(info) {
+		if (info.name && info.name.startsWith('@talend')) {
+			// eslint-disable-next-line no-param-reassign
+			delete info.integrity;
+		}
+		return info;
+	}
 
 	function prepareUrl(url) {
 		let newUrl;
@@ -16,6 +25,6 @@
 		return newUrl || url;
 	}
 
-	window.talendAddStyles(window.cssFiles, prepareUrl);
-	window.talendAddScripts(window.jsFiles, prepareUrl);
+	window.talendAddStyles(window.Talend.cssBuild.map(removeIntegrity), prepareUrl);
+	window.talendAddScripts(window.Talend.build.map(removeIntegrity), prepareUrl);
 })();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current playground inject do not handle integrity.

**What is the chosen solution to this problem?**

Add integrity for non @talend package. We have to remove integrity to let the dev experience being nice.
If we do not remove it hot reload failed because integrity is computed once.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
