### PR TITLE
feat(DataGrid/cell-renderer): PlaygroundCellEditor

### DIFF
--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -37,11 +37,14 @@
   },
   "dependencies": {
     "@talend/assets-api": "^1.2.1",
+    "@talend/design-tokens": "^2.3.0",
+    "@talend/assets-api": "^1.2.1",
     "@talend/icons": "^6.42.0",
     "ag-grid-community": "^27.3.0",
     "ag-grid-react": "^27.3.0",
     "@talend/react-components": "^7.0.1",
     "classnames": "^2.3.1",
+    "focus-trap-react": "^8.11.1",
     "keycode": "^2.2.1",
     "lodash": "^4.17.21"
   },

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -282,7 +282,6 @@ export default class DataGrid extends React.Component {
 		}
 
 		agGridOptions.columnDefs = adaptedColumnDefs;
-
 		return agGridOptions;
 	}
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -282,6 +282,7 @@ export default class DataGrid extends React.Component {
 		}
 
 		agGridOptions.columnDefs = adaptedColumnDefs;
+
 		return agGridOptions;
 	}
 

--- a/packages/datagrid/src/components/PlaygroundCellEditor/ApplyToIdenticalValues.component.tsx
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/ApplyToIdenticalValues.component.tsx
@@ -1,0 +1,40 @@
+import React, { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ButtonPrimary, ButtonSecondary, Form, StackHorizontal } from '@talend/design-system';
+
+import theme from './ApplyToIdenticalValues.scss';
+
+interface ApplyToIdenticalValuesPropTypes {
+	onSubmit: (checked: boolean) => void;
+	onCancel: (checked: boolean) => void;
+	editorType?: string;
+}
+
+function ApplyToIdenticalValues({
+	onSubmit,
+	onCancel,
+	editorType = 'textarea',
+}: ApplyToIdenticalValuesPropTypes) {
+	const { t } = useTranslation();
+	const [checked, setChecked] = useState(false);
+
+	const nextStatus = checked ? 'uncheck' : 'check';
+	const dataFeature = `cell.edition.${editorType}.checkbox.${nextStatus}`;
+
+	return (
+		<div className={theme['apply-to-identical-values']}>
+			<Form.Checkbox
+				label={t('APPLY_TO_ALL_CELLS', 'Apply to identical values')}
+				onClick={() => setChecked(!checked)}
+				data-feature={dataFeature}
+			/>
+
+			<StackHorizontal gap={0} justify="spaceBetween">
+				<ButtonSecondary onClick={() => onCancel(checked)}>{t('CANCEL', 'Cancel')}</ButtonSecondary>
+				<ButtonPrimary onClick={() => onSubmit(checked)}>{t('SUBMIT', 'SUBMIT')}</ButtonPrimary>
+			</StackHorizontal>
+		</div>
+	);
+}
+
+export default ApplyToIdenticalValues;

--- a/packages/datagrid/src/components/PlaygroundCellEditor/ApplyToIdenticalValues.scss
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/ApplyToIdenticalValues.scss
@@ -1,0 +1,13 @@
+@use '~@talend/design-tokens/lib/tokens';
+
+.apply-to-identical-values {
+	min-width: 30rem;
+	box-shadow: tokens.$coral-elevation-shadow-neutral-m;
+	border-radius: tokens.$coral-radius-s;
+	padding: tokens.$coral-spacing-m tokens.$coral-spacing-s tokens.$coral-spacing-s;
+	background: tokens.$coral-color-neutral-background;
+
+	display: flex;
+	flex-direction: column;
+	row-gap: tokens.$coral-spacing-m;
+}

