### PR TITLE
feat(design-system): allow to control popover

### DIFF
--- a/.changeset/silver-wolves-serve.md
+++ b/.changeset/silver-wolves-serve.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): add z-index to popover

--- a/.changeset/weak-beers-worry.md
+++ b/.changeset/weak-beers-worry.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(design-system): Allow children as function for popover component in order to access the popover state

--- a/packages/design-system/src/components/Popover/Popover.stories.mdx
+++ b/packages/design-system/src/components/Popover/Popover.stories.mdx
@@ -21,6 +21,10 @@ Popover displays floating informative and actionable content in relation to its 
 	<Story height="12rem" story={Stories.DefaultStory} />
 </Canvas>
 
+<Canvas>
+	<Story height="12rem" story={Stories.WithFunctionAsChildren} />
+</Canvas>
+
 ## States
 
 ## Content

--- a/packages/design-system/src/components/Popover/Popover.stories.tsx
+++ b/packages/design-system/src/components/Popover/Popover.stories.tsx
@@ -3,10 +3,25 @@ import React from 'react';
 import Popover from './Popover';
 import { ButtonPrimary } from '../Button';
 import { action } from '@storybook/addon-actions';
+import { PopoverStateReturn } from 'reakit/ts';
+import { StackVertical } from '../Stack';
 
 export default {
 	component: Popover,
 };
+
+function EasyPopover() {
+	return <StackVertical gap="S">Hello hello</StackVertical>;
+}
+
+function ControlledPopover({ popover }: { popover?: PopoverStateReturn }) {
+	return (
+		<StackVertical gap="S">
+			There is some content
+			<ButtonPrimary onClick={() => popover?.hide()}>Close Me please</ButtonPrimary>
+		</StackVertical>
+	);
+}
 
 export const DefaultStory = () => (
 	<div style={{ padding: '1.2rem' }}>
@@ -16,7 +31,21 @@ export const DefaultStory = () => (
 				<ButtonPrimary onClick={action('Clicked disclosure')}>Open popover</ButtonPrimary>
 			}
 		>
-			Custom popover
+			Text Content
+		</Popover>
+	</div>
+);
+
+export const WithFunctionAsChildren = () => (
+	<div style={{ padding: '1.2rem' }}>
+		<Popover
+			aria-label="Custom popover"
+			disclosure={
+				<ButtonPrimary onClick={action('Clicked disclosure')}>Open popover</ButtonPrimary>
+			}
+		>
+			{(popover: PopoverStateReturn) => <ControlledPopover popover={popover} />}
+			<EasyPopover />
 		</Popover>
 	</div>
 );

--- a/packages/design-system/src/components/Popover/Popover.stories.tsx
+++ b/packages/design-system/src/components/Popover/Popover.stories.tsx
@@ -14,7 +14,7 @@ function EasyPopover() {
 	return <StackVertical gap="S">Hello hello</StackVertical>;
 }
 
