### PR TITLE
feat(design-system/TUX-1081): private Field component

### DIFF
--- a/packages/design-system/src/components/Form/Primitives/Checkbox/Checkbox.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Checkbox/Checkbox.tsx
@@ -8,7 +8,7 @@ import Label from '../Label/Label';
 import styles from './Checkbox.module.scss';
 
 type CheckboxType = Omit<CheckboxProps, 'type' | 'prefix'> & {
-	label: string | ReactElement;
+	label: string;
 	id: string;
 	indeterminate?: boolean;
 };

--- a/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
@@ -5,13 +5,18 @@ import Label, { LabelProps } from '../Label/Label';
 import { InlineMessageDestructive, InlineMessageInformation } from '../../../InlineMessage';
 import VisuallyHidden from '../../../VisuallyHidden';
 
-export type FieldStatusProps = {
-	isError?: boolean;
-};
+export type FieldStatusProps =
+	| {
+			hasError: true;
+			description: string;
+	  }
+	| {
+			hasError?: false;
+			description?: string;
+	  };
 
 type FieldProps = {
 	link?: LinkProps;
-	description?: string;
 	hideLabel?: boolean;
 	label: LabelProps;
 	id: string;
@@ -28,8 +33,8 @@ const Field = forwardRef(
 			id,
 			label,
 			name,
+			hasError = false,
 			hideLabel = false,
-			isError = false,
 			description,
 			...rest
 		} = props;
@@ -42,22 +47,22 @@ const Field = forwardRef(
 			<Label {...label} htmlFor={id} />
 		);
 
-		const Description = ({ descriptionText }: { descriptionText: string }) => {
-			const descProps = {
-				description: descriptionText,
-			};
-			if (isError) {
-				return <InlineMessageDestructive {...descProps} />;
+		const Description = () => {
+			if (hasError && description) {
+				return <InlineMessageDestructive description={description} />;
 			}
-			return <InlineMessageInformation {...descProps} />;
+			if (!!description) {
+				return <InlineMessageInformation description={description} />;
+			}
+			return null;
 		};
 
 		return (
 			<StackVertical gap="XXS" align={'stretch'} justify={'start'}>
 				{LabelComponent}
-				{cloneElement(children, { id, isError, name, rest }, ref)}
+				{cloneElement(children, { id, hasError, name, rest }, ref)}
 				{link && <Link {...link} />}
-				{description && <Description descriptionText={description} />}
+				{description && <Description />}
 			</StackVertical>
 		);
 	},

--- a/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
@@ -2,19 +2,21 @@ import React, { forwardRef, ReactElement, Ref, cloneElement } from 'react';
 import Link, { LinkProps } from '../../../Link/Link';
 import { StackVertical } from '../../../Stack';
 import Label, { LabelProps } from '../Label/Label';
-import { VisuallyHidden } from '../../../../index';
+import { InlineMessageDestructive, InlineMessageInformation } from '../../../InlineMessage';
+import VisuallyHidden from '../../../VisuallyHidden';
+
+export type FieldStatusProps = {
+	isError?: boolean;
+};
 
 type FieldProps = {
 	link?: LinkProps;
-	hasError?: boolean;
-	hasWarning?: boolean;
-	hasSuccess?: boolean;
-	hasInformation?: boolean;
 	description?: string;
 	hideLabel?: boolean;
 	label: LabelProps;
 	id: string;
-};
+	name: string;
+} & FieldStatusProps;
 
 type FieldPropsWithChildren = FieldProps & { children: ReactElement };
 
@@ -25,11 +27,9 @@ const Field = forwardRef(
 			link,
 			id,
 			label,
+			name,
 			hideLabel = false,
-			hasError = false,
-			hasWarning = false,
-			hasInformation = false,
-			hasSuccess = false,
+			isError = false,
 			description,
 			...rest
 		} = props;
@@ -42,11 +42,22 @@ const Field = forwardRef(
 			<Label {...label} htmlFor={id} />
 		);
 
+		const Description = ({ descriptionText }: { descriptionText: string }) => {
+			const descProps = {
+				description: descriptionText,
+			};
+			if (isError) {
+				return <InlineMessageDestructive {...descProps} />;
+			}
+			return <InlineMessageInformation {...descProps} />;
+		};
+
 		return (
-			<StackVertical gap="XS" align={'stretch'} justify={'start'}>
+			<StackVertical gap="XXS" align={'stretch'} justify={'start'}>
 				{LabelComponent}
-				{cloneElement(children, { id, hasError, rest }, ref)}
+				{cloneElement(children, { id, isError, name, rest }, ref)}
 				{link && <Link {...link} />}
+				{description && <Description descriptionText={description} />}
 			</StackVertical>
 		);
 	},

