### PR TITLE
feat(cmf/ErrorBoundary): Sentry: capture exceptions caught by ErrorBoundary

### DIFF
--- a/.changeset/two-years-sell.md
+++ b/.changeset/two-years-sell.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf': patch
+---
+
+Sentry: capture exceptions caught by ErrorBoundary

--- a/packages/cmf/src/components/ErrorBoundary/ErrorBoundary.component.js
+++ b/packages/cmf/src/components/ErrorBoundary/ErrorBoundary.component.js
@@ -8,8 +8,14 @@ export default class ErrorBoundary extends React.Component {
 		this.state = { errors: [] };
 	}
 
-	componentDidCatch(error) {
+	componentDidCatch(error, errorInfo) {
 		this.setState(state => ({ errors: state.errors.concat(error) }));
+		if (window.Sentry) {
+			window.Sentry.withScope(scope => {
+				scope.setExtras(errorInfo);
+				window.Sentry.captureException(error);
+			});
+		}
 	}
 
 	render() {

--- a/packages/cmf/src/components/ErrorBoundary/ErrorBoundary.component.test.js
+++ b/packages/cmf/src/components/ErrorBoundary/ErrorBoundary.component.test.js
@@ -19,6 +19,7 @@ TestChildren.propTypes = {
 describe('Component ErrorBoundary', () => {
 	beforeEach(() => {
 		global.window.URL.createObjectURL = jest.fn();
+		global.window.Sentry = { withScope: jest.fn() };
 		global.console = {
 			log: jest.fn(),
 			error: jest.fn(),
@@ -41,5 +42,6 @@ describe('Component ErrorBoundary', () => {
 		expect(screen.getByText('Error: Bad')).toBeInTheDocument();
 		expect(() => screen.getByText('hello world')).toThrow();
 		expect(global.console.error).toHaveBeenCalled();
+		expect(global.window.Sentry.withScope).toHaveBeenCalled();
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Exceptions caught by ErrorBoundary need to report to Sentry
**What is the chosen solution to this problem?**
report exceptions to Sentry when it's caught.
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
