### PR TITLE
fix(SkeletonInput): Skeleton doesn't stretch

### DIFF
--- a/.changeset/neat-garlics-love.md
+++ b/.changeset/neat-garlics-love.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+SkeletonInput does not stretch

--- a/packages/design-system/src/components/Skeleton/variations/SkeletonInput.tsx
+++ b/packages/design-system/src/components/Skeleton/variations/SkeletonInput.tsx
@@ -8,7 +8,7 @@ export type SkeletonInputProps = Omit<SkeletonPrimitiveProps, 'className'>;
 
 const SkeletonInput = forwardRef((props: SkeletonInputProps, ref: Ref<HTMLSpanElement>) => {
 	return (
-		<StackVertical as="span" gap="XXS" {...props} ref={ref}>
+		<StackVertical as="span" gap="XXS" align="stretch" {...props} ref={ref}>
 			<span className={styles['skeleton-input__label']}>
 				<SkeletonParagraph size="S" />
 			</span>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

SkeletonInput inner Stack doesn't strech, requiring parent to set a width

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