--- a/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
@@ -48,17 +48,18 @@ const Field = forwardRef(
 		);
 
 		const Description = () => {
-			if (hasError && description) {
-				return <InlineMessageDestructive description={description} />;
-			}
-			if (!!description) {
+			if (description) {
+				if (hasError) {
+					return <InlineMessageDestructive description={description} />;
+				}
+
 				return <InlineMessageInformation description={description} />;
 			}
 			return null;
 		};
 
 		return (
-			<StackVertical gap="XXS" align={'stretch'} justify={'start'}>
+			<StackVertical gap="XXS" align="stretch" justify="start">
 				{LabelComponent}
 				{cloneElement(children, { id, hasError, name, rest }, ref)}
 				{link && <Link {...link} />}

--- a/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
@@ -1,0 +1,57 @@
+import React, { forwardRef, ReactElement, Ref, cloneElement } from 'react';
+import Link, { LinkProps } from '../../../Link/Link';
+import { StackVertical } from '../../../Stack';
+import Label, { LabelProps } from '../Label/Label';
+import { VisuallyHidden } from '../../../../index';
+
+type FieldProps = {
+	link?: LinkProps;
+	hasError?: boolean;
+	hasWarning?: boolean;
+	hasSuccess?: boolean;
+	hasInformation?: boolean;
+	description?: string;
+	hideLabel?: boolean;
+	label: LabelProps;
+	id: string;
+};
+
+type FieldPropsWithChildren = FieldProps & { children: ReactElement };
+
+const Field = forwardRef(
+	(props: FieldPropsWithChildren, ref: Ref<HTMLInputElement | HTMLTextAreaElement>) => {
+		const {
+			children,
+			link,
+			id,
+			label,
+			hideLabel = false,
+			hasError = false,
+			hasWarning = false,
+			hasInformation = false,
+			hasSuccess = false,
+			description,
+			...rest
+		} = props;
+
+		const LabelComponent = hideLabel ? (
+			<VisuallyHidden>
+				<Label {...label} htmlFor={id} />
+			</VisuallyHidden>
+		) : (
+			<Label {...label} htmlFor={id} />
+		);
+
+		return (
+			<StackVertical gap="XS" align={'stretch'} justify={'start'}>
+				{LabelComponent}
+				{cloneElement(children, { id, hasError, rest }, ref)}
+				{link && <Link {...link} />}
+			</StackVertical>
+		);
+	},
+);
+
+Field.displayName = 'Field';
+
+export default Field;

--- a/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
@@ -6,16 +6,18 @@ import React, {
 	FocusEvent,
 	useRef,
 	useImperativeHandle,
-	FocusEventHandler,
 } from 'react';
 import classnames from 'classnames';
 import { useTranslation } from 'react-i18next';
 import InputWrapper, { AffixesProps } from '../InputWrapper/InputWrapper';
+import { FieldStatusProps } from '../Field/Field';
 import Tooltip from '../../../Tooltip';
 import Clickable from '../../../Clickable';
 import { Icon } from '../../../Icon/Icon';
 
-type InputProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> & AffixesProps;
+type InputProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> &
+	AffixesProps &
+	FieldStatusProps;
 
 import styles from './Input.module.scss';
 
@@ -28,6 +30,7 @@ const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) 
 		disabled = false,
 		type,
 		onBlur,
+		isError,
 		...rest
 	} = props;
 
