### PR TITLE
fix(assets-api/ARCH-537): use correct meta attribute

### DIFF
--- a/.changeset/odd-falcons-yawn.md
+++ b/.changeset/odd-falcons-yawn.md
@@ -1,0 +1,5 @@
+---
+'@talend/assets-api': patch
+---
+
+fix: use meta element content attribute

--- a/packages/assets-api/src/index.test.ts
+++ b/packages/assets-api/src/index.test.ts
@@ -20,7 +20,7 @@ describe('assets-api', () => {
 
 		it('should return /cdn url', () => {
 			const original = window.Talend.CDN_URL;
-			window.Talend.CDN_URL = '/cdn'
+			window.Talend.CDN_URL = '/cdn';
 			const url = assetsApi.getURL(bundlePath, '@talend/icons', iconsInfo?.packageJson.version);
 			expect(url).toBe(`/cdn/@talend/icons/${iconsInfo?.packageJson.version}${bundlePath}`);
 			window.Talend.CDN_URL = original;
@@ -28,7 +28,7 @@ describe('assets-api', () => {
 
 		it('should prevent // as start url', () => {
 			const original = window.Talend.CDN_URL;
-			window.Talend.CDN_URL = '/cdn'
+			window.Talend.CDN_URL = '/cdn';
 			const mockedBaseElement = { getAttribute: jest.fn().mockReturnValueOnce('/') };
 			// @ts-ignore
 			jest.spyOn(document, 'querySelector').mockImplementation(() => mockedBaseElement);
@@ -52,6 +52,25 @@ describe('assets-api', () => {
 				`https://mycdn.talend.com/@talend/assets-api/${currentInfo?.packageJson.version}${assetsPath}`,
 			);
 			window.Talend.getCDNUrl = original;
+		});
+		it('should use meta to override the value', () => {
+			const assetsPath = '/package.json';
+			const original = window.Talend.getCDNUrl;
+			window.Talend.getCDNUrl = jest.fn(
+				(info: Asset) => `https://mycdn.talend.com/${info.name}/${info.version}${info.path}`,
+			);
+			const meta = document.createElement('meta');
+			meta.setAttribute('name', '@talend/assets-api');
+			meta.setAttribute('content', '0.0.0');
+			document.head.appendChild(meta);
+			const url = assetsApi.getURL(
+				assetsPath,
+				'@talend/assets-api',
+				currentInfo?.packageJson.version,
+			);
+			expect(url).toBe(`https://mycdn.talend.com/@talend/assets-api/0.0.0${assetsPath}`);
+			window.Talend.getCDNUrl = original;
+			document.head.removeChild(meta);
 		});
 	});
 });

--- a/packages/assets-api/src/index.ts
+++ b/packages/assets-api/src/index.ts
@@ -49,7 +49,7 @@ function getPackageVersion(name?: string, version?: string): string | undefined 
 			console.warn(`Package ${name} is installed multiple times`);
 		}
 		if (metas.length > 0) {
-			return metas[0].getAttribute('value') || version;
+			return metas[0].getAttribute('content') || version;
 		}
 	}
 	return version;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current meta is resolved as null because the attribute value do not exists so current compiled version is used. ..

**What is the chosen solution to this problem?**

use meta content attribute to get the real value

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
