### PR TITLE
chore(ARCH-515): fix order in workspace-run.js

### DIFF
--- a/.changeset/five-kiwis-reply.md
+++ b/.changeset/five-kiwis-reply.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-webpack-plugin': patch
+---
+
+fix: dependencies

--- a/packages/cmf-webpack-plugin/package.json
+++ b/packages/cmf-webpack-plugin/package.json
@@ -1,14 +1,14 @@
 {
   "name": "@talend/react-cmf-webpack-plugin",
   "description": "@talend/react-cmf webpack plugin for merging CMF settings",
-  "main": "lib/index.js",
+  "main": "src/index.js",
   "mainSrc": "src/index.js",
   "scripts": {
-    "build:lib": "talend-scripts build:lib",
+    "build:lib": "echo nothing to build",
     "start": "echo nothing to start",
     "test": "echo nothing to test yet in @talend/react-cmf-webpack-plugin",
     "test:cov": "npm run test",
-    "lint:es": "talend-scripts lint:es"
+    "lint:es": "echo nothing to lint"
   },
   "repository": {
     "type": "git",
@@ -28,12 +28,11 @@
   },
   "homepage": "https://github.com/Talend/ui/blob/master/packages/cmf/README.md",
   "dependencies": {
-    "@talend/react-cmf": "^7.0.2",
     "lodash": "^4.17.21"
   },
-  "devDependencies": {
-    "@talend/scripts-core": "^11.6.0",
-    "@talend/scripts-preset-react-lib": "^11.0.2"
+  "devDependencies": {},
+  "peerDependencies": {
+    "@talend/react-cmf": ">=7.0.2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cmf-webpack-plugin/talend-scripts.json
+++ b/packages/cmf-webpack-plugin/talend-scripts.json
@@ -1,3 +1,0 @@
-{
-  "preset": "@talend/scripts-preset-react-lib"
-}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

there is a circular dependencies which break nx and also workspace run since we have imported scripts in the repository.
It has some side effect like building design-system after react-componnets

**What is the chosen solution to this problem?**

* rewrite the workspace run to compute the order before get the cmd to make it more simple to understand and fail if there is a circular dependnecies inside the repository
* fix the circular dependencies

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
