### PR TITLE
fix(TDC-6341): improve RatioBarComposition accessibility

### DIFF
--- a/.changeset/violet-cherries-repeat.md
+++ b/.changeset/violet-cherries-repeat.md
@@ -1,5 +1,5 @@
 ---
-'@talend/react-components': minor
+'@talend/react-components': patch
 ---
 
 fix(TDC-6341): improve RatioBarComposition accessibility

--- a/.changeset/violet-cherries-repeat.md
+++ b/.changeset/violet-cherries-repeat.md
@@ -2,4 +2,4 @@
 '@talend/react-components': minor
 ---
 
-feat(TDC-6341): improve RatioBarComposition accessibility
+fix(TDC-6341): improve RatioBarComposition accessibility

--- a/.changeset/violet-cherries-repeat.md
+++ b/.changeset/violet-cherries-repeat.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TDC-6341): improve RatioBarComposition accessibility

--- a/packages/components/src/RatioBar/RatioBarComposition.component.js
+++ b/packages/components/src/RatioBar/RatioBarComposition.component.js
@@ -47,7 +47,9 @@ export function RatioBarLine({ percentage, tooltipLabel, className, value, dataF
 			data-feature={dataFeature}
 			onClick={onClick}
 			onKeyDown={onKeyDown}
-		/>
+		>
+			{tooltipLabel && <span className="sr-only">{tooltipLabel}</span>}
+		</div>
 	);
 
 	if (!tooltipLabel) {

--- a/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
+++ b/packages/components/src/VirtualizedList/CellQualityBar/__snapshots__/CellQualityBar.test.js.snap
@@ -11,6 +11,9 @@ exports[`CellQualityBar should render a valid quality bar 1`] = `
          style="flex-basis: 10%;"
          role="button"
     >
+      <span class="sr-only">
+        1 invalid value (10%)
+      </span>
     </div>
   </span>
   <span title="2 empty value (20%)"
@@ -22,6 +25,9 @@ exports[`CellQualityBar should render a valid quality bar 1`] = `
          style="flex-basis: 20%;"
          role="button"
     >
+      <span class="sr-only">
+        2 empty value (20%)
+      </span>
     </div>
   </span>
   <span title="4 not applicable value (40%)"
@@ -33,6 +39,9 @@ exports[`CellQualityBar should render a valid quality bar 1`] = `
          style="flex-basis: 40%;"
          role="button"
     >
+      <span class="sr-only">
+        4 not applicable value (40%)
+      </span>
     </div>
   </span>
   <span title="3 valid value (30%)"
@@ -44,6 +53,9 @@ exports[`CellQualityBar should render a valid quality bar 1`] = `
          style="flex-basis: 30%;"
          role="button"
     >
+      <span class="sr-only">
+        3 valid value (30%)
+      </span>
     </div>
   </span>
 </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

ratiobarcomposition items does not contains the tooltip label

**What is the chosen solution to this problem?**

add it as sr-only : it will also be appreciated by qa guys for their auto ui tests

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
