### PR TITLE
fix(Datalist): keep user filter when suggestion changes (#4080)

### DIFF
--- a/.changeset/light-roses-pretend.md
+++ b/.changeset/light-roses-pretend.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Datalist: keep user filter when suggestion changes

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -111,9 +111,8 @@ function getEntry(titleMap, nameOrValue, restricted) {
 
 function Datalist(props) {
 	// Current persisted value
-	// In case of simple values, this is a string
-	// In case of titleMap, it's the object value key { name: "display value", value: "technical value" }
-	const [value, setValue] = useState();
+	// It's the object value key { name: "display value", value: "technical value" }
+	const [{ name, value }, setEntry] = useState({});
 
 	// suggestions: filter value, display flag, current hover selection
 	const [filterValue, setFilterValue] = useState('');
@@ -145,9 +144,10 @@ function Datalist(props) {
 		}
 
 		if (entry.value !== value) {
-			setValue(entry.value);
+			setEntry(entry);
 		}
-		if (entry.name !== filterValue) {
+		// Update the input value only if user did not change it
+		if (!name || name === filterValue) {
 			setFilterValue(entry.name);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps
@@ -185,7 +185,7 @@ function Datalist(props) {
 		setFilterValue(newFilter);
 
 		if (persist) {
-			setValue(entry.value);
+			setEntry(entry);
 			props.onChange(event, { value: entry.value });
 		} else if (props.onLiveChange) {
 			props.onLiveChange(event, entry.value);

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -1,6 +1,8 @@
 import React from 'react';
-import { render, screen, fireEvent } from '@testing-library/react';
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+
 import Datalist from './Datalist.component';
 
 const props = {
@@ -272,6 +274,24 @@ describe('Datalist component', () => {
 
 		// then
 		expect(screen.getByRole('textbox')).toHaveValue('My foo updated');
+	});
+
+	it('should keep filter when titleMap is updated', async () => {
+		// given
+		const testProps = {
+			id: 'my-datalist',
+			value: 'foo',
+			onChange: jest.fn(),
+			...props,
+		};
+		const { rerender } = render(<Datalist {...testProps} />);
+
+		// when
+		userEvent.type(screen.getByRole('textbox'), 'a');
+		rerender(<Datalist {...testProps} titleMap={[...props.titleMap]} />);
+
+		// then
+		expect(screen.getByRole('textbox')).toHaveValue('a');
 	});
 
 	it('should set highlight on current value suggestion', () => {

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useState } from 'react';
+
 import { action } from '@storybook/addon-actions';
 
 import Datalist from './Datalist.component';
@@ -96,6 +97,7 @@ export const DefaultSingleSection = () => {
 			},
 		})),
 	};
+	const [titleMap, setTitleMap] = useState(defaultValue.titleMap);
 	return (
 		<form className="form">
 			<h3>By default</h3>
@@ -112,6 +114,12 @@ export const DefaultSingleSection = () => {
 			<Datalist {...disabledItems} autoFocus />
 			<h3>With icons</h3>
 			<Datalist {...withIcons} />
+			<h3>With suggestions API</h3>
+			<Datalist {...defaultValue} titleMap={titleMap} onLiveChange={() => {
+				setTimeout(() => {
+					setTitleMap(prev => [...prev])
+				}, 200);
+			}}/>
 			<h3>Insert custom elements via render props</h3>
 			<Datalist {...singleSectionProps}>
 				{(content, { isShown }) => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Cherry-picking https://github.com/Talend/ui/pull/4094 on maintenance branch

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