--- a/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
@@ -1,0 +1,126 @@
+import React, { useEffect, useImperativeHandle, useRef, useState, forwardRef } from 'react';
+import FocusTrap from 'focus-trap-react';
+
+import { AgCellEditorRendererPropTypes, AgGridCellValue } from '../../types';
+import RichCellEditorComponent from '../RichCellEditor';
+
+import ApplyToValues from './ApplyToIdenticalValues.component';
+
+type SemanticType = {
+	type: string;
+};
+
+function formatSuggestions(values: string[]): AgGridCellValue[] {
+	return values && values.length ? values.map(v => ({ name: v, value: v })) : [];
+}
+
+function PlaygroundCellEditor(props: AgCellEditorRendererPropTypes, ref: React.Ref<HTMLElement>) {
+	const { eGridCell, value, colDef, stopEditing } = props;
+	const { domain, cellEditorPopup, cellEditorParams } = colDef;
+	const { getSemanticType, getSemanticTypeSuggestions, onSubmit } = cellEditorParams || {};
+
+	const [state, setState] = useState(value.value);
+	const currentRef = useRef<HTMLDivElement>(null);
+	const [isLoading, setIsLoading] = useState(false);
+	const [showApplyTo, setShowApplyToState] = useState(false);
+	const showApplyToRef = useRef(showApplyTo);
+	const applyToRef = useRef<HTMLDivElement>(null);
+	const [applyToStyles, setApplyToStyles] = useState({});
+
+	const [semanticType, setSemanticType] = useState<SemanticType>();
+
+	const setShowApplyTo = (flag: boolean) => {
+		showApplyToRef.current = flag;
+		setShowApplyToState(flag);
+	};
+
+	useImperativeHandle(ref, (): any => ({ getValue: () => state }));
+
+	useEffect(() => {
+		// Check for misconfiguration in the column definition
+		if (!cellEditorPopup || !getSemanticType || !getSemanticTypeSuggestions || !onSubmit) {
+			throw new Error(
+				`Using EditablePlaygroundCellRenderer as cell editor requires the following in the column definition:
+	- cellEditorParams.getSemanticType()
+	- cellEditorParams.getSemanticTypeSuggestions()
+	- cellEditorParams.onSubmit()
+	- cellEditorPopup (set to true)`,
+			);
+		}
+
+		// Block "Tab keydown" event propagation when "Apply to ..." element is visible
+		currentRef.current?.addEventListener('keydown', (e: KeyboardEvent) => {
+			if (e.key === 'Enter' || (e.key === 'Tab' && showApplyToRef.current)) {
+				e.stopPropagation();
+			}
+		});
+
+		if (domain) {
+			setIsLoading(true);
+			getSemanticType(domain)
+				.then(setSemanticType)
+				.finally(() => {
+					setIsLoading(false);
+				});
+		}
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	useEffect(() => {
+		// Ensure "Apply to ..." is opened where it can be seen
+		if (showApplyTo && applyToRef.current) {
+			const { bottom, right } = applyToRef.current.getBoundingClientRect();
+
+			const overflowsRight = right > window.innerWidth;
+			const overflowsBottom = bottom > window.innerHeight;
+
+			setApplyToStyles({
+				position: 'absolute',
+				...(overflowsRight && { right: 0 }),
+				...(overflowsBottom && { bottom: eGridCell.offsetHeight }),
+			});
+		}
+	}, [applyToRef, eGridCell.offsetHeight, showApplyTo]);
+
+	const hasSuggestions = semanticType?.type === 'DICT';
+
+	const onCancel = () => {
+		stopEditing(true);
+	};
+
+	return (
+		<FocusTrap paused={!showApplyTo}>
+			<div ref={currentRef}>
+				<RichCellEditorComponent
+					eGridCell={eGridCell}
+					initialValue={value.value}
+					hasSuggestions={hasSuggestions}
+					isLoading={isLoading}
+					onChange={newValue => {
+						setShowApplyTo(newValue !== value.value);
+						setState(newValue);
+					}}
+					onCancel={onCancel}
+					onFilter={
+						hasSuggestions
+							? (search: string) =>
+									getSemanticTypeSuggestions(domain, search).then(formatSuggestions)
+							: undefined
+					}
+				/>
+				{showApplyTo && (
+					<div ref={applyToRef} style={applyToStyles}>
+						<ApplyToValues
+							onCancel={onCancel}
+							onSubmit={(applyToValues: boolean) => {
+								stopEditing();
+								onSubmit(state, applyToValues);
+							}}
+						/>
+					</div>
+				)}
+			</div>
+		</FocusTrap>
+	);
+}
+
+export default forwardRef(PlaygroundCellEditor);

--- a/packages/datagrid/src/components/PlaygroundCellEditor/index.ts
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './PlaygroundCellEditor.component';

--- a/packages/datagrid/src/components/RichCellEditor/RichCellEditor.component.scss
+++ b/packages/datagrid/src/components/RichCellEditor/RichCellEditor.component.scss
@@ -1,0 +1,22 @@
+@use '~@talend/design-tokens/lib/tokens';
+
+.rich-cell-editor {
+	&__skeleton {
+		min-height: 100%;
+		padding: 0 tokens.$coral-spacing-xs;
+		display: flex;
+		align-items: center;
+	}
+
+	&--loading,
+	&--datalist {
+		height: 100%;
+	}
+}
+
+.rich-cell-editor-edited-ag-grid-cell {
+	color: transparent;
+	> * {
+		display: none;
+	}
+}

--- a/packages/datagrid/src/components/RichCellEditor/RichCellEditor.component.tsx
+++ b/packages/datagrid/src/components/RichCellEditor/RichCellEditor.component.tsx
@@ -1,0 +1,81 @@
+import React, { useEffect, useState } from 'react';
+import { SkeletonParagraph } from '@talend/design-system';
+import classNames from 'classnames';
+
+import { AgGridCellValue } from '../../types';
+
+import CellEditorDatalist from './components/CellEditorDatalist.component';
+import CellEditorTextarea from './components/CellEditorTextarea.component';
+
+import theme from './RichCellEditor.component.scss';
+
+type CellValue = string;
+
+interface RichCellEditorPropTypes {
+	initialValue: CellValue;
+	isLoading?: boolean;
+	hasSuggestions?: boolean;
+	eGridCell: HTMLDivElement;
+	onChange: (value: CellValue) => void;
+	onFilter?: (search: string) => Promise<AgGridCellValue[]>;
+	onCancel: () => void;
+}
+
+function RichCellEditor(props: RichCellEditorPropTypes) {
+	const { onChange, onFilter, onCancel, initialValue, hasSuggestions, isLoading, eGridCell } =
+		props;
+	const [value, setValue] = useState(initialValue);
+
+	useEffect(() => {
+		eGridCell.classList.add(theme['rich-cell-editor-edited-ag-grid-cell']);
+		return () => {
+			eGridCell.classList.remove(theme['rich-cell-editor-edited-ag-grid-cell']);
+		};
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	const handleInputChange = (
+		_: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>,
+		newValue: CellValue,
+	) => {
+		const hasChanged = newValue !== initialValue;
+		setValue(newValue);
+
+		if (hasSuggestions && !hasChanged) {
+			onCancel();
+		} else {
+			onChange(newValue);
+		}
+	};
+
+	return (
+		<div
+			className={classNames({
+				[theme['rich-cell-editor--loading']]: isLoading,
+				[theme['rich-cell-editor--datalist']]: !!hasSuggestions,
+			})}
+		>
+			{isLoading ? (
+				<div
+					className={theme['rich-cell-editor__skeleton']}
+					style={{
+						height: `${eGridCell.scrollHeight}px`,
+						width: `${eGridCell.scrollWidth}px`,
+					}}
+				>
+					<SkeletonParagraph size="M" />
+				</div>
+			) : hasSuggestions && onFilter ? (
+				<CellEditorDatalist
+					eGridCell={eGridCell}
+					onFilter={onFilter}
+					onChange={handleInputChange}
+					value={value}
+				/>
+			) : (
+				<CellEditorTextarea eGridCell={eGridCell} onChange={handleInputChange} value={value} />
+			)}
+		</div>
+	);
+}
+
+export default RichCellEditor;

--- a/packages/datagrid/src/components/RichCellEditor/components/CellEditorDatalist.component.scss
+++ b/packages/datagrid/src/components/RichCellEditor/components/CellEditorDatalist.component.scss
@@ -1,0 +1,20 @@
+@use '~@talend/design-tokens/lib/tokens' as tokens;
+
+.cell-editor-datalist {
+	font: tokens.$coral-data-m;
+
+	[class*='Datalist__tc-datalist-item'],
+	[class*='Typeahead__tc-typeahead-container'],
+	[class*='Typeahead__typeahead-input'] {
+		height: 100%;
+	}
+
+	[class*='Typeahead__typeahead-input'] {
+		min-width: auto;
+		margin: 0;
+	}
+
+	[class*='Typeahead__items-container'] {
+		margin-top: 0;
+	}
+}

--- a/packages/datagrid/src/components/RichCellEditor/components/CellEditorDatalist.component.tsx
+++ b/packages/datagrid/src/components/RichCellEditor/components/CellEditorDatalist.component.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react';
+import debounce from 'lodash/debounce';
+
+import { Datalist } from '@talend/react-components';
+
+import { AgGridCellValue } from '../../../types';
+
+import theme from './CellEditorDatalist.component.scss';
+
+interface CellEditorDatalistPropTypes {
+	eGridCell: HTMLDivElement;
+	onFilter: (search: string) => Promise<AgGridCellValue[]>;
+	onChange: (event: React.ChangeEvent<HTMLInputElement>, value: string) => void;
+	value: string;
+}
+
+function CellDatalist(props: CellEditorDatalistPropTypes) {
+	const { value: initialValue, eGridCell, onFilter, onChange } = props;
+
+	const [value, setValue] = useState(initialValue);
+	const [isLoading, setIsLoading] = useState(false);
+	const [options, setOptions] = useState([] as AgGridCellValue[]);
+
+	const handleUserInput = (inputValue: string) => {
+		setIsLoading(true);
+
+		onFilter(inputValue)
+			.then(setOptions)
+			.finally(() => {
+				setIsLoading(false);
+			});
+	};
+	const debouncedHandleUserInput = useCallback(debounce(handleUserInput, 300), []);
+
+	return (
+		<div
+			className={theme['cell-editor-datalist']}
+			style={{ height: `${eGridCell.scrollHeight}px`, width: `${eGridCell.scrollWidth}px` }}
+		>
+			<Datalist
+				// Using autoFocus because <Datalist /> does not forward ref, so no manual focus possible
+				autoFocus // eslint-disable-line jsx-a11y/no-autofocus
+				titleMap={options}
+				isLoading={isLoading}
+				onFocus={(event: React.ChangeEvent<HTMLInputElement>) => {
+					event.preventDefault();
+					handleUserInput(event.target?.value);
+				}}
+				onLiveChange={(event: React.ChangeEvent<HTMLInputElement>, changedValue: string) => {
+					event.preventDefault();
+					setValue(changedValue);
+					debouncedHandleUserInput(changedValue);
+				}}
+				onChange={(event: React.ChangeEvent<HTMLInputElement>, state: { value: string }) => {
+					event.preventDefault();
+					setIsLoading(false);
+					onChange(event, state.value);
+				}}
+				value={value}
+			/>
+		</div>
+	);
+}
+
+export default CellDatalist;

--- a/packages/datagrid/src/components/RichCellEditor/components/CellEditorTextarea.component.scss
+++ b/packages/datagrid/src/components/RichCellEditor/components/CellEditorTextarea.component.scss
@@ -1,0 +1,8 @@
+@use '~@talend/design-tokens/lib/tokens' as tokens;
+
+textarea.cell-editor-textarea {
+	margin: 0;
+	padding: tokens.$coral-spacing-xs;
+	font: tokens.$coral-data-m;
+	outline: 0;
+}

--- a/packages/datagrid/src/components/RichCellEditor/components/CellEditorTextarea.component.tsx
+++ b/packages/datagrid/src/components/RichCellEditor/components/CellEditorTextarea.component.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useRef, useState } from 'react';
+import classNames from 'classnames';
+
+import theme from './CellEditorTextarea.component.scss';
+
+interface CellEditorTextareaPropTypes {
+	eGridCell: HTMLDivElement;
+	onChange: (event: React.ChangeEvent<HTMLTextAreaElement>, value: string) => void;
+	value: string;
+}
+
+function CellEditorTextarea({ eGridCell, value, onChange }: CellEditorTextareaPropTypes) {
+	const ref = useRef<HTMLTextAreaElement>(null);
+	const [rows, setRows] = useState(1);
+	const [styles, setStyles] = useState({
+		minHeight: `${eGridCell.scrollHeight}px`,
+		minWidth: `${eGridCell.scrollWidth}px`,
+		height: `${eGridCell.scrollHeight}px`,
+		width: `${eGridCell.scrollWidth}px`,
+	});
+
+	const resizeTextarea = () => {
+		if (ref.current) {
+			const lineHeight = parseInt(
+				window.getComputedStyle(ref.current).getPropertyValue('line-height'),
+				10,
+			);
+
+			const { scrollHeight } = ref.current;
+			setRows(scrollHeight / lineHeight);
+			setStyles({ ...styles, height: `${scrollHeight}px` });
+		}
+	};
+
+	useEffect(() => {
+		ref.current?.focus();
+		resizeTextarea();
+	}, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+	return (
+		<textarea
+			ref={ref}
+			className={classNames(theme['cell-editor-textarea'], 'form-control')}
+			rows={rows}
+			value={value}
+			style={styles}
+			onChange={(event: React.ChangeEvent<HTMLTextAreaElement>) => {
+				resizeTextarea();
+				onChange(event, event.target?.value);
+			}}
+		/>
+	);
+}
+
+export default CellEditorTextarea;

--- a/packages/datagrid/src/components/RichCellEditor/index.ts
+++ b/packages/datagrid/src/components/RichCellEditor/index.ts
@@ -1,0 +1,1 @@
+export { default } from './RichCellEditor.component';

--- a/packages/datagrid/src/components/datagrid.component.stories.js
+++ b/packages/datagrid/src/components/datagrid.component.stories.js
@@ -3,13 +3,14 @@
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
 
-import DataGrid from '.';
+import DataGrid, { PlaygroundCellEditor } from '.';
 import DynamicDataGrid from '../../stories/DynamicDataGrid.component';
 import FasterDatagridComponent from '../../stories/FasterDatagrid.component';
 import sample from '../../stories/sample.json';
 import sample2 from '../../stories/sample2.json';
 import sample3 from '../../stories/sample3.json';
 import sampleWithoutQuality from '../../stories/sampleWithoutQuality.json';
+import { getColumnDefs } from './DatasetSerializer/datasetSerializer';
 
 // eslint-disable-next-line no-irregular-whitespace
 sample.data[0].value.field0.value = `﻿﻿﻿﻿﻿﻿﻿  loreum lo
@@ -30,16 +31,16 @@ export default {
 	],
 };
 
-export const Default = () => (
-	<DataGrid
-		data={sample}
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
-		enableColResize={false}
-	/>
-);
+const defaultGridProps = {
+	data: sample,
+	onFocusedCell: action('onFocusedCell'),
+	onFocusedColumn: action('onFocusedColumn'),
+	onVerticalScroll: event => console.log(event),
+	rowSelection: 'multiple',
+};
+
+export const Default = () => <DataGrid {...defaultGridProps} enableColResize={false} />;
+
 Default.parameters = {
 	chromatic: { disableSnapshot: false },
 };
@@ -67,59 +68,29 @@ WithSelection.parameters = {
 
 export const OnlyColumnName = () => (
 	<DataGrid
+		{...defaultGridProps}
+		data={sampleWithoutQuality}
 		headerHeight={45}
 		columnsConf={{ hideSubType: true }}
-		data={sampleWithoutQuality}
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
 		enableColResize={false}
 	/>
 );
 
 export const NoQuality = () => (
 	<DataGrid
-		headerHeight={55}
+		{...defaultGridProps}
 		data={sampleWithoutQuality}
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
+		headerHeight={55}
 		enableColResize={false}
 	/>
 );
 
-export const ColumnsResizables = () => (
-	<DataGrid
-		data={sample}
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
-	/>
-);
+export const ColumnsResizables = () => <DataGrid {...defaultGridProps} />; // Same as default 🤔
 
-export const StartIndexTo1 = () => (
-	<DataGrid
-		data={sample}
-		startIndex={1}
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
-	/>
-);
+export const StartIndexTo1 = () => <DataGrid {...defaultGridProps} startIndex={1} />;
 
 export const NoRowSpecificMessage = () => (
-	<DataGrid
-		data={[]}
-		overlayNoRowsTemplate="Custom message"
-		onFocusedCell={action('onFocusedCell')}
-		onFocusedColumn={action('onFocusedColumn')}
-		onVerticalScroll={event => console.log(event)}
-		rowSelection="multiple"
-	/>
+	<DataGrid {...defaultGridProps} data={[]} overlayNoRowsTemplate="Custom message" />
 );
 
 export const LoadingDatagrid = () => <DataGrid data={sample} loading />;
@@ -147,13 +118,7 @@ export const DynamicChangeSchema = () => {
 					<input type="button" value="changestatus" onClick={this.changeState} />
 					Number of fields : {currentSample.schema.fields.length}
 					<div style={{ height: '200px' }}>
-						<DataGrid
-							data={currentSample}
-							onFocusedCell={action('onFocusedCell')}
-							onFocusedColumn={action('onFocusedColumn')}
-							onVerticalScroll={event => console.log(event)}
-							rowSelection="multiple"
-						/>
+						<DataGrid {...defaultGridProps} data={currentSample} />
 					</div>
 				</div>
 			);
@@ -184,7 +149,7 @@ export const ControlledFocusedColumn = () => {
 			<input type="button" value="Unselect" onClick={() => setFocusedColumnId(null)} />
 			<input type="button" value={locked ? 'Unlock' : 'Lock'} onClick={() => setLocked(!locked)} />
 			<DataGrid
-				data={sample}
+				{...defaultGridProps}
 				focusedColumnId={focusedColumnId}
 				onFocusedCell={cell => {
 					if (!locked) {
@@ -199,9 +164,68 @@ export const ControlledFocusedColumn = () => {
 					}
 					action('onFocusedColumn')(col);
 				}}
-				onVerticalScroll={event => console.log(event)}
-				rowSelection="multiple"
 			/>
 		</div>
+	);
+};
+
+export const EditablePlaygroundCell = () => {
+	const sleep = () => new Promise(resolve => setTimeout(resolve, 1000));
+	// const sleep = () => new Promise(() => {});
+	const semanticTypeFields = [
+		'Nom de la gare',
+		'Code postal',
+		"volume total d'usagers 2014 (voyageurs+ non voyageurs)",
+	];
+	const searchSampleValues = (search, avroName) => {
+		return sample.data
+			.reduce((values, row) => {
+				const { value } = row.value[avroName];
+				return value &&
+					value.toLowerCase().includes(search.toLowerCase()) &&
+					!values.includes(value)
+					? [...values, value]
+					: values;
+			}, [])
+			.sort((a, b) => {
+				if (a?.startsWith(search) ^ b?.startsWith(search)) {
+					if (a?.startsWith(search)) {
+						return -1;
+					}
+					if (b?.startsWith(search)) {
+						return -1;
+					}
+				}
+
+				return a?.localeCompare(b);
+			});
+	};
+
+	return (
+		<DataGrid
+			{...defaultGridProps}
+			editable
+			getColumnDefsFn={(...args) =>
+				getColumnDefs(...args).map(column => ({
+					...column,
+					domain: column.headerName,
+					editable: true,
+					cellEditor: PlaygroundCellEditor,
+					cellEditorParams: {
+						getSemanticType: async semanticType => {
+							await sleep();
+							const type = semanticTypeFields.includes(semanticType) ? 'DICT' : 'NOT DICT';
+							return { type };
+						},
+						getSemanticTypeSuggestions: async (_, search) => {
+							await sleep();
+							return searchSampleValues(search, column.avro.name);
+						},
+						onSubmit: action('onSubmit'),
+					},
+					cellEditorPopup: true,
+				}))
+			}
+		/>
 	);
 };

--- a/packages/datagrid/src/components/index.ts
+++ b/packages/datagrid/src/components/index.ts
@@ -1,6 +1,7 @@
 import DataGrid from './DataGrid/DataGrid.component';
 import DatasetSerializer from './DatasetSerializer';
 import * as DefaultCellRenderer from './DefaultCellRenderer';
+import PlaygroundCellEditor from './PlaygroundCellEditor';
 
-export { DataGrid, DatasetSerializer, DefaultCellRenderer };
+export { DataGrid, DatasetSerializer, DefaultCellRenderer, PlaygroundCellEditor };
 export default DataGrid;

--- a/packages/datagrid/src/types/index.ts
+++ b/packages/datagrid/src/types/index.ts
@@ -10,3 +10,21 @@ export interface Quality {
 	[QUALITY_EMPTY_KEY]: QualityEntry;
 	[QUALITY_VALID_KEY]: QualityEntry;
 }
+
+export interface AgGridCellValue {
+	name: string;
+	value: string;
+}
+
+export interface AgCellEditorRendererPropTypes {
+	colDef: {
+		cellEditorParams?: Record<string, any>;
+		cellEditorPopup?: boolean;
+		domain: string;
+	};
+	eGridCell: HTMLDivElement;
+	stopEditing: (variable?: boolean) => void;
+	value: {
+		value: string;
+	};
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,6 +3460,21 @@
   resolved "https://registry.yarnpkg.com/@talend/daikon-tql-client/-/daikon-tql-client-1.3.1.tgz#75a764ec14b06355af3924f3b2d65ff8e61db4f0"
   integrity sha512-trwueNzgISaN2jSNBxuiHw76jWX2G/vtSrCtlTaoeS3NzsCIVUlGryqKZnuBLfZWJyVWeImx9xm34mBOHITMIQ==
 
+"@talend/design-system@^2.7.0":
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/@talend/design-system/-/design-system-2.8.0.tgz#d41df96d3963a76231f141fb239b402007bbd6e1"
+  integrity sha512-g6ALaXJDWAIr84uPYrbl87UuuqhlSRFK1yG0HOOCusnWjtDE4UhH8m02+lk8AIT5CAwHmjVyKL6H15LeaDdsLw==
+  dependencies:
+    "@talend/assets-api" "^1.2.1"
+    "@talend/design-tokens" "^2.4.0"
+    classnames "^2.3.1"
+    modern-css-reset "^1.4.0"
+    polished "^4.2.2"
+    react-use "^17.3.2"
+    reakit "^1.3.11"
+    typeface-inconsolata "^1.1.13"
+    typeface-source-sans-pro "^1.1.13"
+
 "@talend/locales-design-system@^1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@talend/locales-design-system/-/locales-design-system-1.12.2.tgz#ed4f5412f052479c920f6baf6995cd4d84db7eb4"
@@ -10444,6 +10459,20 @@ focus-outline-manager@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/focus-outline-manager/-/focus-outline-manager-1.0.2.tgz#7bf3658865341fb6b08d042a037b9d2868b119b5"
   integrity sha512-bHWEmjLsTjGP9gVs7P3Hyl+oY5NlMW8aTSPdTJ+X2GKt6glDctt9fUCLbRV+d/l8NDC40+FxMjp9WlTQXaQALw==
+
+focus-trap-react@^8.11.1:
+  version "8.11.1"
+  resolved "https://registry.yarnpkg.com/focus-trap-react/-/focus-trap-react-8.11.1.tgz#dabda599f6834b8f55368494525167fa0128007c"
+  integrity sha512-ZFElB120Ntdxnq0aSWnzQqQ5QY1XUt8T1yuud/BIYAriMTWvyQghsk558ASSSV0iflaUgFQNRjKq3IEFEjGQGA==
+  dependencies:
+    focus-trap "^6.9.1"
+
+focus-trap@^6.9.1:
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-6.9.2.tgz#a9ef72847869bd2cbf62cb930aaf8e138fef1ca9"
+  integrity sha512-gBEuXOPNOKPrLdZpMFUSTyIo1eT2NSZRrwZ9r/0Jqw5tmT3Yvxfmu8KBHw8xW2XQkw6E/JoG+OlEq7UDtSUNgw==
+  dependencies:
+    tabbable "^5.3.2"
 
 follow-redirects@^1.0.0, follow-redirects@^1.14.0:
   version "1.15.1"
@@ -17661,7 +17690,7 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@^17.4.0:
+react-use@^17.3.2, react-use@^17.4.0:
   version "17.4.0"
   resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.4.0.tgz#cefef258b0a6c534a5c8021c2528ac6e1a4cdc6d"
   integrity sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==
@@ -20228,6 +20257,11 @@ synckit@^0.4.1:
   dependencies:
     tslib "^2.3.1"
     uuid "^8.3.2"
+
+tabbable@^5.3.2:
+  version "5.3.2"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.2.tgz#66d6119ee8a533634c3f17deb0caa1c379e36ac7"
+  integrity sha512-6G/8EWRFx8CiSe2++/xHhXkmCRq2rHtDtZbQFHx34cvDfZzIBfvwG9zGUNTWMXWLCYvDj3aQqOzdl3oCxKuBkQ==
 
 table@^6.0.9, table@^6.6.0:
   version "6.8.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3460,21 +3460,6 @@
   resolved "https://registry.yarnpkg.com/@talend/daikon-tql-client/-/daikon-tql-client-1.3.1.tgz#75a764ec14b06355af3924f3b2d65ff8e61db4f0"
   integrity sha512-trwueNzgISaN2jSNBxuiHw76jWX2G/vtSrCtlTaoeS3NzsCIVUlGryqKZnuBLfZWJyVWeImx9xm34mBOHITMIQ==
 
-"@talend/design-system@^2.7.0":
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/@talend/design-system/-/design-system-2.8.0.tgz#d41df96d3963a76231f141fb239b402007bbd6e1"
-  integrity sha512-g6ALaXJDWAIr84uPYrbl87UuuqhlSRFK1yG0HOOCusnWjtDE4UhH8m02+lk8AIT5CAwHmjVyKL6H15LeaDdsLw==
-  dependencies:
-    "@talend/assets-api" "^1.2.1"
-    "@talend/design-tokens" "^2.4.0"
-    classnames "^2.3.1"
-    modern-css-reset "^1.4.0"
-    polished "^4.2.2"
-    react-use "^17.3.2"
-    reakit "^1.3.11"
-    typeface-inconsolata "^1.1.13"
-    typeface-source-sans-pro "^1.1.13"
-
 "@talend/locales-design-system@^1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@talend/locales-design-system/-/locales-design-system-1.12.2.tgz#ed4f5412f052479c920f6baf6995cd4d84db7eb4"
@@ -17690,7 +17675,7 @@ react-universal-interface@^0.6.2:
   resolved "https://registry.yarnpkg.com/react-universal-interface/-/react-universal-interface-0.6.2.tgz#5e8d438a01729a4dbbcbeeceb0b86be146fe2b3b"
   integrity sha512-dg8yXdcQmvgR13RIlZbTRQOoUrDciFVoSBZILwjE2LFISxZZ8loVJKAkuzswl5js8BHda79bIb2b84ehU8IjXw==
 
-react-use@^17.3.2, react-use@^17.4.0:
+react-use@^17.4.0:
   version "17.4.0"
   resolved "https://registry.yarnpkg.com/react-use/-/react-use-17.4.0.tgz#cefef258b0a6c534a5c8021c2528ac6e1a4cdc6d"
   integrity sha512-TgbNTCA33Wl7xzIJegn1HndB4qTS9u03QUwyNycUnXaweZkE4Kq2SB+Yoxx8qbshkZGYBDvUXbXWRUmQDcZZ/Q==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Custom cell editor is not shared between projects.

**What is the chosen solution to this problem?**
Expose it here.
- `PlaygroundCellEditor` is the editor specific to the playground (it requires methods to fetch semantic types as editor parameters)
- It relies on `RichCellEditor` which allows to dynamically switch between an inline textarea editor and an editor with a dropdown (Datalist)

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
