### PR TITLE
feat(design-system/TUX-1191/SizedIcon): Document SizedIcon component in DS

### DIFF
--- a/packages/design-system/.storybook/docs/Icons.tsx
+++ b/packages/design-system/.storybook/docs/Icons.tsx
@@ -14,7 +14,10 @@ export const Icons = () => {
 	const [border, setBorder] = React.useState<boolean>();
 
 	React.useEffect(() => {
-		IconsProvider.getAllIconIds().then((ids: (string | null)[]) => setIds(ids));
+		IconsProvider.getAllIconIds().then((ids: (string | null)[]) => {
+			const cleanIds = ids.filter(id => id && !id.includes(':'));
+			setIds(cleanIds);
+		});
 	}, []);
 
 	const onChangeQuery = (event: ChangeEvent<HTMLInputElement>) => {

--- a/packages/design-system/.storybook/preview.js
+++ b/packages/design-system/.storybook/preview.js
@@ -233,15 +233,11 @@ export const parameters = {
 				// if wrapped into an arrow function
 				if (input?.trim().startsWith('(')) {
 					const body = input.replace(/\((.*)\) => {?((.|\n)*)?}?/gm, '$2');
-					return format(body)
-						.trim()
-						.replace(/;$/, '');
+					return format(body).trim().replace(/;$/, '');
 				}
 				// try to format JSX
 				// remove last semicolon added by Prettier
-				return format(input)
-					.trim()
-					.replace(/;$/, '');
+				return format(input).trim().replace(/;$/, '');
 			} catch (e) {
 				// otherwise, return the same string
 				return input;
@@ -271,6 +267,7 @@ export const parameters = {
 					['Form', 'Form Fieldset', 'Form Field', 'Form Field Group', 'Fields', 'Form Buttons'],
 					'HeaderBar',
 					'Icon',
+					['About', 'Icon (legacy)', 'SizedIcon'],
 					'Inline Editing',
 					'Inline Message',
 					'Layout',

--- a/packages/design-system/src/components/Icon/Icon.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icon.stories.mdx
@@ -1,8 +1,9 @@
-import { Meta } from '@storybook/addon-docs';
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
 import { IconItem } from '@storybook/components';
 import { Icons } from '~docs';
 import { Icon } from '.';
 import { InlineMessageWarning } from '../InlineMessage';
+import { StackVertical } from '../Stack';
 
 <Meta
 	title="Components/Icon/Icon (legacy)"
@@ -16,11 +17,23 @@ import { InlineMessageWarning } from '../InlineMessage';
 
 All icons can be found below and you can apply transformations on them.
 
-<InlineMessageWarning
-	title="Deprecated"
-	description="This is now a legacy component. It is still provided by this
-package for now for legacy reasons. No new icon will be supported by this component"
-/>
+<StackVertical
+	gap="XS"
+	margin={{
+		top: 0,
+		left: 0,
+		right: 0,
+		bottom: 'M',
+	}}
+>
+	<InlineMessageWarning
+		title="Deprecated"
+		withBackground
+		description="This is now a legacy component. No new icon will be supported by this component."
+	/>
+</StackVertical>
+
+## All icons
 
 <Icons />
 

--- a/packages/design-system/src/components/Icon/Icon.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icon.stories.mdx
@@ -2,9 +2,10 @@ import { Meta } from '@storybook/addon-docs';
 import { IconItem } from '@storybook/components';
 import { Icons } from '~docs';
 import { Icon } from '.';
+import { InlineMessageWarning } from '../InlineMessage';
 
 <Meta
-	title="Components/Icon"
+	title="Components/Icon/Icon (legacy)"
 	component={Icon}
 	parameters={{
 		status: { figma: 'ok', storybook: 'ok', react: 'ok', i18n: 'na' },
@@ -15,11 +16,17 @@ import { Icon } from '.';
 
 All icons can be found below and you can apply transformations on them.
 
+<InlineMessageWarning
+	title="Deprecated"
+	description="This is now a legacy component. It is still provided by this
+package for now for legacy reasons. No new icon will be supported by this component"
+/>
+
 <Icons />
 
 ## Remote icon
 
-Icon can accept an URL as `name` but it must be prefixed by "remote-"
+Icon can accept a URL as `name` but it must be prefixed by "remote-"
 
 <IconItem name="remote-url as svg">
 	<Icon name="remote-https://unpkg.com/@talend/icons@6.1.5/src/svg/core/abc.svg" />

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -191,6 +191,7 @@ export const Icon = React.forwardRef(
 				className={classnames('tc-svg-icon', classname)}
 				border={border}
 				ref={safeRef}
+				shape-rendering="geometricPrecision"
 			/>
 		);
 	},

--- a/packages/design-system/src/components/Icon/Icons.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icons.stories.mdx
@@ -1,0 +1,60 @@
+import { Canvas, Meta, Story } from '@storybook/addon-docs';
+import { SizedIcon } from './SizedIcon';
+import { StackHorizontal } from '../Stack';
+import { Icon } from './Icon';
+
+<Meta title="Components/Icon/About" />
+
+# About Icons
+
+http://localhost:3002/?path=/docs/components-icon-icon-legacy--page&globals=theme:light
+
+To date, Coral provides two `Icon` components. A legacy one and a new one. Eventually, the newer one will remain, alone.
+
+**Why two components?**
+
+- The original one was built around a philosophy of "everything goes". It's a component library approach.
+
+- The newer one does not follow the same principles. It enforces a strict ruleset that is the same for designers and for developers.
+
+The original `Icon` component can take any size we want, support any color etc...whereas the newer `SizedIcon` does not.
+
+## SizedIcon (use this)
+
+Icons are now strictly defined by size.
+
+`SizedIcon` takes two props `size` and `name`. The available `name`s will be dependent on the chosen `size`!
+
+[Checkout the SizedIcon docs here.](/docs/components-icon-sizedIcon)
+
+<Canvas>
+	<Story name="SizedIconExample">
+		<StackHorizontal gap="XS">
+			<SizedIcon size="S" name="note-pencil" />
+			<SizedIcon size="M" name="note-pencil" />
+			<SizedIcon size="L" name="note-pencil" />
+		</StackHorizontal>
+	</Story>
+</Canvas>
+
+Calling `<SizedIcon size="XS" name="note-pencil" />` would not compile in TS because `note-pencil` does not exist at this size.
+
+This is true both for developers and designers.
+
+## Icon (deprecated)
+
+Because a Big Bang Change is not possible, we have chosen to keep the legacy `Icon` component alive. For now.
+
+[Checkout the Icon docs here.](/docs/components-icon-icon-legacy--page)
+
+<Canvas>
+	<Story name="IconExample">
+		<StackHorizontal gap="XS">
+			<Icon name="talend-cross" style={{ width: '1.2rem', height: '1.2rem' }} />
+			<Icon name="talend-cross" />
+			<Icon name="talend-cross" style={{ width: '2.4rem', height: '2.4rem' }} />
+		</StackHorizontal>
+	</Story>
+</Canvas>
+
+These icons are lawless. Some even have their own colorset. They are impossible to homogenize as part of a design language.

--- a/packages/design-system/src/components/Icon/Icons.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icons.stories.mdx
@@ -15,7 +15,7 @@ To date, Coral provides two `Icon` components. A legacy one and a new one. Event
 
 - The newer one does not follow the same principles. It enforces a strict ruleset that is the same for designers and for developers.
 
-The original `Icon` component can take any size we want, support any color etc...whereas the newer `SizedIcon` does not.
+The original `Icon` component can take any size we want, support any color etc... Whereas the newer `SizedIcon` does not.
 
 ## SizedIcon (use this)
 

--- a/packages/design-system/src/components/Icon/Icons.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icons.stories.mdx
@@ -7,8 +7,6 @@ import { Icon } from './Icon';
 
 # About Icons
 
-http://localhost:3002/?path=/docs/components-icon-icon-legacy--page&globals=theme:light
-
 To date, Coral provides two `Icon` components. A legacy one and a new one. Eventually, the newer one will remain, alone.
 
 **Why two components?**

--- a/packages/design-system/src/components/Icon/Icons.stories.mdx
+++ b/packages/design-system/src/components/Icon/Icons.stories.mdx
@@ -23,7 +23,7 @@ Icons are now strictly defined by size.
 
 `SizedIcon` takes two props `size` and `name`. The available `name`s will be dependent on the chosen `size`!
 
-[Checkout the SizedIcon docs here.](/docs/components-icon-sizedIcon)
+[Checkout the SizedIcon docs here.](/docs/components-icon-sizedicon--icon-xs)
 
 <Canvas>
 	<Story name="SizedIconExample">

--- a/packages/design-system/src/components/Icon/SizedIcon.stories.mdx
+++ b/packages/design-system/src/components/Icon/SizedIcon.stories.mdx
@@ -1,0 +1,79 @@
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
+import { SizedIcon } from '.';
+import * as Stories from './SizedIcon.stories';
+
+<Meta
+	title="Components/Icon/SizedIcon"
+	component={SizedIcon}
+	parameters={{
+		status: { figma: 'ok', storybook: 'ok', react: 'ok', i18n: 'na' },
+	}}
+/>
+
+# SizedIcon
+
+This component serves every icon in the new Figma [Icon Library](https://www.figma.com/file/L1QUr28Y79ydAv05nQVmaA/Icon-Library?node-id=2064%3A17133).
+
+It follows the same ruleset: an icon is defined by its size first, its name second.
+
+## Style
+
+All of those icons are styles through `currentColor`: they will take on the color of the parent's `color` CSS attribute.
+
+The expected tokens for icons are the `coral-color-[semantic]-text` or `coral-color-[semantic]-icon` ones.
+
+You may need to wrap your icon with a `span` node to target it specifically.
+
+### Variations
+
+#### Size XS
+
+<Canvas>
+	<Story story={Stories.IconXS} name="XS icons" />
+</Canvas>
+
+<ArgsTable story="XS icons" />
+
+#### Size S
+
+<Canvas>
+	<Story story={Stories.IconS} name="S icons" />
+</Canvas>
+
+<ArgsTable story="S icons" />
+
+#### Size M
+
+<Canvas>
+	<Story story={Stories.IconM} name="M icons" />
+</Canvas>
+
+<ArgsTable story="M icons" />
+
+#### Size L
+
+<Canvas>
+	<Story story={Stories.IconL} name="L icons" />
+</Canvas>
+
+<ArgsTable story="L icons" />
+
+## States
+
+NA
+
+## Interactions
+
+NA
+
+## Content
+
+NA
+
+## Usage
+
+Icons are illustrative elements, not interactive. If you need a clickable icon, check out [the ButtonIcon docs here.](/docs/components-clickable-buttons-buttonicon--variations)
+
+## Accessibility
+
+Icons sport the `aria-hidden` attribute. As purely illustrative elements, they must not have contextual value.

--- a/packages/design-system/src/components/Icon/SizedIcon.stories.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.stories.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+import { IconNameWithSize, icons } from '@talend/icons';
+
+import { SizedIcon } from './SizedIcon';
+
+export default {
+	component: SizedIcon,
+};
+
+export const IconXS = (args: { name: IconNameWithSize<'XS'> }) => {
+	return <SizedIcon size="XS" name={args.name} />;
+};
+export const IconS = (args: { name: IconNameWithSize<'S'> }) => (
+	<SizedIcon size="S" name={args.name} />
+);
+export const IconM = (args: { name: IconNameWithSize<'M'> }) => (
+	<SizedIcon size="M" name={args.name} />
+);
+export const IconL = (args: { name: IconNameWithSize<'L'> }) => (
+	<SizedIcon size="L" name={args.name} />
+);
+
+IconXS.argTypes = {
+	name: {
+		options: icons.XS,
+		control: { type: 'select' },
+		defaultValue: 'pencil',
+	},
+};
+
+IconS.argTypes = {
+	name: {
+		options: ['pencil'],
+		control: { type: 'select' },
+		defaultValue: 'pencil',
+	},
+};
+
+IconM.argTypes = {
+	name: {
+		options: ['pencil'],
+		control: { type: 'select' },
+		defaultValue: 'pencil',
+	},
+};
+
+IconL.argTypes = {
+	name: {
+		options: ['pencil'],
+		control: { type: 'select' },
+		defaultValue: 'pencil',
+	},
+};

--- a/packages/design-system/src/components/Icon/SizedIcon.stories.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IconNameWithSize, icons } from '@talend/icons';
+// eslint-disable-next-line @talend/import-depth
+import { IconNameWithSize, icons } from '@talend/icons/dist/typeUtils';
 
 import { SizedIcon } from './SizedIcon';
 
@@ -30,7 +31,7 @@ IconXS.argTypes = {
 
 IconS.argTypes = {
 	name: {
-		options: ['pencil'],
+		options: icons.S,
 		control: { type: 'select' },
 		defaultValue: 'pencil',
 	},
@@ -38,7 +39,7 @@ IconS.argTypes = {
 
 IconM.argTypes = {
 	name: {
-		options: ['pencil'],
+		options: icons.M,
 		control: { type: 'select' },
 		defaultValue: 'pencil',
 	},
@@ -46,7 +47,7 @@ IconM.argTypes = {
 
 IconL.argTypes = {
 	name: {
-		options: ['pencil'],
+		options: icons.L,
 		control: { type: 'select' },
 		defaultValue: 'pencil',
 	},

--- a/packages/design-system/src/components/Icon/SizedIcon.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.tsx
@@ -19,7 +19,13 @@ const SizedIcon = React.forwardRef(
 		const numericSize = getNumericSize(size);
 		const fullName = size ? `${name}:${size}` : name;
 		return (
-			<svg {...rest} style={{ width: numericSize, height: numericSize }} aria-hidden ref={ref}>
+			<svg
+				{...rest}
+				style={{ width: numericSize, height: numericSize }}
+				aria-hidden
+				ref={ref}
+				shapeRendering="geometricPrecision"
+			>
 				<use xlinkHref={`#${fullName}`} />
 			</svg>
 		);

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
@@ -122,9 +122,9 @@ export function IconsProvider({
 	defaultIcons = {},
 	icons = {},
 }: {
-	bundles: string[] | [];
-	defaultIcons?: {};
-	icons?: {};
+	bundles?: string[] | [];
+	defaultIcons?: Record<string, ReactElement>;
+	icons?: Record<string, ReactElement>;
 }) {
 	const iconset: IconSet = { ...defaultIcons, ...icons };
 	const ref = useRef<SVGSVGElement>(null);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
SizedIcon component is not clearly documented, nor is its difference with Icon.

**What is the chosen solution to this problem?**
Document it. 

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
