### PR TITLE
fix(AMG-202): VList with single column crash

### DIFF
--- a/.changeset/cool-pots-invite.md
+++ b/.changeset/cool-pots-invite.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(AMG-202): VList with single column crash

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -60,8 +60,8 @@ function VList({ children, columnChooser, ...rest }) {
 				headerAction={headerAction}
 				{...rest}
 			>
-				{visibleColumns
-					? children?.filter(column => visibleColumns?.includes(column.props?.dataKey))
+				{visibleColumns && children?.filter
+					? children.filter(column => visibleColumns.includes(column.props?.dataKey))
 					: children}
 			</VirtualizedList>
 		</div>

--- a/packages/components/src/List/ListComposition/VList/VList.component.js
+++ b/packages/components/src/List/ListComposition/VList/VList.component.js
@@ -60,7 +60,7 @@ function VList({ children, columnChooser, ...rest }) {
 				headerAction={headerAction}
 				{...rest}
 			>
-				{visibleColumns && children?.filter
+				{visibleColumns && Array.isArray(children)
 					? children.filter(column => visibleColumns.includes(column.props?.dataKey))
 					: children}
 			</VirtualizedList>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When we define only one column in our `VList` (e.g  bellow example), component couldn't be rendered and crashed with an error. 

```
<List.Manager id="my-list" collection={simpleCollection}>
   <List.VList id="my-vlist" {...props}>
      <List.VList.Text label="Id" dataKey="id" />
   </List.VList>
</List.Manager>
```

Caused by the call `children?.filter` where `children` is an object when only one element and an array when multiple. 

**What is the chosen solution to this problem?**

Do not filter when only one children (no-sense to hide all columns).

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
