### PR TITLE
feat(forms): Use design-system skeleton in FormSkeleton

### DIFF
--- a/packages/forms/src/FormSkeleton.js
+++ b/packages/forms/src/FormSkeleton.js
@@ -1,30 +1,29 @@
 import React from 'react';
+
 import PropTypes from 'prop-types';
-import Skeleton from '@talend/react-components/lib/Skeleton';
+
+import { SkeletonInput, SkeletonButton } from '@talend/design-system';
+
 import theme from './FormSkeleton.scss';
 
 export default function FormSkeleton({ displayMode, actions }) {
 	// null/undefined actions prop will display default buttons
 	const hasButtons = displayMode !== 'text' && actions?.length !== 0;
 	return (
-		<div className={`${theme.container} tc-skeleton-heartbeat`} aria-busy>
-			<div className={theme['form-content']}>
+		<div className={theme.container} aria-busy data-testid="form.skeleton">
+			<div className={theme['form-content']} data-testid="form.skeleton.fields">
 				<div className={theme['form-content-wrapper']}>
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} className="skeleton-fit-content" />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} className="skeleton-fit-content" />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} className="skeleton-fit-content" />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />
-					<Skeleton heartbeat={false} type={Skeleton.TYPES.text} className="skeleton-fit-content" />
+					<SkeletonInput />
+					<SkeletonInput />
+					<SkeletonInput />
+					<SkeletonInput />
 				</div>
 			</div>
 			{hasButtons && (
-				<div className={theme.submit}>
+				<div className={theme.submit} data-testid="form.skeleton.buttons">
 					<div className={theme['submit-wrapper']}>
-						<Skeleton heartbeat={false} type={Skeleton.TYPES.button} />
-						<Skeleton heartbeat={false} type={Skeleton.TYPES.button} />
+						<SkeletonButton />
+						<SkeletonButton />
 					</div>
 				</div>
 			)}

--- a/packages/forms/src/FormSkeleton.scss
+++ b/packages/forms/src/FormSkeleton.scss
@@ -1,3 +1,5 @@
+@use '~@talend/design-tokens/lib/tokens';
+
 $tc-drawer-content-max-width: 65rem !default;
 $tc-drawer-padding: $padding-large !default;
 
@@ -8,16 +10,8 @@ $tc-drawer-padding: $padding-large !default;
 	flex-direction: column;
 }
 
-.form-content {
-	:global {
-		.tc-skeleton {
-			margin: $padding-normal 0;
-
-			&.skeleton-fit-content {
-				width: auto;
-			}
-		}
-	}
+.form-content-wrapper {
+	gap: tokens.$coral-spacing-m;
 }
 
 .submit-wrapper {
@@ -55,7 +49,7 @@ $tc-drawer-padding: $padding-large !default;
 
 @media screen and (min-width: $screen-xs-max) {
 	:global(.stacked) :global(.tc-drawer-container) {
-		.form-content-wrapper,
+		.form-content,
 		.submit-wrapper {
 			margin: 0 auto;
 			padding: $tc-drawer-padding;

--- a/packages/forms/src/FormSkeleton.test.js
+++ b/packages/forms/src/FormSkeleton.test.js
@@ -1,21 +1,19 @@
 import React from 'react';
-import { shallow } from 'enzyme';
-import Skeleton from '@talend/react-components/lib/Skeleton';
+
+import { render, screen } from '@testing-library/react';
+
 import FormSkeleton from './FormSkeleton';
 
 describe('FormSkeleton', () => {
 	it('should render skeleton', () => {
-		const wrapper = shallow(<FormSkeleton />);
-		expect(wrapper.find(Skeleton).length).toBe(10);
-	});
-
-	it('should render skeleton  without its buttons', () => {
-		const wrapper = shallow(<FormSkeleton displayMode="text" />);
-		expect(wrapper.find(Skeleton).length).toBe(8);
+		render(<FormSkeleton />);
+		expect(screen.getByTestId('form.skeleton')).toHaveAttribute('aria-busy', 'true');
+		expect(screen.getByTestId('form.skeleton.fields')).toBeInTheDocument();
+		expect(screen.getByTestId('form.skeleton.buttons')).toBeInTheDocument();
 	});
 
 	it('should render skeleton without actions', () => {
-		const wrapper = shallow(<FormSkeleton actions={[]} />);
-		expect(wrapper.find(Skeleton).length).toBe(8);
+		render(<FormSkeleton actions={[]} />);
+		expect(screen.queryByTestId('form.skeleton.buttons')).not.toBeInTheDocument();
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

FormSkeleton is using deprecated TUI Skeleton

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
