### PR TITLE
fix(eslint): Disable no-extraneous-dependencies for stories & tests

### DIFF
--- a/.changeset/two-ears-doubt.md
+++ b/.changeset/two-ears-doubt.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-eslint': patch
+---
+
+Disable no-extraneous-dependencies for stories & tests

--- a/tools/scripts-config-eslint/.eslintrc
+++ b/tools/scripts-config-eslint/.eslintrc
@@ -38,13 +38,6 @@
 		"implicit-arrow-linebreak": 0,
 		"import/prefer-default-export": 0,
 		"import/no-named-as-default": "off",
-		"import/no-extraneous-dependencies": [
-			2,
-			{
-				"devDependencies": ["**/*.test.js", "**/*.test.ts*", "**/*.stories.js", "**/*.stories.ts*"],
-				"peerDependencies": true
-			}
-		],
 		"jsx-a11y/label-has-associated-control": 2,
 		"jsx-a11y/label-has-for": 0, // deprecated and buggy, replaced by jsx-a11y/label-has-associated-control
 		"max-classes-per-file": 0,
@@ -94,6 +87,14 @@
 		"testing-library/no-node-access": "off",
 		"testing-library/render-result-naming-convention": "off"
 	},
+	"overrides": [
+		{
+			"files": ["**/*.test.js", "**/*.test.ts*", "**/*.stories.js", "**/*.stories.ts*"],
+			"rules": {
+				"import/no-extraneous-dependencies": "off"
+			}
+		}
+	],
 	"env": {
 		"es6": true,
 		"browser": true,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Storybook & friends are imported by our presets and are not listed in project dependencies

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
