### PR TITLE
chore(icons): Github Action to download icons from Figma

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -20,8 +20,6 @@ jobs:
         with:
           node-version: 16
           check-latest: true
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
           cache: "yarn"
 
       - name: Download icons

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -1,0 +1,59 @@
+name: Download icons from Figma
+
+on:
+  repository_dispatch:
+  workflow_dispatch:
+
+jobs:
+  download:
+    runs-on: ubuntu-latest
+    name: Download icons from Figma
+    defaults:
+      run:
+        working-directory: ./packages/icons
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          check-latest: true
+          registry-url: "https://registry.npmjs.org/"
+          scope: "@talend"
+          cache: "yarn"
+
+      - name: Download icons
+        run: npx @talend/figma-icons-downloader
+        env:
+          FIGMA_ACCESS_TOKEN: ${{ secrets.STORYBOOK_FIGMA_ACCESS_TOKEN }}
+
+      - name: Generate Pull Request Body
+        id: get-pr-body
+        run: |
+          git add output
+          git diff --name-only HEAD ./output | zip diff.zip -@
+          mkdir .tmp
+          unzip diff.zip -d .tmp/
+          body="<h1>This Pull-Request was auto-generated</h1><p>Please, don't update this PR manually!</p><br/><h2>Modified files</h2> <pre>$(cd .tmp && du -sh && find . | sed 's;[^/]*/;|____;g' | sed 's;____|; |;g' | head -n 1000)</pre>"
+          body="${body//'%'/'%25'}"
+          body="${body//$'\n'/'%0A'}"
+          body="${body//$'\r'/'%0D'}"
+          echo ::set-output name=body::$body
+          rm -rf diff.zip .tmp
+
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@v4
+        with:
+          commit-message: "chore(icons): from Figma"
+          title: "chore(icons): from Figma"
+          body: ${{ steps.get-pr-body.outputs.body }}
+          branch: ci/icons
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check outputs
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Icons from Figma have been pushed manually

**What is the chosen solution to this problem?**

They must come from a Github Action, because why not.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
