### PR TITLE
chore(ARCH-515): add jira ticket check in PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,7 @@
 
 **Please check if the PR fulfills these requirements**
 
+- [ ] The PR title references a jira ticket (ex: `feat(ARCH-424): ...`).
 - [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
 - [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
 - [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For SOC2 and Jellyfish stats, we need to have jira ticket refs in each PR title

**What is the chosen solution to this problem?**
Add this check in the github PR template

PLEASE DO NOT MERGE YET

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
