### PR TITLE
feat(datagrid): Bump ag-grid to v27

### DIFF
--- a/.changeset/perfect-garlics-visit.md
+++ b/.changeset/perfect-garlics-visit.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-datagrid': minor
+---
+
+- Bump ag-grid to v27
+- Drop assets-api as it's too painful to use ATM

--- a/packages/datagrid/.eslintrc.js
+++ b/packages/datagrid/.eslintrc.js
@@ -1,0 +1,3 @@
+module.exports = {
+	extends: ['../../node_modules/@talend/scripts-config-eslint/.eslintrc.js'],
+};

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -39,8 +39,8 @@
     "@talend/assets-api": "^1.1.0",
     "@talend/icons": "^6.40.0",
     "@talend/react-components": "^6.46.2",
-    "ag-grid-community": "^25.3.0",
-    "ag-grid-react": "^25.3.0",
+    "ag-grid-community": "^27.2.1",
+    "ag-grid-react": "^27.2.1",
     "classnames": "^2.3.1",
     "keycode": "^2.2.1",
     "lodash": "^4.17.21"

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -2,7 +2,9 @@
 import React from 'react';
 import classNames from 'classnames';
 import keycode from 'keycode';
-import assetsApi from '@talend/assets-api';
+import { AgGridReact } from 'ag-grid-react';
+import 'ag-grid-community/dist/styles/ag-grid.css';
+
 import { Icon } from '@talend/design-system';
 import DefaultHeaderRenderer, { HEADER_RENDERER_COMPONENT } from '../DefaultHeaderRenderer';
 import DefaultCellRenderer, { CELL_RENDERER_COMPONENT } from '../DefaultCellRenderer';
@@ -16,13 +18,6 @@ import DATAGRID_PROPTYPES from './DataGrid.proptypes';
 import { NAMESPACE_INDEX } from '../../constants';
 import serializer from '../DatasetSerializer';
 import theme from './DataGrid.scss';
-
-const AgGridReact = React.lazy(() =>
-	assetsApi
-		.getUMD('ag-grid-community')
-		.then(() => assetsApi.getUMD('ag-grid-react'))
-		.then(mod => assetsApi.toDefaultModule(mod.AgGridReact)),
-);
 
 export const AG_GRID = {
 	CUSTOM_HEADER_KEY: 'headerComponent',
@@ -93,11 +88,6 @@ export default class DataGrid extends React.Component {
 		this.updateStyleFocusColumn = this.updateStyleFocusColumn.bind(this);
 		this.onKeyDownHeaderColumn = this.onKeyDownHeaderColumn.bind(this);
 		this.currentColId = null;
-	}
-
-	componentDidMount() {
-		const href = assetsApi.getURL('/dist/styles/ag-grid.css', 'ag-grid-community');
-		assetsApi.addStyle({ href });
 	}
 
 	/**
@@ -328,11 +318,7 @@ export default class DataGrid extends React.Component {
 				</div>
 			);
 		} else {
-			content = (
-				<React.Suspense fallback={<Icon name="talend-table" />}>
-					<AgGridReact {...this.getAgGridConfig()} />
-				</React.Suspense>
-			);
+			content = <AgGridReact {...this.getAgGridConfig()} />;
 		}
 
 		return (

--- a/packages/datagrid/src/components/DataGrid/DataGrid.scss
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.scss
@@ -27,11 +27,6 @@ $td-datagrid-skeleton-height: 9.6rem !default;
 	}
 
 	/* ==== HEADER ==== */
-	:global(.ag-react-container) {
-		height: 100%;
-		width: 100%;
-	}
-
 	:global(.ag-header-cell-resize) {
 		cursor: col-resize;
 	}

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/DefaultHeaderRenderer.scss
@@ -17,6 +17,7 @@ $td-grip-resize-width: 6px !default;
 
 .td-header-component {
 	height: 100%;
+	width: 100%;
 	display: flex;
 	flex-direction: column;
 	padding: tokens.$coral-spacing-xs;

--- a/packages/datagrid/src/components/DefaultPinHeaderRenderer/PinHeaderRenderer.scss
+++ b/packages/datagrid/src/components/DefaultPinHeaderRenderer/PinHeaderRenderer.scss
@@ -1,6 +1,7 @@
 .td-pin-header {
-	display: flex;
 	height: 100%;
+	width: 100%;
+	display: flex;
 	justify-content: center;
 	align-items: center;
 

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -1,4 +1,4 @@
-/* eslint-disable no-console */
+/* eslint-disable no-console, react/prop-types */
 
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';

--- a/yarn.lock
+++ b/yarn.lock
@@ -4920,17 +4920,17 @@ adjust-sourcemap-loader@3.0.0:
     loader-utils "^2.0.0"
     regex-parser "^2.2.11"
 
-ag-grid-community@^25.3.0:
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/ag-grid-community/-/ag-grid-community-25.3.0.tgz#9a0acce6d35f0c23313aa559dbd8acd737d5ef19"
-  integrity sha512-Xe4NZG0PP9kvhila1uHU4BeVfLDCWBmcuBYLBZ+49jvK+jYpuwdAjV3AwIlxpZGRR3WTdBUvUkSz9rmi2DRE3Q==
+ag-grid-community@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/ag-grid-community/-/ag-grid-community-27.2.1.tgz#7642cd0cd8451d1b4f8fc93ea2b46b1ee97d452d"
+  integrity sha512-MCnbqZHVDvd6KNRx1g6vjuz/X9tE8YUV7kaWKpRupFF1M1fPsAt+CqkfOr3X2ybOooorYao3Z/GGskRlGaHlFQ==
 
-ag-grid-react@^25.3.0:
-  version "25.3.0"
-  resolved "https://registry.yarnpkg.com/ag-grid-react/-/ag-grid-react-25.3.0.tgz#7dce91fc7ef1821765357517562ba49299d4fddb"
-  integrity sha512-sRu4Mgxe26GkCKZL9XNMf/jbxLrYOuJo0pumD+LgA3e1x0mKeG8fqMbDLBKfKthIZbTaopIiwn4basThPnVdTg==
+ag-grid-react@^27.2.1:
+  version "27.2.1"
+  resolved "https://registry.yarnpkg.com/ag-grid-react/-/ag-grid-react-27.2.1.tgz#8391a922ac95d937e41b726b1222cd6697fb924e"
+  integrity sha512-MWYhi16CHltIojdnHjPp6U5TPsHQHVtX+gJqhEwNM7h55Iwe9NPFfoypBwz9kEyR7dSIL8pvMZ5O/nEeBBoxWA==
   dependencies:
-    prop-types "^15.6.2"
+    prop-types "^15.8.1"
 
 agent-base@6, agent-base@^6.0.2:
   version "6.0.2"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`ag-react-container` div were removed, update style
`assets-api` is not stable enough: drop it for now (also, it's loader doesn't match UX guidelines)

**Changes:**
https://www.ag-grid.com/changelog/?fixVersion=27.0.0
https://www.ag-grid.com/changelog/?fixVersion=26.0.0

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
