### PR TITLE
chore(ci): security scan fix

### DIFF
--- a/.github/actions/sourceclear/entrypoint.sh
+++ b/.github/actions/sourceclear/entrypoint.sh
@@ -7,8 +7,6 @@ echo "Script execution rights added"
 
 packages=$(yarn --silent workspaces info  | jq '.[].location' | sed 's/\"//g')
 
-echo "Packages: $packages"
-
 # scan each folder
 echo "Starting scan on . (root) ..."
 ./srcclr.sh scan .
@@ -17,13 +15,9 @@ echo "Scan completed on . (root)"
 for folder in $packages;
 do
     echo "Starting scan on ./$folder ..."
-    echo "ln -s yarn.lock ./$folder/yarn.lock"
     ln -s yarn.lock ./$folder/yarn.lock
-    echo "./srcclr.sh scan ./$folder"
     ./srcclr.sh scan ./$folder
     echo "Scan completed on ./$folder"
 done
 
-# set back default field separator
-IFS=$Field_Separator
 

--- a/.github/actions/sourceclear/entrypoint.sh
+++ b/.github/actions/sourceclear/entrypoint.sh
@@ -10,6 +10,9 @@ packages=$(yarn --silent workspaces info  | jq '.[].location' | sed 's/\"//g')
 Field_Separator=$IFS
 IFS=,
 
+pwd
+ls -l
+
 # scan each folder
 echo "Starting scan on . (root) ..."
 ./srcclr.sh scan .

--- a/.github/actions/sourceclear/entrypoint.sh
+++ b/.github/actions/sourceclear/entrypoint.sh
@@ -6,12 +6,6 @@ chmod a+x srcclr.sh
 echo "Script execution rights added"
 
 packages=$(yarn --silent workspaces info  | jq '.[].location' | sed 's/\"//g')
-# set comma as internal field separator for the string list
-Field_Separator=$IFS
-IFS=,
-
-pwd
-ls -l
 
 echo "Packages: $packages"
 

--- a/.github/actions/sourceclear/entrypoint.sh
+++ b/.github/actions/sourceclear/entrypoint.sh
@@ -13,6 +13,8 @@ IFS=,
 pwd
 ls -l
 
+echo "Packages: $packages"
+
 # scan each folder
 echo "Starting scan on . (root) ..."
 ./srcclr.sh scan .
@@ -21,7 +23,9 @@ echo "Scan completed on . (root)"
 for folder in $packages;
 do
     echo "Starting scan on ./$folder ..."
+    echo "ln -s yarn.lock ./$folder/yarn.lock"
     ln -s yarn.lock ./$folder/yarn.lock
+    echo "./srcclr.sh scan ./$folder"
     ./srcclr.sh scan ./$folder
     echo "Scan completed on ./$folder"
 done

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,7 +7,8 @@ on:
 
 jobs:
   build:
-    environment: main
+    # environment: main
+    environment: pull_request_unsafe
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -7,8 +7,7 @@ on:
 
 jobs:
   build:
-    # environment: main
-    environment: pull_request_unsafe
+    environment: main
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Security scan script now list the packages and loop over this list.
But it still has the old configuration managing a comma-separated list.

**What is the chosen solution to this problem?**
Remove the custom separator configuration to loop over the packages list properly

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
