### PR TITLE
fix(upgrade-deps): npm view command on windows

### DIFF
--- a/.changeset/olive-cooks-boil.md
+++ b/.changeset/olive-cooks-boil.md
@@ -1,0 +1,5 @@
+---
+'@talend/upgrade-deps': patch
+---
+
+Fix npm view command on Windows

--- a/tools/upgrade-deps/src/npm.js
+++ b/tools/upgrade-deps/src/npm.js
@@ -71,7 +71,7 @@ async function getLatest(dependency) {
 async function getUpdate(dependency, requirement) {
 	const cachekey = `${dependency}@${requirement}`;
 	if (!CACHE[cachekey]) {
-		const latest = await execProm(`npm view ${dependency}@'${requirement}' version --json`);
+		const latest = await execProm(`npm view ${dependency}@${requirement} version --json`);
 		const output = JSON.parse(stripAnsi(latest.stdout));
 		if (Array.isArray(output)) {
 			CACHE[cachekey] = output.pop();

--- a/tools/upgrade-deps/src/npm.js
+++ b/tools/upgrade-deps/src/npm.js
@@ -71,7 +71,7 @@ async function getLatest(dependency) {
 async function getUpdate(dependency, requirement) {
 	const cachekey = `${dependency}@${requirement}`;
 	if (!CACHE[cachekey]) {
-		const latest = await execProm(`npm view ${dependency}@${requirement} version --json`);
+		const latest = await execProm(`npm view ${dependency}@"${requirement}" version --json`);
 		const output = JSON.parse(stripAnsi(latest.stdout));
 		if (Array.isArray(output)) {
 			CACHE[cachekey] = output.pop();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The npm view command is returning an empty result on Windows: 
```bash
> npm view @talend/react-components@'^6.44.0' version --json
SyntaxError: Unexpected end of JSON input
```

**What is the chosen solution to this problem?**
Removing the quotes solves the issue.
but we need to support space 
`npm view @talend/react-components@'<5 || ^6.44.0' version --json`

double quote works

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