@@ -49,7 +52,13 @@ const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) 
 	}
 
 	return (
-		<InputWrapper prefix={prefix} suffix={suffix} disabled={disabled} readOnly={readOnly}>
+		<InputWrapper
+			prefix={prefix}
+			suffix={suffix}
+			disabled={disabled}
+			readOnly={readOnly}
+			isError={isError}
+		>
 			<>
 				<input
 					{...rest}

--- a/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
@@ -17,7 +17,7 @@ import { Icon } from '../../../Icon/Icon';
 
 type InputProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> &
 	AffixesProps &
-	FieldStatusProps;
+	Omit<FieldStatusProps, 'errorMessage'>;
 
 import styles from './Input.module.scss';
 
@@ -30,7 +30,7 @@ const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) 
 		disabled = false,
 		type,
 		onBlur,
-		isError,
+		hasError,
 		...rest
 	} = props;
 
@@ -57,7 +57,7 @@ const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) 
 			suffix={suffix}
 			disabled={disabled}
 			readOnly={readOnly}
-			isError={isError}
+			hasError={hasError}
 		>
 			<>
 				<input

--- a/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
+++ b/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
@@ -6,6 +6,7 @@ import { AffixButton, AffixReadOnly } from '../../FieldGroup/Affix';
 
 import styles from './InputWrapper.module.scss';
 import classnames from 'classnames';
+import { FieldStatusProps } from '../Field/Field';
 
 type AffixProps =
 	| ({ type: 'button' } & AffixButtonPropsType)
