### PR TITLE
feat(components): new icons in old buttons

### DIFF
--- a/.changeset/old-socks-obey.md
+++ b/.changeset/old-socks-obey.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(components): allow to use new icons in legacy buttons

--- a/packages/components/src/ActionList/ActionList.scss
+++ b/packages/components/src/ActionList/ActionList.scss
@@ -1,10 +1,12 @@
+@use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
+
 ////
 /// Action list
 /// @group Custom widgets
 ////
 
 $tc-action-list-item-width: 20rem !default;
-$tc-action-list-item-icons-size: 2rem !default;
+$tc-action-list-item-icons-size: tokens.$coral-sizing-xxxs !default;
 $tc-action-list-item-border-size: 0.2rem !default;
 
 .tc-action-list {

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -11,7 +11,7 @@ const actions = [
 	},
 	{
 		label: 'Favorite datasets of the year 2019',
-		sizedIconName: 'star',
+		iconName: 'star',
 		'data-feature': 'actionlist.item',
 		onClick: action('Favorite clicked'),
 		beta: true,

--- a/packages/components/src/ActionList/ActionList.stories.js
+++ b/packages/components/src/ActionList/ActionList.stories.js
@@ -11,7 +11,7 @@ const actions = [
 	},
 	{
 		label: 'Favorite datasets of the year 2019',
-		icon: 'talend-star',
+		sizedIconName: 'star',
 		'data-feature': 'actionlist.item',
 		onClick: action('Favorite clicked'),
 		beta: true,

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -18,7 +18,7 @@ import { SizedIcon } from '@talend/design-system';
 const LEFT = 'left';
 const RIGHT = 'right';
 
-function getIcon({ icon, sizedIconName, iconTransform, inProgress, loading }) {
+function getIcon({ icon, iconName, iconTransform, inProgress, loading }) {
 	if (inProgress) {
 		return <CircularProgress size="small" key="icon" />;
 	}
@@ -37,8 +37,8 @@ function getIcon({ icon, sizedIconName, iconTransform, inProgress, loading }) {
 		);
 	}
 
-	if (sizedIconName) {
-		return <SizedIcon name={sizedIconName} transform={iconTransform} key="icon" size="M" />;
+	if (iconName) {
+		return <SizedIcon name={iconName} transform={iconTransform} key="icon" size="M" />;
 	}
 
 	if (icon) {
@@ -247,7 +247,7 @@ ActionButton.propTypes = {
 	model: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 	name: PropTypes.string,
 	onClick: PropTypes.func,
-	sizedIconName: PropTypes.string,
+	iconName: PropTypes.string,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,
 	t: PropTypes.func,
 	tooltip: PropTypes.bool,

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -248,7 +248,6 @@ ActionButton.propTypes = {
 	name: PropTypes.string,
 	onClick: PropTypes.func,
 	sizedIconName: PropTypes.string,
-	sizedIconSize: PropTypes.string,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,
 	t: PropTypes.func,
 	tooltip: PropTypes.bool,

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -13,11 +13,12 @@ import theme from './ActionButton.scss';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
 import OverlayTrigger, { overlayPropTypes } from '../../OverlayTrigger';
+import { SizedIcon } from '@talend/design-system';
 
 const LEFT = 'left';
 const RIGHT = 'right';
 
-function getIcon({ icon, iconTransform, inProgress, loading }) {
+function getIcon({ icon, sizedIconName, sizedIconSize = 'M', iconTransform, inProgress, loading }) {
 	if (inProgress) {
 		return <CircularProgress size="small" key="icon" />;
 	}
@@ -33,6 +34,12 @@ function getIcon({ icon, iconTransform, inProgress, loading }) {
 					'tc-action-button-skeleton-circle',
 				)}
 			/>
+		);
+	}
+
+	if (sizedIconName) {
+		return (
+			<SizedIcon name={sizedIconName} transform={iconTransform} key="icon" size={sizedIconSize} />
 		);
 	}
 
@@ -242,6 +249,8 @@ ActionButton.propTypes = {
 	model: PropTypes.object, // eslint-disable-line react/forbid-prop-types
 	name: PropTypes.string,
 	onClick: PropTypes.func,
+	sizedIconName: PropTypes.string,
+	sizedIconSize: PropTypes.string,
 	tooltipPlacement: OverlayTrigger.propTypes.placement,
 	t: PropTypes.func,
 	tooltip: PropTypes.bool,

--- a/packages/components/src/Actions/ActionButton/ActionButton.component.js
+++ b/packages/components/src/Actions/ActionButton/ActionButton.component.js
@@ -18,7 +18,7 @@ import { SizedIcon } from '@talend/design-system';
 const LEFT = 'left';
 const RIGHT = 'right';
 
-function getIcon({ icon, sizedIconName, sizedIconSize = 'M', iconTransform, inProgress, loading }) {
+function getIcon({ icon, sizedIconName, iconTransform, inProgress, loading }) {
 	if (inProgress) {
 		return <CircularProgress size="small" key="icon" />;
 	}
@@ -38,9 +38,7 @@ function getIcon({ icon, sizedIconName, sizedIconSize = 'M', iconTransform, inPr
 	}
 
 	if (sizedIconName) {
-		return (
-			<SizedIcon name={sizedIconName} transform={iconTransform} key="icon" size={sizedIconSize} />
-		);
+		return <SizedIcon name={sizedIconName} transform={iconTransform} key="icon" size="M" />;
 	}
 
 	if (icon) {

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -78,14 +78,6 @@ export const Default = () => (
 		<ActionButton id="bsStyle" {...myAction} className="btn-primary btn-inverse" />
 		<h3>With new icons</h3>
 		<ActionButton id="newIcon" {...myAction} sizedIconName="badge-star" className="btn-primary" />
-		<ActionButton
-			id="newIconBig"
-			{...myAction}
-			sizedIconName="badge-star"
-			sizedIconSize="L"
-			className="btn-primary btn-inverse"
-		/>
-
 		<h3>With hideLabel option</h3>
 		<ActionButton id="hidelabel" {...myAction} hideLabel />
 		<h3>In progress</h3>

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -76,6 +76,16 @@ export const Default = () => (
 		<h3>Bootstrap style :</h3>
 		<ActionButton id="bsStyle" {...myAction} bsStyle="primary" />
 		<ActionButton id="bsStyle" {...myAction} className="btn-primary btn-inverse" />
+		<h3>With new icons</h3>
+		<ActionButton id="newIcon" {...myAction} sizedIconName="badge-star" className="btn-primary" />
+		<ActionButton
+			id="newIconBig"
+			{...myAction}
+			sizedIconName="badge-star"
+			sizedIconSize="L"
+			className="btn-primary btn-inverse"
+		/>
+
 		<h3>With hideLabel option</h3>
 		<ActionButton id="hidelabel" {...myAction} hideLabel />
 		<h3>In progress</h3>

--- a/packages/components/src/Actions/ActionButton/Button.stories.js
+++ b/packages/components/src/Actions/ActionButton/Button.stories.js
@@ -77,7 +77,7 @@ export const Default = () => (
 		<ActionButton id="bsStyle" {...myAction} bsStyle="primary" />
 		<ActionButton id="bsStyle" {...myAction} className="btn-primary btn-inverse" />
 		<h3>With new icons</h3>
-		<ActionButton id="newIcon" {...myAction} sizedIconName="badge-star" className="btn-primary" />
+		<ActionButton id="newIcon" {...myAction} iconName="badge-star" className="btn-primary" />
 		<h3>With hideLabel option</h3>
 		<ActionButton id="hidelabel" {...myAction} hideLabel />
 		<h3>In progress</h3>

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -1,3 +1,5 @@
+@use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
+
 ////
 /// Side panel
 /// @group Custom widgets
@@ -11,7 +13,7 @@ $list-item-reverse-color: $brand-primary !default;
 $toggle-height: 70px;
 $toggle-button-opacity: 0.75;
 $tc-side-panel-large-padding: 25px !default;
-$tc-side-panel-icons-size: $svg-md-size;
+$tc-side-panel-icons-size: tokens.$coral-sizing-xxxs;
 $toggle-button-padding: $padding-small;
 
 $docked-width: 6rem;

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -11,7 +11,7 @@ $list-item-reverse-color: $brand-primary !default;
 $toggle-height: 70px;
 $toggle-button-opacity: 0.75;
 $tc-side-panel-large-padding: 25px !default;
-$tc-side-panel-icons-size: $svg-rg-size;
+$tc-side-panel-icons-size: $svg-md-size;
 $toggle-button-padding: $padding-small;
 
 $docked-width: 6rem;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow to use the new icons in ord buttons (mainly for existing migration and sidepanel)

**What is the chosen solution to this problem?**
Allow to pass a props to mount a SizedIcon instead of an Icon

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
