### PR TITLE
feat(components/DrawerTitle): add a tooltip to the tag

### DIFF
--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -5,7 +5,7 @@ import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import { Transition } from 'react-transition-group';
 import classnames from 'classnames';
-import { TagDefault, StackHorizontal } from '@talend/design-system';
+import { TagDefault, StackHorizontal, Tooltip } from '@talend/design-system';
 import ActionBar from '../ActionBar';
 import Action from '../Actions/Action';
 import TabBar from '../TabBar';
@@ -102,14 +102,30 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 	);
 }
 
-export function SubtitleComponent({ subtitle, subtitleTagLabel }) {
+function renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip) {
+	if (subtitleTagLabel && subtitleTagTooltip)
+		return (
+			<Tooltip placement="top" title={subtitleTagTooltip}>
+				<TagDefault>{subtitleTagLabel}</TagDefault>
+			</Tooltip>
+		);
+
+	if (subtitleTagLabel && !subtitleTagTooltip) {
+		return <TagDefault>{subtitleTagLabel}</TagDefault>;
+	}
+
+	return null;
+}
+export function SubtitleComponent({ subtitle, ...rest }) {
 	if (!subtitle || !subtitle.length) {
 		return null;
 	}
+
+	const { subtitleTagLabel, subtitleTagTooltip } = rest;
 	return (
 		<StackHorizontal gap="XXS">
 			<h2 title={subtitle}>{subtitle}</h2>
-			{subtitleTagLabel ? <TagDefault>{subtitleTagLabel}</TagDefault> : null}
+			{renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip)}
 		</StackHorizontal>
 	);
 }
@@ -117,6 +133,7 @@ export function SubtitleComponent({ subtitle, subtitleTagLabel }) {
 SubtitleComponent.propTypes = {
 	subtitle: PropTypes.string,
 	subtitleTagLabel: PropTypes.string,
+	subtitleTagTooltip: PropTypes.string,
 };
 
 export function subtitleComponent(subtitle) {
@@ -133,6 +150,7 @@ function DrawerTitle({
 	editable,
 	inProgress,
 	subtitleTagLabel,
+	subtitleTagTooltip,
 	onEdit,
 	onSubmit,
 	onCancel,
@@ -182,7 +200,11 @@ function DrawerTitle({
 					/>
 				)}
 				{!isEditMode ? (
-					<SubtitleComponent subtitle={subtitle} subtitleTagLabel={subtitleTagLabel} />
+					<SubtitleComponent
+						subtitle={subtitle}
+						subtitleTagLabel={subtitleTagLabel}
+						subtitleTagTooltip={subtitleTagTooltip}
+					/>
 				) : null}
 				{renderTitleActions()}
 				{cancelActionComponent(onCancelAction, getComponent)}
@@ -202,6 +224,7 @@ DrawerTitle.propTypes = {
 	editable: PropTypes.bool,
 	inProgress: PropTypes.bool,
 	subtitleTagLabel: PropTypes.string,
+	subtitleTagTooltip: PropTypes.string,
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
 	onCancel: PropTypes.func,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
PO needs a tooltip over the tag

**What is the chosen solution to this problem?**
Impl

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
