### PR TITLE
chore(ci): secu scan cp yarn.lock instead of symlink

### DIFF
--- a/.github/actions/sourceclear/entrypoint.sh
+++ b/.github/actions/sourceclear/entrypoint.sh
@@ -16,7 +16,7 @@ for folder in $packages;
 do
     echo "Starting scan on ./$folder ..."
     echo "> ln -s yarn.lock ./$folder/yarn.lock"
-    ln -s yarn.lock ./$folder/yarn.lock
+    cp yarn.lock ./$folder/yarn.lock
     ls -l ./$folder
     echo "> ./srcclr.sh scan ./$folder"
     ./srcclr.sh scan ./$folder


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Secu scan fails because srcclr script can't read the symlink to yarn.lock that is created under root user.
The symlink read doesn't work, which is weird as we have all the rights on it (777). But it's possible that the link is stored somewhere in owner's home that we don't have access.

**What is the chosen solution to this problem?**
Copy the yarn.lock instead.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
