### PR TITLE
 fix(Containers): add react-dom as peer dep

### DIFF
--- a/.changeset/fast-ducks-stare.md
+++ b/.changeset/fast-ducks-stare.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': patch
+---
+
+fix(Containers): add react-dom as peer dep

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -69,6 +69,7 @@
     "i18next": "^20.1.0",
     "prop-types": "^15.5.10",
     "react": ">= 16.14.0 < 18.0.0",
+    "react-dom": ">= 16.14.0 < 18.0.0",
     "react-i18next": "^11.8.13"
   },
   "publishConfig": {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`react-dom` doesn't appear in containers' [dependencies.json](https://unpkg.com/browse/@talend/react-containers@7.2.0/dist/TalendReactContainers.js.dependencies.json)

**What is the chosen solution to this problem?**
Add react-dom in peer dep

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
