### PR TITLE
fix(ARCH-537): add language attribute to i18next mock

### DIFF
--- a/.changeset/wild-owls-warn.md
+++ b/.changeset/wild-owls-warn.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+fix: provide default language to formatNumber

--- a/.changeset/wild-owls-warn.md
+++ b/.changeset/wild-owls-warn.md
@@ -1,5 +1,5 @@
 ---
-'@talend/react-dataviz': patch
+'@talend/scripts-config-jest': patch
 ---
 
-fix: provide default language to formatNumber
+fix: add missing language attribute in i18next mock

--- a/packages/dataviz/src/formatters/formatters.ts
+++ b/packages/dataviz/src/formatters/formatters.ts
@@ -26,7 +26,7 @@ export function formatDateTime(value: number): string {
 export function formatNumber(value: number, precision?: number): string {
 	return value > 1e10
 		? value.toFixed(0)
-		: value.toLocaleString(i18next.language || 'en-EN', {
+		: value.toLocaleString(i18next.language, {
 				maximumFractionDigits: precision,
 		  });
 }

--- a/packages/dataviz/src/formatters/formatters.ts
+++ b/packages/dataviz/src/formatters/formatters.ts
@@ -26,7 +26,7 @@ export function formatDateTime(value: number): string {
 export function formatNumber(value: number, precision?: number): string {
 	return value > 1e10
 		? value.toFixed(0)
-		: value.toLocaleString(i18next.language, {
+		: value.toLocaleString(i18next.language || 'en-EN', {
 				maximumFractionDigits: precision,
 		  });
 }

--- a/tools/scripts-config-jest/test-setup.js
+++ b/tools/scripts-config-jest/test-setup.js
@@ -68,6 +68,7 @@ jest.mock('i18next', () => {
 	}
 	const i18nextMock = jest.genMockFromModule('i18next');
 	i18nextMock.t = tMock;
+	i18nextMock.language = 'en';
 	i18nextMock.getFixedT = () => tMock;
 	i18nextMock.use = () => i18nextMock;
 	i18nextMock.addResources = () => {};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current test fail of dataviz fails on my os because my locale is en and i18next.language is undefined during test.

```
    expect(received).toEqual(expected) // deep equality

    - Expected  - 3
    + Received  + 3

      Object {
    -   "131035911": "131,035,911",
    -   "500000000": "500,000,000",
    -   "831035920": "831,035,920",
    +   "131035911": "131 035 911",
    +   "500000000": "500 000 000",
    +   "831035920": "831 035 920",
      }

      62 |              });
      63 |
    > 64 |              expect(ticks).toEqual({
         |                            ^
      65 |                      '131035911': '131,035,911',
      66 |                      '500000000': '500,000,000',
      67 |                      '831035920': '831,035,920',

```

**What is the chosen solution to this problem?**

add missing language attribute to i18next mock

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
