### PR TITLE
feat(forms): Add helper to transform nested properties to flat object

### DIFF
--- a/.changeset/grumpy-papayas-applaud.md
+++ b/.changeset/grumpy-papayas-applaud.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': minor
+---
+
+Add helper to transform nested properties to flat object

--- a/packages/forms/src/UIForm/utils/properties.js
+++ b/packages/forms/src/UIForm/utils/properties.js
@@ -84,3 +84,32 @@ export function extractDataAttributes(props, index) {
 	});
 	return dataProps;
 }
+
+/**
+ * Transform nested objects, to flat key/value object
+ * { a: { b: ["c", { d: "e" } ] } }
+ * ===>
+ * {
+ *     "a.b[0]": "c",
+ *     "a.b[1].d": "e"
+ * }
+ * Adapted from https://github.com/lodash/lodash/issues/2240
+ */
+export function flattenProperties(object, initialPathPrefix = '') {
+	if (!object || typeof object !== 'object') {
+		if (initialPathPrefix === '') {
+			return object;
+		}
+		return [{ [initialPathPrefix]: object }];
+	}
+	return Object.keys(object)
+		.flatMap(key =>
+			flattenProperties(
+				object[key],
+				Array.isArray(object)
+					? `${initialPathPrefix}[${key}]`
+					: `${initialPathPrefix}.${key}`.replace(/^./, ''),
+			),
+		)
+		.reduce((acc, path) => ({ ...acc, ...path }));
+}

--- a/packages/forms/src/UIForm/utils/properties.test.js
+++ b/packages/forms/src/UIForm/utils/properties.test.js
@@ -1,4 +1,4 @@
-import { convertValue, getValue, mutateValue } from './properties';
+import { convertValue, flattenProperties, getValue, mutateValue } from './properties';
 
 describe('Properties utils', () => {
 	describe('#getValue', () => {
@@ -133,6 +133,37 @@ describe('Properties utils', () => {
 					lastname: 'tata',
 				},
 			});
+		});
+	});
+
+	describe('#flattenProperties', () => {
+		it('should handle object and arrays', () => {
+			// given
+			const properties = {
+				$datasetMetadata: {
+					name: 'test payload',
+				},
+				configuration: {
+					connection: {
+						parameters: [{ key: 'debug', value: '4' }],
+					},
+				},
+				$remoteEngineId: 'test-id',
+			};
+			// when
+			const value = flattenProperties(properties);
+
+			// then
+			expect(value).toEqual({
+				$remoteEngineId: 'test-id',
+				'datasetMetadata.name': 'test payload',
+				'figuration.connection.parameters[0].key': 'debug',
+				'figuration.connection.parameters[0].value': '4',
+			});
+		});
+		it('should handle primitive types', () => {
+			expect(flattenProperties(null));
+			expect(flattenProperties('flat')).toEqual('flat');
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Some tck APIs are using nested objects while other are expecting flat ones...
```
TDC: { a: { b: ["c", { d: "e" } ] } }
TPD: {
    "a.b[0]": "c",
    "a.b[1].d": "e"
}
```
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
