### PR TITLE
fix(TDC-6368): no ellipsis on long subheaderbar titles

### DIFF
--- a/.changeset/serious-bulldogs-hug.md
+++ b/.changeset/serious-bulldogs-hug.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDC-6368): no ellipsis on long subheaderbar titles

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -5,7 +5,8 @@ import Tag from '../Tag';
 import SubHeaderBar from './SubHeaderBar.component';
 
 const viewProps = {
-	title: 'My Long Title is Long Long Lé Long La La La Lé Long Long Long Long',
+	title:
+		'My Long Title is Long Long Lé Long La La La Lé Long Long Long Long archi Long Lé Long La La La Lé Long Long Long Long Lé Long La La La Lé Long Long Long Long Long Lé Long La La La Lé Long Long Long Long Lé Long La La La Lé Long Long Long Long Long Lé Long La La La Lé Long Long Long Long Lé Long La La La Lé Long Long Long Long',
 	onEdit: action('onEdit'),
 	onSubmit: action('onSubmit'),
 	onCancel: action('onCancel'),

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.scss
@@ -39,6 +39,7 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 		&-title {
 			display: inline-flex;
 			align-items: center;
+			width: 100%;
 
 			&-wording,
 			&-wording-button {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
no ellipsis on long subheaderbar titles

**What is the chosen solution to this problem?**
ellipsis on long subheaderbar titles

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
