### PR TITLE
fix(assetApi): prevent getCdnUrl to start with double slash

### DIFF
--- a/.changeset/curvy-balloons-jog.md
+++ b/.changeset/curvy-balloons-jog.md
@@ -1,0 +1,5 @@
+---
+'@talend/assets-api': patch
+---
+
+fix(assetApi): prevent getCdnUrl to start with double slash //

--- a/packages/assets-api/src/index.ts
+++ b/packages/assets-api/src/index.ts
@@ -186,7 +186,7 @@ if (!window.Talend.getCDNUrl) {
 				const baseTag = document.querySelector('base');
 				if (baseTag) {
 					const root = baseTag.getAttribute('href') || '';
-					if (`${root}${CDN_URL}`.substr(0, 2) !== '//') {
+					if (root !== '/') {
 						return `${root}${CDN_URL}/${info.name}/${info.version}${info.path}`;
 					}
 				}

--- a/packages/assets-api/src/index.ts
+++ b/packages/assets-api/src/index.ts
@@ -186,7 +186,9 @@ if (!window.Talend.getCDNUrl) {
 				const baseTag = document.querySelector('base');
 				if (baseTag) {
 					const root = baseTag.getAttribute('href') || '';
-					return `${root}${CDN_URL}/${info.name}/${info.version}${info.path}`;
+					if (`${root}${CDN_URL}`.substr(0, 2) !== '//') {
+						return `${root}${CDN_URL}/${info.name}/${info.version}${info.path}`;
+					}
 				}
 			}
 			return `${CDN_URL}/${info.name}/${info.version}${info.path}`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`Talend.getCDNUrl` is doing a concatenation of both `base` url and `CDN_URL` env variable.
In most of our apps, base is set to `/` and `CDN_URL` is set to `/cdn` which leads to `//cdn/etc` 
The browser then fails to call the resource due to double slashes

**What is the chosen solution to this problem?**

Prevent the getCDNUrl to return an url starting with a double slash.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
