### PR TITLE
fix(design-system): Popover transparent background

### DIFF
--- a/.changeset/curvy-games-suffer.md
+++ b/.changeset/curvy-games-suffer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): add white background to popover component

--- a/packages/design-system/src/components/Popover/Popover.module.scss
+++ b/packages/design-system/src/components/Popover/Popover.module.scss
@@ -12,6 +12,7 @@
 	}
 
 	&__animated {
+		background-color: tokens.$coral-color-neutral-background;
 		transition: opacity tokens.$coral-transition-fast;
 		box-shadow: tokens.$coral-elevation-shadow-neutral-m;
 		border-radius: tokens.$coral-radius-s;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Transparency is a good thing in life in general.
But when it comes to popover, it provide some weird behaviours

<img width="299" alt="CleanShot 2022-06-13 at 15 06 27@2x" src="https://user-images.githubusercontent.com/2909671/173360420-868a823d-bb18-42dd-9042-544445a5e3c2.png">

We can specify a background for the content but still the padding will not be impacted and will remain transparent.

**What is the chosen solution to this problem?**
Add white background to the popover


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
