### PR TITLE
fix(ui-scripts): invalid source-maps for apps built with prod mode

### DIFF
--- a/.changeset/hot-swans-explode.md
+++ b/.changeset/hot-swans-explode.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix source-map for apps built with prod mode. Change `devtool` to 'source-map' because Terser plugin only supports limited source-map types.

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -318,7 +318,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				publicPath: '/',
 				globalObject: 'this',
 			},
-			devtool: 'cheap-module-source-map',
+			devtool: 'source-map',
 			resolve: {
 				extensions: ['.js', useTypescript && '.ts', useTypescript && '.tsx'].filter(Boolean),
 			},

--- a/tools/scripts-config-react-webpack/config/webpack.config.prod.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.prod.js
@@ -10,6 +10,7 @@ module.exports = () => ({
 			// This is only used in production mode
 			new TerserPlugin({
 				terserOptions: {
+					sourceMap: true,
 					parse: {
 						// we want terser to parse ecma 8 code. However, we don't want it
 						// to apply any minfication steps that turns valid ecma 5 code
@@ -48,7 +49,6 @@ module.exports = () => ({
 				parallel: true,
 				// Enable file caching
 				cache: true,
-				sourceMap: true,
 			}),
 		],
 	},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The source-maps for apps built with prod mode are invalid.

**What is the chosen solution to this problem?**
Change `devtool` to another source-map type which Terser plugin will support.
Tested under playground. can see the original source code:
![image](https://user-images.githubusercontent.com/3214228/171140853-459f9d5f-7597-4dcc-94bc-7549837da7d4.png)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
