### PR TITLE
fix(VList): handle VList without columns

### DIFF
--- a/.changeset/mighty-ghosts-sing.md
+++ b/.changeset/mighty-ghosts-sing.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(VList): handle VList without columns

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -891,3 +891,15 @@ export const TableWithColumnChooserAndLockedColumns = () => (
 		</section>
 	</div>
 );
+
+export const ListWithoutColumns = () => {
+	return (
+		<div className="virtualized-list">
+			<section style={{ height: '50vh' }}>
+				<List.Manager id="my-list" collection={simpleCollection}>
+					<List.VList></List.VList>
+				</List.Manager>
+			</section>
+		</div>
+	);
+};

--- a/packages/components/src/List/ListComposition.stories.js
+++ b/packages/components/src/List/ListComposition.stories.js
@@ -891,15 +891,3 @@ export const TableWithColumnChooserAndLockedColumns = () => (
 		</section>
 	</div>
 );
-
-export const ListWithoutColumns = () => {
-	return (
-		<div className="virtualized-list">
-			<section style={{ height: '50vh' }}>
-				<List.Manager id="my-list" collection={simpleCollection}>
-					<List.VList></List.VList>
-				</List.Manager>
-			</section>
-		</div>
-	);
-};

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -61,7 +61,7 @@ function VList({ children, columnChooser, ...rest }) {
 				{...rest}
 			>
 				{visibleColumns
-					? children.filter(column => visibleColumns?.includes(column.props?.dataKey))
+					? children?.filter(column => visibleColumns?.includes(column.props?.dataKey))
 					: children}
 			</VirtualizedList>
 		</div>

--- a/packages/components/src/List/ListComposition/VList/VList.component.test.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.test.js
@@ -3,6 +3,7 @@ import { mount } from 'enzyme';
 
 import VList from './VList.component';
 import VirtualizedList from '../../../VirtualizedList';
+import Manager from '../Manager';
 import { ListContext } from '../context';
 
 describe('List VList', () => {
@@ -86,5 +87,15 @@ describe('List VList', () => {
 		expect(wrapper.html()).toMatchSnapshot();
 
 		expect(wrapper.find('ColumnChooser')).toHaveLength(1);
+	});
+
+	it('should display a list without columns', () => {
+		const wrapper = mount(
+			<Manager id="my-list" collection={[]}>
+				<VList type="TABLE" />
+			</Manager>,
+		);
+
+		expect(wrapper.find('Table .tc-list-table')).toHaveLength(1);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When VList is instanciated without column definition as children, it was crashing trying to `filter` on `undefined` object.

**What is the chosen solution to this problem?**

Add possibility to have `undefined` children with `?` operator

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
