### PR TITLE
fix(datagrid) int cell doesn't display text align right

### DIFF
--- a/.changeset/small-tables-roll.md
+++ b/.changeset/small-tables-roll.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+int cell doesn't display text align right

--- a/packages/datagrid/src/components/DefaultIntCellRenderer/DefaultIntCell.scss
+++ b/packages/datagrid/src/components/DefaultIntCellRenderer/DefaultIntCell.scss
@@ -1,3 +1,4 @@
 .td-cell-int {
+	flex: 1;
 	text-align: right;
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Int cell renderer doesn't display text align right

**What is the chosen solution to this problem?**
Update Int cell renderer style

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
