### PR TITLE
fix(TDC-6341): RatioBarLine should use Tooltip from DS

### DIFF
--- a/.changeset/cool-apples-joke.md
+++ b/.changeset/cool-apples-joke.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDC-6341): quality bars should use Tooltip from DS

--- a/packages/components/src/RatioBar/RatioBarComposition.component.js
+++ b/packages/components/src/RatioBar/RatioBarComposition.component.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import keycode from 'keycode';
-import TooltipTrigger from '../TooltipTrigger';
+import { Tooltip } from '@talend/design-system';
 import { getTheme } from '../theme';
 import ratioBarTheme from './RatioBar.scss';
 
@@ -55,9 +55,9 @@ export function RatioBarLine({ percentage, tooltipLabel, className, value, dataF
 	}
 
 	return (
-		<TooltipTrigger label={tooltipLabel} tooltipPlacement="bottom">
+		<Tooltip title={tooltipLabel} placement="bottom">
 			{content}
-		</TooltipTrigger>
+		</Tooltip>
 	);
 }
 RatioBarLine.propTypes = {

--- a/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
@@ -2,33 +2,49 @@
 
 exports[`CellQualityBar should render a valid quality bar 1`] = `
 <div class="tc-ratio-bar theme-tc-ratio-bar">
-  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid"
-       tabindex="0"
-       style="flex-basis: 10%;"
-       role="button"
-       aria-describedby="42"
+  <span title="1 invalid value (10%)"
+        placement="bottom"
+        class="CoralTooltip"
   >
-  </div>
-  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty"
-       tabindex="0"
-       style="flex-basis: 20%;"
-       role="button"
-       aria-describedby="42"
+    <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid theme-tc-ratio-bar-line-quality-invalid"
+         tabindex="0"
+         style="flex-basis: 10%;"
+         role="button"
+    >
+    </div>
+  </span>
+  <span title="2 empty value (20%)"
+        placement="bottom"
+        class="CoralTooltip"
   >
-  </div>
-  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na"
-       tabindex="0"
-       style="flex-basis: 40%;"
-       role="button"
-       aria-describedby="42"
+    <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty theme-tc-ratio-bar-line-quality-empty"
+         tabindex="0"
+         style="flex-basis: 20%;"
+         role="button"
+    >
+    </div>
+  </span>
+  <span title="4 not applicable value (40%)"
+        placement="bottom"
+        class="CoralTooltip"
   >
-  </div>
-  <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid"
-       tabindex="0"
-       style="flex-basis: 30%;"
-       role="button"
-       aria-describedby="42"
+    <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na theme-tc-ratio-bar-line-quality-na"
+         tabindex="0"
+         style="flex-basis: 40%;"
+         role="button"
+    >
+    </div>
+  </span>
+  <span title="3 valid value (30%)"
+        placement="bottom"
+        class="CoralTooltip"
   >
-  </div>
+    <div class="tc-ratio-bar-line theme-tc-ratio-bar-line tc-ratio-bar-line-grow theme-tc-ratio-bar-line-grow tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid theme-tc-ratio-bar-line-quality-valid"
+         tabindex="0"
+         style="flex-basis: 30%;"
+         role="button"
+    >
+    </div>
+  </span>
 </div>
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

RatioBarLine uses the _old_ tooltip implem, which is not really accessible

**What is the chosen solution to this problem?**

Use the DS one

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
