### PR TITLE
feat(compoments): add beta tag for sidepanel

### DIFF
--- a/.changeset/nasty-chairs-push.md
+++ b/.changeset/nasty-chairs-push.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(components/sidepanel): allow beta tag

--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { StackHorizontal, TagBeta } from '@talend/design-system';
 import { Action } from '../Actions';
 import Inject from '../Inject';
 import theme from './ActionList.scss';
@@ -57,7 +58,7 @@ function ActionListItem({ getComponent, id, onSelect, action, isSelected, isNav,
 			})}
 			{...a11y}
 		>
-			<Renderers.Action {...actionProps} />
+			<Renderers.Action {...actionProps}>{action.beta && <TagBeta>Beta</TagBeta>}</Renderers.Action>
 		</li>
 	);
 }

--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -116,6 +116,7 @@ if (process.env.NODE_ENV !== 'production') {
 		icon: PropTypes.string,
 		key: PropTypes.string,
 		label: PropTypes.string,
+		beta: PropTypes.bool,
 		onClick: PropTypes.func,
 	});
 

--- a/packages/components/src/ActionList/ActionList.component.js
+++ b/packages/components/src/ActionList/ActionList.component.js
@@ -1,10 +1,14 @@
 import PropTypes from 'prop-types';
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import classNames from 'classnames';
-import { StackHorizontal, TagBeta } from '@talend/design-system';
+
+import { TagBeta } from '@talend/design-system';
+
 import { Action } from '../Actions';
 import Inject from '../Inject';
 import theme from './ActionList.scss';
+import I18N_DOMAIN_COMPONENTS from '../constants';
 
 /**
  * return the formatted action id
@@ -22,6 +26,7 @@ function getActionId(id, action) {
 }
 
 function ActionListItem({ getComponent, id, onSelect, action, isSelected, isNav, itemClassName }) {
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	const a11y = {
 		role: 'presentation',
 	};
@@ -58,7 +63,9 @@ function ActionListItem({ getComponent, id, onSelect, action, isSelected, isNav,
 			})}
 			{...a11y}
 		>
-			<Renderers.Action {...actionProps}>{action.beta && <TagBeta>Beta</TagBeta>}</Renderers.Action>
+			<Renderers.Action {...actionProps}>
+				{action.beta && <TagBeta>{t('BETA', 'Beta')}</TagBeta>}
+			</Renderers.Action>
 		</li>
 	);
 }

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -10,10 +10,11 @@ const actions = [
 		onClick: action('Recent clicked'),
 	},
 	{
-		label: 'Favorite datasets',
+		label: 'Favorite datasets of the year 2019',
 		icon: 'talend-star',
 		'data-feature': 'actionlist.item',
 		onClick: action('Favorite clicked'),
+		beta: true,
 		active: true,
 	},
 	{

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -105,6 +105,7 @@ function ActionButton(props) {
 	const {
 		bsStyle,
 		buttonRef,
+		children,
 		inProgress,
 		disabled,
 		hideLabel,
@@ -186,6 +187,7 @@ function ActionButton(props) {
 			{...buttonProps}
 		>
 			{buttonContent}
+			{children}
 		</Button>
 	);
 	if (hasPopup) {

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -20,6 +20,7 @@ const actions = [
 	{
 		label: 'Favorites',
 		icon: 'talend-star',
+		beta: true,
 		onClick: action('Favorites clicked'),
 	},
 ];
@@ -30,11 +31,13 @@ const actionsLinks = [
 		icon: 'talend-dataprep',
 		href: '/preparations',
 		active: true,
+		beta: true,
 	},
 	{
 		label: 'Datasets',
 		icon: 'talend-download',
 		href: '/datasets',
+		beta: true,
 	},
 	{
 		label: 'Favorites',
@@ -47,6 +50,7 @@ const items = [
 	{
 		key: 'preparations',
 		label: 'Preparations',
+		beta: true,
 		icon: 'talend-dataprep',
 	},
 	{
@@ -71,6 +75,7 @@ const other = [
 		key: 'groups',
 		label: 'Groups',
 		icon: 'talend-group-circle',
+		beta: true,
 	},
 	{
 		key: 'roles',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
What about having beta features in a sidepanel !? 😉

<img width="196" alt="CleanShot 2022-06-17 at 16 28 09@2x" src="https://user-images.githubusercontent.com/2909671/174318337-f3cd25b0-2b67-4b02-8fa6-6b6e7704b424.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
