### PR TITLE
fix(FormatValue): Handle string without whitespaces

### DIFF
--- a/.changeset/silver-buckets-allow.md
+++ b/.changeset/silver-buckets-allow.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': fix
+---
+
+FormatValue: Handle string without whitespaces

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.component.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import has from 'lodash/has';
 import TooltipTrigger from '../../../TooltipTrigger';
-import FormatValue, { hasWhiteSpaceCharacters } from '../../../FormatValue/FormatValue.component';
+import FormatValue from '../../../FormatValue/FormatValue.component';
 
 import theme from './DefaultValueRenderer.scss';
 
@@ -35,8 +35,7 @@ export default class DefaultValueRenderer extends React.Component {
 			stringValue = String(this.props.value);
 		}
 
-		const hasWhiteSpace = hasWhiteSpaceCharacters(stringValue);
-		const formattedContent = hasWhiteSpace ? <FormatValue value={stringValue} /> : stringValue;
+		const formattedContent = <FormatValue value={stringValue} />;
 
 		const content = (
 			<div

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.test.js
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 
 import DefaultValueRenderer from './DefaultValueRenderer.component';
 
@@ -29,7 +29,7 @@ describe('#DefaultValueRenderer', () => {
 	});
 
 	it('should render empty when the value is undefined', () => {
-		const wrapper = shallow(<DefaultValueRenderer value={undefined} />);
+		const wrapper = mount(<DefaultValueRenderer value={undefined} />);
 
 		expect(wrapper.find('div').text()).toBe('');
 	});

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/DefaultValueRenderer.test.js.snap
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/__snapshots__/DefaultValueRenderer.test.js.snap
@@ -2,13 +2,19 @@
 
 exports[`#DefaultValueRenderer should render DefaultValueRenderer with the tooltip when the label overflow in width 1`] = `
 <TooltipTrigger
-  label="loreum"
+  label={
+    <FormatValueComponent
+      value="loreum"
+    />
+  }
   tooltipPlacement="bottom"
 >
   <div
     className="theme-td-default-cell td-default-cell theme-shrink-value"
   >
-    loreum
+    <FormatValueComponent
+      value="loreum"
+    />
   </div>
 </TooltipTrigger>
 `;
@@ -17,7 +23,9 @@ exports[`#DefaultValueRenderer should render DefaultValueRenderer with the toolt
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  loreum
+  <FormatValueComponent
+    value="loreum"
+  />
 </div>
 `;
 
@@ -25,7 +33,9 @@ exports[`#DefaultValueRenderer should render a boolean 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  false
+  <FormatValueComponent
+    value="false"
+  />
 </div>
 `;
 
@@ -33,7 +43,9 @@ exports[`#DefaultValueRenderer should render a bytes 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  ejfiejifje
+  <FormatValueComponent
+    value="ejfiejifje"
+  />
 </div>
 `;
 
@@ -41,7 +53,9 @@ exports[`#DefaultValueRenderer should render empty when the value is null 1`] = 
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  
+  <FormatValueComponent
+    value=""
+  />
 </div>
 `;
 
@@ -49,8 +63,7 @@ exports[`#DefaultValueRenderer should render the leading/trailing special charac
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  <withI18nextTranslation(FormatValueComponent)
-    t={[Function]}
+  <FormatValueComponent
     value=" loreum "
   />
 </div>
@@ -60,6 +73,8 @@ exports[`#DefaultValueRenderer should render without the tooltip 1`] = `
 <div
   className="theme-td-default-cell td-default-cell"
 >
-  loreum
+  <FormatValueComponent
+    value="loreum"
+  />
 </div>
 `;

--- a/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
+++ b/packages/dataviz/src/components/TooltipContent/__snapshots__/TooltipContent.component.test.tsx.snap
@@ -8,9 +8,7 @@ exports[`TooltipContent Should render 1`] = `
     </dt>
     <dd>
       <span class="theme-dataviz-tooltip__value">
-        <span class="theme-td-value td-value">
-          value1
-        </span>
+        value1
       </span>
     </dd>
   </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

FormatValue is exporting an `hasWhiteSpaceCharacters` for conditional rendering., this logic is duplicated in every component usage

**What is the chosen solution to this problem?**

Handle the case inside the component

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
