### PR TITLE
fix(stories): add copy assets and configure assets-api

### DIFF
--- a/packages/dataviz/.storybook/main.js
+++ b/packages/dataviz/.storybook/main.js
@@ -1,0 +1,7 @@
+const path = require('path');
+const fr = path.join(__dirname, '/../assets');
+const pkg = require(path.join(__dirname, '..', 'package.json'));
+
+module.exports = {
+	staticDirs: [{ from: fr, to: `/cdn/${pkg.name}/${pkg.version}/dist/assets/` }],
+};

--- a/packages/dataviz/.storybook/preview-head.html
+++ b/packages/dataviz/.storybook/preview-head.html
@@ -1,0 +1,20 @@
+<script>
+	if (!window.Talend) {
+		window.Talend = {};
+	}
+	window.Talend.CDN_URL = 'https://statics.cloud.talend.com';
+
+	// let's override the assets-api's getCDNUrl to serve local package
+	window.Talend.getCDNUrl = function getCDNUrl(pkg = {}) {
+		// if local to the repository load from /cdn
+		if (['@talend/react-dataviz', '@talend/icons'].includes(pkg.name)) {
+			const baseTag = document.querySelector('base');
+			if (baseTag) {
+				const root = baseTag.getAttribute('href') || '';
+				return `${root}/cdn/${pkg.name}/${pkg.version}${pkg.path}`;
+			}
+			return `/cdn/${pkg.name}/${pkg.version}${pkg.path}`;
+		}
+		return `${window.Talend.CDN_URL}/${pkg.name}/${pkg.version}${pkg.path}`;
+	};
+</script>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

assets-api fallback on unpkg when it is not configured.
This is the case in our storybooks so all stories using assets-api will be broken on release PR because the version is not published. It also means it rely on the published assets and not the local assets.

This is an issue for :
* dataviz because the topology fall in 404.


**What is the chosen solution to this problem?**

* [x] configure dataviz storybook to rely on /cdn for it's assets

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
