### PR TITLE
fix(ARCH-537): dynamic-cdn use find instead of require.resolve

### DIFF
--- a/.changeset/flat-rivers-wait.md
+++ b/.changeset/flat-rivers-wait.md
@@ -1,0 +1,5 @@
+---
+'@talend/dynamic-cdn-webpack-plugin': patch
+---
+
+fix: use find to resolve pkg instead of require.resolve

--- a/.changeset/flat-rivers-wait.md
+++ b/.changeset/flat-rivers-wait.md
@@ -2,4 +2,4 @@
 '@talend/dynamic-cdn-webpack-plugin': patch
 ---
 
-fix: use find to resolve pkg instead of require.resolve
+fix: resolvePkg use find first and fallback to require.resolve

--- a/fork/dynamic-cdn-webpack-plugin/src/index.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/index.js
@@ -69,9 +69,12 @@ function getDeps(cdnConfig) {
 	}, {});
 }
 
-function getPackageRootPath(cdnConfig) {
-	const main = resolvePkg(cdnConfig.name, cdnConfig);
-
+function getPackageRootPath(cdnConfig, cwd) {
+	const opts = { cwd, ...cdnConfig };
+	const main = resolvePkg(cdnConfig.name, opts);
+	if (!main) {
+		console.error(`DynamicCdnWebpackPlugin package ${cdnConfig.name} not found in ${cwd}`);
+	}
 	const depPath = path.normalize(path.join(path.sep, cdnConfig.name, path.sep));
 	const index = main.indexOf(depPath);
 	// index may equal -1:
@@ -261,7 +264,7 @@ class DynamicCdnWebpackPlugin {
 				}
 				continue;
 			}
-			const contextModulePath = getPackageRootPath(cdnConfig) || contextPath;
+			const contextModulePath = getPackageRootPath(cdnConfig, contextPath) || contextPath;
 			const depPath = `${path.join(contextModulePath, cdnConfig.path)}.dependencies.json`;
 			if (fs.existsSync(depPath)) {
 				this.addDependencies(contextModulePath, require(depPath), {
@@ -358,7 +361,7 @@ class DynamicCdnWebpackPlugin {
 		}
 
 		// Try to get the manifest
-		const contextModulePath = getPackageRootPath(cdnConfig) || contextPath;
+		const contextModulePath = getPackageRootPath(cdnConfig, contextPath) || contextPath;
 		const depPath = `${path.join(contextModulePath, cdnConfig.path)}.dependencies.json`;
 		cdnConfig.local = path.join(contextModulePath, cdnConfig.path);
 

--- a/fork/dynamic-cdn-webpack-plugin/src/index.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/index.js
@@ -69,10 +69,10 @@ function getDeps(cdnConfig) {
 	}, {});
 }
 
-function getPackageRootPath(name, contextPath) {
-	const main = resolvePkg(name, { cwd: contextPath });
+function getPackageRootPath(cdnConfig) {
+	const main = resolvePkg(cdnConfig.name, cdnConfig);
 
-	const depPath = path.normalize(path.join(path.sep, name, path.sep));
+	const depPath = path.normalize(path.join(path.sep, cdnConfig.name, path.sep));
 	const index = main.indexOf(depPath);
 	// index may equal -1:
 	// name = @talend/react-cmf
@@ -261,8 +261,7 @@ class DynamicCdnWebpackPlugin {
 				}
 				continue;
 			}
-			const contextModulePath =
-				getPackageRootPath(cdnConfig.name, contextPath) || contextPath;
+			const contextModulePath = getPackageRootPath(cdnConfig) || contextPath;
 			const depPath = `${path.join(contextModulePath, cdnConfig.path)}.dependencies.json`;
 			if (fs.existsSync(depPath)) {
 				this.addDependencies(contextModulePath, require(depPath), {
@@ -359,7 +358,7 @@ class DynamicCdnWebpackPlugin {
 		}
 
 		// Try to get the manifest
-		const contextModulePath = getPackageRootPath(cdnConfig.name, contextPath) || contextPath;
+		const contextModulePath = getPackageRootPath(cdnConfig) || contextPath;
 		const depPath = `${path.join(contextModulePath, cdnConfig.path)}.dependencies.json`;
 		cdnConfig.local = path.join(contextModulePath, cdnConfig.path);
 

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -8,8 +8,8 @@ const { findPackage } = require('./find');
  * @returns {string|undefined} the full path of the module id requested
  */
 function resolve(moduleId, options) {
-	if (options.version) {
-		return findPackage({ ...options, name: moduleId });
+	if (options && options.version) {
+		return findPackage(options);
 	}
 	let paths = require.resolve.paths(moduleId) || [];
 

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -8,19 +8,21 @@ const { findPackage } = require('./find');
  * @returns {string|undefined} the full path of the module id requested
  */
 function resolve(moduleId, options) {
-	if (options && options.version) {
-		return findPackage(options);
-	}
 	let paths = require.resolve.paths(moduleId) || [];
-
 	if (options && options.cwd) {
 		paths = [options.cwd].concat(paths);
 	}
+	let result;
+	if (options && options.version) {
+		result = findPackage(options);
+	}
+	if (!result) {
+		try {
+			return require.resolve(moduleId, { paths });
+		} catch {}
+	}
 
-	try {
-		return require.resolve(moduleId, { paths });
-	} catch {}
-	return undefined;
+	return result;
 }
 
 module.exports = resolve;

--- a/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
+++ b/fork/dynamic-cdn-webpack-plugin/src/resolve-pkg.js
@@ -8,15 +8,15 @@ const { findPackage } = require('./find');
  * @returns {string|undefined} the full path of the module id requested
  */
 function resolve(moduleId, options) {
-	let paths = require.resolve.paths(moduleId) || [];
-	if (options && options.cwd) {
-		paths = [options.cwd].concat(paths);
-	}
 	let result;
 	if (options && options.version) {
 		result = findPackage(options);
 	}
 	if (!result) {
+		let paths = require.resolve.paths(moduleId) || [];
+		if (options && options.cwd) {
+			paths = [options.cwd].concat(paths);
+		}
 		try {
 			return require.resolve(moduleId, { paths });
 		} catch {}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

dependency error: history in 404 of in bad URL (5.0.0 instead of 3.3.0)
react-cmf-router has a dependencies.json which request history

current webpack plugin use require.resolve from react-cmf-router to find history.

why ?

```
- history v5
- @talend/react-cmf-router
- react-router v3
   - history
```
in this context dynamic cdn plugin is doing the following actions

```
cd node_modules/@talend/react-cmf-router
node
> require.resolve('history')
```
so it will give us 5.0.0

**What is the chosen solution to this problem?**

use find first then fallback to require.resolve to keep existing working code based on context only

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
