### PR TITLE
chore: build icons from github actions

### DIFF
--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Build @talend/design-tokens
         run: |
           yarn workspace @talend/assets-api run build:lib
+          yarn workspace @talend/icons run build:lib
           yarn workspace @talend/design-tokens run build:lib
 
       - name: Cypress Component Testing

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -30,6 +30,7 @@ jobs:
       - name: Build Storybook of the design tokens
         run: |
           yarn workspace @talend/assets-api run build:lib
+          yarn workspace @talend/icons run build:lib
           yarn workspace @talend/design-tokens run build:lib
           yarn workspace @talend/design-tokens run build-storybook
 

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -68,6 +68,7 @@ jobs:
         if: matrix.package == 'design-system'
         run: |
           yarn workspace @talend/assets-api run build:lib
+          yarn workspace @talend/icons run build:lib
           yarn workspace @talend/design-tokens run build:lib
 
       - name: Build @talend/icons


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook build was failing on github action

**What is the chosen solution to this problem?**
Fixing the build by...building the requisite dependancy 

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