-function ControlledPopover({ popover }: { popover?: PopoverStateReturn }) {
+function ChildrenAsFunctionPopoverContent({ popover }: { popover?: PopoverStateReturn }) {
 	return (
 		<StackVertical gap="S">
 			There is some content
@@ -44,7 +44,7 @@ export const WithFunctionAsChildren = () => (
 				<ButtonPrimary onClick={action('Clicked disclosure')}>Open popover</ButtonPrimary>
 			}
 		>
-			{(popover: PopoverStateReturn) => <ControlledPopover popover={popover} />}
+			{(popover: PopoverStateReturn) => <ChildrenAsFunctionPopoverContent popover={popover} />}
 			<EasyPopover />
 		</Popover>
 	</div>

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -21,9 +21,15 @@ export type PopoverPropsType = HTMLAttributes<HTMLDivElement> & {
 	disclosure: ReactElement<typeof Clickable>;
 	children: PopoverChildren | PopoverChildren[];
 	position?: Placement;
+	zIndex?: string | number;
 } & DataAttributes;
 
-function Popover({ disclosure, position = 'auto', ...props }: PopoverPropsType) {
+function Popover({
+	disclosure,
+	position = 'auto',
+	zIndex = tokens.coralElevationLayerStandardFront,
+	...props
+}: PopoverPropsType) {
 	const popover = usePopoverState({ animated: ANIMATION_DURATION, placement: position });
 	const children = Array.isArray(props.children) ? props.children : [props.children];
 
@@ -32,11 +38,7 @@ function Popover({ disclosure, position = 'auto', ...props }: PopoverPropsType) 
 			<ReakitPopoverDisclosure {...popover}>
 				{disclosureProps => cloneElement(disclosure, disclosureProps)}
 			</ReakitPopoverDisclosure>
-			<ReakitPopover
-				{...popover}
-				style={{ zIndex: tokens.coralElevationLayerStandardFront, ...props.style }}
-				{...props}
-			>
+			<ReakitPopover {...popover} {...props} style={{ zIndex }}>
 				<div className={style.popover__animated}>
 					<ReakitPopoverArrow {...popover} className={style.popover__arrow} />
 					{children.map(child => {

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,9 +1,16 @@
-import React, { HTMLAttributes, ReactElement, ReactNode } from 'react';
+import React, {
+	HTMLAttributes,
+	ReactElement,
+	ReactNode,
+	cloneElement,
+	isValidElement,
+} from 'react';
 import {
 	usePopoverState,
 	Popover as ReakitPopover,
 	PopoverArrow as ReakitPopoverArrow,
 	PopoverDisclosure as ReakitPopoverDisclosure,
+	PopoverStateReturn,
 } from 'reakit';
 import Clickable from '../Clickable';
 import { Placement } from '../Tooltip/Tooltip';
@@ -13,24 +20,32 @@ import style from './Popover.module.scss';
 
 const ANIMATION_DURATION = 150; // Sync with @talend/design-token animations duration
 
+export type PopoverChildren = ReactNode | ((popover: PopoverStateReturn) => ReactNode);
+
 export type PopoverPropsType = HTMLAttributes<HTMLDivElement> & {
 	disclosure: ReactElement<typeof Clickable>;
-	children: ReactNode | ReactNode[];
+	children: PopoverChildren | PopoverChildren[];
 	position?: Placement;
 } & DataAttributes;
 
 function Popover({ disclosure, position = 'auto', ...props }: PopoverPropsType) {
 	const popover = usePopoverState({ animated: ANIMATION_DURATION, placement: position });
+	const children = Array.isArray(props.children) ? props.children : [props.children];
 
 	return (
 		<>
 			<ReakitPopoverDisclosure {...popover}>
-				{disclosureProps => React.cloneElement(disclosure, disclosureProps)}
+				{disclosureProps => cloneElement(disclosure, disclosureProps)}
 			</ReakitPopoverDisclosure>
 			<ReakitPopover {...popover} {...props}>
 				<div className={style.popover__animated}>
 					<ReakitPopoverArrow {...popover} className={style.popover__arrow} />
-					{props.children}
+					{children.map(child => {
+						if (typeof child === 'function') {
+							return child(popover);
+						}
+						return child;
+					})}
 				</div>
 			</ReakitPopover>
 		</>

--- a/packages/design-system/src/components/Popover/Popover.tsx
+++ b/packages/design-system/src/components/Popover/Popover.tsx
@@ -1,10 +1,5 @@
-import React, {
-	HTMLAttributes,
-	ReactElement,
-	ReactNode,
-	cloneElement,
-	isValidElement,
-} from 'react';
+import React, { HTMLAttributes, ReactElement, ReactNode, cloneElement } from 'react';
+import tokens from '@talend/design-tokens';
 import {
 	usePopoverState,
 	Popover as ReakitPopover,
@@ -37,7 +32,11 @@ function Popover({ disclosure, position = 'auto', ...props }: PopoverPropsType) 
 			<ReakitPopoverDisclosure {...popover}>
 				{disclosureProps => cloneElement(disclosure, disclosureProps)}
 			</ReakitPopoverDisclosure>
-			<ReakitPopover {...popover} {...props}>
+			<ReakitPopover
+				{...popover}
+				style={{ zIndex: tokens.coralElevationLayerStandardFront, ...props.style }}
+				{...props}
+			>
 				<div className={style.popover__animated}>
 					<ReakitPopoverArrow {...popover} className={style.popover__arrow} />
 					{children.map(child => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can have button into a popover that close the popover at the end of the day (like setting up stuff inside the popover)
To allow the popover content to close the popover, we would like to access to the popover state that is contained into the component.

**What is the chosen solution to this problem?**
Here the integration is allowing to pass children as before if we don't have to handle this kind of use case and we can also provide children as function if we want to access the popover in the content

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
