### PR TITLE
feat(codemod): react-boostrap to @talend/react-bootstrap

### DIFF
--- a/tools/codemods/rb-to-talend-rb/README.md
+++ b/tools/codemods/rb-to-talend-rb/README.md
@@ -1,0 +1,25 @@
+# React-bootstrap to @talend/react-bootstrap
+
+```bash
+jscodeshift -t ./index.js TARGET_PATH
+```
+
+This script transform react-bootstrap imports
+
+```javascript
+import React from 'react';
+import ReactBootstrap from 'react-bootstrap';
+import { Modal } from 'react-bootstrap';
+
+const Button = props => <button {...props} />;
+```
+
+into
+
+```javascript
+import React from 'react';
+import ReactBootstrap from '@talend/react-bootstrap';
+import { Modal } from '@talend/react-bootstrap';
+
+const Button = props => <button {...props} />;
+```

--- a/tools/codemods/rb-to-talend-rb/README.md
+++ b/tools/codemods/rb-to-talend-rb/README.md
@@ -1,7 +1,7 @@
 # React-bootstrap to @talend/react-bootstrap
 
 ```bash
-jscodeshift -t ./index.js TARGET_PATH
+find -E TARGET_PATH -regex '.*\.(jsx?|tsx?)' | xargs npx jscodeshift -t ./index.js
 ```
 
 This script transform react-bootstrap imports

--- a/tools/codemods/rb-to-talend-rb/index.js
+++ b/tools/codemods/rb-to-talend-rb/index.js
@@ -1,0 +1,14 @@
+export default function transformer(file, { jscodeshift: j }, options) {
+	const source = j(file.source);
+
+	source
+		.find(j.ImportDeclaration) // Find all nodes that match a type of `ImportDeclaration`
+		.filter(path => path.node.source.value === 'react-bootstrap') // Filter imports "react-bootstrap"
+		.forEach(p => {
+			j(p).replaceWith(
+				j.importDeclaration(p.value.specifiers, j.literal('@talend/react-bootstrap')),
+			);
+		});
+
+	return source.toSource();
+}

--- a/tools/codemods/rb-to-talend-rb/index.js
+++ b/tools/codemods/rb-to-talend-rb/index.js
@@ -1,3 +1,5 @@
+export const parser = 'tsx';
+
 export default function transformer(file, { jscodeshift: j }, options) {
 	const source = j(file.source);
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This goes with the fork of react-bootstrap to make v0.33 compatible with react 18.
This codemod replaces imports from `react-bootstrap` to `@talend/react-bootstrap`

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
