### PR TITLE
feat(cmf-router): allow children with composition

### DIFF
--- a/.changeset/real-walls-relax.md
+++ b/.changeset/real-walls-relax.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': minor
+---
+
+feat(cmf-router): allow to have children when no cmf routes are defined

--- a/packages/cmf-router/src/UIRouter.js
+++ b/packages/cmf-router/src/UIRouter.js
@@ -118,6 +118,15 @@ export function getRouter(history, basename) {
 		if (props.loading) {
 			return <Inject component={props.loading} />;
 		}
+
+		if (Object.keys(props.routes).length === 0) {
+			return (
+				<Router basename={basename} location={location} navigationType={action} navigator={history}>
+					{props.children}
+				</Router>
+			);
+		}
+
 		return <div className="is-loading">loading</div>;
 	}
 
@@ -126,6 +135,7 @@ export function getRouter(history, basename) {
 		routes: PropTypes.object,
 		loading: PropTypes.node,
 		action: PropTypes.string,
+		children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
 		location: PropTypes.shape({
 			key: PropTypes.string,
 		}),

--- a/packages/cmf-router/src/index.js
+++ b/packages/cmf-router/src/index.js
@@ -50,8 +50,8 @@ function getModule(...args) {
 
 	// router is renderer after the store is created so we refer to routerHistory
 	const UIRouter = getRouter(history, basename);
-	function CMFRouter({ children }) {
-		return <UIRouter>{children}</UIRouter>;
+	function CMFRouter(props) {
+		return <UIRouter {...props} />;
 	}
 	CMFRouter.displayName = 'CMFRouter';
 	CMFRouter.propTypes = {

--- a/packages/cmf-router/src/index.js
+++ b/packages/cmf-router/src/index.js
@@ -1,4 +1,5 @@
 import React from 'react';
+import PropTypes from 'prop-types';
 import { routerMiddleware, connectRouter } from 'connected-react-router';
 import cmf from '@talend/react-cmf';
 import { fork, takeLatest } from 'redux-saga/effects';

--- a/packages/cmf-router/src/index.js
+++ b/packages/cmf-router/src/index.js
@@ -49,10 +49,13 @@ function getModule(...args) {
 
 	// router is renderer after the store is created so we refer to routerHistory
 	const UIRouter = getRouter(history, basename);
-	function CMFRouter() {
-		return <UIRouter />;
+	function CMFRouter({ children }) {
+		return <UIRouter>{children}</UIRouter>;
 	}
 	CMFRouter.displayName = 'CMFRouter';
+	CMFRouter.propTypes = {
+		children: PropTypes.oneOfType([PropTypes.node, PropTypes.arrayOf(PropTypes.node)]),
+	};
 
 	return {
 		cmfModule: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, the RootComponent of the cmf-router is only usable when loading a route coming from the settings.
To be compatible with a composition approach, if the `routes` entry of the settings is empty, the render of the sub component would be the children instead of creating route components driven by the settings.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
