### PR TITLE
chore(ci): update apt-get to install jq in security scan action

### DIFF
--- a/.github/actions/sourceclear/Dockerfile
+++ b/.github/actions/sourceclear/Dockerfile
@@ -1,4 +1,5 @@
 FROM node:16
+RUN apt-get update
 RUN apt-get install -y --no-install-recommends curl jq
 COPY entrypoint.sh /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
jq not found while trying to install it in security scan workflow

<img width="796" alt="image" src="https://user-images.githubusercontent.com/10761073/167372846-28df2b1b-3835-402d-8159-3acb867e4d70.png">


**What is the chosen solution to this problem?**

`apt-get update`

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
