### PR TITLE
feat(storybook-preset): Add design-system decorator

### DIFF
--- a/.changeset/shy-buses-search.md
+++ b/.changeset/shy-buses-search.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+Add design-system providers if available

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
-import { IconsProvider } from '@talend/design-system';
+import { IconsProvider, ThemeProvider } from '@talend/design-system';
 import { merge } from 'lodash';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 
@@ -40,20 +40,30 @@ const defaultPreview = {
 			},
 		},
 	},
-	loaders: [cmfLoader].filter(Boolean),
+	loaders: [
+		cmfLoader,
+	].filter(Boolean),
 	decorators: [
 		mswDecorator,
 		(Story, context) => {
 			i18n.changeLanguage(context.globals && context.globals.locale);
-			return React.createElement(React.Suspense, { fallback: null }, [
-				React.createElement(I18nextProvider, { i18n: i18n, key: 'i18n' }, [
-					React.createElement(IconsProvider, {
-						bundles: ['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg'],
-						key: 'icons'
-					}),
-					React.createElement(Story, {...context, key: 'story'}),
-				])
-			]);
+			return React.createElement(React.Suspense, { fallback: null },
+				React.createElement(I18nextProvider, { i18n: i18n, key: 'i18n' },
+					React.createElement(Story, {...context, key: 'story'})
+				)
+			);
+		},
+		(Story, context) => {
+			const storyElement = React.createElement(Story, {...context, key: 'story'});
+			return [
+				React.createElement(IconsProvider, {
+					bundles: ['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg'],
+					key: 'icons-provider-decorator'
+				}),
+				React.createElement(ThemeProvider, {
+					key: 'theme-provider-decorator'
+				}, storyElement)
+			];
 		},
 		cmfDecorator
 	].filter(Boolean),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Preset is not importing ThemeProvider

**What is the chosen solution to this problem?**

Add both Icons & Theme provider

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
