### PR TITLE
fix(components): datalist blur persist value when one is selected

### DIFF
--- a/.changeset/quiet-radios-clap.md
+++ b/.changeset/quiet-radios-clap.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Datalist : Blur should persist value only if the filter value is different from the selected one

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -112,7 +112,7 @@ function getEntry(titleMap, nameOrValue, restricted) {
 function Datalist(props) {
 	// Current persisted value
 	// In case of simple values, this is a string
-	// In case of titleMap, it's an object { name: "display value", value: "technical value" }
+	// In case of titleMap, it's the object value key { name: "display value", value: "technical value" }
 	const [value, setValue] = useState();
 
 	// suggestions: filter value, display flag, current hover selection
@@ -225,11 +225,17 @@ function Datalist(props) {
 	 */
 	function persistValue(event) {
 		hideSuggestions();
-		const entry = getEntryFromName(props.titleMap, filterValue, props.restricted);
-		if (entry && entry.value !== value) {
-			updateValue(event, entry, true);
-		} else {
-			resetFilter();
+		const selectedEntry = getEntryFromValue(props.titleMap, value, props.restricted);
+
+		// If the filterValue is different from the selected entry
+		if (!selectedEntry || selectedEntry.name !== filterValue) {
+			const entry = getEntryFromName(props.titleMap, filterValue, props.restricted);
+
+			if (entry && entry.value !== value) {
+				updateValue(event, entry, true);
+			} else {
+				resetFilter();
+			}
 		}
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we have a titlemap in a datalist with multiple items with the same name, we select the 2nd duplicate item in the list.
But when onBlur is triggered, we call `updateValue` again with the value from `getEntryFromValue` which will select the first item in the list of duplicates.

**What is the chosen solution to this problem?**
If an item is selected and has the same name as the filter value , we don't need to call `updateValue` again, it's already selected.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
