### PR TITLE
chore: pre-release only triggered by changeset workflow if release

### DIFF
--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -27,7 +27,7 @@ jobs:
           cache: "yarn"
 
       - name: Install Dependencies
-        run: yarn --frozen-lockfile && yarn pre-release
+        run: yarn --frozen-lockfile
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "postinstall": "node workspace-run.js build:lib",
     "pre-release": "node workspace-run.js pre-release",
     "start": "yarn workspace @talend/ui-playground run start",
-    "release": "yarn changeset publish",
+    "release": "yarn pre-release && yarn changeset publish",
     "lint-staged": "lint-staged",
     "lint:es": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:es",
     "lint:style": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:style",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current release workflow on master run pre-release scripts even if it just want to create the PR.

**What is the chosen solution to this problem?**

* remove pre-release call from the workflow
* add it in release script already triggered by the workflow

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
