### PR TITLE
chore(design-tokens): Disable Chromatic tests on legacy Switch before redesign

### DIFF
--- a/packages/design-system/src/components/Switch/docs/Switch.stories.mdx
+++ b/packages/design-system/src/components/Switch/docs/Switch.stories.mdx
@@ -8,6 +8,7 @@ import Switch from '../';
 	component={Switch}
 	parameters={{
 		status: { figma: 'ok', storybook: 'ok', react: 'ok', i18n: 'na' },
+		chromatic: { disableSnapshot: true },
 	}}
 />
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The current Switch component has a lot of false positives on Chromatic

**What is the chosen solution to this problem?**
Disable the chromatic tests for the component before its planned redesign

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
