### PR TITLE
feat(TDC-6235): pass input reference to datalist rendering function

### DIFF
--- a/.changeset/spicy-lemons-rhyme.md
+++ b/.changeset/spicy-lemons-rhyme.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TDC-6235): pass input reference to datalist rendering function

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -114,15 +114,15 @@ export const DefaultSingleSection = () => {
 			<Datalist {...withIcons} />
 			<h3>Insert custom elements via render props</h3>
 			<Datalist {...singleSectionProps}>
-				{(content, { isShown }) => (
+				{(content, { isShown }, _, inputRef) => (
 					<div>
 						{isShown && (
 							<button
-								onClick={action('onBeforeClick')}
+								onClick={() => inputRef.blur()}
 								onMouseDown={e => e.preventDefault()}
 								type="button"
 							>
-								before
+								Close dropdown
 							</button>
 						)}
 						{content}

--- a/packages/components/src/Typeahead/Typeahead.component.renderers.js
+++ b/packages/components/src/Typeahead/Typeahead.component.renderers.js
@@ -171,6 +171,7 @@ export function renderItemsContainerFactory(
 							searching,
 						},
 						containerProps.ref,
+						referenceElement,
 					)}
 				</div>
 			</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When we render a custom datalist dropdown (with extra components) we want to be able to close dropdown on extra component interaction. 

**What is the chosen solution to this problem?**

Datalist now passes a new parameter to children rendering function : the input reference. 
In this way, we'll be able to blur input focus.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
