### PR TITLE
chore(design-system): remark plugin into Storybook

### DIFF
--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -1,6 +1,8 @@
 const path = require('path');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 
+const groupBy = require('./mdx/groupBy');
+
 module.exports = {
 	features: {
 		buildStoriesJson: true,
@@ -78,6 +80,17 @@ module.exports = {
 				codeSync: false,
 			}),
 		);
+		config.module.rules.map(rule => {
+			if (rule.use?.some(use => use.loader?.includes('@mdx-js'))) {
+				return rule.use.map(use => {
+					if (use.options?.remarkPlugins) {
+						use.options.remarkPlugins.push(groupBy);
+					}
+					return use;
+				});
+			}
+			return rule;
+		});
 		const existingAlias = config.resolve.alias || {};
 		config.resolve.alias = {
 			...existingAlias,

--- a/packages/design-system/.storybook/mdx/groupBy.js
+++ b/packages/design-system/.storybook/mdx/groupBy.js
@@ -1,0 +1,81 @@
+const visit = require('unist-util-visit');
+
+const groupByDetails = require('./groupByDetails');
+
+function findGroups(node, index, parent) {
+	const groups = [];
+	let depth = null;
+	let group;
+	const { children } = parent;
+	while (++index < children.length) {
+		const child = children[index];
+		if (child.type === 'heading') {
+			if (depth == null) {
+				depth = child.depth;
+			}
+			if (child.depth < depth) {
+				group.end = index;
+				break;
+			}
+			if (child.depth === depth) {
+				if (group) {
+					group.end = index;
+				}
+				group = {};
+				group.start = index;
+				group.end = children.length;
+				groups.push(group);
+			}
+		}
+		if (child.type === 'comment' && child.value.trim() === '/group') {
+			if (group) {
+				group.end = index;
+			}
+			break;
+		}
+	}
+	return groups;
+}
+
+function groupBy() {
+	return root => {
+		let foundGroups = false;
+		let alreadyImported = false;
+		visit(root, (node, index, parent) => {
+			if (node.type === 'import') {
+				// TODO Useful if we use third library
+				// if (node.value.includes("@radix-ui")) {
+				//    alreadyImported = true;
+				// }
+			} else if (node.type === 'comment') {
+				const commentValue = node.value.trim();
+				if (commentValue.startsWith('group') && !commentValue.startsWith('/')) {
+					let renderFn = groupByDetails;
+					// TODO Useful if we use several renderers
+					// const variantValue = commentValue.split(":").reverse()[0];
+					// if (variantValue === "accordion") {
+					//    renderFn = groupByAccordion;
+					// }
+					const groups = findGroups(node, index, parent);
+					if (groups.length > 0) {
+						foundGroups = true;
+						const start = groups[0].start;
+						const end = groups[groups.length - 1].end;
+						const newChildren = renderFn(groups, parent.children);
+						parent.children.splice(start, end - start, ...newChildren);
+						return index + newChildren.length;
+					}
+				}
+			}
+		});
+		if (foundGroups && !alreadyImported) {
+			// TODO Useful if we use third library here, again
+			// root.children.unshift({
+			//    type: "import",
+			//    value: "import * as Tabs from '@radix-ui/react-tabs';",
+			// });
+		}
+	};
+}
+
+module.exports = groupBy;

--- a/packages/design-system/.storybook/mdx/groupByDetails.js
+++ b/packages/design-system/.storybook/mdx/groupByDetails.js
@@ -1,0 +1,25 @@
+const toString = require('mdast-util-to-string');
+
+function groupByDetails(groups, nodes) {
+	let groupNodes = [];
+	groups.forEach(group => {
+		const node = nodes[group.start];
+		const label = toString(node);
+		groupNodes.push({
+			type: 'jsx',
+			value: `<details>`,
+		});
+		groupNodes.push({
+			type: 'jsx',
+			value: `<summary>${label}</summary>`,
+		});
+		groupNodes.push(...nodes.slice(group.start + 1, group.end));
+		groupNodes.push({
+			type: 'jsx',
+			value: `</details>`,
+		});
+	});
+	return groupNodes;
+}
+
+module.exports = groupByDetails;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We can't wrap documentation sections into tabs, accordions, or anything else.

**What is the chosen solution to this problem?**

Let's bring a solution to do that using a custom Remark plugin.

```mdx

# Title 

<!-- group --->

## Section A 

Lorem ipsum

## Section B

Lorem ipsum

<!-- /group -->

Extra content here  
```

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
