### PR TITLE
fix(design-system): Fix types for collection components

### DIFF
--- a/.changeset/calm-poets-jam.md
+++ b/.changeset/calm-poets-jam.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Spread in default case for collection component switch was not typesafe. Default case should be unreachable in TS anyways.

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -4,7 +4,6 @@ import ButtonPrimary, { ButtonPrimaryPropsType } from './variations/ButtonPrimar
 import ButtonSecondary, { ButtonSecondaryPropsType } from './variations/ButtonSecondary';
 import ButtonTertiary, { ButtonTertiaryPropsType } from './variations/ButtonTertiary';
 import ButtonDestructive, { ButtonDestructivePropsType } from './variations/ButtonDestructive';
-import Clickable from '../Clickable';
 import { ButtonVariantType } from './Primitive/ButtonPrimitive';
 
 type Primary = ButtonVariantType<'primary', ButtonPrimaryPropsType>;
@@ -37,7 +36,7 @@ const Button = forwardRef((props: ButtonType, ref: Ref<HTMLButtonElement>) => {
 		}
 
 		default: {
-			return <Clickable {...props} ref={ref} />;
+			return null;
 		}
 	}
 });

--- a/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.tsx
@@ -13,7 +13,6 @@ import ButtonDestructiveAsLink, {
 	ButtonDestructiveAsLinkPropsType,
 } from './variations/ButtonDestructiveAsLink';
 import { ButtonVariantType } from '../Button/Primitive/ButtonPrimitive';
-import Linkable from '../Linkable';
 
 type Primary = ButtonVariantType<'primary', ButtonPrimaryAsLinkPropsType>;
 type Secondary = ButtonVariantType<'secondary', ButtonSecondaryAsLinkPropsType>;
@@ -45,7 +44,7 @@ const ButtonAsLink = forwardRef((props: ButtonType, ref: Ref<any>) => {
 		}
 
 		default: {
-			return <Linkable {...props} ref={ref} />;
+			return null;
 		}
 	}
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Default case spread in collection component was not compiling in TS 4.7.

**What is the chosen solution to this problem?**
Remove the default component as it should not happen anyways.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
