### PR TITLE
fix(router-bridge): Router props not passed

### DIFF
--- a/.changeset/odd-suns-check.md
+++ b/.changeset/odd-suns-check.md
@@ -1,0 +1,5 @@
+---
+'@talend/router-bridge': patch
+---
+
+fix: allow props to be well passed to Router component

--- a/packages/router-bridge/src/redux/index.js
+++ b/packages/router-bridge/src/redux/index.js
@@ -1,7 +1,7 @@
-import { isV5 } from '../router';
+import { isLegacy } from '../router';
 
 export function push(url, state, baseAction) {
-	if (isV5) {
+	if (!isLegacy) {
 		try {
 			const { push: connectedPush } = require('connected-react-router');
 			return connectedPush(url, state);
@@ -22,7 +22,7 @@ export function push(url, state, baseAction) {
 }
 
 export function replace(url, state, baseAction) {
-	if (isV5) {
+	if (!isLegacy) {
 		try {
 			const { replace: connectedReplace } = require('connected-react-router');
 			return connectedReplace(url, state);

--- a/packages/router-bridge/src/router/index.js
+++ b/packages/router-bridge/src/router/index.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies, global-require */
 import React from 'react';
 
-let reactRouterV5;
+let reactRouter;
 let Switch = () => null;
 let Route = () => null;
 let Router = () => null;
@@ -12,22 +12,23 @@ let useParams = () => {};
 let useRouteMatch = () => {};
 
 let history = null;
-let isV5 = false;
+let isLegacy = true;
 
 try {
-	reactRouterV5 = require('react-router-dom');
-	isV5 = true;
+	reactRouter = require('react-router-dom');
+	isLegacy = false;
 	const { createBrowserHistory } = require('history');
 
-	Switch = reactRouterV5.Routes;
-	Route = reactRouterV5.Route;
-	Link = reactRouterV5.Link;
-	Redirect = reactRouterV5.Redirect;
-	useParams = reactRouterV5.useParams;
-	useRouteMatch = reactRouterV5.useRouteMatch;
+	Switch = reactRouter.Routes;
+	Route = reactRouter.Route;
+	Link = reactRouter.Link;
+	Redirect = reactRouter.Redirect;
+	useParams = reactRouter.useParams;
+	useRouteMatch = reactRouter.useRouteMatch;
 
 	history = createBrowserHistory({ basename: window.basename || '/' });
-	Router = (...props) => <reactRouterV5.Router {...props} history={history} />;
+	// eslint-disable-next-line
+	Router = props => <reactRouter.Router {...props} history={history} location={history.location} />;
 } catch (e) {
 	if (process.env.NODE_ENV !== 'production') {
 		console.warn(
@@ -36,5 +37,4 @@ try {
 	}
 }
 
-// TODO: export all V5 content before the overrides
-export { history, Switch, Route, Router, Link, Redirect, useParams, useRouteMatch, isV5 };
+export { history, Switch, Route, Router, Link, Redirect, useParams, useRouteMatch, isLegacy };

--- a/packages/router-bridge/src/router/router-legacy-mode.test.js
+++ b/packages/router-bridge/src/router/router-legacy-mode.test.js
@@ -5,11 +5,12 @@ jest.mock('react-router-dom', () => {
 describe('router bridge - legacy mode', () => {
 	it('should not export any router implementation', () => {
 		// when
-		const { history, Route, isV5 } = require('./index');
+		const { history, Route, isLegacy } = require('./index');
 
 		// then
 		expect(history).toBe(null);
+		// eslint-disable-next-line
 		expect(Route()).toBe(null);
-		expect(isV5).toBe(false);
+		expect(isLegacy).toBe(true);
 	});
 });

--- a/packages/router-bridge/src/router/router-rr5-mode.test.js
+++ b/packages/router-bridge/src/router/router-rr5-mode.test.js
@@ -3,11 +3,11 @@ import { Route as ReactRouterRoute } from 'react-router-dom';
 describe('router bridge - rr5 mode', () => {
 	it('should not export react router v5 implementation', () => {
 		// when
-		const { history, Route, isV5 } = require('./index');
+		const { history, Route, isLegacy } = require('./index');
 
 		// then
 		expect(history).toBeDefined();
 		expect(Route).toBe(ReactRouterRoute);
-		expect(isV5).toBe(true);
+		expect(isLegacy).toBe(false);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Props are spread into the Router component exposed by router bridge.
This is not working well as we have to pass a new prop (location) with react router v6

**What is the chosen solution to this problem?**
Write the component to spread the props and not an array

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
