### PR TITLE
chore(ci): Setup chromatic on datagrid & dataviz

### DIFF
--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -1,4 +1,4 @@
-name: Design System visual testing
+name: Visual testing
 
 on:
   workflow_dispatch:
@@ -14,21 +14,37 @@ on:
     types: [labeled, synchronize, opened, reopened, ready_for_review]
     branches:
       - master
-    paths:
-      - "packages/design-tokens/**"
-      - "packages/design-system/**"
   push:
     branches:
       - master
-    paths:
-      - "packages/design-tokens/**"
-      - "packages/design-system/**"
 
 jobs:
-  build:
+  changes:
     runs-on: ubuntu-latest
-    if: ( !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'need visual approval') )
+    outputs:
+      packages: ${{ steps.filter.outputs.changes }}
+    steps:
+      - uses: dorny/paths-filter@v2
+        id: filter
+        with:
+          filters: |
+            design-system:
+             - 'packages/design-tokens/**'
+             - 'packages/design-system/**'
+            datagrid: packages/datagrid/**
+            dataviz: packages/dataviz/**
+
+  build:
+    needs: changes
+    strategy:
+      # Avoid // deploys when multiple packages are changed
+      max-parallel: 1
+      fail-fast: false
+      matrix:
+        package: ${{ fromJSON(needs.changes.outputs.packages) }}
+    runs-on: ubuntu-latest
     environment: pull_request_unsafe
+    if: needs.changes.outputs.packages != '[]'
     steps:
       - uses: actions/checkout@v2
         with:
@@ -37,16 +53,21 @@ jobs:
       - uses: actions/setup-node@v3
         with:
           node-version: 16
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
           cache: "yarn"
 
       - name: Install dependencies
         run: yarn --frozen-lock --ignore-scripts
 
       - name: Build @talend/design-tokens
+        if: matrix.package == 'design-system'
         run: |
           yarn workspace @talend/design-tokens run build:lib
+
+      - name: Build @talend/*
+        if: matrix.package != 'design-system'
+        run: |
+          # We need to build all dependencies (cmf, coponents...)
+          yarn postinstall
 
       - name: Publish PR to DS Chromatic
         if: github.ref != 'refs/heads/master'
@@ -54,8 +75,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: "packages/design-system"
+          workingDir: packages/${{ matrix.package }}
           exitZeroOnChanges: true # Option to prevent the workflow from failing in PR
+          # Handle monorepos https://www.chromatic.com/docs/monorepos
+          preserveMissing: true
+          forceRebuild: true
 
       - name: Publish Master to DS Chromatic
         if: github.ref == 'refs/heads/master'
@@ -63,5 +87,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
-          workingDir: "packages/design-system"
+          workingDir: packages/${{ matrix.package }}
           autoAcceptChanges: true # Option to accept any change for this baseline refresh
+          preserveMissing: true
+          forceRebuild: true

--- a/packages/datagrid/.storybook/preview.js
+++ b/packages/datagrid/.storybook/preview.js
@@ -37,3 +37,10 @@ export const decorators = [
 		</App>
 	),
 ];
+
+export const parameters = {
+	chromatic: {
+		// Disable by default and enable only on some stories
+		disableSnapshot: true,
+	},
+};

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -9,6 +9,7 @@
     "build:prod": "talend-scripts build:lib:umd --prod",
     "pre-release": "yarn build:dev && yarn build:prod",
     "build:lib": "talend-scripts build:lib",
+    "build-storybook": "talend-scripts build-storybook",
     "start": "talend-scripts start-storybook -p 6010",
     "test": "talend-scripts test --silent",
     "test:noisy": "talend-scripts test",

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -40,6 +40,9 @@ export const Default = () => (
 		enableColResize={false}
 	/>
 );
+Default.parameters = {
+	chromatic: { disableSnapshot: false },
+};
 
 export const NoSubtype = () => (
 	<DataGrid

--- a/packages/dataviz/.storybook/preview.js
+++ b/packages/dataviz/.storybook/preview.js
@@ -13,4 +13,8 @@ export const i18n = {
 
 export const parameters = {
 	actions: { argTypesRegex: '^on[A-Z].*' },
+	chromatic: {
+		// To avoid issues with charts, we'll need to improve this later on
+		diffThreshold: 0.6,
+	},
 };

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -11,6 +11,7 @@
     "build:umd:dev": "talend-scripts build:lib:umd --dev",
     "build:umd:prod": "talend-scripts build:lib:umd",
     "build:lib": "talend-scripts build:ts:lib",
+    "build-storybook": "talend-scripts build-storybook",
     "extract-i18n": "tsc --jsx preserve --outDir tmp && i18next-scanner && rm -rf tmp",
     "lint": "yarn lint:es && yarn lint:style",
     "lint:es": "talend-scripts lint:es --format json -o eslint-report.json",

--- a/packages/dataviz/src/components/BoxPlot/BoxPlot.stories.tsx
+++ b/packages/dataviz/src/components/BoxPlot/BoxPlot.stories.tsx
@@ -7,6 +7,11 @@ const Template: Story<BoxPlotProps> = args => <BoxPlot {...args} />;
 export default {
 	title: 'Dataviz/BoxPlot',
 	component: BoxPlot,
+	parameters: {
+		chromatic: {
+			delay: 1500,
+		},
+	},
 } as Meta<BoxPlotProps>;
 
 export const Default = Template.bind({});

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.stories.tsx
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.stories.tsx
@@ -40,6 +40,11 @@ export default {
 			);
 		},
 	],
+	parameters: {
+		chromatic: {
+			disableSnapshot: true,
+		},
+	},
 } as Meta<RangeFilterProps>;
 
 export const IntegerRangeFilter = Template.bind({});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We want to enable chromatic UI tests on packages other then design-system.
Monorepos are not supported OOTB (https://www.chromatic.com/docs/monorepos), this is a first quick iteration to support datagrid package which we is going to change a lot in the next few weeks

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
