### PR TITLE
feat(upgrade:deps): add --next support

### DIFF
--- a/.changeset/gentle-spoons-build.md
+++ b/.changeset/gentle-spoons-build.md
@@ -1,0 +1,5 @@
+---
+'@talend/upgrade-deps': minor
+---
+
+add --next option to get beta release of packages

--- a/tools/upgrade-deps/README.md
+++ b/tools/upgrade-deps/README.md
@@ -17,6 +17,7 @@ The binary installed in this package is `talend-upgrade-deps`.
 | package   | undefined | Used for single package upgrade. The name of the package.                        |
 | scope     | undefined | Used for single npm scope packages. (Example: `@talend`). The name of the scope. |
 | latest    | false     | If true, it forces the update to use **latest** tag on npm.                      |
+| next      | false     | If true, it forces the update to use **next** tag on npm.                        |
 | dry       | false     | Do not change anything, just look at what could be changed in your package.json. |
 | security  | undefined | Activates dependencies security mode, providing a configuration file path.       |
 | changeset | undefined | Create a changeset file based on git diff of each package.json.                  |
@@ -143,7 +144,7 @@ Example
 
 ### Manual fix
 
-In some cases, the security mode won't succeed to solve some dependencies vulnerabilities.  
+In some cases, the security mode won't succeed to solve some dependencies vulnerabilities.
 The run will output a `talend-security-report.json` file.
 
 Example:

--- a/tools/upgrade-deps/src/index.js
+++ b/tools/upgrade-deps/src/index.js
@@ -54,6 +54,7 @@ async function upgradeYarnProject(program) {
 		startsWith: program['starts-with'],
 		dry: program.dry || false,
 		latest: program.latest,
+		next: program.next,
 		security: program.security,
 		message: program.message,
 	};
@@ -78,6 +79,9 @@ async function upgradeYarnProject(program) {
 		}
 		if (opts.latest) {
 			throw new Error('Deps security fix mode is incompatible with "latest" option.');
+		}
+		if (opts.next) {
+			throw new Error('Deps security fix mode is incompatible with "next" option.');
 		}
 
 		const securityConfPath = path.join(CWD, program.security);

--- a/tools/upgrade-deps/src/npm.js
+++ b/tools/upgrade-deps/src/npm.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-await-in-loop, no-restricted-syntax */
 const fs = require('fs');
@@ -60,6 +61,17 @@ function createPackageJsonManager(filePath) {
 	return new PackageJson(filePath);
 }
 
+async function getNext(dependency) {
+	if (!CACHE[dependency]) {
+		const nextVersion = await execProm(`npm dist-tag ls ${dependency}`);
+		CACHE[dependency] = nextVersion.stdout
+			.split('\n')
+			.filter(line => line.includes('next:'))[0]
+			.replace('next: ', '');
+	}
+	return CACHE[dependency];
+}
+
 async function getLatest(dependency) {
 	if (!CACHE[dependency]) {
 		const latest = await execProm(`npm view ${dependency} version latest`);
@@ -111,11 +123,14 @@ async function checkVersionsOf(pkgJson, opts) {
 
 		try {
 			let newVersion;
-			if (opts.latest) {
+			if (opts.next) {
+				newVersion = await getNext(depName);
+			} else if (opts.latest) {
 				newVersion = await getLatest(depName);
 			} else {
 				newVersion = await getUpdate(depName, requestedVersion);
 			}
+			console.log(newVersion, requestedVersion);
 			if (newVersion && requestedVersion !== `${semantic}${newVersion}`) {
 				const isMajor = !semver.satisfies(newVersion, requestedVersion);
 				let msg = `"${depName}": "${requestedVersion}" => "^${newVersion}"`;
@@ -139,7 +154,9 @@ async function checkPackageJson(filePath, opts) {
 	console.log(
 		`\n${
 			opts.dry ? 'check' : `update ${opts.scope || opts.package || 'all'} packages`
-		} versions of ${filePath} ${opts.latest ? 'using latest' : 'using same requirements'}`,
+		} versions of ${filePath} using ${
+			(opts.latest && 'latest') || (opts.next && 'next') || 'same requirements'
+		}`,
 	);
 
 	const pkgJson = createPackageJsonManager(filePath);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

today if you want to try next storybook release you have to do it by hand (change all the package.json version to point to 6.5.0-beta.8 for example)

**What is the chosen solution to this problem?**

add the option so final it goes on

`talend-scripts upgrade:deps --scope=@storybook --next`

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
