### PR TITLE
chore(Datalist): Allow reset to empty in restricted mode

### DIFF
--- a/.changeset/cool-months-help.md
+++ b/.changeset/cool-months-help.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+chore(Datalist): Allow reset to empty in restricted mode

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -78,6 +78,10 @@ function findEntry(titleMap, attributeName, attributeValue = '') {
 }
 
 function getEntryFromName(titleMap, name, restricted) {
+	if (name === '') {
+		return { name: '', value: '' };
+	}
+
 	const entry = findEntry(titleMap, 'name', name);
 	if (entry) {
 		return entry;

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -79,7 +79,7 @@ function findEntry(titleMap, attributeName, attributeValue = '') {
 
 function getEntryFromName(titleMap, name, restricted) {
 	if (name === '') {
-		return { name: '', value: '' };
+		return { name, value: '' };
 	}
 
 	const entry = findEntry(titleMap, 'name', name);

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -393,5 +393,37 @@ describe('Datalist component', () => {
 			expect(onChange).not.toBeCalled();
 			expect(input).toHaveValue('My foo');
 		});
+
+		it('should persist empty value on enter', () => {
+			// given
+			const onChange = jest.fn();
+			render(<Datalist id="my-datalist" value="foo" onChange={onChange} restricted {...props} />);
+			expect(onChange).not.toBeCalled();
+
+			// when
+			const input = screen.getByRole('textbox');
+			userEvent.clear(input);
+			userEvent.type(input, '{enter}');
+
+			// then
+			expect(onChange).toBeCalledWith(expect.anything(), { value: '' });
+		});
+
+		it('should persist empty value on blur', () => {
+			// given
+			jest.useFakeTimers();
+			const onChange = jest.fn();
+			render(<Datalist id="my-datalist" value="foo" onChange={onChange} restricted {...props} />);
+			expect(onChange).not.toBeCalled();
+
+			// when
+			const input = screen.getByRole('textbox');
+			userEvent.clear(input);
+			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
+
+			// then
+			expect(onChange).toBeCalledWith(expect.anything(), { value: '' });
+		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When used in `restricted` mode, the datalist cannot be reset to an empty value, unless that empty value is explicitly an option in the `titleMap`.

**What is the chosen solution to this problem?**
Allow the reset of the value in restricted mode by simply cleaning the input, and persist the change (i.e. call the onChange props).

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
