### PR TITLE
fix(design-system/Dropdown): Default styles should be in CSS module

### DIFF
--- a/.changeset/fluffy-items-applaud.md
+++ b/.changeset/fluffy-items-applaud.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Move style to CSS module file

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -51,14 +51,7 @@ const Dropdown = forwardRef(
 				<MenuButton {...menu} data-test="dropdown.button">
 					{disclosureProps => cloneElement(children, disclosureProps)}
 				</MenuButton>
-				<Menu
-					{...menu}
-					as={DropdownShell}
-					{...rest}
-					ref={ref}
-					data-test="dropdown.menu"
-					style={{ zIndex: tokens.coralElevationLayerInteractiveFront }}
-				>
+				<Menu {...menu} as={DropdownShell} {...rest} ref={ref} data-test="dropdown.menu">
 					{items.map((entry, index) => {
 						if (entry.type === 'button') {
 							const { label, ...entryRest } = entry;

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownShell.module.scss
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownShell.module.scss
@@ -1,6 +1,8 @@
 @use '~@talend/design-tokens/lib/tokens';
 
 .dropdownShell {
+	z-index: tokens.$coral-elevation-layer-interactive-front;
+
 	.animatedZone {
 		background: tokens.$coral-color-neutral-background;
 		border-radius: tokens.$coral-radius-s;
@@ -13,6 +15,7 @@
 		opacity: 0;
 		transform: translateY(-10%);
 	}
+
 	&[data-enter] {
 		.animatedZone {
 			opacity: 1;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
zIndex for dropdown was in the JSX

**What is the chosen solution to this problem?**
Styles should be as much in possible in CSS modules.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