@@ -21,7 +22,8 @@ type InputWrapperProps = {
 	children: ReactElement;
 	disabled?: boolean;
 	readOnly?: boolean;
-} & AffixesProps;
+} & AffixesProps &
+	FieldStatusProps;
 
 function buildAffix(affixProps: AffixProps) {
 	if (isElement(affixProps)) {
@@ -42,13 +44,23 @@ function buildAffix(affixProps: AffixProps) {
 }
 
 const InputWrapper = forwardRef((props: InputWrapperProps, ref: Ref<HTMLDivElement>) => {
-	const { children, prefix, suffix, disabled = false, readOnly = false } = props;
+	const {
+		children,
+		prefix,
+		suffix,
+		disabled = false,
+		readOnly = false,
+		isError = false,
+		...rest
+	} = props;
 	return (
 		<div
+			{...rest}
 			ref={ref}
 			className={classnames(styles.inputShell, {
 				[styles.inputShell_disabled]: disabled,
 				[styles.inputShell_readOnly]: readOnly,
+				[styles.inputShell_borderError]: isError,
 			})}
 		>
 			{prefix && buildAffix(prefix)}

--- a/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
+++ b/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
@@ -23,7 +23,7 @@ type InputWrapperProps = {
 	disabled?: boolean;
 	readOnly?: boolean;
 } & AffixesProps &
-	FieldStatusProps;
+	Omit<FieldStatusProps, 'errorMessage'>;
 
 function buildAffix(affixProps: AffixProps) {
 	if (isElement(affixProps)) {
@@ -50,7 +50,7 @@ const InputWrapper = forwardRef((props: InputWrapperProps, ref: Ref<HTMLDivEleme
 		suffix,
 		disabled = false,
 		readOnly = false,
-		isError = false,
+		hasError = false,
 		...rest
 	} = props;
 	return (
@@ -60,7 +60,7 @@ const InputWrapper = forwardRef((props: InputWrapperProps, ref: Ref<HTMLDivEleme
 			className={classnames(styles.inputShell, {
 				[styles.inputShell_disabled]: disabled,
 				[styles.inputShell_readOnly]: readOnly,
-				[styles.inputShell_borderError]: isError,
+				[styles.inputShell_borderError]: hasError,
 			})}
 		>
 			{prefix && buildAffix(prefix)}

--- a/packages/design-system/src/components/Form/Primitives/Label/Label.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Label/Label.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, ReactElement, Ref, LabelHTMLAttributes } from 'react';
 import classnames from 'classnames';
 
-type LabelProps = LabelHTMLAttributes<any> & {
+export type LabelProps = LabelHTMLAttributes<any> & {
 	children: string | ReactElement;
 	inline?: boolean;
 };

--- a/packages/design-system/src/components/Form/Primitives/Primitives.stories.mdx
+++ b/packages/design-system/src/components/Form/Primitives/Primitives.stories.mdx
@@ -1,7 +1,7 @@
 import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
 // import { FigmaImage, Use } from '~docs';
 
-import InlineMessage from '../../InlineMessage/InlineMessage';
+import { InlineMessageInformation } from '../../InlineMessage';
 import * as Stories from './Primitives.stories';
 import { StackVertical } from '../../Stack';
 
@@ -16,7 +16,7 @@ import { StackVertical } from '../../Stack';
 # Form Primitives
 
 <StackVertical gap="0" padding={{ x: '0', y: 'M' }}>
-	<InlineMessage.Information
+	<InlineMessageInformation
 		withBackground
 		description="Primitives are unexported components used within
     the design system. They are composed together to create the public components."
@@ -57,6 +57,12 @@ import { StackVertical } from '../../Stack';
 
 <Canvas>
 	<Story story={Stories.RadioPrimitive} />
+</Canvas>
+
+## Field
+
+<Canvas>
+	<Story story={Stories.FieldStory} />
 </Canvas>
 
 ## Advanced affixes

--- a/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
@@ -9,6 +9,7 @@ import { StackHorizontal, StackVertical } from '../../Stack';
 import Checkbox from './Checkbox/Checkbox';
 import Label from './Label/Label';
 import Radio from './Radio/Radio';
+import Field from './Field/Field';
 
 export default {
 	component: Textarea,
@@ -181,6 +182,31 @@ export const InputPrimitiveWithDropdown = () => {
 					</Dropdown>
 				}
 			/>
+		</StackVertical>
+	);
+};
+
+export const FieldStory = () => {
+	return (
+		<StackVertical gap="XS" padding="XS" align="stretch" justify="start">
+			<Field
+				label={{ children: 'Test label' }}
+				id="testId"
+				description="This is a description"
+				isError
+				name="test"
+			>
+				<Input type="text" />
+			</Field>
+			<Field
+				label={{ children: 'Test Textarea' }}
+				id="testId2"
+				description="This is a description for a textarea"
+				isError
+				name="test"
+			>
+				<Textarea />
+			</Field>
 		</StackVertical>
 	);
 };

--- a/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
@@ -10,6 +10,7 @@ import Checkbox from './Checkbox/Checkbox';
 import Label from './Label/Label';
 import Radio from './Radio/Radio';
 import Field from './Field/Field';
+import { ButtonPrimary } from '../../Button';
 
 export default {
 	component: Textarea,
@@ -187,13 +188,14 @@ export const InputPrimitiveWithDropdown = () => {
 };
 
 export const FieldStory = () => {
+	const [isError, setIsError] = useState<boolean>(false);
 	return (
 		<StackVertical gap="XS" padding="XS" align="stretch" justify="start">
 			<Field
 				label={{ children: 'Test label' }}
 				id="testId"
-				description="This is a description"
-				isError
+				description={isError ? 'This is the error message' : 'This is a description'}
+				hasError={isError}
 				name="test"
 			>
 				<Input type="text" />
@@ -201,12 +203,15 @@ export const FieldStory = () => {
 			<Field
 				label={{ children: 'Test Textarea' }}
 				id="testId2"
-				description="This is a description for a textarea"
-				isError
+				description={isError ? 'This is the error message' : 'This is a description for a textarea'}
 				name="test"
+				hasError={isError}
 			>
 				<Textarea />
 			</Field>
+			<div>
+				<ButtonPrimary onClick={() => setIsError(!isError)}>Set as error</ButtonPrimary>
+			</div>
 		</StackVertical>
 	);
 };

--- a/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Primitives.stories.tsx
@@ -235,7 +235,7 @@ export const FakeForm = () => {
 					<Label>Send me emails</Label>
 					<Checkbox id="emails" label="Yes I love emails" />
 				</StackVertical>
-				<StackVertical gap={'XXS'} align={'stretch'} justify={'start'}>
+				<StackVertical gap="XXS" align="stretch" justify="start">
 					<Label>Pick a thing</Label>
 					<StackVertical gap="XXS" align="stretch" justify="start">
 						<Radio id="choice1" label="Choice 1" value="choice1" name="choice" />

--- a/packages/design-system/src/components/Form/Primitives/Radio/Radio.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Radio/Radio.tsx
@@ -6,7 +6,7 @@ import useReadOnly from '../../Field/Input/hooks/useReadOnly';
 import styles from './Radio.module.scss';
 
 type RadioType = Omit<InputHTMLAttributes<HTMLInputElement>, 'type' | 'prefix'> & {
-	label: string | ReactElement;
+	label: string;
 	id: string;
 };
 

--- a/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
@@ -1,12 +1,12 @@
 import React, { forwardRef, Ref, TextareaHTMLAttributes } from 'react';
 import classnames from 'classnames';
 
-type TextareaProps = TextareaHTMLAttributes<any> & { isError?: boolean };
+type TextareaProps = TextareaHTMLAttributes<any> & { hasError?: boolean };
 
 import styles from './Textarea.module.scss';
 
 const Textarea = forwardRef((props: TextareaProps, ref: Ref<HTMLTextAreaElement>) => {
-	const { className, readOnly = false, disabled = false, isError = false, ...rest } = props;
+	const { className, readOnly = false, disabled = false, hasError = false, ...rest } = props;
 	return (
 		<textarea
 			{...rest}
@@ -18,7 +18,7 @@ const Textarea = forwardRef((props: TextareaProps, ref: Ref<HTMLTextAreaElement>
 				{
 					[styles.textarea_readOnly]: readOnly,
 					[styles.textarea_disabled]: disabled,
-					[styles.textarea_borderError]: isError,
+					[styles.textarea_borderError]: hasError,
 				},
 				className,
 			)}

--- a/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
@@ -1,12 +1,12 @@
 import React, { forwardRef, Ref, TextareaHTMLAttributes } from 'react';
 import classnames from 'classnames';
 
-type TextareaProps = TextareaHTMLAttributes<any>;
+type TextareaProps = TextareaHTMLAttributes<any> & { isError?: boolean };
 
 import styles from './Textarea.module.scss';
 
 const Textarea = forwardRef((props: TextareaProps, ref: Ref<HTMLTextAreaElement>) => {
-	const { className, readOnly = false, disabled = false, ...rest } = props;
+	const { className, readOnly = false, disabled = false, isError = false, ...rest } = props;
 	return (
 		<textarea
 			{...rest}
@@ -15,7 +15,11 @@ const Textarea = forwardRef((props: TextareaProps, ref: Ref<HTMLTextAreaElement>
 			readOnly={readOnly}
 			className={classnames(
 				styles.textarea,
-				{ [styles.textarea_readOnly]: readOnly, [styles.textarea_disabled]: disabled },
+				{
+					[styles.textarea_readOnly]: readOnly,
+					[styles.textarea_disabled]: disabled,
+					[styles.textarea_borderError]: isError,
+				},
 				className,
 			)}
 		/>

--- a/packages/design-system/src/components/Form/Primitives/_mixins.scss
+++ b/packages/design-system/src/components/Form/Primitives/_mixins.scss
@@ -82,8 +82,12 @@ $standardInputHeight: calc(#{tokens.$coral-sizing-m} - 0.2rem);
     box-shadow: 0 0 0 0.1rem tokens.$coral-color-accent-border;
   }
 
-  &.border_error {
+  &_borderError {
     border: tokens.$coral-border-s-solid tokens.$coral-color-danger-border;
+
+    &:hover {
+      border: tokens.$coral-border-s-solid tokens.$coral-color-danger-border-hover;
+    }
 
     &:focus-within, &:focus {
       border: tokens.$coral-border-s-solid tokens.$coral-color-danger-border;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Field is primitive wrapper component that handles the label, description, link and error logic for all text components. Previous `Field` did not use the tokens not Stack. 

It's only going to be used to build the public components. You won't use `Field` in your code. You will use `InputText` for instance that underneath is a composition of `Field` and `Input`. 

**What is the chosen solution to this problem?**
Use the tokens and stack.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
