### PR TITLE
chore(ARCH-537): udpate github url in package.json

### DIFF
--- a/.changeset/silent-cheetahs-count.md
+++ b/.changeset/silent-cheetahs-count.md
@@ -1,0 +1,22 @@
+---
+'@talend/module-to-cdn': patch
+'@talend/babel-plugin-import-d3': patch
+'@talend/babel-plugin-import-from-index': patch
+'@talend/cypress-api-mock-plugin': patch
+'@talend/scripts-build-cdn': patch
+'@talend/scripts-config-babel': patch
+'@talend/scripts-config-eslint': patch
+'@talend/scripts-config-jest': patch
+'@talend/scripts-config-ng-webpack': patch
+'@talend/scripts-config-prettier': patch
+'@talend/scripts-config-react-webpack': patch
+'@talend/scripts-config-storybook-lib': patch
+'@talend/scripts-config-stylelint': patch
+'@talend/scripts-config-typescript': patch
+'@talend/scripts-core': patch
+'@talend/scripts-preset-react': patch
+'@talend/scripts-preset-react-lib': patch
+'@talend/upgrade-deps': patch
+---
+
+fix: url of repository in package.json

--- a/fork/module-to-cdn/package.json
+++ b/fork/module-to-cdn/package.json
@@ -3,7 +3,7 @@
   "version": "9.8.2",
   "description": "Get cdn config from npm module name",
   "license": "MIT",
