### PR TITLE
fix(ARCH-537/Forms): build and configure modes

### DIFF
--- a/.changeset/slimy-swans-scream.md
+++ b/.changeset/slimy-swans-scream.md
@@ -2,5 +2,5 @@
 '@talend/react-forms': patch
 ---
 
-fix: build ace (code widget) modes (languages support)
-add tools to configure the copy of modes in your apps
+fix: build ace (code widget) modes, theme and snippets.
+Add tools to configure the copy of modes in your apps.

--- a/.changeset/slimy-swans-scream.md
+++ b/.changeset/slimy-swans-scream.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-forms': patch
+---
+
+fix: build ace (code widget) modes (languages support)
+add tools to configure the copy of modes in your apps

--- a/packages/forms/README.md
+++ b/packages/forms/README.md
@@ -135,8 +135,33 @@ You can use validation from outside (let say button outside the form) this way:
 ```javascript
 import validate from '@talend/react-forms/lib/validate';
 
-function isValid({ payload}) {
+function isValid({ payload }) {
 	return validate(payload.jsonSchema, payload.formData);
+}
+```
+
+## Build with webpack
+
+@talend/react-forms comes with react-ace lazy loaded.
+No modes are loaded with the build and ace is trying to fetch modes,
+this is why you need to add a copyconfig to your build to use the 'code' widget.
+
+Please adapt from this webpack config example:
+
+```javascript
+const CopyWebpackPlugin = require('copy-webpack-plugin');
+const buildFormUtils = require('@talend/react-forms/build-utils');
+
+const patterns = buildFormUtils.getWebpackCopyConfig();
+
+module.exports = {
+	entry: './src/app/index.js'
+	output: {
+		//...
+	},
+	plugins: [
+		new CopyWebpackPlugin({ patterns })
+	]
 }
 ```
 

--- a/packages/forms/build-utils.js
+++ b/packages/forms/build-utils.js
@@ -1,0 +1,15 @@
+const path = require('path');
+
+function getWebpackCopyConfig() {
+	return [
+		{
+			from: 'mode-*.js',
+			context: path.resolve(__dirname, 'dist'),
+			info: { minimized: true },
+		},
+	];
+}
+
+module.exports = {
+	getWebpackCopyConfig,
+};

--- a/packages/forms/build-utils.js
+++ b/packages/forms/build-utils.js
@@ -3,7 +3,7 @@ const path = require('path');
 function getWebpackCopyConfig() {
 	return [
 		{
-			from: '+(mode|theme)-*.js',
+			from: '+(mode|theme|snippets)-*.js',
 			context: path.resolve(__dirname, 'dist'),
 			info: { minimized: true },
 		},

--- a/packages/forms/build-utils.js
+++ b/packages/forms/build-utils.js
@@ -3,7 +3,7 @@ const path = require('path');
 function getWebpackCopyConfig() {
 	return [
 		{
-			from: 'mode-*.js',
+			from: '+(mode|theme)-*.js',
 			context: path.resolve(__dirname, 'dist'),
 			info: { minimized: true },
 		},

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -5,10 +5,11 @@
   "mainSrc": "src/index.js",
   "license": "Apache-2.0",
   "scripts": {
+    "build:ace": "webpack --config=./webpack.ace.config.js",
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
     "build-storybook": "talend-scripts build-storybook",
-    "pre-release": "yarn build:dev && yarn build:prod",
+    "pre-release": "yarn build:dev && yarn build:prod && yarn bild:ace",
     "build:lib": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -9,7 +9,7 @@
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
     "build-storybook": "talend-scripts build-storybook",
-    "pre-release": "yarn build:dev && yarn build:prod && yarn bild:ace",
+    "pre-release": "yarn build:dev && yarn build:prod && yarn build:ace",
     "build:lib": "talend-scripts build:lib",
     "test": "talend-scripts test",
     "test:watch": "talend-scripts test --watch",

--- a/packages/forms/webpack.ace.config.js
+++ b/packages/forms/webpack.ace.config.js
@@ -1,0 +1,13 @@
+const path = require('path');
+const MODES = ['json', 'python', 'sql'];
+
+module.exports = MODES.map(mode => {
+	return {
+		mode: 'production',
+		entry: `brace/mode/${mode}`,
+		output: {
+			path: path.resolve(__dirname, 'dist'),
+			filename: `mode-${mode}.js`,
+		},
+	};
+});

--- a/packages/forms/webpack.ace.config.js
+++ b/packages/forms/webpack.ace.config.js
@@ -9,13 +9,24 @@ module.exports = MODES.map(mode => ({
 		path: path.resolve(__dirname, 'dist'),
 		filename: `mode-${mode}.js`,
 	},
-})).concat(
-	THEMES.map(theme => ({
-		mode: 'production',
-		entry: `brace/theme/${theme}`,
-		output: {
-			path: path.resolve(__dirname, 'dist'),
-			filename: `theme-${theme}.js`,
-		},
-	})),
-);
+}))
+	.concat(
+		MODES.map(snippets => ({
+			mode: 'production',
+			entry: `brace/snippets/${snippets}`,
+			output: {
+				path: path.resolve(__dirname, 'dist'),
+				filename: `snippets-${snippets}.js`,
+			},
+		})),
+	)
+	.concat(
+		THEMES.map(theme => ({
+			mode: 'production',
+			entry: `brace/theme/${theme}`,
+			output: {
+				path: path.resolve(__dirname, 'dist'),
+				filename: `theme-${theme}.js`,
+			},
+		})),
+	);

--- a/packages/forms/webpack.ace.config.js
+++ b/packages/forms/webpack.ace.config.js
@@ -1,13 +1,21 @@
 const path = require('path');
 const MODES = ['json', 'python', 'sql'];
+const THEMES = ['chrome'];
 
-module.exports = MODES.map(mode => {
-	return {
+module.exports = MODES.map(mode => ({
+	mode: 'production',
+	entry: `brace/mode/${mode}`,
+	output: {
+		path: path.resolve(__dirname, 'dist'),
+		filename: `mode-${mode}.js`,
+	},
+})).concat(
+	THEMES.map(theme => ({
 		mode: 'production',
-		entry: `brace/mode/${mode}`,
+		entry: `brace/theme/${theme}`,
 		output: {
 			path: path.resolve(__dirname, 'dist'),
-			filename: `mode-${mode}.js`,
+			filename: `theme-${theme}.js`,
 		},
-	};
-});
+	})),
+);

--- a/packages/playground/webpack.config.dev.js
+++ b/packages/playground/webpack.config.dev.js
@@ -5,6 +5,7 @@
 const path = require('path');
 const webpack = require('webpack');
 const resolve = require('@talend/dynamic-cdn-webpack-plugin/src/resolve-pkg');
+const buildFormUtils = require('@talend/react-forms/build-utils');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 
 const mockBackend = require('./mockBackend/server');
@@ -50,7 +51,7 @@ const patterns = PKGS.map(pkg => ({
 	from: path.resolve(getPath(pkg), 'dist'),
 	to: `${to(pkg)}/`,
 	info: { minimized: true },
-}));
+})).concat(buildFormUtils.getWebpackCopyConfig());
 
 const webpackConfig = {
 	plugins: [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

since code widget is lazy the way to add modes has been restricted to copy them into your app assets.

Before that it was possible by using import like this

```javascript
import 'brace/mode/json';
```
This was an issue as it force your app to have ace editor even if you don't use it.


**What is the chosen solution to this problem?**

* copy modes json, sql and python also theme chrome and snippets into forms/dist
* add utils to configure webpack
* use them in the playground

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
