### PR TITLE
fix(ARCH-537/fork/bootstrap): add publish access config

### DIFF
--- a/.changeset/two-tables-eat.md
+++ b/.changeset/two-tables-eat.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-bootstrap': patch
+---
+
+fix: add publishConfig with access public

--- a/fork/react-bootstrap/package.json
+++ b/fork/react-bootstrap/package.json
@@ -69,5 +69,8 @@
     "react-transition-group": "^2.9.0",
     "uncontrollable": "^7.2.1",
     "warning": "^3.0.0"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current bootrap fork is not accessible without npm token

**What is the chosen solution to this problem?**

add publish access config and trigger a new release

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
