### PR TITLE
fix(Components/Vlist): proptypes 

### DIFF
--- a/.changeset/fluffy-games-press.md
+++ b/.changeset/fluffy-games-press.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: proptypes of VList

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -70,7 +70,7 @@ function VList({ children, columnChooser, ...rest }) {
 
 VList.propTypes = {
 	children: PropTypes.arrayOf(PropTypes.node),
-	columnChooser: PropTypes.oneOfType([PropTypes.bool, ...ColumnChooser.propTypes]),
+	columnChooser: PropTypes.oneOfType([PropTypes.bool, ...Object.values(ColumnChooser.propTypes)]),
 };
 
 // we port the VirtualizedList columns to VList to allow VList.Title/Badge/...

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -70,7 +70,7 @@ function VList({ children, columnChooser, ...rest }) {
 
 VList.propTypes = {
 	children: PropTypes.arrayOf(PropTypes.node),
-	columnChooser: PropTypes.oneOfType([PropTypes.bool, ColumnChooser.propTypes]),
+	columnChooser: PropTypes.oneOfType([PropTypes.bool, ...ColumnChooser.propTypes]),
 };
 
 // we port the VirtualizedList columns to VList to allow VList.Title/Badge/...


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
```
[Error] Warning: Invalid argument supplied to oneOfType. Expected an array of check functions, but received an object at index 1.
	printWarning (prop-types.js:196)
	createUnionTypeChecker (prop-types.js:550)
	./src/List/ListComposition/VList/VList.component.js (TalendReactComponents.js:27373)
	__webpack_require__ (TalendReactComponents.js:73021)
	./src/List/ListComposition/VList/index.js (TalendReactComponents.js:27396:94)
	__webpack_require__ (TalendReactComponents.js:73021)
	./src/List/ListComposition/LazyLoadingList/LazyLoadingList.component.js (TalendReactComponents.js:26424:84)
	__webpack_require__ (TalendReactComponents.js:73021)
	./src/List/ListComposition/LazyLoadingList/index.js (TalendReactComponents.js:26527:104)
	__webpack_require__ (TalendReactComponents.js:73021)
	./src/List/ListComposition/index.js (TalendReactComponents.js:27470:94)
	__webpack_require__ (TalendReactComponents.js:73021)
	./src/List/index.js (TalendReactComponents.js:29932:94)
	__webpack_require__ (TalendReactComponents.js:73021)
	(anonymous function) (TalendReactComponents.js:73221:84)
	(anonymous function) (TalendReactComponents.js:73320)
	(anonymous function) (TalendReactComponents.js:73323)
	webpackUniversalModuleDefinition (TalendReactComponents.js:9)
	Global Code (TalendReactComponents.js:10)
```

**What is the chosen solution to this problem?**

spread the prototypes.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
