### PR TITLE
fix: add missing changeset for cmf-webpack-plugin

### DIFF
--- a/.changeset/soft-ears-fold.md
+++ b/.changeset/soft-ears-fold.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-webpack-plugin': patch
+---
+
+fix: move scripts to dedicated package to avoid circular deps


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Last version of the plugin has not been published and it's not compatible with the latest version of cmf
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
