### PR TITLE
feat(TDC-6337): allow multiple values in Emphasis

### DIFF
--- a/.changeset/quick-tomatoes-shake.md
+++ b/.changeset/quick-tomatoes-shake.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TDC-6337): allow multiple values in Emphasis

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -17,14 +17,18 @@ function emphasiseAll(text, value) {
 	if (!value) {
 		return text;
 	}
-	const strText = `${text}`;
-	const strValue = `${value}`;
 
-	return strText
-		.split(new RegExp(`(${escapeRegexCharacters(strValue)})`, 'gi'))
+	if (!Array.isArray(value)) {
+		value = [value];
+	}
+
+	const valuesUC = value.map(e => `${e}`.toLocaleUpperCase());
+
+	return `${text}`
+		.split(new RegExp(`(${valuesUC.map(e => escapeRegexCharacters(e)).join('|')})`, 'gi'))
 		.filter(isNotEmpty)
 		.map((part, index) => {
-			if (part.toLocaleUpperCase() === strValue.toLocaleUpperCase()) {
+			if (valuesUC.includes(part.toLocaleUpperCase())) {
 				return (
 					<em key={index} className={theme.highlight}>
 						{part}

--- a/packages/components/src/Emphasis/Emphasis.component.js
+++ b/packages/components/src/Emphasis/Emphasis.component.js
@@ -22,13 +22,13 @@ function emphasiseAll(text, value) {
 		value = [value];
 	}
 
-	const valuesUC = value.map(e => `${e}`.toLocaleUpperCase());
+	const valuesInUpperCase = value.map(e => `${e}`.toLocaleUpperCase());
 
 	return `${text}`
-		.split(new RegExp(`(${valuesUC.map(e => escapeRegexCharacters(e)).join('|')})`, 'gi'))
+		.split(new RegExp(`(${valuesInUpperCase.map(e => escapeRegexCharacters(e)).join('|')})`, 'gi'))
 		.filter(isNotEmpty)
 		.map((part, index) => {
-			if (valuesUC.includes(part.toLocaleUpperCase())) {
+			if (valuesInUpperCase.includes(part.toLocaleUpperCase())) {
 				return (
 					<em key={index} className={theme.highlight}>
 						{part}

--- a/packages/components/src/Emphasis/Emphasis.stories.js
+++ b/packages/components/src/Emphasis/Emphasis.stories.js
@@ -19,5 +19,19 @@ export const WithValue = () => (
 		<h1>With multiple occurences</h1>
 		<p>The emphasised text is returned (value = lazy) :</p>
 		<Emphasis value="lazy" text="The lazy quick brown fox jumps over the lazy dog" />
+
+		<h1>With multiple words</h1>
+		<p>The emphasised text is returned (value = [lazy,fox,dog]) :</p>
+		<Emphasis
+			value={['lazy', 'fox', 'dog']}
+			text="The lazy quick brown fox jumps over the lazy dog"
+		/>
+
+		<h1>With multiple substrings</h1>
+		<p>The emphasised text is returned (value = [quick brown fox, lazy dog]) :</p>
+		<Emphasis
+			value={['quick brown fox', 'lazy dog']}
+			text="The lazy quick brown fox jumps over the lazy dog"
+		/>
 	</div>
 );

--- a/packages/components/src/Emphasis/Emphasis.test.js
+++ b/packages/components/src/Emphasis/Emphasis.test.js
@@ -66,4 +66,20 @@ describe('Emphasis', () => {
 		// then
 		expect(wrapper.find('em').length).toBe(1);
 	});
+
+	it('should emphasize multiple words', () => {
+		// given
+		const wrapper = shallow(<Emphasis {...props} value={['lazy', 'fox', 'dog']} />);
+
+		// then
+		expect(wrapper.find('em').length).toBe(4);
+	});
+
+	it('should emphasize multiple substrings', () => {
+		// given
+		const wrapper = shallow(<Emphasis {...props} value={['quick brown fox', 'lazy dog']} />);
+
+		// then
+		expect(wrapper.find('em').length).toBe(2);
+	});
 });

--- a/packages/components/src/Emphasis/Emphasis.test.js
+++ b/packages/components/src/Emphasis/Emphasis.test.js
@@ -1,5 +1,6 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { render, screen } from '@testing-library/react';
+
 import Emphasis from './Emphasis.component';
 
 describe('Emphasis', () => {
@@ -9,77 +10,86 @@ describe('Emphasis', () => {
 
 	it('should return a span containing the emphatised text', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value="brown" />);
+		render(<Emphasis {...props} value="brown" />);
 
 		// then
-		expect(wrapper.html()).toBe(
-			'<span>The lazy quick <em class="theme-highlight">brown</em> fox jumps over the lazy dog</span>',
-		);
+		expect(screen.getByText('brown')).toHaveClass('theme-highlight');
 	});
 
 	it('should be case insensitive', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value="bRoWn" />);
+		render(<Emphasis {...props} value="bRoWn" />);
 
 		// then
-		expect(wrapper.find('em').text()).toBe('brown');
+		expect(screen.getByText('brown')).toHaveClass('theme-highlight');
 	});
 
 	it('should support special chars', () => {
 		// given
-		const wrapper = shallow(<Emphasis text="aze.*+?^${}()|[]\wxc" value=".*+?^${}()|[]\" />);
+		render(<Emphasis text="aze.*+?^${}()|[]\wxc" value=".*+?^${}()|[]\" />);
 
 		// then
-		expect(wrapper.find('em').text()).toBe('.*+?^${}()|[]\\');
+		expect(screen.getByText('.*+?^${}()|[]\\')).toHaveClass('theme-highlight');
 	});
 
 	it('should wrap the original text in a span if no value is provided', () => {
 		// when
-		const wrapper = shallow(<Emphasis {...props} />);
+		render(<Emphasis {...props} />);
 
 		// then
-		expect(wrapper.html()).toBe(`<span>${props.text}</span>`);
+		expect(screen.getByText(props.text)).not.toHaveClass('theme-highlight');
 	});
 
 	it('should not emphasise anything if the value is not part of the text', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value="nopnopnop" />);
+		render(<Emphasis {...props} value="nopnopnop" />);
 
 		// then
-		expect(wrapper.text()).toBe(props.text);
-		expect(wrapper.find('em').length).toBe(0);
+		expect(screen.getByText(props.text)).not.toHaveClass('theme-highlight');
 	});
 
 	it('should emphasise every occurences', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value="lazy" />);
+		render(<Emphasis {...props} value="lazy" />);
 
 		// then
-		expect(wrapper.find('em').length).toBe(2);
+		const nodes = screen.getAllByText('lazy');
+		for (const node of nodes) {
+			expect(node).toHaveClass('theme-highlight');
+		}
+		expect(nodes.length).toBe(2);
 	});
 
 	it('should emphasize if value is not string', () => {
 		const text = 85;
 		// given
-		const wrapper = shallow(<Emphasis text={text} value={8} />);
+		render(<Emphasis text={85} value={8} />);
 
 		// then
-		expect(wrapper.find('em').length).toBe(1);
+		expect(screen.getByText('8')).toHaveClass('theme-highlight');
 	});
 
 	it('should emphasize multiple words', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value={['lazy', 'fox', 'dog']} />);
+		render(<Emphasis {...props} value={['lazy', 'fox', 'dog']} />);
 
 		// then
-		expect(wrapper.find('em').length).toBe(4);
+		const nodes = screen.getAllByText(/lazy|fox|dog/);
+		for (const node of nodes) {
+			expect(node).toHaveClass('theme-highlight');
+		}
+		expect(nodes.length).toBe(4);
 	});
 
 	it('should emphasize multiple substrings', () => {
 		// given
-		const wrapper = shallow(<Emphasis {...props} value={['quick brown fox', 'lazy dog']} />);
+		render(<Emphasis {...props} value={['quick brown fox', 'lazy dog']} />);
 
 		// then
-		expect(wrapper.find('em').length).toBe(2);
+		const nodes = screen.getAllByText(/quick brown fox|lazy dog/);
+		for (const node of nodes) {
+			expect(node).toHaveClass('theme-highlight');
+		}
+		expect(nodes.length).toBe(2);
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Give the capacity to emphasis multiple words ou substring into a string

**What is the chosen solution to this problem?**

add capacity for `Emphasis` component to get an array as `value` parameter and emphasis each token in array.

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
