### PR TITLE
fix(ARCH-515/cdn): use findPackage instead of require.resolve

### DIFF
--- a/.changeset/short-chefs-drive.md
+++ b/.changeset/short-chefs-drive.md
@@ -1,0 +1,5 @@
+---
+'@talend/dynamic-cdn-webpack-plugin': patch
+---
+
+use findPackage to ensure the version during dependency resolution from manifest

--- a/.changeset/short-chefs-drive.md
+++ b/.changeset/short-chefs-drive.md
@@ -2,4 +2,4 @@
 '@talend/dynamic-cdn-webpack-plugin': patch
 ---
 
-use findPackage to ensure the version during dependency resolution from manifest
+use findPackage to ensure the version is compatible during dependency resolution from manifest

--- a/fork/dynamic-cdn-webpack-plugin/src/find.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.js
@@ -13,7 +13,8 @@ function findPackage(info) {
 		const {
 			packageJson: { version },
 		} = readPkgUp.sync({ cwd });
-		return semver.major(version) === semver.major(info.version);
+		// check we are at least upper or equal using caret range syntax
+		return semver.satisfies(`^${info.version}`, version);
 	});
 }
 

--- a/fork/dynamic-cdn-webpack-plugin/src/find.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.js
@@ -10,10 +10,9 @@ function findPackage(info) {
 		[scope, name] = info.name.split('/');
 	}
 	return findPackages(scope, name).find(cwd => {
-		const pkg = readPkgUp.sync({ cwd });
 		const {
 			packageJson: { version },
-		} = pkg;
+		} = readPkgUp.sync({ cwd });
 		// check we are at least upper or equal using caret range syntax
 		return semver.satisfies(version, `^${info.version}`);
 	});

--- a/fork/dynamic-cdn-webpack-plugin/src/find.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.js
@@ -10,11 +10,12 @@ function findPackage(info) {
 		[scope, name] = info.name.split('/');
 	}
 	return findPackages(scope, name).find(cwd => {
+		const pkg = readPkgUp.sync({ cwd });
 		const {
 			packageJson: { version },
-		} = readPkgUp.sync({ cwd });
+		} = pkg;
 		// check we are at least upper or equal using caret range syntax
-		return semver.satisfies(`^${info.version}`, version);
+		return semver.satisfies(version, `^${info.version}`);
 	});
 }
 

--- a/fork/dynamic-cdn-webpack-plugin/src/find.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.js
@@ -1,7 +1,7 @@
-/* eslint-disable @typescript-eslint/no-use-before-define */
 const fs = require('fs');
 const path = require('path');
 const readPkgUp = require('read-pkg-up');
+const semver = require('semver');
 
 function findPackage(info) {
 	let name = info.name;
@@ -13,7 +13,7 @@ function findPackage(info) {
 		const {
 			packageJson: { version },
 		} = readPkgUp.sync({ cwd });
-		return version === info.version;
+		return semver.major(version) === semver.major(info.version);
 	});
 }
 

--- a/fork/dynamic-cdn-webpack-plugin/src/find.test.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.test.js
@@ -1,52 +1,79 @@
 /* eslint-disable global-require */
 /* eslint-disable no-underscore-dangle */
-const { findPackages } = require('./find');
-
+const path = require('path');
+const { findPackages, findPackage } = require('./find');
 jest.mock('fs');
+const MOCK_FILE_INFO = {
+	'/node_modules/classnames/index.js': 'console.log("classnames");',
+	'/node_modules/react/index.js': 'console.log("react");',
+	'/node_modules/react/package.json': '{"name": "react", "version": "16.14.0"}',
+	'/node_modules/@types/classnames/index.js': 'console.log("@types/classnames");',
+	'/node_modules/@talend/react-components/index.js': 'console.log("@talend/react-components");',
+	'/node_modules/@talend/react-components/node_modules/react/index.js': 'console.log("react");',
+	'/node_modules/@talend/react-containers/index.js': 'console.log("@talend/react-containers");',
+};
+jest.mock('read-pkg-up', () => ({
+	sync: () => {
+		return {
+			packageJson: { name: 'react', version: '16.14.0' },
+		};
+	},
+}));
 
