### PR TITLE
doc(design-system): Add gaps in form skeleton story

### DIFF
--- a/packages/design-system/src/components/Form/Form.stories.tsx
+++ b/packages/design-system/src/components/Form/Form.stories.tsx
@@ -8,21 +8,23 @@ import Skeleton from '../Skeleton';
 import Link from '../Link';
 
 import CountryCodes from './docs/data/CountryCodes.json';
+import { StackVertical } from '../Stack';
 
 export default {
 	component: Form,
 };
 
 function getCountryCodes() {
-	// eslint-disable-next-line @typescript-eslint/camelcase
 	return CountryCodes.map(({ name, dial_code }) => `${name} (${dial_code})`);
 }
 
 export const FormSkeleton = () => (
 	<Form>
-		<Skeleton variant="heading" />
-		<Skeleton variant="paragraph" />
-		<Skeleton variant="paragraph" />
+		<StackVertical gap="S">
+			<Skeleton variant="heading" />
+			<Skeleton variant="paragraph" />
+			<Skeleton variant="paragraph" />
+		</StackVertical>
 		<Form.Buttons>
 			<Skeleton variant="button" />
 			<Skeleton variant="button" />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Missing gap in story

https://design.talend.com/?path=/docs/components-form-form--form-skeleton&globals=theme:light#skeleton

<img width="1008" alt="Screenshot 2022-05-16 at 11 25 06" src="https://user-images.githubusercontent.com/58977230/168561835-3689e17d-414b-4c92-9457-8d5400ba1147.png">


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
