### PR TITLE
fix(cdn): DS and assets-api available cdn versions

### DIFF
--- a/tools/scripts-config-cdn/modules.json
+++ b/tools/scripts-config-cdn/modules.json
@@ -2,7 +2,7 @@
   "@talend/assets-api": {
     "var": "TalendAssetsApi",
     "versions": {
-      ">= 1.0.0": {
+      ">= 1.1.0": {
         "development": "/dist/TalendAssetsApi.js",
         "production": "/dist/TalendAssetsApi.min.js"
       }
@@ -41,13 +41,13 @@
   "@talend/design-system": {
     "var": "TalendDesignSystem",
     "versions": {
-      ">= 1.0.0": {
+      "> 1.1.0": {
         "development": "/dist/TalendDesignSystem.js",
         "production": "/dist/TalendDesignSystem.min.js"
       }
     },
     "style-versions": {
-      ">= 1.0.0": {
+      "> 1.1.0": {
         "development": "/dist/TalendDesignSystem.css",
         "production": "/dist/TalendDesignSystem.css"
       }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
cdn-content download action has errors on 
- `@talend/design-system` v1.1.0 --> wrong version deployment
- `@talend/assets-api` v1.0.0 and v1.0.1 --> not umds

**What is the chosen solution to this problem?**
Fix range of versions in modules.json

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
