### PR TITLE
fix(components): Datalist should update its value when the titleMap changes

### DIFF
--- a/.changeset/heavy-jobs-appear.md
+++ b/.changeset/heavy-jobs-appear.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Datalist should update its value when the titleMap changes

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -151,7 +151,7 @@ function Datalist(props) {
 			setFilterValue(entry.name);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [props.value]);
+	}, [props.value, props.titleMap]);
 
 	// Suggestion display syntaxic sugar
 	const resetSelection = () =>

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -255,6 +255,25 @@ describe('Datalist component', () => {
 		expect(screen.getByRole('textbox')).toHaveValue('My bar');
 	});
 
+	it('should set value on props titleMap update', () => {
+		// given
+		const onChange = jest.fn();
+		const { rerender } = render(
+			<Datalist id="my-datalist" onChange={onChange} {...props} value="foo" />,
+		);
+		expect(screen.getByRole('textbox')).toHaveValue('My foo');
+
+		// when
+		const propsNewTitlemap = {
+			...props,
+			titleMap: [{ name: 'My foo updated', value: 'foo', description: 'foo description' }],
+		};
+		rerender(<Datalist id="my-datalist" onChange={onChange} {...propsNewTitlemap} value="foo" />);
+
+		// then
+		expect(screen.getByRole('textbox')).toHaveValue('My foo updated');
+	});
+
 	it('should set highlight on current value suggestion', () => {
 		// given
 		render(<Datalist id="my-datalist" onChange={jest.fn()} {...props} value="foo" />);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When updating the titleMap of a datalist, the value does not get updated
It has been detected on TMC side : https://jira.talendforge.org/browse/TDOPS-2240

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
