### PR TITLE
feat: distribute assets-api in UMD

### DIFF
--- a/.changeset/healthy-maps-report.md
+++ b/.changeset/healthy-maps-report.md
@@ -1,0 +1,8 @@
+---
+'@talend/react-datagrid': patch
+'@talend/react-dataviz': patch
+'@talend/design-system': patch
+'@talend/react-forms': patch
+---
+
+fix: use assets-api from CDN

--- a/.changeset/wicked-badgers-rest.md
+++ b/.changeset/wicked-badgers-rest.md
@@ -1,0 +1,6 @@
+---
+'@talend/assets-api': minor
+'@talend/scripts-config-cdn': minor
+---
+
+@talend/assets-api is now distributed as UMD file

--- a/packages/assets-api/package.json
+++ b/packages/assets-api/package.json
@@ -6,7 +6,7 @@
   "mainSrc": "src/index.ts",
   "license": "Apache-2.0",
   "scripts": {
-    "pre-release": "echo no pre-release for assets-api",
+    "pre-release": "talend-scripts build:lib:umd && talend-scripts build:lib:umd --dev",
     "build:lib": "talend-scripts build:ts:lib",
     "start": "echo nothing to start",
     "test": "talend-scripts test",

--- a/packages/playground/webpack.config.dev.js
+++ b/packages/playground/webpack.config.dev.js
@@ -28,6 +28,7 @@ function getVersion(pkg) {
 }
 
 const PKGS = [
+	'@talend/assets-api',
 	'@talend/design-tokens',
 	'@talend/design-system',
 	'@talend/design-tokens',

--- a/tools/scripts-config-cdn/modules.json
+++ b/tools/scripts-config-cdn/modules.json
@@ -1,4 +1,13 @@
 {
+  "@talend/assets-api": {
+    "var": "TalendAssetsApi",
+    "versions": {
+      ">= 1.0.0": {
+        "development": "/dist/TalendAssetsApi.js",
+        "production": "/dist/TalendAssetsApi.min.js"
+      }
+    }
+  },
   "@talend/bootstrap-theme": {
     "var": "TalendBootstrapTheme",
     "versions": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

assets-api has been fixed in #3969 but the fix can be deployed project side because the code is embeded in all UMD (forms, ds, datagrid)

**What is the chosen solution to this problem?**

* distribute assets-api in UMD
* add it to cdn config
* ask for release of packages

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
