### PR TITLE
fix(TDOPS-2364/components): datalist selection by id should allow all types

### DIFF
--- a/.changeset/eighty-buses-search.md
+++ b/.changeset/eighty-buses-search.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(components): datalist selection by id should allow all types

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -207,19 +207,20 @@ export function renderItem(item, { value, valueId, ...rest }) {
 	let itemValueId;
 	let description;
 	if (typeof item === 'string') {
-		title = itemValueId = item;
+		title = itemValueId = item.toString();
 	} else {
-		title = (item.title || item.name || '').trim();
-		itemValueId = item.value || item.id;
+		title = (item.title || item.name || '').toString().trim();
+		itemValueId = (item.value ?? item.id ?? '').toString().trim();
 		description = item.description;
 	}
+
 	return (
 		<div
 			className={classNames(theme.item, {
 				[theme.disabled]: item.disabled,
 				[theme.selected]:
-					(valueId !== undefined && valueId === itemValueId) ||
-					(valueId === undefined && value === title),
+					(valueId !== undefined && valueId?.toString() === itemValueId) ||
+					(valueId === undefined && value?.toString() === title),
 				[theme.multiline]: title && description,
 			})}
 			title={title}

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -207,7 +207,7 @@ export function renderItem(item, { value, valueId, ...rest }) {
 	let itemValueId;
 	let description;
 	if (typeof item === 'string') {
-		title = itemValueId = item.toString();
+		title = itemValueId = item;
 	} else {
 		title = (item.title || item.name || '').toString().trim();
 		itemValueId = (item.value ?? item.id ?? '').toString().trim();

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -210,14 +210,16 @@ export function renderItem(item, { value, valueId, ...rest }) {
 		title = itemValueId = item;
 	} else {
 		title = (item.title || item.name || '').trim();
-		itemValueId = (item.value || item.id || '').trim();
+		itemValueId = item.value || item.id;
 		description = item.description;
 	}
 	return (
 		<div
 			className={classNames(theme.item, {
 				[theme.disabled]: item.disabled,
-				[theme.selected]: (valueId && valueId === itemValueId) || (!valueId && value === title),
+				[theme.selected]:
+					(valueId !== undefined && valueId === itemValueId) ||
+					(valueId === undefined && value === title),
 				[theme.multiline]: title && description,
 			})}
 			title={title}

--- a/packages/components/src/Typeahead/Typeahead.test.js
+++ b/packages/components/src/Typeahead/Typeahead.test.js
@@ -73,7 +73,7 @@ describe('Typeahead', () => {
 		},
 	];
 
-	const itemsObjectWithId = [
+	const itemsObjectWithStringId = [
 		{
 			title: 'category 1',
 			suggestions: [
@@ -88,6 +88,26 @@ describe('Typeahead', () => {
 				{
 					title: 'le title 2',
 					value: 'letitle2',
+				},
+			],
+		},
+	];
+
+	const itemsObjectWithId = [
+		{
+			title: 'category 1',
+			suggestions: [
+				{
+					title: 'le title 1',
+					value: 6,
+				},
+				{
+					title: 'le title 1',
+					value: 0,
+				},
+				{
+					title: 'le title 2',
+					value: 19,
 				},
 			],
 		},
@@ -204,8 +224,26 @@ describe('Typeahead', () => {
 			const props = {
 				...initialProps,
 				value: 'le title 1',
-				valueId: 'letitle1copy',
+				valueId: 0,
 				items: itemsObjectWithId,
+			};
+
+			// when
+			render(<Typeahead {...props} />);
+
+			// then
+			const titleList = screen.getAllByTitle('le title 1');
+			expect(titleList[0]).not.toHaveClass('theme-selected');
+			expect(titleList[1]).toHaveClass('theme-selected');
+		});
+
+		it('should render typeahead selected item by string id', () => {
+			// given
+			const props = {
+				...initialProps,
+				value: 'le title 1',
+				valueId: 'letitle1copy',
+				items: itemsObjectWithStringId,
 			};
 
 			// when


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Datalist selection by ID should allow all types, not only string

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
