### PR TITLE
fix: remove bundles attributes

### DIFF
--- a/.changeset/shiny-foxes-refuse.md
+++ b/.changeset/shiny-foxes-refuse.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: remove bundles props of IconsProvider

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -57,7 +57,6 @@ const defaultPreview = {
 			const storyElement = React.createElement(Story, {...context, key: 'story'});
 			return [
 				React.createElement(IconsProvider, {
-					bundles: ['https://unpkg.com/@talend/icons/dist/svg-bundle/all.svg'],
 					key: 'icons-provider-decorator'
 				}),
 				React.createElement(ThemeProvider, {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

new Icons do not work in stories

**What is the chosen solution to this problem?**

remove the bundles override in default storybook config.
assets api should take the lead and use unpkg by default.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
