### PR TITLE
chore(ci): Restore chromatic label condition

### DIFF
--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -20,7 +20,10 @@ on:
 
 jobs:
   changes:
-    if: ( !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'need visual approval') )
+    # Trigger on ready PRs or draft with label
+    # if: ( !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'need visual approval') )
+    # We ran out of screenshots, trigger only on label
+    if: ( github.ref == 'refs/heads/master' || contains(github.event.pull_request.labels.*.name, 'need visual approval') )
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -20,6 +20,7 @@ on:
 
 jobs:
   changes:
+    if: ( !github.event.pull_request.draft || contains(github.event.pull_request.labels.*.name, 'need visual approval') )
     runs-on: ubuntu-latest
     outputs:
       packages: ${{ steps.filter.outputs.changes }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Execution condition was unfortunately removed 

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
