### PR TITLE
feat(Tooltip): compute a uuid v4 baseId if not provided

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -40,7 +40,8 @@
     "react-use": "^17.3.2",
     "reakit": "^1.3.11",
     "typeface-inconsolata": "^1.1.13",
-    "typeface-source-sans-pro": "^1.1.13"
+    "typeface-source-sans-pro": "^1.1.13",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@algolia/autocomplete-js": "^1.6.2",
@@ -71,6 +72,7 @@
     "@types/react-dom": "^16.9.15",
     "@types/react-is": "^16.7.2",
     "@types/styled-components": "^5.1.25",
+    "@types/uuid": "^8.3.4",
     "algoliasearch": "^4.13.0",
     "babel-plugin-styled-components": "^1.13.3",
     "browser-sync": "^2.27.9",

--- a/packages/design-system/src/components/Tooltip/Tooltip.spec.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.spec.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import Tooltip from './Tooltip';
+
+const expectUUID = (value: string, match: boolean = true) => {
+	let assertion = expect(value);
+	if (!match) {
+		assertion = assertion.not;
+	}
+	assertion.to.match(/^[0-9A-F]{8}-[0-9A-F]{4}-4[0-9A-F]{3}-[89AB][0-9A-F]{3}-[0-9A-F]{12}$/i);
+};
+
+context('<Tooltip />', () => {
+	describe('default', () => {
+		it('should show a tooltip', () => {
+			cy.mount(
+				<Tooltip title="hover me" role="tooltip">
+					<button>button</button>
+				</Tooltip>,
+			);
+
+			cy.getByRole('tooltip').should('not.be.visible');
+			cy.get('button').click();
+			cy.getByRole('tooltip').should('be.visible');
+		});
+		it('Should use uuid as tooltip id', () => {
+			cy.mount(
+				<Tooltip title="hover me" role="tooltip">
+					<button>button</button>
+				</Tooltip>,
+			);
+
+			cy.getByRole('tooltip')
+				.invoke('attr', 'id')
+				.then(id => {
+					expectUUID(id);
+					cy.get('button').invoke('attr', 'aria-describedby').should('eq', id);
+				});
+		});
+
+		it('Should be able to override baseId', () => {
+			const tooltipBaseId = 'base-id';
+			cy.mount(
+				<Tooltip title="hover me" role="tooltip" baseId={tooltipBaseId}>
+					<button>button</button>
+				</Tooltip>,
+			);
+
+			cy.getByRole('tooltip')
+				.invoke('attr', 'id')
+				.should('eq', tooltipBaseId)
+				.then(id => expectUUID(id, false));
+		});
+	});
+});

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -6,6 +6,7 @@ import {
 	TooltipArrow as ReakitTooltipArrow,
 	TooltipReference as ReakitTooltipReference,
 } from 'reakit';
+import { v4 as uuidV4 } from 'uuid';
 
 import styles from './Tooltip.module.scss';
 
@@ -31,14 +32,16 @@ export type TooltipProps = React.PropsWithChildren<any> &
 		title?: string;
 	};
 
-const Tooltip: React.FC<TooltipProps> = ({ children, title, ...rest }: TooltipProps) => {
+const Tooltip: React.FC<TooltipProps> = ({ children, title, baseId, ...rest }: TooltipProps) => {
 	const tooltipState = useReakitTooltipState({
 		...rest,
 		animated: 250,
 		gutter: 15,
 		unstable_flip: true,
 		unstable_preventOverflow: true,
+		baseId: baseId || uuidV4(),
 	});
+
 	return (
 		<>
 			<ReakitTooltipReference {...tooltipState} ref={children.ref} {...children.props}>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4316,6 +4316,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
 
+"@types/uuid@^8.3.4":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.4.tgz#bd86a43617df0594787d38b735f55c805becf1bc"
+  integrity sha512-c/I8ZRb51j+pYGAu5CrFMRxqZ2ke4y2grEBO5AUjgSkSk+qT2Ea+OdWElz/OiMf5MNpn2b17kuVBwZLQJXzihw==
+
 "@types/webpack-env@^1.16.0":
   version "1.16.4"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.16.4.tgz#1f4969042bf76d7ef7b5914f59b3b60073f4e1f4"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When we want to test with snapshot a component containing a Design-system `Tooltip` (Reakit), its id is computed (and different) at each build and id generator function can't be mocked. Leading to unstable and failing tests.

**What is the chosen solution to this problem?**

I've re-used the [`TooltipTrigger`](https://github.com/Talend/ui/blob/master/packages/components/src/TooltipTrigger/TooltipTrigger.component.js#L115) (old component) behaviour for id computation using `uuid.v4` function. 

Id generation for `Tooltip` component is `uuid.v4` (which can be mocked in tests) but can be overwritten with `baseId` property of `Tooltip`

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
