### PR TITLE
fix(Dropdown): Close on button or link click

### DIFF
--- a/.changeset/gentle-beds-yawn.md
+++ b/.changeset/gentle-beds-yawn.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(Dropdown): close the dropdown menu while clicking on a button or a link inside.

--- a/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
@@ -28,6 +28,14 @@ context('<Dropdown />', () => {
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
 
+	it('should hide the menu clicking on a link', () => {
+		cy.mount(<WithIcons />);
+		cy.getByTest('dropdown.button').click();
+		cy.getByTest('dropdown.menu').should('be.visible');
+		cy.get('a[data-test="dropdown.menuitem"]').eq(0).invoke('removeAttr', 'href').click();
+		cy.getByTest('dropdown.menu').should('not.be.visible');
+	});
+
 	it('should display menu with keyboard', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').type(' ');

--- a/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
@@ -20,6 +20,14 @@ context('<Dropdown />', () => {
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
 
+	it('should hide the menu clicking on a button', () => {
+		cy.mount(<WithIcons />);
+		cy.getByTest('dropdown.button').click();
+		cy.getByTest('dropdown.menu').should('be.visible');
+		cy.get('button[data-test="dropdown.menuitem"]').click();
+		cy.getByTest('dropdown.menu').should('not.be.visible');
+	});
+
 	it('should display menu with keyboard', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').type(' ');

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, forwardRef, MouseEventHandler, ReactElement, Ref } from 'react';
+import React, { cloneElement, forwardRef, ReactElement, Ref } from 'react';
 import { Menu, MenuButton, useMenuState } from 'reakit';
 import { IconName } from '@talend/icons';
 import DropdownButton from './Primitive/DropdownButton';

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -93,8 +93,11 @@ const Dropdown = forwardRef(
 								{...menu}
 								key={`${label}-${index}`}
 								id={`${label}-${index}`}
-								onClick={() => {
+								onClick={event => {
 									menu.hide();
+									if (entry.onClick) {
+										entry.onClick(event);
+									}
 								}}
 								data-test="dropdown.menuitem"
 							>

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -1,4 +1,4 @@
-import React, { cloneElement, forwardRef, ReactElement, Ref } from 'react';
+import React, { cloneElement, forwardRef, MouseEventHandler, ReactElement, Ref } from 'react';
 import { Menu, MenuButton, useMenuState } from 'reakit';
 import { IconName } from '@talend/icons';
 import DropdownButton from './Primitive/DropdownButton';
@@ -57,6 +57,10 @@ const Dropdown = forwardRef(
 								<DropdownButton
 									{...entryRest}
 									{...menu}
+									onClick={event => {
+										menu.hide();
+										entry?.onClick(event);
+									}}
 									key={`${label}-${index}`}
 									id={`${label}-${index}`}
 									data-test="dropdown.menuitem"
@@ -89,6 +93,9 @@ const Dropdown = forwardRef(
 								{...menu}
 								key={`${label}-${index}`}
 								id={`${label}-${index}`}
+								onClick={() => {
+									menu.hide();
+								}}
 								data-test="dropdown.menuitem"
 							>
 								{label}
@@ -100,5 +107,7 @@ const Dropdown = forwardRef(
 		);
 	},
 );
+
+Dropdown.displayName = 'Dropdown';
 
 export default Dropdown;

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -59,7 +59,7 @@ const Dropdown = forwardRef(
 									{...menu}
 									onClick={event => {
 										menu.hide();
-										entry?.onClick(event);
+										entry.onClick(event);
 									}}
 									key={`${label}-${index}`}
 									id={`${label}-${index}`}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, we have no way to close the dropdown other than click outside.
While the user has made his selection in the dropdown, the menu should close itself when actionned

**What is the chosen solution to this problem?**
Close automatically the menu while clicking on a button or a link.
For the link part, i was asking myself if it's required but for some use cases of internal routing, if the dropdown stays in the view, it could have some purprose.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
