### PR TITLE
fix(scripts-cmf): path to bin

### DIFF
--- a/.changeset/forty-tools-rest.md
+++ b/.changeset/forty-tools-rest.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-cmf': patch
+---
+
+fix: links to bin

--- a/tools/scripts-cmf/package.json
+++ b/tools/scripts-cmf/package.json
@@ -7,7 +7,7 @@
     "access": "public"
   },
   "bin": {
-    "cmf-settings": "./scripts/cmf-settings.js"
+    "cmf-settings": "./cmf-settings.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

current cmf-settings bin is not installed by the package because of a wrong path

**What is the chosen solution to this problem?**

fix the path to main script

```
$ ls -lh node_modules/.bin/cmf-settings 
node_modules/.bin/cmf-settings -> ../../tools/scripts-cmf/cmf-settimgs.js
```

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