-describe('findPackages', () => {
-	const MOCK_FILE_INFO = {
-		'/node_modules/classnames/index.js': 'console.log("classnames");',
-		'/node_modules/react/index.js': 'console.log("react");',
-		'/node_modules/@types/classnames/index.js': 'console.log("@types/classnames");',
-		'/node_modules/@talend/react-components/index.js':
-			'console.log("@talend/react-components");',
-		'/node_modules/@talend/react-components/node_modules/react/index.js':
-			'console.log("react");',
-		'/node_modules/@talend/react-containers/index.js':
-			'console.log("@talend/react-containers");',
-	};
+describe('find', () => {
+	describe('findPackages', () => {
+		beforeEach(() => {
+			// Set up some mocked out file info before each test
+			require('fs').__setMockFiles(MOCK_FILE_INFO);
+		});
+		afterEach(() => {
+			jest.resetAllMocks();
+		});
+		test('should find root and nested package', () => {
+			// when
+			const result = findPackages(undefined, 'react');
 
-	beforeEach(() => {
-		// Set up some mocked out file info before each test
-		require('fs').__setMockFiles(MOCK_FILE_INFO);
+			// then
+			expect(result.length).toBe(2);
+			expect(result[0]).toBe('/node_modules/react');
+			expect(result[1]).toBe('/node_modules/@talend/react-components/node_modules/react');
+		});
+
+		test('should find non scoped package', () => {
+			// when
+			const result = findPackages('', 'classnames');
+
+			// then
+			expect(result.length).toBe(1);
+			expect(result[0]).toBe('/node_modules/classnames');
+		});
+
+		test('should find scoped package', () => {
+			// when
+			const result = findPackages('@types', 'classnames');
+
+			// then
+			expect(result.length).toBe(1);
+			expect(result[0]).toBe('/node_modules/@types/classnames');
+		});
 	});
 
-	test('should find root and nested package', () => {
-		// when
-		const result = findPackages('', 'react');
-
-		// then
-		expect(result.length).toBe(2);
-		expect(result[0]).toBe('/node_modules/react');
-		expect(result[1]).toBe('/node_modules/@talend/react-components/node_modules/react');
-	});
-
-	test('should find non scoped package', () => {
-		// when
-		const result = findPackages('', 'classnames');
-
-		// then
-		expect(result.length).toBe(1);
-		expect(result[0]).toBe('/node_modules/classnames');
-	});
-
-	test('should find scoped package', () => {
-		// when
-		const result = findPackages('@types', 'classnames');
-
-		// then
-		expect(result.length).toBe(1);
-		expect(result[0]).toBe('/node_modules/@types/classnames');
+	describe('findPackage', () => {
+		test('should find package name only', () => {
+			const result = findPackage({ name: 'react', version: '16.14.0' });
+			expect(result).toBe('/node_modules/react');
+		});
+		test('should find package from cdnConfig object if present version is higher', () => {
+			const results = findPackage({ name: 'react', version: '16.13.0' });
+			expect(results).toBe('/node_modules/react');
+		});
+		test('should not find package from cdnConfig object if version is lower', () => {
+			const results = findPackage({ name: 'react', version: '16.15.0' });
+			expect(results).toBeUndefined();
+		});
+		test('should not find package from cdnConfig object if version is next major', () => {
+			const results = findPackage({ name: 'react', version: '17.0.0' });
+			expect(results).toBeUndefined();
+		});
 	});
 });

--- a/fork/dynamic-cdn-webpack-plugin/src/find.test.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.test.js
@@ -75,5 +75,9 @@ describe('find', () => {
 			const results = findPackage({ name: 'react', version: '17.0.0' });
 			expect(results).toBeUndefined();
 		});
+		test('should not find package from cdnConfig object if version is previous major', () => {
+			const results = findPackage({ name: 'react', version: '15.0.0' });
+			expect(results).toBeUndefined();
+		});
 	});
 });

--- a/fork/dynamic-cdn-webpack-plugin/src/find.test.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/find.test.js
@@ -1,17 +1,8 @@
 /* eslint-disable global-require */
 /* eslint-disable no-underscore-dangle */
-const path = require('path');
 const { findPackages, findPackage } = require('./find');
+
 jest.mock('fs');
-const MOCK_FILE_INFO = {
-	'/node_modules/classnames/index.js': 'console.log("classnames");',
-	'/node_modules/react/index.js': 'console.log("react");',
-	'/node_modules/react/package.json': '{"name": "react", "version": "16.14.0"}',
-	'/node_modules/@types/classnames/index.js': 'console.log("@types/classnames");',
-	'/node_modules/@talend/react-components/index.js': 'console.log("@talend/react-components");',
-	'/node_modules/@talend/react-components/node_modules/react/index.js': 'console.log("react");',
-	'/node_modules/@talend/react-containers/index.js': 'console.log("@talend/react-containers");',
-};
 jest.mock('read-pkg-up', () => ({
 	sync: () => {
 		return {
@@ -20,64 +11,73 @@ jest.mock('read-pkg-up', () => ({
 	},
 }));
 
-describe('find', () => {
-	describe('findPackages', () => {
-		beforeEach(() => {
-			// Set up some mocked out file info before each test
-			require('fs').__setMockFiles(MOCK_FILE_INFO);
-		});
-		afterEach(() => {
-			jest.resetAllMocks();
-		});
-		test('should find root and nested package', () => {
-			// when
-			const result = findPackages(undefined, 'react');
+describe('findPackages', () => {
+	const MOCK_FILE_INFO = {
+		'/node_modules/classnames/index.js': 'console.log("classnames");',
+		'/node_modules/react/index.js': 'console.log("react");',
+		'/node_modules/react/package.json': '{"name": "react", "version": "16.14.0"}',
+		'/node_modules/@types/classnames/index.js': 'console.log("@types/classnames");',
+		'/node_modules/@talend/react-components/index.js':
+			'console.log("@talend/react-components");',
+		'/node_modules/@talend/react-components/node_modules/react/index.js':
+			'console.log("react");',
+		'/node_modules/@talend/react-containers/index.js':
+			'console.log("@talend/react-containers");',
+	};
 
-			// then
-			expect(result.length).toBe(2);
-			expect(result[0]).toBe('/node_modules/react');
-			expect(result[1]).toBe('/node_modules/@talend/react-components/node_modules/react');
-		});
-
-		test('should find non scoped package', () => {
-			// when
-			const result = findPackages('', 'classnames');
-
-			// then
-			expect(result.length).toBe(1);
-			expect(result[0]).toBe('/node_modules/classnames');
-		});
-
-		test('should find scoped package', () => {
-			// when
-			const result = findPackages('@types', 'classnames');
-
-			// then
-			expect(result.length).toBe(1);
-			expect(result[0]).toBe('/node_modules/@types/classnames');
-		});
+	beforeEach(() => {
+		// Set up some mocked out file info before each test
+		require('fs').__setMockFiles(MOCK_FILE_INFO);
 	});
 
-	describe('findPackage', () => {
-		test('should find package name only', () => {
-			const result = findPackage({ name: 'react', version: '16.14.0' });
-			expect(result).toBe('/node_modules/react');
-		});
-		test('should find package from cdnConfig object if present version is higher', () => {
-			const results = findPackage({ name: 'react', version: '16.13.0' });
-			expect(results).toBe('/node_modules/react');
-		});
-		test('should not find package from cdnConfig object if version is lower', () => {
-			const results = findPackage({ name: 'react', version: '16.15.0' });
-			expect(results).toBeUndefined();
-		});
-		test('should not find package from cdnConfig object if version is next major', () => {
-			const results = findPackage({ name: 'react', version: '17.0.0' });
-			expect(results).toBeUndefined();
-		});
-		test('should not find package from cdnConfig object if version is previous major', () => {
-			const results = findPackage({ name: 'react', version: '15.0.0' });
-			expect(results).toBeUndefined();
-		});
+	test('should find root and nested package', () => {
+		// when
+		const result = findPackages(undefined, 'react');
+
+		// then
+		expect(result.length).toBe(2);
+		expect(result[0]).toBe('/node_modules/react');
+		expect(result[1]).toBe('/node_modules/@talend/react-components/node_modules/react');
+	});
+
+	test('should find non scoped package', () => {
+		// when
+		const result = findPackages('', 'classnames');
+
+		// then
+		expect(result.length).toBe(1);
+		expect(result[0]).toBe('/node_modules/classnames');
+	});
+
+	test('should find scoped package', () => {
+		// when
+		const result = findPackages('@types', 'classnames');
+
+		// then
+		expect(result.length).toBe(1);
+		expect(result[0]).toBe('/node_modules/@types/classnames');
+	});
+});
+
+describe('findPackage', () => {
+	test('should find package name only', () => {
+		const result = findPackage({ name: 'react', version: '16.14.0' });
+		expect(result).toBe('/node_modules/react');
+	});
+	test('should find package from cdnConfig object if present version is higher', () => {
+		const results = findPackage({ name: 'react', version: '16.13.0' });
+		expect(results).toBe('/node_modules/react');
+	});
+	test('should not find package from cdnConfig object if version is lower', () => {
+		const results = findPackage({ name: 'react', version: '16.15.0' });
+		expect(results).toBeUndefined();
+	});
+	test('should not find package from cdnConfig object if version is next major', () => {
+		const results = findPackage({ name: 'react', version: '17.0.0' });
+		expect(results).toBeUndefined();
+	});
+	test('should not find package from cdnConfig object if version is previous major', () => {
+		const results = findPackage({ name: 'react', version: '15.0.0' });
+		expect(results).toBeUndefined();
 	});
 });

--- a/fork/dynamic-cdn-webpack-plugin/src/index.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/index.js
@@ -8,7 +8,6 @@
 /* eslint-disable global-require */
 /* eslint-disable no-restricted-syntax */
 
-const semver = require('semver');
 const readPkgUp = require('read-pkg-up');
 const ExternalModule = require('webpack/lib/ExternalModule');
 const RawSource = require('webpack-sources').RawSource;
@@ -237,11 +236,6 @@ class DynamicCdnWebpackPlugin {
 			}
 			const pkg = readPkgUp.sync({ cwd });
 			const installedVersion = pkg.packageJson.version;
-			if (semver.major(installedVersion) !== semver.major(cdnConfig.version)) {
-				throw new Error(
-					`not compatible version of ${cdnConfig.name}, based on ${cdnConfig.version} installed ${installeVersion}`,
-				);
-			}
 			cdnConfig.version = installedVersion;
 			cdnConfig.local = path.resolve(
 				pkg.path,

--- a/fork/dynamic-cdn-webpack-plugin/src/index.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/index.js
@@ -8,6 +8,7 @@
 /* eslint-disable global-require */
 /* eslint-disable no-restricted-syntax */
 
+const semver = require('semver');
 const readPkgUp = require('read-pkg-up');
 const ExternalModule = require('webpack/lib/ExternalModule');
 const RawSource = require('webpack-sources').RawSource;
@@ -223,7 +224,9 @@ class DynamicCdnWebpackPlugin {
 	addDependencies(contextPath, manifest, { env, requester }) {
 		for (const dependencyName of Object.keys(manifest)) {
 			const cdnConfig = manifest[dependencyName];
-			const cwd = resolvePkg(cdnConfig.name, { cwd: contextPath });
+			const cwd = resolvePkg(cdnConfig.name, {
+				version: cdnConfig.version,
+			});
 			if (!cwd) {
 				this.error(
 					'\n❌',
@@ -234,6 +237,11 @@ class DynamicCdnWebpackPlugin {
 			}
 			const pkg = readPkgUp.sync({ cwd });
 			const installedVersion = pkg.packageJson.version;
+			if (semver.major(installedVersion) !== semver.major(cdnConfig.version)) {
+				throw new Error(
+					`not compatible version of ${cdnConfig.name}, based on ${cdnConfig.version} installed ${installeVersion}`,
+				);
+			}
 			cdnConfig.version = installedVersion;
 			cdnConfig.local = path.resolve(
 				pkg.path,

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -9,10 +9,6 @@ const { findPackage } = require('./find');
  */
 function resolve(moduleId, options) {
 	if (options.version) {
-		let scope;
-		if (moduleId.startsWith('@')) {
-			scope = moduleId.split('/')[0];
-		}
 		return findPackage({ name: moduleId, version: options.version });
 	}
 	let paths = require.resolve.paths(moduleId) || [];

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -13,7 +13,7 @@ function resolve(moduleId, options) {
 		if (moduleId.startsWith('@')) {
 			scope = moduleId.split('/')[0];
 		}
-		const found = findPackage({ name: moduleId, version: options.version });
+		return findPackage({ name: moduleId, version: options.version });
 	}
 	let paths = require.resolve.paths(moduleId) || [];
 

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -1,4 +1,4 @@
-const { findPackages } = require('./find');
+const { findPackage } = require('./find');
 
 /* eslint-disable no-empty */
 /**

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -1,3 +1,5 @@
+const { findPackages } = require('./find');
+
 /* eslint-disable no-empty */
 /**
  *
@@ -6,6 +8,13 @@
  * @returns {string|undefined} the full path of the module id requested
  */
 function resolve(moduleId, options) {
+	if (options.version) {
+		let scope;
+		if (moduleId.startsWith('@')) {
+			scope = moduleId.split('/')[0];
+		}
+		const found = findPackage({ name: moduleId, version: options.version });
+	}
 	let paths = require.resolve.paths(moduleId) || [];
 
 	if (options && options.cwd) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

in the case you have storybook and react-cmf-router yarn may install you the history into different possible context.

require.resolve(history) will return you the one closest to the provided webpack context.

```
const resolvePkg = require('@talend/dynamic-cdn-webpack-plugin/src/resolve-pkg');
resolvePkg('history', {cwd: './node_modules/@talend/react-cmf-router'})
// '/Users/jmfrancois/github/talend/data-processing-pipeline-designer/webapp/node_modules/history/main.js'
```

but that is history 5 !! and not history 3 (so the one for storybook).
so we ends with 404 on the cdn request.

**What is the chosen solution to this problem?**

* add check on semver.major from the dependencies.json and throw exception if it do not match
* use findPackage on this particular part to be sure we get the right version here
* ensure compatibility with the rest of the code

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
