### PR TITLE
fix(components): align icons in sidepanel

### DIFF
--- a/.changeset/wise-lizards-sell.md
+++ b/.changeset/wise-lizards-sell.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+feat(components): align new and old icons in the sidepanel

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -66,6 +66,8 @@ $large-docked-width: 7rem;
 			.tc-svg-icon {
 				width: $tc-side-panel-icons-size;
 				height: $tc-side-panel-icons-size;
+			}
+			:global(svg){
 				margin-left: $padding-smaller;
 			}
 

--- a/packages/components/src/SidePanel/SidePanel.stories.js
+++ b/packages/components/src/SidePanel/SidePanel.stories.js
@@ -14,7 +14,7 @@ const actions = [
 	},
 	{
 		label: 'Datasets',
-		icon: 'talend-download',
+		iconName: 'dataset',
 		onClick: action('Datasets clicked'),
 	},
 	{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
New icons and old one's are not aligned
**What is the chosen solution to this problem?**
Put the margin back
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
