### PR TITLE
chore(design-system): PropsType naming

### DIFF
--- a/.changeset/eight-pillows-search.md
+++ b/.changeset/eight-pillows-search.md
@@ -1,5 +1,5 @@
 ---
-'@talend/design-system': major
+'@talend/design-system': minor
 ---
 
 chore(design-system): PropsType naming

--- a/.changeset/eight-pillows-search.md
+++ b/.changeset/eight-pillows-search.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': major
+---
+
+chore(design-system): PropsType naming

--- a/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixButton.tsx
+++ b/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixButton.tsx
@@ -9,7 +9,7 @@ import { StackHorizontal } from '../../../../Stack';
 import styles from '../AffixStyles.module.scss';
 import Clickable, { ClickableProps } from '../../../../Clickable';
 
-type CommonAffixButtonPropTypes = {
+type CommonAffixButtonPropsType = {
 	children: string;
 	isDropdown?: boolean;
 	onClick: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
@@ -25,8 +25,8 @@ type AffixButtonShowTextProps = {
 	icon?: IconName;
 };
 
-export type AffixButtonPropTypes = Omit<ClickableProps, 'className' | 'children'> &
-	CommonAffixButtonPropTypes &
+export type AffixButtonPropsType = Omit<ClickableProps, 'className' | 'children'> &
+	CommonAffixButtonPropsType &
 	(AffixButtonHideTextProps | AffixButtonShowTextProps);
 
 const AffixButton = forwardRef(
@@ -38,7 +38,7 @@ const AffixButton = forwardRef(
 			onClick,
 			hideText = false,
 			...rest
-		}: AffixButtonPropTypes,
+		}: AffixButtonPropsType,
 		ref: Ref<HTMLButtonElement>,
 	) => {
 		const element = (

--- a/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixReadOnly.tsx
+++ b/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixReadOnly.tsx
@@ -7,7 +7,7 @@ import VisuallyHidden from '../../../../VisuallyHidden';
 
 import styles from '../AffixStyles.module.scss';
 
-type CommonAffixReadOnlyPropTypes = {
+type CommonAffixReadOnlyPropsType = {
 	children: string;
 };
 
@@ -21,13 +21,13 @@ type AffixReadOnlyShowTextProps = {
 	icon?: IconName;
 };
 
-export type AffixReadOnlyPropTypes = Omit<HTMLAttributes<HTMLSpanElement>, 'className' | 'style'> &
-	CommonAffixReadOnlyPropTypes &
+export type AffixReadOnlyPropsType = Omit<HTMLAttributes<HTMLSpanElement>, 'className' | 'style'> &
+	CommonAffixReadOnlyPropsType &
 	(AffixReadOnlyHideTextProps | AffixReadOnlyShowTextProps);
 
 const AffixReadOnly = forwardRef(
 	(
-		{ children, icon, hideText = false, ...rest }: AffixReadOnlyPropTypes,
+		{ children, icon, hideText = false, ...rest }: AffixReadOnlyPropsType,
 		ref: Ref<HTMLSpanElement>,
 	) => {
 		return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
PropsType naming is inconsistent in some components, the sooner it's fixed the better 😬 

**What is the chosen solution to this problem?**
Use `~PropsType` since it's used everywhere else.
Considered breaking because types are exported.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
