### PR TITLE
chore(datagrid): Cleanup internal renderer API

### DIFF
--- a/.changeset/plenty-cobras-fix.md
+++ b/.changeset/plenty-cobras-fix.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Cleanup internal renderer API: remove usage of `frameworkComponents` to stick to ag-grid API & documentation

--- a/packages/datagrid/src/components/DataGrid/DataGrid.component.js
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.component.js
@@ -6,9 +6,9 @@ import { AgGridReact } from 'ag-grid-react';
 import 'ag-grid-community/dist/styles/ag-grid.css';
 
 import { Icon } from '@talend/design-system';
-import DefaultHeaderRenderer, { HEADER_RENDERER_COMPONENT } from '../DefaultHeaderRenderer';
-import DefaultCellRenderer, { CELL_RENDERER_COMPONENT } from '../DefaultCellRenderer';
-import DefaultPinHeaderRenderer, { PIN_HEADER_RENDERER_COMPONENT } from '../PinHeaderRenderer';
+import DefaultHeaderRenderer from '../DefaultHeaderRenderer';
+import DefaultCellRenderer from '../DefaultCellRenderer';
+import DefaultPinHeaderRenderer from '../PinHeaderRenderer';
 import DefaultIntCellRenderer from '../DefaultIntCellRenderer';
 import DefaultRenderer from '../DefaultCellRenderer/DefaultRenderer.component';
 
@@ -234,12 +234,21 @@ export default class DataGrid extends React.Component {
 				minWidth: this.props.columnMinWidth,
 				valueGetter: this.props.getCellValueFn,
 				width: CELL_WIDTH,
+				[AG_GRID.CUSTOM_HEADER_KEY]: DefaultPinHeaderRenderer,
 				...pinnedColumnDef,
-				[AG_GRID.CUSTOM_HEADER_KEY]: PIN_HEADER_RENDERER_COMPONENT,
 			}));
 		}
 
 		if (columnDefs) {
+			const cellRenderer = injectCellRenderer(
+				this.props.cellRenderer,
+				getAvroRenderer(this.props.avroRenderer),
+			);
+			const headerRenderer = injectHeaderRenderer(
+				this.props.headerRenderer,
+				this.onFocusedColumn,
+				this.onKeyDownHeaderColumn,
+			);
 			adaptedColumnDefs = adaptedColumnDefs.concat(
 				columnDefs.map(columnDef => ({
 					lockPinned: true,
@@ -247,26 +256,14 @@ export default class DataGrid extends React.Component {
 					valueGetter: this.props.getCellValueFn,
 					width: CELL_WIDTH,
 					resizable: this.props.enableColResize,
+					[AG_GRID.CUSTOM_CELL_KEY]: cellRenderer,
+					[AG_GRID.CUSTOM_HEADER_KEY]: headerRenderer,
 					...columnDef,
-					[AG_GRID.CUSTOM_CELL_KEY]: CELL_RENDERER_COMPONENT,
-					[AG_GRID.CUSTOM_HEADER_KEY]: HEADER_RENDERER_COMPONENT,
 				})),
 			);
 		}
 
 		agGridOptions.columnDefs = adaptedColumnDefs;
-		agGridOptions.frameworkComponents = {
-			[CELL_RENDERER_COMPONENT]: injectCellRenderer(
-				this.props.cellRenderer,
-				getAvroRenderer(this.props.avroRenderer),
-			),
-			[HEADER_RENDERER_COMPONENT]: injectHeaderRenderer(
-				this.props.headerRenderer,
-				this.onFocusedColumn,
-				this.onKeyDownHeaderColumn,
-			),
-			[PIN_HEADER_RENDERER_COMPONENT]: this.props.pinHeaderRenderer,
-		};
 		return agGridOptions;
 	}
 

--- a/packages/datagrid/src/components/DefaultCellRenderer/DefaultCellRenderer.component.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/DefaultCellRenderer.component.js
@@ -10,8 +10,6 @@ import QualityIndicator from './QualityIndicator.component';
 import AvroRenderer from './AvroRenderer.component';
 import theme from './DefaultCell.scss';
 
-export const CELL_RENDERER_COMPONENT = 'cellRenderer';
-
 function convertValue(value) {
 	if (!value.toJS) {
 		return value;

--- a/packages/datagrid/src/components/DefaultCellRenderer/index.js
+++ b/packages/datagrid/src/components/DefaultCellRenderer/index.js
@@ -1,7 +1,7 @@
-import DefaultCellRenderer, { CELL_RENDERER_COMPONENT } from './DefaultCellRenderer.component';
-import QualityIndicator from './QualityIndicator.component';
 import AvroRenderer from './AvroRenderer.component';
 import theme from './DefaultCell.scss';
+import DefaultCellRenderer from './DefaultCellRenderer.component';
+import QualityIndicator from './QualityIndicator.component';
 
-export { DefaultCellRenderer, CELL_RENDERER_COMPONENT, QualityIndicator, AvroRenderer, theme };
+export { DefaultCellRenderer, QualityIndicator, AvroRenderer, theme };
 export default DefaultCellRenderer;

--- a/packages/datagrid/src/components/DefaultHeaderRenderer/index.ts
+++ b/packages/datagrid/src/components/DefaultHeaderRenderer/index.ts
@@ -1,6 +1,1 @@
-import DefaultHeaderRenderer, {
-	HEADER_RENDERER_COMPONENT,
-} from './DefaultHeaderRenderer.component';
-
-export { HEADER_RENDERER_COMPONENT };
-export default DefaultHeaderRenderer;
+export { default } from './DefaultHeaderRenderer.component';

--- a/packages/datagrid/src/components/PinHeaderRenderer/PinHeaderRenderer.component.tsx
+++ b/packages/datagrid/src/components/PinHeaderRenderer/PinHeaderRenderer.component.tsx
@@ -1,6 +1,7 @@
-import theme from './PinHeaderRenderer.scss';
-import { ButtonIcon } from '@talend/design-system';
 import React from 'react';
+import { ButtonIcon } from '@talend/design-system';
+
+import theme from './PinHeaderRenderer.scss';
 
 export type PinHeaderRendererProps = Omit<Parameters<typeof ButtonIcon>[0], 'size' | 'icon'>;
 

--- a/packages/datagrid/src/components/PinHeaderRenderer/PinHeaderRenderer.component.tsx
+++ b/packages/datagrid/src/components/PinHeaderRenderer/PinHeaderRenderer.component.tsx
@@ -1,8 +1,6 @@
-import React from 'react';
-import { ButtonIcon } from '@talend/design-system';
 import theme from './PinHeaderRenderer.scss';
-
-export const PIN_HEADER_RENDERER_COMPONENT = 'pinHeaderRenderer';
+import { ButtonIcon } from '@talend/design-system';
+import React from 'react';
 
 export type PinHeaderRendererProps = Omit<Parameters<typeof ButtonIcon>[0], 'size' | 'icon'>;
 

--- a/packages/datagrid/src/components/PinHeaderRenderer/index.ts
+++ b/packages/datagrid/src/components/PinHeaderRenderer/index.ts
@@ -1,1 +1,1 @@
-export { default, PIN_HEADER_RENDERER_COMPONENT } from './PinHeaderRenderer.component';
+export { default } from './PinHeaderRenderer.component';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Keep cleaning up datagrid api, to stick as much as possible to ag-grid documentation.
https://www.ag-grid.com/react-data-grid/column-properties/

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