-  "repository": "https://github.com/Talend/ui-scripts/tree/master/packages/module-to-cdn",
+  "repository": "https://github.com/Talend/ui/tree/master/packages/module-to-cdn",
   "author": {
     "name": "Thomas Sileghem",
     "email": "th.sileghem@gmail.com",

--- a/fork/module-to-cdn/package.json
+++ b/fork/module-to-cdn/package.json
@@ -3,7 +3,7 @@
   "version": "9.8.2",
   "description": "Get cdn config from npm module name",
   "license": "MIT",
-  "repository": "https://github.com/Talend/ui-scripts/tree/master/packages/module-to-cdn",
+  "repository": "https://github.com/Talend/ui",
   "author": {
     "name": "Thomas Sileghem",
     "email": "th.sileghem@gmail.com",

--- a/fork/module-to-cdn/package.json
+++ b/fork/module-to-cdn/package.json
@@ -3,7 +3,7 @@
   "version": "9.8.2",
   "description": "Get cdn config from npm module name",
   "license": "MIT",
-  "repository": "https://github.com/Talend/ui/tree/master/packages/module-to-cdn",
+  "repository": "https://github.com/Talend/ui-scripts/tree/master/packages/module-to-cdn",
   "author": {
     "name": "Thomas Sileghem",
     "email": "th.sileghem@gmail.com",

--- a/tools/babel-plugin-import-d3/package.json
+++ b/tools/babel-plugin-import-d3/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/babel/plugin-import-from-index#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/babel-plugin-import-d3/package.json
+++ b/tools/babel-plugin-import-d3/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/babel/plugin-import-from-index#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/babel-plugin-import-from-index/package.json
+++ b/tools/babel-plugin-import-from-index/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/babel/plugin-import-from-index#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/babel-plugin-import-from-index/package.json
+++ b/tools/babel-plugin-import-from-index/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/babel/plugin-import-from-index#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/cypress-api-mock-plugin/package.json
+++ b/tools/cypress-api-mock-plugin/package.json
@@ -4,10 +4,10 @@
   "description": "Cypress plugin to record/serve api calls",
   "main": "index.js",
   "author": "Talend Frontend <frontend@talend.com>",
-  "homepage": "https://github.com/Talend/ui-scripts/tree/master/cypress/cypress-api-mock-plugin#readme",
+  "homepage": "https://github.com/Talend/ui",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/tools/cypress-api-mock-plugin/package.json
+++ b/tools/cypress-api-mock-plugin/package.json
@@ -4,10 +4,10 @@
   "description": "Cypress plugin to record/serve api calls",
   "main": "index.js",
   "author": "Talend Frontend <frontend@talend.com>",
-  "homepage": "https://github.com/Talend/ui/tree/master/cypress/cypress-api-mock-plugin#readme",
+  "homepage": "https://github.com/Talend/ui-scripts/tree/master/cypress/cypress-api-mock-plugin#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/tools/cypress-api-mock-plugin/package.json
+++ b/tools/cypress-api-mock-plugin/package.json
@@ -4,10 +4,10 @@
   "description": "Cypress plugin to record/serve api calls",
   "main": "index.js",
   "author": "Talend Frontend <frontend@talend.com>",
-  "homepage": "https://github.com/Talend/ui-scripts/tree/master/cypress/cypress-api-mock-plugin#readme",
+  "homepage": "https://github.com/Talend/ui/tree/master/cypress/cypress-api-mock-plugin#readme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "license": "Apache-2.0",
   "keywords": [

--- a/tools/scripts-build-cdn/package.json
+++ b/tools/scripts-build-cdn/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/Talend/ui"
+    "url": "github.com/talend/ui-scripts"
   },
   "keywords": [
     "talend"

--- a/tools/scripts-build-cdn/package.json
+++ b/tools/scripts-build-cdn/package.json
@@ -12,7 +12,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "github.com/talend/ui-scripts"
+    "url": "github.com/Talend/ui"
   },
   "keywords": [
     "talend"

--- a/tools/scripts-config-babel/package.json
+++ b/tools/scripts-config-babel/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/scripts-config-babel/package.json
+++ b/tools/scripts-config-babel/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/scripts-config-eslint/package.json
+++ b/tools/scripts-config-eslint/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-eslint/package.json
+++ b/tools/scripts-config-eslint/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-jest/package.json
+++ b/tools/scripts-config-jest/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-jest/package.json
+++ b/tools/scripts-config-jest/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-ng-webpack/package.json
+++ b/tools/scripts-config-ng-webpack/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "dependencies": {
     "@talend/scripts-config-babel": "^9.9.0",

--- a/tools/scripts-config-ng-webpack/package.json
+++ b/tools/scripts-config-ng-webpack/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "dependencies": {
     "@talend/scripts-config-babel": "^9.9.0",

--- a/tools/scripts-config-prettier/package.json
+++ b/tools/scripts-config-prettier/package.json
@@ -5,11 +5,11 @@
   "main": ".prettierrc.js",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-prettier/package.json
+++ b/tools/scripts-config-prettier/package.json
@@ -5,11 +5,11 @@
   "main": ".prettierrc.js",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-react-webpack/package.json
+++ b/tools/scripts-config-react-webpack/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-react-webpack/package.json
+++ b/tools/scripts-config-react-webpack/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-config-stylelint/package.json
+++ b/tools/scripts-config-stylelint/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "dependencies": {
     "stylelint": "^13.13.1",

--- a/tools/scripts-config-stylelint/package.json
+++ b/tools/scripts-config-stylelint/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "dependencies": {
     "stylelint": "^13.13.1",

--- a/tools/scripts-config-typescript/package.json
+++ b/tools/scripts-config-typescript/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/scripts-config-typescript/package.json
+++ b/tools/scripts-config-typescript/package.json
@@ -7,14 +7,14 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "publishConfig": {
     "access": "public"

--- a/tools/scripts-core/package.json
+++ b/tools/scripts-core/package.json
@@ -10,11 +10,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/scripts-core/package.json
+++ b/tools/scripts-core/package.json
@@ -10,11 +10,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/scripts-preset-react-lib/package.json
+++ b/tools/scripts-preset-react-lib/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-preset-react-lib/package.json
+++ b/tools/scripts-preset-react-lib/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-preset-react/package.json
+++ b/tools/scripts-preset-react/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/scripts-preset-react/package.json
+++ b/tools/scripts-preset-react/package.json
@@ -7,11 +7,11 @@
   "author": "Talend Frontend <frontend@talend.com>",
   "homepage": "https://github.com/Talend/ui/tree/master/packages/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "echo \"Nothing to test\""

--- a/tools/upgrade-deps/package.json
+++ b/tools/upgrade-deps/package.json
@@ -17,13 +17,13 @@
     "jest": "^26.6.3"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Talend/ui#readme",
+  "homepage": "https://github.com/Talend/ui-scripts#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui/issues"
+    "url": "https://github.com/Talend/ui-scripts/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui.git"
+    "url": "https://github.com/Talend/ui-scripts.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/upgrade-deps/package.json
+++ b/tools/upgrade-deps/package.json
@@ -17,13 +17,13 @@
     "jest": "^26.6.3"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Talend/ui-scripts#readme",
+  "homepage": "https://github.com/Talend/ui#readme",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"

--- a/tools/upgrade-deps/package.json
+++ b/tools/upgrade-deps/package.json
@@ -17,13 +17,13 @@
     "jest": "^26.6.3"
   },
   "license": "Apache-2.0",
-  "homepage": "https://github.com/Talend/ui-scripts#readme",
+  "homepage": "https://github.com/Talend/ui",
   "bugs": {
-    "url": "https://github.com/Talend/ui-scripts/issues"
+    "url": "https://github.com/Talend/ui/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/Talend/ui-scripts.git"
+    "url": "https://github.com/Talend/ui.git"
   },
   "scripts": {
     "test": "jest"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

lots of url point to ui-scripts repository which was a private repo.

**What is the chosen solution to this problem?**

point to this repository

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
