### PR TITLE
feat(design-system): Expose TooltipPlacement

### DIFF
--- a/.changeset/rude-rules-sneeze.md
+++ b/.changeset/rude-rules-sneeze.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Expose `TooltipPlacement` type

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -1,5 +1,4 @@
 import Accordion from './components/Accordion';
-import { AffixButton, AffixReadOnly } from './components/Form/FieldGroup/Affix';
 import {
 	ButtonPrimary,
 	ButtonSecondary,
@@ -26,6 +25,7 @@ import EmptyState, {
 	EmptyStateSmall,
 } from './components/EmptyState';
 import Form from './components/Form';
+import { AffixButton, AffixReadOnly } from './components/Form/FieldGroup/Affix';
 import HeaderBar from './components/HeaderBar';
 import { Icon, SizedIcon } from './components/Icon';
 import { IconsProvider } from './components/IconsProvider';
@@ -60,8 +60,8 @@ import {
 	StatusFailed,
 	Status,
 } from './components/Status';
-import Switch from './components/Switch';
 import Stepper from './components/Stepper';
+import Switch from './components/Switch';
 import Tabs from './components/Tabs';
 import {
 	Tag,
@@ -73,9 +73,8 @@ import {
 	TagDestructive,
 } from './components/Tag';
 import ThemeProvider from './components/ThemeProvider';
-import Tooltip from './components/Tooltip';
+import Tooltip, { TooltipPlacement } from './components/Tooltip';
 import VisuallyHidden from './components/VisuallyHidden';
-
 import * as themes from './themes';
 import tokens from './tokens';
 
@@ -154,3 +153,5 @@ export {
 	themes,
 	tokens,
 };
+
+export type { TooltipPlacement };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

TooltipPlacement is not exported, it can only be retrieved using typeof Tooltip

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
