### PR TITLE
chore(icons): Build & test action is not triggered

### DIFF
--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -15,6 +15,9 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+        with:
+          # Required when using a PAT for opening the PR
+          persist-credentials: false
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -55,3 +58,5 @@ jobs:
           body: ${{ steps.get-pr-body.outputs.body }}
           branch: ci/icons
           token: ${{ secrets.GITHUB_TOKEN }}
+          # Opening a PR with default token would not start build & test action
+          GITHUB_TOKEN: ${{ secrets.CHANGESET_GITHUB_TOKEN }}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Workflows can't trigger other workflow events when using default token, we need a PAT for this
https://github.com/peter-evans/create-pull-request#action-inputs

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
