### PR TITLE
feat(design-system/icons): Typing for icons in buttons

### DIFF
--- a/.changeset/popular-walls-divide.md
+++ b/.changeset/popular-walls-divide.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Buttons can handle the new iconset

--- a/packages/design-system/src/components/Button/Button.spec.tsx
+++ b/packages/design-system/src/components/Button/Button.spec.tsx
@@ -9,11 +9,25 @@ const { Loading } = composeStories(Stories);
 context('<Button />', () => {
 	describe('default', () => {
 		it('should be focusable', () => {
-			cy.mount(<ButtonPrimitive onClick={() => {}}>button</ButtonPrimitive>);
+			cy.mount(
+				<ButtonPrimitive size="M" onClick={() => {}}>
+					button
+				</ButtonPrimitive>,
+			);
 			cy.get('button').focus();
 		});
 		it('should accept data-feature', () => {
-			cy.mount(<ButtonPrimitive data-testid="my.button" data-feature="my.feature" onClick={() => {}}>button</ButtonPrimitive>);
+			cy.mount(
+				<ButtonPrimitive
+					size="M"
+					data-testid="my.button"
+					data-feature="my.feature"
+					onClick={() => {}}
+				>
+					button
+				</ButtonPrimitive>,
+			);
+			// eslint-disable-next-line testing-library/prefer-screen-queries
 			cy.getByTestId('my.button').should('have.attr', 'data-feature', 'my.feature');
 		});
 	});
@@ -21,6 +35,7 @@ context('<Button />', () => {
 	describe('loading state', () => {
 		it('should load', () => {
 			cy.mount(<Loading data-testid="my.button" />);
+			// eslint-disable-next-line testing-library/prefer-screen-queries
 			cy.getByTestId('my.button')
 				.should('have.attr', 'aria-busy', 'false')
 				.click()
@@ -30,6 +45,7 @@ context('<Button />', () => {
 
 		it('should have a tooltip', () => {
 			cy.mount(<Loading data-testid="my.button" />);
+			// eslint-disable-next-line testing-library/prefer-screen-queries
 			cy.getByTestId('my.button')
 				.focus()
 				.should('have.attr', 'aria-describedby')

--- a/packages/design-system/src/components/Button/Button.stories.mdx
+++ b/packages/design-system/src/components/Button/Button.stories.mdx
@@ -27,7 +27,7 @@ Buttons are clickable items used for actions. They can have different styles dep
 
 Coral supports two button sizes: `M` and `S`.
 
-The small size won't display icons.
+The small size can only display icons from [SizedIcon's "S" batch](/docs/components-icon-sizedicon--icon-xs).
 
 ### Variations
 

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -101,43 +101,43 @@ export const PrimaryVariations = () => (
 			<ButtonPrimary onClick={action('Clicked')} icon="pencil">
 				Primary M
 			</ButtonPrimary>
-			<ButtonPrimary onClick={action('Clicked')} size="S" icon="badge-star">
+			<ButtonPrimary onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With icon</h3>
-			<ButtonPrimary icon="talend-upload" onClick={action('Clicked')}>
+			<ButtonPrimary icon="upload" onClick={action('Clicked')}>
 				Primary M
 			</ButtonPrimary>
-			<ButtonPrimary icon="talend-upload" onClick={action('Clicked')} size="S">
+			<ButtonPrimary onClick={action('Clicked')} size="S" icon="upload">
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With dropdown indicator</h3>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')}>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')}>
 				Primary M
 			</ButtonPrimary>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S">
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Disabled</h3>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')} disabled>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} disabled>
 				Primary M
 			</ButtonPrimary>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S" disabled>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Loading</h3>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')} isLoading>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
 				Primary M
 			</ButtonPrimary>
-			<ButtonPrimary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
@@ -155,49 +155,37 @@ export const DestructiveVariations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With icon</h3>
-			<ButtonDestructive icon="talend-upload" onClick={action('Clicked')}>
+			<ButtonDestructive icon="upload" onClick={action('Clicked')}>
 				Primary M
 			</ButtonDestructive>
-			<ButtonDestructive icon="talend-upload" onClick={action('Clicked')} size="S">
+			<ButtonDestructive icon="upload" onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonDestructive>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With dropdown indicator</h3>
-			<ButtonDestructive icon="talend-upload" isDropdown onClick={action('Clicked')}>
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')}>
 				Destructive M
 			</ButtonDestructive>
-			<ButtonDestructive icon="talend-upload" isDropdown onClick={action('Clicked')} size="S">
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')} size="S">
 				Destructive S
 			</ButtonDestructive>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Disabled</h3>
-			<ButtonDestructive icon="talend-upload" isDropdown onClick={action('Clicked')} disabled>
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')} disabled>
 				Destructive M
 			</ButtonDestructive>
-			<ButtonDestructive
-				icon="talend-upload"
-				isDropdown
-				onClick={action('Clicked')}
-				size="S"
-				disabled
-			>
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
 				Destructive S
 			</ButtonDestructive>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Loading</h3>
-			<ButtonDestructive icon="talend-upload" isDropdown onClick={action('Clicked')} isLoading>
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')} isLoading>
 				Destructive M
 			</ButtonDestructive>
-			<ButtonDestructive
-				icon="talend-upload"
-				isDropdown
-				onClick={action('Clicked')}
-				size="S"
-				isLoading
-			>
+			<ButtonDestructive icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
 				Destructive S
 			</ButtonDestructive>
 		</StackVertical>
@@ -215,49 +203,37 @@ export const SecondaryVariations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With icon</h3>
-			<ButtonSecondary icon="talend-upload" onClick={action('Clicked')}>
+			<ButtonSecondary icon="upload" onClick={action('Clicked')}>
 				Primary M
 			</ButtonSecondary>
-			<ButtonSecondary icon="talend-upload" onClick={action('Clicked')} size="S">
+			<ButtonSecondary icon="upload" onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonSecondary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With dropdown indicator</h3>
-			<ButtonSecondary icon="talend-upload" isDropdown onClick={action('Clicked')}>
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')}>
 				Secondary M
 			</ButtonSecondary>
-			<ButtonSecondary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S">
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')} size="S">
 				Secondary S
 			</ButtonSecondary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Disabled</h3>
-			<ButtonSecondary icon="talend-upload" isDropdown onClick={action('Clicked')} disabled>
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')} disabled>
 				Secondary M
 			</ButtonSecondary>
-			<ButtonSecondary
-				icon="talend-upload"
-				isDropdown
-				onClick={action('Clicked')}
-				size="S"
-				disabled
-			>
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
 				Secondary S
 			</ButtonSecondary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Loading</h3>
-			<ButtonSecondary icon="talend-upload" isDropdown onClick={action('Clicked')} isLoading>
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
 				Secondary M
 			</ButtonSecondary>
-			<ButtonSecondary
-				icon="talend-upload"
-				isDropdown
-				onClick={action('Clicked')}
-				size="S"
-				isLoading
-			>
+			<ButtonSecondary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
 				Secondary S
 			</ButtonSecondary>
 		</StackVertical>
@@ -275,43 +251,37 @@ export const TertiaryVariations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With icon</h3>
-			<ButtonTertiary icon="talend-upload" onClick={action('Clicked')}>
+			<ButtonTertiary icon="upload" onClick={action('Clicked')}>
 				Primary M
 			</ButtonTertiary>
-			<ButtonTertiary icon="talend-upload" onClick={action('Clicked')} size="S">
+			<ButtonTertiary icon="upload" onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonTertiary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>With dropdown indicator</h3>
-			<ButtonTertiary icon="talend-upload" isDropdown onClick={action('Clicked')}>
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')}>
 				Tertiary M
 			</ButtonTertiary>
-			<ButtonTertiary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S">
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')} size="S">
 				Tertiary S
 			</ButtonTertiary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Disabled</h3>
-			<ButtonTertiary icon="talend-upload" isDropdown onClick={action('Clicked')} disabled>
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')} disabled>
 				Tertiary M
 			</ButtonTertiary>
-			<ButtonTertiary icon="talend-upload" isDropdown onClick={action('Clicked')} size="S" disabled>
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
 				Tertiary S
 			</ButtonTertiary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Loading</h3>
-			<ButtonTertiary icon="talend-upload" isDropdown onClick={action('Clicked')} isLoading>
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
 				Tertiary M
 			</ButtonTertiary>
-			<ButtonTertiary
-				icon="talend-upload"
-				isDropdown
-				onClick={action('Clicked')}
-				size="S"
-				isLoading
-			>
+			<ButtonTertiary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
 				Tertiary S
 			</ButtonTertiary>
 		</StackVertical>
@@ -366,37 +336,37 @@ export const Variations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Primary</h3>
-			<ButtonPrimary icon="talend-upload" onClick={action('Clicked')} isDropdown>
+			<ButtonPrimary icon="upload" onClick={action('Clicked')} isDropdown>
 				Label
 			</ButtonPrimary>
-			<ButtonPrimary icon="talend-upload" onClick={action('Clicked')} size="S" isDropdown>
+			<ButtonPrimary icon="upload" onClick={action('Clicked')} size="S" isDropdown>
 				Label
 			</ButtonPrimary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Destructive</h3>
-			<ButtonDestructive icon="talend-upload" onClick={action('Clicked')} isDropdown>
+			<ButtonDestructive icon="upload" onClick={action('Clicked')} isDropdown>
 				Label
 			</ButtonDestructive>
-			<ButtonDestructive icon="talend-upload" onClick={action('Clicked')} size="S" isDropdown>
+			<ButtonDestructive icon="upload" onClick={action('Clicked')} size="S" isDropdown>
 				Label
 			</ButtonDestructive>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Secondary</h3>
-			<ButtonSecondary icon="talend-upload" onClick={action('Clicked')} isDropdown>
+			<ButtonSecondary icon="upload" onClick={action('Clicked')} isDropdown>
 				Label
 			</ButtonSecondary>
-			<ButtonSecondary icon="talend-upload" onClick={action('Clicked')} size="S" isDropdown>
+			<ButtonSecondary icon="upload" onClick={action('Clicked')} size="S" isDropdown>
 				Label
 			</ButtonSecondary>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Tertiary</h3>
-			<ButtonTertiary icon="talend-upload" onClick={action('Clicked')} isDropdown>
+			<ButtonTertiary icon="upload" onClick={action('Clicked')} isDropdown>
 				Label
 			</ButtonTertiary>
-			<ButtonTertiary icon="talend-upload" onClick={action('Clicked')} size="S" isDropdown>
+			<ButtonTertiary icon="upload" onClick={action('Clicked')} size="S" isDropdown>
 				Label
 			</ButtonTertiary>
 		</StackVertical>

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -99,9 +99,7 @@ export const PrimaryVariations = () => (
 	<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Default</h3>
-			<ButtonPrimary onClick={action('Clicked')} icon="pencil">
-				Primary M
-			</ButtonPrimary>
+			<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
 			<ButtonPrimary onClick={action('Clicked')} size="S">
 				Primary S
 			</ButtonPrimary>

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -4,7 +4,7 @@ import { action } from '@storybook/addon-actions';
 
 import Skeleton from '../Skeleton';
 import Tooltip from '../Tooltip';
-import { BaseButtonProps } from './Primitive/ButtonPrimitive';
+import { AvailableSizes, BaseButtonProps } from './Primitive/ButtonPrimitive';
 import ButtonPrimary from './variations/ButtonPrimary';
 import ButtonSecondary from './variations/ButtonSecondary';
 import ButtonDestructive from './variations/ButtonDestructive';
@@ -98,8 +98,10 @@ export const PrimaryVariations = () => (
 	<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Default</h3>
-			<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
-			<ButtonPrimary onClick={action('Clicked')} size="S">
+			<ButtonPrimary onClick={action('Clicked')} icon="pencil">
+				Primary M
+			</ButtonPrimary>
+			<ButtonPrimary onClick={action('Clicked')} size="S" icon="badge-star">
 				Primary S
 			</ButtonPrimary>
 		</StackVertical>
@@ -325,7 +327,7 @@ export const SkeletonButton = () => {
 	);
 };
 
-export const TooltipButton = (props: Story<BaseButtonProps>) => (
+export const TooltipButton = (props: Story<BaseButtonProps<AvailableSizes>>) => (
 	<Tooltip title="Relevant information about contacting the support">
 		<ButtonPrimary onClick={action('I have been clicked')} icon="talend-bubbles" {...props}>
 			Contact support
@@ -334,7 +336,8 @@ export const TooltipButton = (props: Story<BaseButtonProps>) => (
 );
 
 export const Loading = {
-	render: (props: Story<BaseButtonProps>) => {
+	render: (props: Story<BaseButtonProps<AvailableSizes>>) => {
+		// eslint-disable-next-line react-hooks/rules-of-hooks
 		const [loading, isLoading] = React.useState(false);
 		return (
 			<Tooltip title="Relevant description of the basic button">

--- a/packages/design-system/src/components/Button/Button.stories.tsx
+++ b/packages/design-system/src/components/Button/Button.stories.tsx
@@ -26,7 +26,8 @@ const commonArgTypes = {
 	icon: {
 		control: { type: 'text' },
 		defaultValue: 'talend-plus',
-		description: 'optional',
+		description:
+			'optional. In regular size, it supports both Icon (legacy) and SizedIcon<"M"> names. In small size, it only supports SizedIcon<"S"> names.',
 	},
 	isLoading: {
 		control: { type: 'boolean' },

--- a/packages/design-system/src/components/Button/Button.tsx
+++ b/packages/design-system/src/components/Button/Button.tsx
@@ -4,16 +4,29 @@ import ButtonPrimary, { ButtonPrimaryPropsType } from './variations/ButtonPrimar
 import ButtonSecondary, { ButtonSecondaryPropsType } from './variations/ButtonSecondary';
 import ButtonTertiary, { ButtonTertiaryPropsType } from './variations/ButtonTertiary';
 import ButtonDestructive, { ButtonDestructivePropsType } from './variations/ButtonDestructive';
-import { ButtonVariantType } from './Primitive/ButtonPrimitive';
+import { AvailableSizes, ButtonVariantType } from './Primitive/ButtonPrimitive';
 
-type Primary = ButtonVariantType<'primary', ButtonPrimaryPropsType>;
-type Secondary = ButtonVariantType<'secondary', ButtonSecondaryPropsType>;
-type Tertiary = ButtonVariantType<'tertiary', ButtonTertiaryPropsType>;
-type Destructive = ButtonVariantType<'destructive', ButtonDestructivePropsType>;
+type Primary<S extends AvailableSizes> = ButtonVariantType<'primary', ButtonPrimaryPropsType<S>>;
+type Secondary<S extends AvailableSizes> = ButtonVariantType<
+	'secondary',
+	ButtonSecondaryPropsType<S>
+>;
+type Tertiary<S extends AvailableSizes> = ButtonVariantType<'tertiary', ButtonTertiaryPropsType<S>>;
+type Destructive<S extends AvailableSizes> = ButtonVariantType<
+	'destructive',
+	ButtonDestructivePropsType<S>
+>;
 
-type ButtonType = Primary | Secondary | Tertiary | Destructive;
+type ButtonType<S extends AvailableSizes> =
+	| Primary<S>
+	| Secondary<S>
+	| Tertiary<S>
+	| Destructive<S>;
 
-const Button = forwardRef((props: ButtonType, ref: Ref<HTMLButtonElement>) => {
+function ButtonPlatform<S extends AvailableSizes>(
+	props: ButtonType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
 	switch (props.variant) {
 		case 'primary': {
 			const { variant, ...rest } = props;
@@ -39,6 +52,10 @@ const Button = forwardRef((props: ButtonType, ref: Ref<HTMLButtonElement>) => {
 			return null;
 		}
 	}
-});
+}
+
+const Button = forwardRef(ButtonPlatform) as <S extends AvailableSizes>(
+	props: ButtonType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof ButtonPlatform>;
 
 export default Button;

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -7,7 +7,7 @@ import Clickable, { ClickableProps } from '../../Clickable';
 import { DataAttributes, DeprecatedIconNames } from '../../../types';
 import { StackHorizontal } from '../../Stack';
 import Loading from '../../Loading';
-import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
+import { getIconWithDeprecatedSupport } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './ButtonStyles.module.scss';
 import { SizedIcon } from '../../Icon';
@@ -63,7 +63,7 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 				)}
 				{!isLoading && icon && (
 					<span className={styles.button__icon}>
-						{parseDeprecatedIcon({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
+						{getIconWithDeprecatedSupport({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
 					</span>
 				)}
 				{children}

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref, ReactElement } from 'react';
+import React, { forwardRef, ReactElement, Ref } from 'react';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
@@ -69,7 +69,7 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 				{children}
 				{isDropdown && (
 					<span className={styles.button__caret}>
-						<SizedIcon size="S" name="chevron-down" />
+						<SizedIcon size="XS" name="chevron-down" />
 					</span>
 				)}
 			</StackHorizontal>

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -69,7 +69,7 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 				{children}
 				{isDropdown && (
 					<span className={styles.button__caret}>
-						<SizedIcon size="XS" name="chevron-down" />
+						<SizedIcon size="S" name="chevron-down" />
 					</span>
 				)}
 			</StackHorizontal>

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -21,8 +21,8 @@ export type ButtonVariantType<T extends AvailableVariantsTypes, P extends object
 export type SharedButtonTypes<S extends AvailableSizes> = {
 	isLoading?: boolean;
 	isDropdown?: boolean;
-	size: S;
-	icon?: S extends 'S'
+	size?: S;
+	icon?: S extends 'XS'
 		? IconNameWithSize<'S'>
 		: DeprecatedIconNames | React.ReactElement | IconNameWithSize<'M'>;
 };
@@ -33,7 +33,7 @@ export type BaseButtonProps<S extends AvailableSizes> = Omit<ClickableProps, 'st
 
 function ButtonPrimitiveInner<S extends AvailableSizes>(
 	props: BaseButtonProps<S>,
-	ref: Ref<HTMLButtonElement>,
+	ref?: Ref<HTMLButtonElement>,
 ) {
 	function parsedIcon() {
 		const { icon, size } = props;
@@ -93,7 +93,7 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 }
 
 const ButtonPrimitive = forwardRef(ButtonPrimitiveInner) as <S extends AvailableSizes>(
-	props: BaseButtonProps<S> & { ref: Ref<HTMLButtonElement> },
+	props: BaseButtonProps<S> & { ref?: Ref<HTMLButtonElement> },
 ) => ReturnType<typeof ButtonPrimitiveInner>;
 
 export default ButtonPrimitive;

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -1,13 +1,14 @@
 import React, { forwardRef, Ref } from 'react';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
 import Clickable, { ClickableProps } from '../../Clickable';
 
 import { StackHorizontal } from '../../Stack';
 import Loading from '../../Loading';
 import { Icon } from '../../Icon/Icon';
-import { DataAttributes } from '../../../types';
+import { DataAttributes, DeprecatedIconNames } from '../../../types';
+import { SizedIcon } from '../../Icon';
 
 import styles from './ButtonStyles.module.scss';
 
@@ -17,62 +18,82 @@ export type ButtonVariantType<T extends AvailableVariantsTypes, P extends object
 	variant: T;
 } & P;
 
-export type SharedButtonTypes = {
-	size?: AvailableSizes;
-	icon?: IconName | React.ReactElement;
+export type SharedButtonTypes<S extends AvailableSizes> = {
 	isLoading?: boolean;
 	isDropdown?: boolean;
+	size: S;
+	icon?: S extends 'S'
+		? IconNameWithSize<'S'>
+		: DeprecatedIconNames | React.ReactElement | IconNameWithSize<'M'>;
 };
 
-export type BaseButtonProps = Omit<ClickableProps, 'style'> &
-	SharedButtonTypes &
+export type BaseButtonProps<S extends AvailableSizes> = Omit<ClickableProps, 'style'> &
+	SharedButtonTypes<S> &
 	Partial<DataAttributes>;
 
-const ButtonPrimitive = forwardRef(
-	(
-		{
-			className,
-			children,
-			onClick,
-			size = 'M',
-			icon,
-			isLoading = false,
-			isDropdown = false,
-			...props
-		}: BaseButtonProps,
-		ref: Ref<HTMLButtonElement>,
-	) => {
-		return (
-			<Clickable
-				className={classnames(styles.button, className, {
-					[styles['size-S']]: size === 'S',
-				})}
-				{...props}
-				aria-busy={isLoading}
-				ref={ref}
-				onClick={!isLoading ? onClick : () => {}}
-			>
-				<StackHorizontal gap="XS" as="span" align="center">
-					{isLoading && (
-						<span className={styles.button__loading}>
-							<Loading data-test="button.loading" name={icon} aria-hidden />
-						</span>
-					)}
-					{!isLoading && icon && size === 'M' && (
-						<span className={styles.button__icon}>
-							{typeof icon === 'string' ? <Icon name={icon} /> : React.cloneElement(icon, {})}
-						</span>
-					)}
-					{children}
-					{isDropdown && (
-						<span className={styles.button__caret}>
-							<Icon name="talend-caret-down" />
-						</span>
-					)}
-				</StackHorizontal>
-			</Clickable>
-		);
-	},
-);
+function ButtonPrimitiveInner<S extends AvailableSizes>(
+	props: BaseButtonProps<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
+	function parsedIcon() {
+		const { icon, size } = props;
+		if (!icon) {
+			return null;
+		}
+		if (typeof icon === 'string') {
+			if (icon.includes('talend-')) {
+				return <Icon name={icon} />;
+			}
+			return (
+				<SizedIcon
+					size={size ? size : 'M'}
+					name={size === 'M' ? (icon as IconNameWithSize<'M'>) : (icon as IconNameWithSize<'S'>)}
+				/>
+			);
+		}
+
+		return React.cloneElement(icon, {});
+	}
+	const {
+		className,
+		children,
+		onClick,
+		size = 'M',
+		icon,
+		isLoading = false,
+		isDropdown = false,
+		...rest
+	} = props;
+	return (
+		<Clickable
+			className={classnames(styles.button, className, {
+				[styles['size-S']]: size === 'S',
+			})}
+			{...rest}
+			aria-busy={isLoading}
+			ref={ref}
+			onClick={!isLoading ? onClick : () => {}}
+		>
+			<StackHorizontal gap="XS" as="span" align="center">
+				{isLoading && (
+					<span className={styles.button__loading}>
+						<Loading data-test="button.loading" aria-hidden />
+					</span>
+				)}
+				{!isLoading && icon && <span className={styles.button__icon}>{parsedIcon()}</span>}
+				{children}
+				{isDropdown && (
+					<span className={styles.button__caret}>
+						<Icon name="talend-caret-down" />
+					</span>
+				)}
+			</StackHorizontal>
+		</Clickable>
+	);
+}
+
+const ButtonPrimitive = forwardRef(ButtonPrimitiveInner) as <S extends AvailableSizes>(
+	props: BaseButtonProps<S> & { ref: Ref<HTMLButtonElement> },
+) => ReturnType<typeof ButtonPrimitiveInner>;
 
 export default ButtonPrimitive;

--- a/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
+++ b/packages/design-system/src/components/Button/Primitive/ButtonPrimitive.tsx
@@ -1,16 +1,16 @@
-import React, { forwardRef, Ref } from 'react';
+import React, { forwardRef, Ref, ReactElement } from 'react';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
 import Clickable, { ClickableProps } from '../../Clickable';
 
+import { DataAttributes, DeprecatedIconNames } from '../../../types';
 import { StackHorizontal } from '../../Stack';
 import Loading from '../../Loading';
-import { Icon } from '../../Icon/Icon';
-import { DataAttributes, DeprecatedIconNames } from '../../../types';
-import { SizedIcon } from '../../Icon';
+import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './ButtonStyles.module.scss';
+import { SizedIcon } from '../../Icon';
 
 export type AvailableVariantsTypes = 'primary' | 'destructive' | 'secondary' | 'tertiary';
 export type AvailableSizes = 'M' | 'S';
@@ -22,9 +22,9 @@ export type SharedButtonTypes<S extends AvailableSizes> = {
 	isLoading?: boolean;
 	isDropdown?: boolean;
 	size?: S;
-	icon?: S extends 'XS'
+	icon?: S extends 'S'
 		? IconNameWithSize<'S'>
-		: DeprecatedIconNames | React.ReactElement | IconNameWithSize<'M'>;
+		: DeprecatedIconNames | ReactElement | IconNameWithSize<'M'>;
 };
 
 export type BaseButtonProps<S extends AvailableSizes> = Omit<ClickableProps, 'style'> &
@@ -35,25 +35,6 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 	props: BaseButtonProps<S>,
 	ref?: Ref<HTMLButtonElement>,
 ) {
-	function parsedIcon() {
-		const { icon, size } = props;
-		if (!icon) {
-			return null;
-		}
-		if (typeof icon === 'string') {
-			if (icon.includes('talend-')) {
-				return <Icon name={icon} />;
-			}
-			return (
-				<SizedIcon
-					size={size ? size : 'M'}
-					name={size === 'M' ? (icon as IconNameWithSize<'M'>) : (icon as IconNameWithSize<'S'>)}
-				/>
-			);
-		}
-
-		return React.cloneElement(icon, {});
-	}
 	const {
 		className,
 		children,
@@ -80,11 +61,15 @@ function ButtonPrimitiveInner<S extends AvailableSizes>(
 						<Loading data-test="button.loading" aria-hidden />
 					</span>
 				)}
-				{!isLoading && icon && <span className={styles.button__icon}>{parsedIcon()}</span>}
+				{!isLoading && icon && (
+					<span className={styles.button__icon}>
+						{parseDeprecatedIcon({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
+					</span>
+				)}
 				{children}
 				{isDropdown && (
 					<span className={styles.button__caret}>
-						<Icon name="talend-caret-down" />
+						<SizedIcon size="S" name="chevron-down" />
 					</span>
 				)}
 			</StackHorizontal>

--- a/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
+++ b/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
@@ -36,6 +36,13 @@
 	&.size-S {
 		height: tokens.$coral-sizing-s;
 		padding: tokens.$coral-spacing-xxs tokens.$coral-spacing-xs;
+
+		.button__icon {
+			display: inline-flex;
+			width: tokens.$coral-sizing-minimal;
+			height: tokens.$coral-sizing-minimal;
+			align-items: center;
+		}
 	}
 
 	&:disabled,

--- a/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
+++ b/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
@@ -19,8 +19,6 @@
 
 	&__caret {
 		display: inline-flex;
-		width: tokens.$coral-sizing-minimal;
-		height: tokens.$coral-sizing-minimal;
 		align-items: center;
 		transition: transform tokens.$coral-transition-fast;
 	}
@@ -36,13 +34,6 @@
 	&.size-S {
 		height: tokens.$coral-sizing-s;
 		padding: tokens.$coral-spacing-xxs tokens.$coral-spacing-xs;
-
-		.button__icon {
-			display: inline-flex;
-			width: tokens.$coral-sizing-minimal;
-			height: tokens.$coral-sizing-minimal;
-			align-items: center;
-		}
 	}
 
 	&:disabled,
@@ -57,4 +48,11 @@
 			transform: rotate(-180deg);
 		}
 	}
+}
+
+.button.size-S .button__icon {
+	display: inline-flex;
+	width: tokens.$coral-sizing-minimal;
+	height: tokens.$coral-sizing-minimal;
+	align-items: center;
 }

--- a/packages/design-system/src/components/Button/index.ts
+++ b/packages/design-system/src/components/Button/index.ts
@@ -4,7 +4,7 @@ import ButtonTertiary from './variations/ButtonTertiary';
 import ButtonDestructive from './variations/ButtonDestructive';
 import Button from './Button';
 
-import { BaseButtonProps } from './Primitive/ButtonPrimitive';
+import { AvailableSizes, BaseButtonProps } from './Primitive/ButtonPrimitive';
 
 export type ButtonComponentTypes =
 	| typeof ButtonPrimary
@@ -12,6 +12,6 @@ export type ButtonComponentTypes =
 	| typeof ButtonTertiary
 	| typeof ButtonDestructive;
 
-export type SharedButtonComponentProps = Omit<BaseButtonProps, 'className'>;
+export type SharedButtonComponentProps = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
 
 export { Button, ButtonPrimary, ButtonSecondary, ButtonTertiary, ButtonDestructive };

--- a/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
@@ -14,8 +14,7 @@ function Destructive<S extends AvailableSizes>(
 	props: ButtonDestructivePropsType<S>,
 	ref: Ref<HTMLButtonElement>,
 ) {
-	const { size = 'M', ...rest } = props;
-	return <ButtonPrimitive size={size} {...rest} ref={ref} className={styles.destructive} />;
+	return <ButtonPrimitive {...props} ref={ref} className={styles.destructive} />;
 }
 
 const ButtonDestructive = forwardRef(Destructive) as <S extends AvailableSizes>(

--- a/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitive, { BaseButtonProps } from '../Primitive/ButtonPrimitive';
+import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonDestructive.module.scss';
 
-export type ButtonDestructivePropsType = Omit<BaseButtonProps, 'className'>;
+export type ButtonDestructivePropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
 
 const ButtonDestructive = forwardRef(
 	(props: ButtonDestructivePropsType, ref: Ref<HTMLButtonElement>) => {

--- a/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonDestructive.tsx
@@ -3,12 +3,23 @@ import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/B
 
 import styles from './ButtonDestructive.module.scss';
 
-export type ButtonDestructivePropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
+export type ButtonDestructivePropsType<S extends AvailableSizes> = Omit<
+	BaseButtonProps<S>,
+	'className' | 'size'
+> & {
+	size?: S;
+};
 
-const ButtonDestructive = forwardRef(
-	(props: ButtonDestructivePropsType, ref: Ref<HTMLButtonElement>) => {
-		return <ButtonPrimitive {...props} ref={ref} className={styles.destructive} />;
-	},
-);
+function Destructive<S extends AvailableSizes>(
+	props: ButtonDestructivePropsType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
+	const { size = 'M', ...rest } = props;
+	return <ButtonPrimitive size={size} {...rest} ref={ref} className={styles.destructive} />;
+}
+
+const ButtonDestructive = forwardRef(Destructive) as <S extends AvailableSizes>(
+	props: ButtonDestructivePropsType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Destructive>;
 
 export default ButtonDestructive;

--- a/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
@@ -1,12 +1,23 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitive, { BaseButtonProps } from '../Primitive/ButtonPrimitive';
+import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonPrimary.module.scss';
 
-export type ButtonPrimaryPropsType = Omit<BaseButtonProps, 'className'>;
+export type ButtonPrimaryPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonProps<S>,
+	'className' | 'size'
+> & {
+	size?: S;
+};
 
-const ButtonPrimary = forwardRef((props: ButtonPrimaryPropsType, ref: Ref<HTMLButtonElement>) => {
-	return <ButtonPrimitive {...props} ref={ref} className={styles.primary} />;
-});
+function Primary<S extends AvailableSizes>(
+	props: ButtonPrimaryPropsType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
+	const { size = 'M', ...rest } = props;
+	return <ButtonPrimitive size={size} {...rest} ref={ref} className={styles.primary} />;
+}
+
+const ButtonPrimary = forwardRef(Primary);
 
 export default ButtonPrimary;

--- a/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
@@ -14,8 +14,7 @@ function Primary<S extends AvailableSizes>(
 	props: ButtonPrimaryPropsType<S>,
 	ref: Ref<HTMLButtonElement>,
 ) {
-	const { size = 'M', ...rest } = props;
-	return <ButtonPrimitive size={size} {...rest} ref={ref} className={styles.primary} />;
+	return <ButtonPrimitive {...props} ref={ref} className={styles.primary} />;
 }
 
 const ButtonPrimary = forwardRef(Primary) as <S extends AvailableSizes>(

--- a/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonPrimary.tsx
@@ -18,6 +18,8 @@ function Primary<S extends AvailableSizes>(
 	return <ButtonPrimitive size={size} {...rest} ref={ref} className={styles.primary} />;
 }
 
-const ButtonPrimary = forwardRef(Primary);
+const ButtonPrimary = forwardRef(Primary) as <S extends AvailableSizes>(
+	props: ButtonPrimaryPropsType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Primary>;
 
 export default ButtonPrimary;

--- a/packages/design-system/src/components/Button/variations/ButtonSecondary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonSecondary.tsx
@@ -2,13 +2,24 @@ import React, { forwardRef, Ref } from 'react';
 import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonSecondary.module.scss';
+import { ButtonDestructivePropsType } from './ButtonDestructive';
 
-export type ButtonSecondaryPropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
+export type ButtonSecondaryPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonProps<S>,
+	'className' | 'size'
+> & {
+	size?: S;
+};
 
-const ButtonSecondary = forwardRef(
-	(props: ButtonSecondaryPropsType, ref: Ref<HTMLButtonElement>) => {
-		return <ButtonPrimitive {...props} ref={ref} className={styles.secondary} />;
-	},
-);
+function Secondary<S extends AvailableSizes>(
+	props: ButtonSecondaryPropsType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
+	return <ButtonPrimitive {...props} ref={ref} className={styles.secondary} />;
+}
+
+const ButtonSecondary = forwardRef(Secondary) as <S extends AvailableSizes>(
+	props: ButtonDestructivePropsType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Secondary>;
 
 export default ButtonSecondary;

--- a/packages/design-system/src/components/Button/variations/ButtonSecondary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonSecondary.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitive, { BaseButtonProps } from '../Primitive/ButtonPrimitive';
+import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonSecondary.module.scss';
 
-export type ButtonSecondaryPropsType = Omit<BaseButtonProps, 'className'>;
+export type ButtonSecondaryPropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
 
 const ButtonSecondary = forwardRef(
 	(props: ButtonSecondaryPropsType, ref: Ref<HTMLButtonElement>) => {

--- a/packages/design-system/src/components/Button/variations/ButtonTertiary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonTertiary.tsx
@@ -2,11 +2,24 @@ import React, { forwardRef, Ref } from 'react';
 import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonTertiary.module.scss';
+import { ButtonDestructivePropsType } from './ButtonDestructive';
 
-export type ButtonTertiaryPropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
+export type ButtonTertiaryPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonProps<S>,
+	'className' | 'size'
+> & {
+	size?: S;
+};
 
-const ButtonTertiary = forwardRef((props: ButtonTertiaryPropsType, ref: Ref<HTMLButtonElement>) => {
+function Tertiary<S extends AvailableSizes>(
+	props: ButtonTertiaryPropsType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
 	return <ButtonPrimitive {...props} ref={ref} className={styles.tertiary} />;
-});
+}
+
+const ButtonTertiary = forwardRef(Tertiary) as <S extends AvailableSizes>(
+	props: ButtonDestructivePropsType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Tertiary>;
 
 export default ButtonTertiary;

--- a/packages/design-system/src/components/Button/variations/ButtonTertiary.tsx
+++ b/packages/design-system/src/components/Button/variations/ButtonTertiary.tsx
@@ -1,9 +1,9 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitive, { BaseButtonProps } from '../Primitive/ButtonPrimitive';
+import ButtonPrimitive, { AvailableSizes, BaseButtonProps } from '../Primitive/ButtonPrimitive';
 
 import styles from './ButtonTertiary.module.scss';
 
-export type ButtonTertiaryPropsType = Omit<BaseButtonProps, 'className'>;
+export type ButtonTertiaryPropsType = Omit<BaseButtonProps<AvailableSizes>, 'className'>;
 
 const ButtonTertiary = forwardRef((props: ButtonTertiaryPropsType, ref: Ref<HTMLButtonElement>) => {
 	return <ButtonPrimitive {...props} ref={ref} className={styles.tertiary} />;

--- a/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.stories.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.stories.tsx
@@ -10,11 +10,6 @@ import ButtonDestructiveAsLink from './variations/ButtonDestructiveAsLink';
 import ButtonAsLink from './ButtonAsLink';
 
 import { StackHorizontal, StackVertical } from '../Stack';
-import ButtonPrimary from '../Button/variations/ButtonPrimary';
-import { action } from '@storybook/addon-actions';
-import ButtonDestructive from '../Button/variations/ButtonDestructive';
-import ButtonSecondary from '../Button/variations/ButtonSecondary';
-import ButtonTertiary from '../Button/variations/ButtonTertiary';
 
 const commonLinkArgTypes = {
 	children: {
@@ -124,37 +119,37 @@ export const Variations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Primary</h3>
-			<ButtonPrimaryAsLink icon="talend-upload" href="/">
+			<ButtonPrimaryAsLink icon="upload" href="/">
 				Label
 			</ButtonPrimaryAsLink>
-			<ButtonPrimaryAsLink icon="talend-upload" href="/" size="S">
+			<ButtonPrimaryAsLink icon="upload" href="/" size="S">
 				Label
 			</ButtonPrimaryAsLink>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Destructive</h3>
-			<ButtonDestructiveAsLink icon="talend-upload" href="/">
+			<ButtonDestructiveAsLink icon="upload" href="/">
 				Label
 			</ButtonDestructiveAsLink>
-			<ButtonDestructiveAsLink icon="talend-upload" href="/" size="S">
+			<ButtonDestructiveAsLink icon="upload" href="/" size="S">
 				Label
 			</ButtonDestructiveAsLink>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Secondary</h3>
-			<ButtonSecondaryAsLink icon="talend-upload" href="/">
+			<ButtonSecondaryAsLink icon="upload" href="/">
 				Label
 			</ButtonSecondaryAsLink>
-			<ButtonSecondaryAsLink icon="talend-upload" href="/" size="S">
+			<ButtonSecondaryAsLink icon="upload" href="/" size="S">
 				Label
 			</ButtonSecondaryAsLink>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Tertiary</h3>
-			<ButtonTertiaryAsLink icon="talend-upload" href="/">
+			<ButtonTertiaryAsLink icon="upload" href="/">
 				Label
 			</ButtonTertiaryAsLink>
-			<ButtonTertiaryAsLink icon="talend-upload" href="/" size="S">
+			<ButtonTertiaryAsLink icon="upload" href="/" size="S">
 				Label
 			</ButtonTertiaryAsLink>
 		</StackVertical>

--- a/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/ButtonAsLink.tsx
@@ -12,16 +12,32 @@ import ButtonTertiaryAsLink, {
 import ButtonDestructiveAsLink, {
 	ButtonDestructiveAsLinkPropsType,
 } from './variations/ButtonDestructiveAsLink';
-import { ButtonVariantType } from '../Button/Primitive/ButtonPrimitive';
+import { AvailableSizes, ButtonVariantType } from '../Button/Primitive/ButtonPrimitive';
 
-type Primary = ButtonVariantType<'primary', ButtonPrimaryAsLinkPropsType>;
-type Secondary = ButtonVariantType<'secondary', ButtonSecondaryAsLinkPropsType>;
-type Tertiary = ButtonVariantType<'tertiary', ButtonTertiaryAsLinkPropsType>;
-type Destructive = ButtonVariantType<'destructive', ButtonDestructiveAsLinkPropsType>;
+type Primary<S extends AvailableSizes> = ButtonVariantType<
+	'primary',
+	ButtonPrimaryAsLinkPropsType<S>
+>;
+type Secondary<S extends AvailableSizes> = ButtonVariantType<
+	'secondary',
+	ButtonSecondaryAsLinkPropsType<S>
+>;
+type Tertiary<S extends AvailableSizes> = ButtonVariantType<
+	'tertiary',
+	ButtonTertiaryAsLinkPropsType<S>
+>;
+type Destructive<S extends AvailableSizes> = ButtonVariantType<
+	'destructive',
+	ButtonDestructiveAsLinkPropsType<S>
+>;
 
-type ButtonType = Primary | Secondary | Tertiary | Destructive;
+type ButtonType<S extends AvailableSizes> =
+	| Primary<S>
+	| Secondary<S>
+	| Tertiary<S>
+	| Destructive<S>;
 
-const ButtonAsLink = forwardRef((props: ButtonType, ref: Ref<any>) => {
+function ButtonPlatform<S extends AvailableSizes>(props: ButtonType<S>, ref: Ref<any>) {
 	switch (props.variant) {
 		case 'primary': {
 			const { variant, ...rest } = props;
@@ -47,6 +63,10 @@ const ButtonAsLink = forwardRef((props: ButtonType, ref: Ref<any>) => {
 			return null;
 		}
 	}
-});
+}
+
+const ButtonAsLink = forwardRef(ButtonPlatform) as <S extends AvailableSizes>(
+	props: ButtonType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof ButtonPlatform>;
 
 export default ButtonAsLink;

--- a/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.module.scss
+++ b/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.module.scss
@@ -10,6 +10,6 @@
 
 	// External icon offset override in flex context
 	[data-test='link.icon.external'] {
-		margin-bottom: 0;
+		top: 0;
 	}
 }

--- a/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
@@ -5,13 +5,13 @@ import Linkable, { LinkableType } from '../../Linkable';
 import { StackHorizontal } from '../../Stack';
 import { Icon } from '../../Icon/Icon';
 
-import { SharedButtonTypes } from '../../Button/Primitive/ButtonPrimitive';
+import { AvailableSizes, SharedButtonTypes } from '../../Button/Primitive/ButtonPrimitive';
 
 import sharedStyles from '../../Button/Primitive/ButtonStyles.module.scss';
 import linkStyles from './ButtonPrimitiveAsLink.module.scss';
 
 export type BaseButtonPropsAsLink = LinkableType &
-	Omit<SharedButtonTypes, 'isDropdown' | 'isLoading'>;
+	Omit<SharedButtonTypes<AvailableSizes>, 'isDropdown' | 'isLoading'>;
 
 const ButtonPrimitiveAsLink = forwardRef(
 	(

--- a/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
@@ -8,7 +8,7 @@ import { AvailableSizes, SharedButtonTypes } from '../../Button/Primitive/Button
 
 import sharedStyles from '../../Button/Primitive/ButtonStyles.module.scss';
 import linkStyles from './ButtonPrimitiveAsLink.module.scss';
-import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
+import { getIconWithDeprecatedSupport } from '../../Icon/DeprecatedIconHelper';
 
 export type BaseButtonPropsAsLink<S extends AvailableSizes> = LinkableType &
 	Omit<SharedButtonTypes<S>, 'isDropdown' | 'isLoading'>;
@@ -29,7 +29,7 @@ function PrimitiveAsLink<S extends AvailableSizes>(
 			<StackHorizontal gap="XXS" as="span" align="center">
 				{icon && (
 					<span className={sharedStyles.button__icon}>
-						{parseDeprecatedIcon({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
+						{getIconWithDeprecatedSupport({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
 					</span>
 				)}
 				{children}

--- a/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/Primitive/ButtonPrimitiveAsLink.tsx
@@ -3,40 +3,43 @@ import classnames from 'classnames';
 import Linkable, { LinkableType } from '../../Linkable';
 
 import { StackHorizontal } from '../../Stack';
-import { Icon } from '../../Icon/Icon';
 
 import { AvailableSizes, SharedButtonTypes } from '../../Button/Primitive/ButtonPrimitive';
 
 import sharedStyles from '../../Button/Primitive/ButtonStyles.module.scss';
 import linkStyles from './ButtonPrimitiveAsLink.module.scss';
+import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
 
-export type BaseButtonPropsAsLink = LinkableType &
-	Omit<SharedButtonTypes<AvailableSizes>, 'isDropdown' | 'isLoading'>;
+export type BaseButtonPropsAsLink<S extends AvailableSizes> = LinkableType &
+	Omit<SharedButtonTypes<S>, 'isDropdown' | 'isLoading'>;
 
-const ButtonPrimitiveAsLink = forwardRef(
-	(
-		{ className, children, onClick, size = 'M', icon, ...props }: BaseButtonPropsAsLink,
-		ref: Ref<HTMLAnchorElement>,
-	) => {
-		return (
-			<Linkable
-				className={classnames(sharedStyles.button, linkStyles.button, className, {
-					[sharedStyles['size-S']]: size === 'S',
-				})}
-				{...props}
-				ref={ref}
-			>
-				<StackHorizontal gap="XXS" as="span" align="center">
-					{icon && size === 'M' && (
-						<span className={sharedStyles.button__icon}>
-							{typeof icon === 'string' ? <Icon name={icon} /> : React.cloneElement(icon, {})}
-						</span>
-					)}
-					{children}
-				</StackHorizontal>
-			</Linkable>
-		);
-	},
-);
+function PrimitiveAsLink<S extends AvailableSizes>(
+	props: BaseButtonPropsAsLink<S>,
+	ref: Ref<HTMLAnchorElement>,
+) {
+	const { className, children, onClick, size = 'M', icon, ...rest } = props;
+	return (
+		<Linkable
+			className={classnames(sharedStyles.button, linkStyles.button, className, {
+				[sharedStyles['size-S']]: size === 'S',
+			})}
+			{...rest}
+			ref={ref}
+		>
+			<StackHorizontal gap="XXS" as="span" align="center">
+				{icon && (
+					<span className={sharedStyles.button__icon}>
+						{parseDeprecatedIcon({ iconSrc: icon, size: size === 'S' ? 'S' : 'M' })}
+					</span>
+				)}
+				{children}
+			</StackHorizontal>
+		</Linkable>
+	);
+}
+
+const ButtonPrimitiveAsLink = forwardRef(PrimitiveAsLink) as <S extends AvailableSizes>(
+	props: BaseButtonPropsAsLink<S> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof PrimitiveAsLink>;
 
 export default ButtonPrimitiveAsLink;

--- a/packages/design-system/src/components/ButtonAsLink/variations/ButtonDestructiveAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/variations/ButtonDestructiveAsLink.tsx
@@ -1,16 +1,23 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitiveAsLink, {
-	BaseButtonPropsAsLink,
-} from '../Primitive/ButtonPrimitiveAsLink';
+import ButtonPrimitiveAsLink, { BaseButtonPropsAsLink } from '../Primitive/ButtonPrimitiveAsLink';
+import { AvailableSizes } from '../../Button/Primitive/ButtonPrimitive';
 
 import styles from '../../Button/variations/ButtonDestructive.module.scss';
 
-export type ButtonDestructiveAsLinkPropsType = Omit<BaseButtonPropsAsLink, 'className'>;
+export type ButtonDestructiveAsLinkPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonPropsAsLink<S>,
+	'className'
+>;
 
-const ButtonDestructiveAsLink = forwardRef(
-	(props: ButtonDestructiveAsLinkPropsType, ref: Ref<HTMLAnchorElement>) => {
-		return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.destructive} />;
-	},
-);
+function DestructiveAsLink<S extends AvailableSizes>(
+	props: ButtonDestructiveAsLinkPropsType<S>,
+	ref: Ref<HTMLAnchorElement>,
+) {
+	return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.destructive} />;
+}
+
+const ButtonDestructiveAsLink = forwardRef(DestructiveAsLink) as <S extends AvailableSizes>(
+	props: ButtonDestructiveAsLinkPropsType<S> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof DestructiveAsLink>;
 
 export default ButtonDestructiveAsLink;

--- a/packages/design-system/src/components/ButtonAsLink/variations/ButtonPrimaryAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/variations/ButtonPrimaryAsLink.tsx
@@ -1,16 +1,23 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitiveAsLink, {
-	BaseButtonPropsAsLink,
-} from '../Primitive/ButtonPrimitiveAsLink';
+import ButtonPrimitiveAsLink, { BaseButtonPropsAsLink } from '../Primitive/ButtonPrimitiveAsLink';
+import { AvailableSizes } from '../../Button/Primitive/ButtonPrimitive';
 
 import styles from '../../Button/variations/ButtonPrimary.module.scss';
 
-export type ButtonPrimaryAsLinkPropsType = Omit<BaseButtonPropsAsLink, 'className'>;
+export type ButtonPrimaryAsLinkPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonPropsAsLink<S>,
+	'className'
+>;
 
-const ButtonPrimaryAsLink = forwardRef(
-	(props: ButtonPrimaryAsLinkPropsType, ref: Ref<HTMLAnchorElement>) => {
-		return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.primary} />;
-	},
-);
+function PrimaryAsLink<S extends AvailableSizes>(
+	props: ButtonPrimaryAsLinkPropsType<S>,
+	ref: Ref<HTMLAnchorElement>,
+) {
+	return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.primary} />;
+}
+
+const ButtonPrimaryAsLink = forwardRef(PrimaryAsLink) as <S extends AvailableSizes>(
+	props: ButtonPrimaryAsLinkPropsType<S> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof PrimaryAsLink>;
 
 export default ButtonPrimaryAsLink;

--- a/packages/design-system/src/components/ButtonAsLink/variations/ButtonSecondaryAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/variations/ButtonSecondaryAsLink.tsx
@@ -1,16 +1,22 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitiveAsLink, {
-	BaseButtonPropsAsLink,
-} from '../Primitive/ButtonPrimitiveAsLink';
+import ButtonPrimitiveAsLink, { BaseButtonPropsAsLink } from '../Primitive/ButtonPrimitiveAsLink';
+import { AvailableSizes } from '../../Button/Primitive/ButtonPrimitive';
 
 import styles from '../../Button/variations/ButtonSecondary.module.scss';
 
-export type ButtonSecondaryAsLinkPropsType = Omit<BaseButtonPropsAsLink, 'className'>;
+export type ButtonSecondaryAsLinkPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonPropsAsLink<S>,
+	'className'
+>;
 
-const ButtonSecondaryAsLink = forwardRef(
-	(props: ButtonSecondaryAsLinkPropsType, ref: Ref<HTMLAnchorElement>) => {
-		return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.secondary} />;
-	},
-);
+function SecondaryAsLink<S extends AvailableSizes>(
+	props: ButtonSecondaryAsLinkPropsType<S>,
+	ref: Ref<HTMLAnchorElement>,
+) {
+	return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.secondary} />;
+}
+const ButtonSecondaryAsLink = forwardRef(SecondaryAsLink) as <S extends AvailableSizes>(
+	props: ButtonSecondaryAsLinkPropsType<S> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof SecondaryAsLink>;
 
 export default ButtonSecondaryAsLink;

--- a/packages/design-system/src/components/ButtonAsLink/variations/ButtonTertiaryAsLink.tsx
+++ b/packages/design-system/src/components/ButtonAsLink/variations/ButtonTertiaryAsLink.tsx
@@ -1,16 +1,23 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonPrimitiveAsLink, {
-	BaseButtonPropsAsLink,
-} from '../Primitive/ButtonPrimitiveAsLink';
+import ButtonPrimitiveAsLink, { BaseButtonPropsAsLink } from '../Primitive/ButtonPrimitiveAsLink';
+import { AvailableSizes } from '../../Button/Primitive/ButtonPrimitive';
 
 import styles from '../../Button/variations/ButtonTertiary.module.scss';
 
-export type ButtonTertiaryAsLinkPropsType = Omit<BaseButtonPropsAsLink, 'className'>;
+export type ButtonTertiaryAsLinkPropsType<S extends AvailableSizes> = Omit<
+	BaseButtonPropsAsLink<S>,
+	'className'
+>;
 
-const ButtonTertiaryAsLink = forwardRef(
-	(props: ButtonTertiaryAsLinkPropsType, ref: Ref<HTMLAnchorElement>) => {
-		return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.tertiary} />;
-	},
-);
+function TertiaryAsLink<S extends AvailableSizes>(
+	props: ButtonTertiaryAsLinkPropsType<S>,
+	ref: Ref<HTMLAnchorElement>,
+) {
+	return <ButtonPrimitiveAsLink {...props} ref={ref} className={styles.tertiary} />;
+}
+
+const ButtonTertiaryAsLink = forwardRef(TertiaryAsLink) as <S extends AvailableSizes>(
+	props: ButtonTertiaryAsLinkPropsType<S> & { ref?: Ref<HTMLAnchorElement> },
+) => ReturnType<typeof TertiaryAsLink>;
 
 export default ButtonTertiaryAsLink;

--- a/packages/design-system/src/components/ButtonIcon/ButtonIcon.stories.tsx
+++ b/packages/design-system/src/components/ButtonIcon/ButtonIcon.stories.tsx
@@ -16,7 +16,9 @@ const commonArgTypes = {
 	},
 	icon: {
 		control: { type: 'text' },
-		defaultValue: 'talend-plus',
+		defaultValue: 'plus',
+		description:
+			'In regular size, it supports both Icon (legacy) and SizedIcon<"M"> names. In size "XS", it supports the legacy icon name still, and the SizedIcon<"S"> names.',
 	},
 	onClick: {
 		disabled: true,
@@ -156,40 +158,40 @@ export const Variations = () => (
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Default</h3>
-			<ButtonIcon icon="talend-plus" onClick={action('Clicked')}>
+			<ButtonIcon icon="plus" onClick={action('Clicked')}>
 				Size M
 			</ButtonIcon>
-			<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="S">
+			<ButtonIcon icon="plus" onClick={action('Clicked')} size="S">
 				Size S
 			</ButtonIcon>
-			<ButtonIcon size="XS" icon="pouet" onClick={action('Clicked')}>
+			<ButtonIcon size="XS" icon="plus" onClick={action('Clicked')}>
 				Size XS
 			</ButtonIcon>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Floating</h3>
-			<ButtonIconFloating icon="talend-plus" onClick={action('Clicked')}>
+			<ButtonIconFloating icon="plus" onClick={action('Clicked')}>
 				Size M
 			</ButtonIconFloating>
-			<ButtonIconFloating icon="talend-plus" onClick={action('Clicked')} size="S">
+			<ButtonIconFloating icon="plus" onClick={action('Clicked')} size="S">
 				Size S
 			</ButtonIconFloating>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Toggle-ON</h3>
-			<ButtonIconToggle isActive icon="talend-plus" onClick={action('Clicked')}>
+			<ButtonIconToggle isActive icon="plus" onClick={action('Clicked')}>
 				Size M + Active
 			</ButtonIconToggle>
-			<ButtonIconToggle isActive icon="talend-plus" onClick={action('Clicked')} size="S">
+			<ButtonIconToggle isActive icon="plus" onClick={action('Clicked')} size="S">
 				Size S + Active
 			</ButtonIconToggle>
 		</StackVertical>
 		<StackVertical gap="S" justify="start" align="center">
 			<h3>Toggle-OFF</h3>
-			<ButtonIconToggle isActive={false} icon="talend-plus" onClick={action('Clicked')}>
+			<ButtonIconToggle isActive={false} icon="plus" onClick={action('Clicked')}>
 				Size M + Inactive
 			</ButtonIconToggle>
-			<ButtonIconToggle isActive={false} icon="talend-plus" onClick={action('Clicked')} size="S">
+			<ButtonIconToggle isActive={false} icon="plus" onClick={action('Clicked')} size="S">
 				Size S + Inactive
 			</ButtonIconToggle>
 		</StackVertical>
@@ -198,10 +200,10 @@ export const Variations = () => (
 
 export const DefaultButtonIcon = () => (
 	<StackHorizontal gap="XS" justify="center" align="center">
-		<ButtonIcon icon="talend-plus" onClick={action('Clicked')}>
+		<ButtonIcon icon="plus" onClick={action('Clicked')}>
 			Size M
 		</ButtonIcon>
-		<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="S">
+		<ButtonIcon icon="plus" onClick={action('Clicked')} size="S">
 			Size S
 		</ButtonIcon>
 		<ButtonIcon icon="plus" onClick={action('Clicked')} size="XS">
@@ -212,17 +214,17 @@ export const DefaultButtonIcon = () => (
 
 export const DefaultButtonIconToggle = () => (
 	<StackHorizontal gap="XS" justify="center" align="center">
-		<ButtonIconToggle isActive={false} icon="talend-plus" onClick={action('Clicked')}>
+		<ButtonIconToggle isActive={false} icon="plus" onClick={action('Clicked')}>
 			Size M + Inactive
 		</ButtonIconToggle>
-		<ButtonIconToggle isActive={false} icon="talend-plus" onClick={action('Clicked')} size="S">
+		<ButtonIconToggle isActive={false} icon="plus" onClick={action('Clicked')} size="S">
 			Size S + Inactive
 		</ButtonIconToggle>
 
-		<ButtonIconToggle isActive icon="talend-plus" onClick={action('Clicked')}>
+		<ButtonIconToggle isActive icon="plus" onClick={action('Clicked')}>
 			Size M + Active
 		</ButtonIconToggle>
-		<ButtonIconToggle isActive icon="talend-plus" onClick={action('Clicked')} size="S">
+		<ButtonIconToggle isActive icon="plus" onClick={action('Clicked')} size="S">
 			Size S + Active
 		</ButtonIconToggle>
 	</StackHorizontal>
@@ -230,10 +232,10 @@ export const DefaultButtonIconToggle = () => (
 
 export const DefaultButtonIconFloating = () => (
 	<StackHorizontal gap="XS" justify="center" align="center">
-		<ButtonIconFloating icon="talend-plus" onClick={action('Clicked')}>
+		<ButtonIconFloating icon="plus" onClick={action('Clicked')}>
 			Size M
 		</ButtonIconFloating>
-		<ButtonIconFloating icon="talend-plus" onClick={action('Clicked')} size="S">
+		<ButtonIconFloating icon="plus" onClick={action('Clicked')} size="S">
 			Size S
 		</ButtonIconFloating>
 	</StackHorizontal>

--- a/packages/design-system/src/components/ButtonIcon/ButtonIcon.stories.tsx
+++ b/packages/design-system/src/components/ButtonIcon/ButtonIcon.stories.tsx
@@ -162,7 +162,7 @@ export const Variations = () => (
 			<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="S">
 				Size S
 			</ButtonIcon>
-			<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="XS">
+			<ButtonIcon size="XS" icon="pouet" onClick={action('Clicked')}>
 				Size XS
 			</ButtonIcon>
 		</StackVertical>
@@ -204,7 +204,7 @@ export const DefaultButtonIcon = () => (
 		<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="S">
 			Size S
 		</ButtonIcon>
-		<ButtonIcon icon="talend-plus" onClick={action('Clicked')} size="XS">
+		<ButtonIcon icon="plus" onClick={action('Clicked')} size="XS">
 			Size XS
 		</ButtonIcon>
 	</StackHorizontal>

--- a/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
+++ b/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef, Ref, ButtonHTMLAttributes } from 'react';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+import { DeprecatedIconNames } from '../../../types';
 import Button from '../../Clickable';
 import Tooltip, { TooltipPlacement } from '../../Tooltip';
 import { Icon } from '../../Icon/Icon';
@@ -12,7 +12,7 @@ import styles from './ButtonIcon.module.scss';
 export type PossibleVariants = 'toggle' | 'floating' | 'default';
 
 type CommonTypes = Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'className' | 'style'> & {
-	icon: IconName;
+	icon: DeprecatedIconNames;
 	children: string;
 	isLoading?: boolean;
 	onClick: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;

--- a/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
+++ b/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
@@ -1,23 +1,20 @@
 import React, { forwardRef, Ref, ButtonHTMLAttributes, ReactElement } from 'react';
 import classnames from 'classnames';
-import { IconNameWithSize, IconName } from '@talend/icons/dist/typeUtils';
+// eslint-disable-next-line @talend/import-depth
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 
+import { DeprecatedIconNames } from '../../../types';
 import Button from '../../Clickable';
 import Tooltip, { TooltipPlacement } from '../../Tooltip';
-import { Icon } from '../../Icon/Icon';
 import Loading from '../../Loading';
+import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './ButtonIcon.module.scss';
-import { SizedIcon } from '../../Icon';
 
 export type AvailableSizes = 'M' | 'S' | 'XS';
 export type PossibleVariants = 'toggle' | 'floating' | 'default';
-type IconType<S extends AvailableSizes> =
-	| React.ReactElement
-	| IconNameWithSize<S extends 'XS' ? 'S' : 'M'>
-	| IconName;
 
-type CommonTypes<S extends AvailableSizes> = Omit<
+type CommonTypes<S extends Partial<AvailableSizes>> = Omit<
 	ButtonHTMLAttributes<HTMLButtonElement>,
 	'className' | 'style'
 > & {
@@ -26,15 +23,15 @@ type CommonTypes<S extends AvailableSizes> = Omit<
 	onClick: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
 	tooltipPlacement?: TooltipPlacement;
 	size?: S;
-	icon: IconType<S>;
+	icon: ReactElement | IconNameWithSize<S extends 'XS' ? 'S' : 'M'> | DeprecatedIconNames;
 };
 
-export type ToggleTypes<S extends AvailableSizes> = CommonTypes<S> & {
+export type ToggleTypes<S extends Partial<AvailableSizes>> = CommonTypes<S> & {
 	variant: 'toggle';
 	isActive: boolean;
 };
 
-export type FloatingTypes<S extends AvailableSizes> = CommonTypes<S> & {
+export type FloatingTypes<S extends Partial<AvailableSizes>> = CommonTypes<S> & {
 	variant: 'floating';
 };
 
@@ -51,24 +48,6 @@ function Primitive<S extends AvailableSizes>(
 	props: ButtonIconProps<S>,
 	ref: Ref<HTMLButtonElement>,
 ) {
-	function parsedIcon(iconSrc: string | ReactElement) {
-		const { icon, size } = props;
-
-		if (typeof iconSrc === 'string') {
-			if (iconSrc.includes('talend-') || iconSrc.includes('remote-') || iconSrc.includes('src-')) {
-				return <Icon name={icon} />;
-			}
-			return (
-				<SizedIcon
-					size={size === 'XS' ? 'S' : 'M'}
-					name={size === 'M' ? (icon as IconNameWithSize<'M'>) : (icon as IconNameWithSize<'S'>)}
-				/>
-			);
-		}
-
-		return React.cloneElement(iconSrc, {});
-	}
-
 	const {
 		children,
 		variant,
@@ -96,7 +75,7 @@ function Primitive<S extends AvailableSizes>(
 				{...(variant === 'toggle' && { 'aria-pressed': activeButtonIconPrimitive })}
 			>
 				<span className={styles.buttonIcon__icon} aria-hidden>
-					{!isLoading && parsedIcon()}
+					{!isLoading && parseDeprecatedIcon({ iconSrc: icon, size: size === 'XS' ? 'S' : 'M' })}
 					{isLoading && <Loading />}
 				</span>
 			</Button>

--- a/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
+++ b/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref, ButtonHTMLAttributes, ReactElement } from 'react';
+import React, { ButtonHTMLAttributes, forwardRef, ReactElement, Ref } from 'react';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
@@ -7,7 +7,7 @@ import { DeprecatedIconNames } from '../../../types';
 import Button from '../../Clickable';
 import Tooltip, { TooltipPlacement } from '../../Tooltip';
 import Loading from '../../Loading';
-import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
+import { getIconWithDeprecatedSupport } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './ButtonIcon.module.scss';
 
@@ -75,7 +75,8 @@ function Primitive<S extends AvailableSizes>(
 				{...(variant === 'toggle' && { 'aria-pressed': activeButtonIconPrimitive })}
 			>
 				<span className={styles.buttonIcon__icon} aria-hidden>
-					{!isLoading && parseDeprecatedIcon({ iconSrc: icon, size: size === 'XS' ? 'S' : 'M' })}
+					{!isLoading &&
+						getIconWithDeprecatedSupport({ iconSrc: icon, size: size === 'XS' ? 'S' : 'M' })}
 					{isLoading && <Loading />}
 				</span>
 			</Button>

--- a/packages/design-system/src/components/ButtonIcon/variations/ButtonIcon.tsx
+++ b/packages/design-system/src/components/ButtonIcon/variations/ButtonIcon.tsx
@@ -1,10 +1,17 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonIconPrimitive, { DefaultTypes } from '../Primitive/ButtonIconPrimitive';
+import ButtonIconPrimitive, {
+	AvailableSizes,
+	DefaultTypes,
+} from '../Primitive/ButtonIconPrimitive';
 
-export type ButtonIconType = Omit<DefaultTypes, 'variant'>;
+export type ButtonIconType<S extends AvailableSizes> = Omit<DefaultTypes<S>, 'variant'>;
 
-const ButtonIcon = forwardRef((props: ButtonIconType, ref: Ref<HTMLButtonElement>) => {
+function Button<S extends AvailableSizes>(props: ButtonIconType<S>, ref: Ref<HTMLButtonElement>) {
 	return <ButtonIconPrimitive {...props} variant="default" ref={ref} />;
-});
+}
+
+const ButtonIcon = forwardRef(Button) as <S extends AvailableSizes>(
+	props: ButtonIconType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Button>;
 
 export default ButtonIcon;

--- a/packages/design-system/src/components/ButtonIcon/variations/ButtonIconFloating.tsx
+++ b/packages/design-system/src/components/ButtonIcon/variations/ButtonIconFloating.tsx
@@ -1,10 +1,23 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonIconPrimitive, { FloatingTypes } from '../Primitive/ButtonIconPrimitive';
+import ButtonIconPrimitive, {
+	AvailableSizes,
+	FloatingTypes,
+} from '../Primitive/ButtonIconPrimitive';
 
-export type ButtonFloatingType = Omit<FloatingTypes, 'variant'>;
+export type ButtonFloatingType<S extends Partial<AvailableSizes>> = Omit<
+	FloatingTypes<S>,
+	'variant' | 'size'
+> & { size?: 'M' | 'S' };
 
-const ButtonIconFloating = forwardRef((props: ButtonFloatingType, ref: Ref<HTMLButtonElement>) => {
+function Floating<S extends Partial<AvailableSizes>>(
+	props: ButtonFloatingType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
 	return <ButtonIconPrimitive {...props} variant="floating" ref={ref} />;
-});
+}
+
+const ButtonIconFloating = forwardRef(Floating) as <S extends Partial<AvailableSizes>>(
+	props: ButtonFloatingType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Floating>;
 
 export default ButtonIconFloating;

--- a/packages/design-system/src/components/ButtonIcon/variations/ButtonIconToggle.tsx
+++ b/packages/design-system/src/components/ButtonIcon/variations/ButtonIconToggle.tsx
@@ -1,10 +1,20 @@
 import React, { forwardRef, Ref } from 'react';
-import ButtonIconPrimitive, { ToggleTypes } from '../Primitive/ButtonIconPrimitive';
+import ButtonIconPrimitive, { AvailableSizes, ToggleTypes } from '../Primitive/ButtonIconPrimitive';
 
-export type ButtonToggleType = Omit<ToggleTypes, 'variant'>;
+export type ButtonToggleType<S extends Partial<AvailableSizes>> = Omit<
+	ToggleTypes<S>,
+	'variant' | 'size'
+> & { size?: 'M' | 'S' };
 
-const ButtonIconToggle = forwardRef((props: ButtonToggleType, ref: Ref<HTMLButtonElement>) => {
+function Toggle<S extends Partial<AvailableSizes>>(
+	props: ButtonToggleType<S>,
+	ref: Ref<HTMLButtonElement>,
+) {
 	return <ButtonIconPrimitive {...props} variant="toggle" ref={ref} />;
-});
+}
+
+const ButtonIconToggle = forwardRef(Toggle) as <S extends Partial<AvailableSizes>>(
+	props: ButtonToggleType<S> & { ref?: Ref<HTMLButtonElement> },
+) => ReturnType<typeof Toggle>;
 
 export default ButtonIconToggle;

--- a/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
@@ -32,7 +32,8 @@ context('<Dropdown />', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').click();
 		cy.getByTest('dropdown.menu').should('be.visible');
-		cy.get('a[data-test="dropdown.menuitem"]').eq(0).invoke('removeAttr', 'href').click();
+		cy.get('a[data-test="dropdown.menuitem"]').eq(0).invoke('removeAttr', 'href');
+		cy.get('a[data-test="dropdown.menuitem"]').click();
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
 

--- a/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Story } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
-import { Link as RouterLink, BrowserRouter } from 'react-router-dom';
+import { BrowserRouter, Link as RouterLink } from 'react-router-dom';
 import Dropdown from './Dropdown';
 import { ButtonPrimary, ButtonSecondary, ButtonTertiary } from '../Button';
 import { ButtonIcon } from '../ButtonIcon';
@@ -128,7 +128,7 @@ export const WithRouterLinks = () => (
 				},
 			]}
 		>
-			<ButtonIcon icon="talend-caret-down" onClick={() => {}}>
+			<ButtonIcon icon="chevron-down" onClick={() => {}}>
 				Dropdown
 			</ButtonIcon>
 		</Dropdown>
@@ -206,14 +206,14 @@ export const Basic = () => (
 					{
 						label: 'Button with icon',
 						type: 'button',
-						icon: 'talend-zoomin',
+						icon: 'zoom-plus',
 						onClick: () => {
 							action('clicked');
 						},
 					},
 					{
 						label: 'Button with too much copy to create an overflow',
-						icon: 'talend-plus-circle',
+						icon: 'plus-stroke',
 						type: 'button',
 						onClick: () => {
 							action('clicked');
@@ -234,18 +234,18 @@ export const Basic = () => (
 						label: 'Link with icon',
 						type: 'link',
 						href: '/doc',
-						icon: 'talend-plus-circle',
+						icon: 'plus-stroke',
 					},
 					{
 						label: 'Router link with too much copy to create an overflow',
 						type: 'link',
-						icon: 'talend-plus-circle',
+						icon: 'plus-stroke',
 						as: <RouterLink to="/documentation" />,
 					},
 					{
 						label: 'External link with too much copy to create an overflow',
 						type: 'link',
-						icon: 'talend-plus-circle',
+						icon: 'plus-stroke',
 						target: '_blank',
 						href: 'https://talend.com',
 					},

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,6 @@
 import React, { cloneElement, forwardRef, MouseEvent, ReactElement, Ref } from 'react';
 import { Menu, MenuButton, useMenuState } from 'reakit';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 import DropdownButton from './Primitive/DropdownButton';
 import DropdownLink from './Primitive/DropdownLink';
 import DropdownShell from './Primitive/DropdownShell';
@@ -9,12 +8,12 @@ import DropdownTitle from './Primitive/DropdownTitle';
 import DropdownDivider from './Primitive/DropdownDivider';
 import Clickable, { ClickableProps } from '../Clickable';
 import { LinkableType } from '../Linkable';
-import tokens from '@talend/design-tokens';
+import { DeprecatedIconNames } from '../../types';
 
 type DropdownButtonType = Omit<ClickableProps, 'children' | 'as'> & {
 	label: string;
 	onClick: () => void;
-	icon?: IconName;
+	icon?: DeprecatedIconNames;
 	type: 'button';
 };
 

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
@@ -1,13 +1,13 @@
 import React, { forwardRef, Ref } from 'react';
 import { MenuItem, MenuItemProps } from 'reakit';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+import { DeprecatedIconNames } from '../../../types';
 import Clickable, { ClickableProps } from '../../Clickable';
-
-import styles from './DropdownEntry.module.scss';
 import { Icon } from '../../Icon/Icon';
 
-export type DropdownButtonType = Omit<ClickableProps, 'as'> & MenuItemProps & { icon?: IconName };
+import styles from './DropdownEntry.module.scss';
+
+export type DropdownButtonType = Omit<ClickableProps, 'as'> &
+	MenuItemProps & { icon?: DeprecatedIconNames };
 
 const DropdownButton = forwardRef(
 	({ children, icon, ...props }: DropdownButtonType, ref: Ref<HTMLButtonElement>) => {

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
@@ -5,7 +5,7 @@ import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 
 import { DeprecatedIconNames } from '../../../types';
 import Clickable, { ClickableProps } from '../../Clickable';
-import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
+import { getIconWithDeprecatedSupport } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './DropdownEntry.module.scss';
 
@@ -18,7 +18,11 @@ const DropdownButton = forwardRef(
 			<MenuItem {...props} as={Clickable} className={styles.dropdownEntry} ref={ref}>
 				{icon && (
 					<span className={styles.buttonIcon}>
-						{parseDeprecatedIcon({ iconSrc: icon, size: 'M', ['data-test']: 'button.icon.before' })}
+						{getIconWithDeprecatedSupport({
+							iconSrc: icon,
+							size: 'M',
+							['data-test']: 'button.icon.before',
+						})}
 					</span>
 				)}
 				<span className={styles.buttonContent}>{children}</span>

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
@@ -1,19 +1,26 @@
 import React, { forwardRef, Ref } from 'react';
 import { MenuItem, MenuItemProps } from 'reakit';
+// eslint-disable-next-line @talend/import-depth
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
+
 import { DeprecatedIconNames } from '../../../types';
 import Clickable, { ClickableProps } from '../../Clickable';
-import { Icon } from '../../Icon/Icon';
+import { parseDeprecatedIcon } from '../../Icon/DeprecatedIconHelper';
 
 import styles from './DropdownEntry.module.scss';
 
 export type DropdownButtonType = Omit<ClickableProps, 'as'> &
-	MenuItemProps & { icon?: DeprecatedIconNames };
+	MenuItemProps & { icon?: DeprecatedIconNames | IconNameWithSize<'M'> };
 
 const DropdownButton = forwardRef(
 	({ children, icon, ...props }: DropdownButtonType, ref: Ref<HTMLButtonElement>) => {
 		return (
 			<MenuItem {...props} as={Clickable} className={styles.dropdownEntry} ref={ref}>
-				{icon && <Icon name={icon} data-test="button.icon.before" className={styles.buttonIcon} />}
+				{icon && (
+					<span className={styles.buttonIcon}>
+						{parseDeprecatedIcon({ iconSrc: icon, size: 'M', ['data-test']: 'button.icon.before' })}
+					</span>
+				)}
 				<span className={styles.buttonContent}>{children}</span>
 			</MenuItem>
 		);

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownEntry.module.scss
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownEntry.module.scss
@@ -23,7 +23,8 @@ $iconAlignmentOffsetM: -0.3rem;
 		width: tokens.$coral-sizing-xxxs;
 		margin-right: tokens.$coral-spacing-xxs;
 		flex-shrink: 0;
-		margin-bottom: $iconAlignmentOffsetM;
+		position: relative;
+		bottom: $iconAlignmentOffsetM;
 	}
 
 	.buttonContent {

--- a/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
+++ b/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
@@ -11,7 +11,7 @@ import { ButtonPrimaryAsLinkPropsType } from '../../ButtonAsLink/variations/Butt
 import styles from './EmptyStatePrimitive.module.scss';
 
 type CallbackTypes =
-	| (ButtonPrimaryPropsType & { actionType: 'button' })
+	| (Omit<ButtonPrimaryPropsType<'M'>, 'size'> & { actionType: 'button' })
 	| (ButtonPrimaryAsLinkPropsType & { actionType: 'link' });
 
 export type EmptyStatePrimitiveProps = Omit<

--- a/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
+++ b/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
@@ -12,7 +12,7 @@ import styles from './EmptyStatePrimitive.module.scss';
 
 type CallbackTypes =
 	| (Omit<ButtonPrimaryPropsType<'M'>, 'size'> & { actionType: 'button' })
-	| (ButtonPrimaryAsLinkPropsType & { actionType: 'link' });
+	| (Omit<ButtonPrimaryAsLinkPropsType<'M'>, 'size'> & { actionType: 'link' });
 
 export type EmptyStatePrimitiveProps = Omit<
 	HTMLAttributes<HTMLElement>,

--- a/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
@@ -141,7 +141,7 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 	const [drag, setDrag] = React.useState(false);
 	const [files, setFiles] = React.useState<FileList | null>(props.files);
 
-	const inputRef = React.useRef<HTMLInputElement>();
+	const inputRef = React.useRef<HTMLInputElement | null>(null);
 	const { t } = useTranslation();
 
 	function handleChange() {
@@ -215,7 +215,6 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 						{...props}
 						type="file"
 						className={`input-file__input input ${files ? 'input--filled' : ''}`}
-						// @ts-ignore
 						ref={inputRef}
 					/>
 					{!files ? (
@@ -249,7 +248,7 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 									))}
 							</ol>
 							<div className="preview__button">
-								<ButtonIcon icon="talend-cross-circle" onClick={() => clear()} size="S">
+								<ButtonIcon icon="cross-filled" onClick={() => clear()} size="S">
 									{t('INPUT_FILE_CLEAR_SELECTION', 'Clear selection')}
 								</ButtonIcon>
 							</div>

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from 'react-i18next';
 
 import Clickable from '../../../../Clickable';
 import Tooltip from '../../../../Tooltip';
-import { Icon } from '../../../../Icon/Icon';
+import { SizedIcon } from '../../../../Icon';
 
 export default function useRevealPassword() {
 	const [revealed, setRevealed] = useState(false);
@@ -37,7 +37,7 @@ export default function useRevealPassword() {
 					data-testid="form.password.reveal"
 					{...props}
 				>
-					<Icon name={revealed ? 'talend-eye-slash' : 'talend-eye'} />
+					<SizedIcon size="M" name={revealed ? 'eye-slash' : 'eye'} />
 				</Clickable>
 			</Tooltip>
 		);

--- a/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixButton.tsx
+++ b/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixButton.tsx
@@ -1,14 +1,13 @@
 import React, { forwardRef, Ref } from 'react';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
 
+import { DeprecatedIconNames } from '../../../../../types';
 import { Icon } from '../../../../Icon/Icon';
 import Tooltip from '../../../../Tooltip';
 import { StackHorizontal } from '../../../../Stack';
+import Clickable, { ClickableProps } from '../../../../Clickable';
 
 import styles from '../AffixStyles.module.scss';
-import Clickable, { ClickableProps } from '../../../../Clickable';
 
 type CommonAffixButtonPropsType = {
 	children: string;
@@ -18,12 +17,12 @@ type CommonAffixButtonPropsType = {
 
 type AffixButtonHideTextProps = {
 	hideText?: true;
-	icon: IconName;
+	icon: DeprecatedIconNames;
 };
 
 type AffixButtonShowTextProps = {
 	hideText?: false;
-	icon?: IconName;
+	icon?: DeprecatedIconNames;
 };
 
 export type AffixButtonPropsType = Omit<ClickableProps, 'className' | 'children'> &

--- a/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixReadOnly.tsx
+++ b/packages/design-system/src/components/Form/FieldGroup/Affix/variations/AffixReadOnly.tsx
@@ -1,7 +1,6 @@
 import React, { forwardRef, Ref, HTMLAttributes } from 'react';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 
+import { DeprecatedIconNames } from '../../../../../types';
 import { Icon } from '../../../../Icon/Icon';
 import { StackHorizontal } from '../../../../Stack';
 import VisuallyHidden from '../../../../VisuallyHidden';
@@ -14,12 +13,12 @@ type CommonAffixReadOnlyPropsType = {
 
 type AffixReadOnlyHideTextProps = {
 	hideText?: true;
-	icon: IconName;
+	icon: DeprecatedIconNames;
 };
 
 type AffixReadOnlyShowTextProps = {
 	hideText?: false;
-	icon?: IconName;
+	icon?: DeprecatedIconNames;
 };
 
 export type AffixReadOnlyPropsType = Omit<HTMLAttributes<HTMLSpanElement>, 'className' | 'style'> &

--- a/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
+++ b/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
@@ -1,20 +1,22 @@
 import React, { ReactElement } from 'react';
+import { IconNameWithSize } from '@talend/icons';
+import { DataAttributes } from '../../types';
 import { Icon } from './Icon';
 import { SizedIcon } from './SizedIcon';
-import { IconNameWithSize } from '@talend/icons';
 
 export function parseDeprecatedIcon({
 	iconSrc,
 	size,
+	...rest
 }: {
 	iconSrc: string | ReactElement;
 	size: 'XS' | 'S' | 'M' | 'L';
-}) {
+} & DataAttributes) {
 	if (typeof iconSrc === 'string') {
 		if (iconSrc.includes('talend-') || iconSrc.includes('remote-') || iconSrc.includes('src-')) {
-			return <Icon name={iconSrc} />;
+			return <Icon name={iconSrc} {...rest} />;
 		}
-		return <SizedIcon size={size} name={iconSrc as IconNameWithSize<typeof size>} />;
+		return <SizedIcon size={size} name={iconSrc as IconNameWithSize<typeof size>} {...rest} />;
 	}
 
 	return React.cloneElement(iconSrc, {});

--- a/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
+++ b/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
@@ -4,7 +4,7 @@ import { DataAttributes } from '../../types';
 import { Icon } from './Icon';
 import { SizedIcon } from './SizedIcon';
 
-export function parseDeprecatedIcon({
+export function getIconWithDeprecatedSupport({
 	iconSrc,
 	size,
 	...rest

--- a/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
+++ b/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
@@ -3,25 +3,18 @@ import { Icon } from './Icon';
 import { SizedIcon } from './SizedIcon';
 import { IconNameWithSize } from '@talend/icons';
 
-export function parsedIcon({
+export function parseDeprecatedIcon({
 	iconSrc,
 	size,
 }: {
 	iconSrc: string | ReactElement;
-	size: 'XS' | 'S' | 'M';
+	size: 'XS' | 'S' | 'M' | 'L';
 }) {
 	if (typeof iconSrc === 'string') {
 		if (iconSrc.includes('talend-') || iconSrc.includes('remote-') || iconSrc.includes('src-')) {
 			return <Icon name={iconSrc} />;
 		}
-		return (
-			<SizedIcon
-				size={size === 'XS' ? 'S' : 'M'}
-				name={
-					size === 'M' ? (iconSrc as IconNameWithSize<'M'>) : (iconSrc as IconNameWithSize<'S'>)
-				}
-			/>
-		);
+		return <SizedIcon size={size} name={iconSrc as IconNameWithSize<typeof size>} />;
 	}
 
 	return React.cloneElement(iconSrc, {});

--- a/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
+++ b/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
@@ -1,5 +1,6 @@
 import React, { ReactElement } from 'react';
-import { IconNameWithSize } from '@talend/icons';
+// eslint-disable-next-line @talend/import-depth
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import { DataAttributes } from '../../types';
 import { Icon } from './Icon';
 import { SizedIcon } from './SizedIcon';

--- a/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
+++ b/packages/design-system/src/components/Icon/DeprecatedIconHelper.tsx
@@ -1,0 +1,28 @@
+import React, { ReactElement } from 'react';
+import { Icon } from './Icon';
+import { SizedIcon } from './SizedIcon';
+import { IconNameWithSize } from '@talend/icons';
+
+export function parsedIcon({
+	iconSrc,
+	size,
+}: {
+	iconSrc: string | ReactElement;
+	size: 'XS' | 'S' | 'M';
+}) {
+	if (typeof iconSrc === 'string') {
+		if (iconSrc.includes('talend-') || iconSrc.includes('remote-') || iconSrc.includes('src-')) {
+			return <Icon name={iconSrc} />;
+		}
+		return (
+			<SizedIcon
+				size={size === 'XS' ? 'S' : 'M'}
+				name={
+					size === 'M' ? (iconSrc as IconNameWithSize<'M'>) : (iconSrc as IconNameWithSize<'S'>)
+				}
+			/>
+		);
+	}
+
+	return React.cloneElement(iconSrc, {});
+}

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -2,8 +2,8 @@ import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 
+import { DeprecatedIconNames } from '../../types';
 import tokens from '../../tokens';
 import { IconsProvider } from '../IconsProvider';
 
@@ -22,7 +22,7 @@ export enum SVG_TRANSFORMS {
 }
 
 export type IconProps = PropsWithChildren<any> & {
-	name: IconName;
+	name: DeprecatedIconNames;
 	transform: SVG_TRANSFORMS;
 	preserveColor: boolean;
 	border: boolean;

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -2,7 +2,6 @@ import React, { PropsWithChildren } from 'react';
 import styled from 'styled-components';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
-
 import { DeprecatedIconNames } from '../../types';
 import tokens from '../../tokens';
 import { IconsProvider } from '../IconsProvider';
@@ -191,6 +190,7 @@ export const Icon = React.forwardRef(
 				className={classnames('tc-svg-icon', classname)}
 				border={border}
 				ref={safeRef}
+				pointerEvents="none"
 				shape-rendering="geometricPrecision"
 			/>
 		);

--- a/packages/design-system/src/components/Icon/SizedIcon.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 // eslint-disable-next-line @talend/import-depth
-import { Icon, IconSize, icons } from '@talend/icons/dist/typeUtils';
+import { Icon, icons, IconSize } from '@talend/icons/dist/typeUtils';
 
 const getNumericSize = (size: IconSize) => {
 	return {
@@ -30,6 +30,7 @@ const SizedIcon = React.forwardRef(
 				aria-hidden
 				ref={ref}
 				shapeRendering="geometricPrecision"
+				pointerEvents="none"
 			>
 				<use xlinkHref={`#${fullName}`} />
 			</svg>

--- a/packages/design-system/src/components/Icon/SizedIcon.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.tsx
@@ -1,6 +1,6 @@
 import React, { HTMLAttributes } from 'react';
 // eslint-disable-next-line @talend/import-depth
-import { Icon, IconSize } from '@talend/icons/dist/typeUtils';
+import { Icon, IconSize, icons } from '@talend/icons/dist/typeUtils';
 
 const getNumericSize = (size: IconSize) => {
 	return {
@@ -18,6 +18,11 @@ const SizedIcon = React.forwardRef(
 	) => {
 		const numericSize = getNumericSize(size);
 		const fullName = size ? `${name}:${size}` : name;
+		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+		// @ts-ignore
+		if (!icons[size].includes(name)) {
+			console.error(`Icon ${name} does not exist. Check sizes other than ${size}.`);
+		}
 		return (
 			<svg
 				{...rest}

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
@@ -39,7 +39,7 @@ export type InlineEditingProps = PropsWithChildren<any> &
 
 export type StyledInlineEditing = {
 	renderAs?: React.ComponentType<any> | string;
-} & React.PropsWithRef<InlineEditingProps>;
+} & InlineEditingProps;
 
 const InlineEditing = React.forwardRef(
 	(
@@ -126,7 +126,7 @@ const InlineEditing = React.forwardRef(
 								>
 									<ButtonIcon
 										onClick={handleCancel}
-										icon="talend-cross-circle"
+										icon="cross-filled"
 										data-test="inlineediting.button.cancel"
 										size="XS"
 									>
@@ -134,7 +134,7 @@ const InlineEditing = React.forwardRef(
 									</ButtonIcon>
 									<ButtonIcon
 										onClick={handleSubmit}
-										icon="talend-check-circle"
+										icon="check-filled"
 										data-test="inlineediting.button.submit"
 										size="XS"
 									>
@@ -162,7 +162,7 @@ const InlineEditing = React.forwardRef(
 								data-test="inlineediting.button.edit"
 								onClick={() => setEditMode(true)}
 								aria-label={ariaLabel}
-								icon="talend-pencil"
+								icon="pencil"
 								disabled={loading}
 								size="XS"
 							>

--- a/packages/design-system/src/components/InlineMessage/Primitive/InlineMessagePrimitive.tsx
+++ b/packages/design-system/src/components/InlineMessage/Primitive/InlineMessagePrimitive.tsx
@@ -1,12 +1,11 @@
 import React, { forwardRef, HTMLAttributes, Ref } from 'react';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
-
-import { Icon } from '../../Icon/Icon';
 
 import styles from './InlineMessagePrimitive.module.scss';
 import Link, { LinkProps } from '../../Link/Link';
+import { SizedIcon } from '../../Icon';
 
 export type AvailableVariantsTypes = 'destructive' | 'success' | 'information' | 'warning' | 'beta';
 export type InlineMessageVariantType<T extends AvailableVariantsTypes, P extends object> = {
@@ -18,7 +17,7 @@ export type SharedInlineMessageTypes = {
 	link?: LinkProps;
 	title?: string;
 	description: string;
-	icon: IconName;
+	icon: IconNameWithSize<'M'>;
 	iconClassname: string;
 	withBackgroundClassname: string;
 };
@@ -53,7 +52,7 @@ const InlineMessagePrimitive = forwardRef(
 				ref={ref}
 			>
 				<span className={classnames(styles.icon, iconClassname)}>
-					<Icon name={icon} />
+					<SizedIcon size="M" name={icon} />
 				</span>
 				<p className={styles.inlineMessage__contents}>
 					{title && <strong>{title}</strong>}

--- a/packages/design-system/src/components/InlineMessage/variations/InlineMessageBeta.tsx
+++ b/packages/design-system/src/components/InlineMessage/variations/InlineMessageBeta.tsx
@@ -15,7 +15,7 @@ const InlineMessageBeta = forwardRef((props: InlineMessageBetaProps, ref: Ref<HT
 	return (
 		<InlineMessagePrimitive
 			{...props}
-			icon="talend-info-circle"
+			icon="information-filled"
 			withBackgroundClassname={styles.beta_withBackground}
 			iconClassname={styles.beta__icon}
 			ref={ref}

--- a/packages/design-system/src/components/InlineMessage/variations/InlineMessageDestructive.tsx
+++ b/packages/design-system/src/components/InlineMessage/variations/InlineMessageDestructive.tsx
@@ -16,7 +16,7 @@ const InlineMessageDestructive = forwardRef(
 		return (
 			<InlineMessagePrimitive
 				{...props}
-				icon="talend-error"
+				icon="square-cross"
 				withBackgroundClassname={styles.destructive_withBackground}
 				iconClassname={styles.destructive__icon}
 				ref={ref}

--- a/packages/design-system/src/components/InlineMessage/variations/InlineMessageInformation.tsx
+++ b/packages/design-system/src/components/InlineMessage/variations/InlineMessageInformation.tsx
@@ -16,7 +16,7 @@ const InlineMessageInformation = forwardRef(
 		return (
 			<InlineMessagePrimitive
 				{...props}
-				icon="talend-info-circle"
+				icon="information-filled"
 				withBackgroundClassname={styles.information_withBackground}
 				iconClassname={styles.information__icon}
 				ref={ref}

--- a/packages/design-system/src/components/InlineMessage/variations/InlineMessageSuccess.tsx
+++ b/packages/design-system/src/components/InlineMessage/variations/InlineMessageSuccess.tsx
@@ -16,7 +16,7 @@ const InlineMessageSuccess = forwardRef(
 		return (
 			<InlineMessagePrimitive
 				{...props}
-				icon="talend-check-circle"
+				icon="check-filled"
 				withBackgroundClassname={styles.success_withBackground}
 				iconClassname={styles.success__icon}
 				ref={ref}

--- a/packages/design-system/src/components/InlineMessage/variations/InlineMessageWarning.tsx
+++ b/packages/design-system/src/components/InlineMessage/variations/InlineMessageWarning.tsx
@@ -16,7 +16,7 @@ const InlineMessageWarning = forwardRef(
 		return (
 			<InlineMessagePrimitive
 				{...props}
-				icon="talend-warning"
+				icon="exclamation"
 				withBackgroundClassname={styles.warning_withBackground}
 				iconClassname={styles.warning__icon}
 				ref={ref}

--- a/packages/design-system/src/components/Link/Link.spec.tsx
+++ b/packages/design-system/src/components/Link/Link.spec.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable testing-library/prefer-screen-queries */
 import React from 'react';
 import { composeStories } from '@storybook/testing-react';
 
@@ -14,12 +15,12 @@ context('<Link />', () => {
 
 	it('should render icon before', () => {
 		cy.mount(<WithIcon />);
-		cy.getByTest('link.icon.before').should('have.attr', 'name', 'talend-info-circle');
+		cy.getByTest('link.icon.before').should('be.visible');
 	});
 
 	it('should render external', () => {
 		cy.mount(<External />);
-		cy.getByTest('link.icon.external').should('have.attr', 'name', 'talend-link');
+		cy.getByTest('link.icon.external').should('be.visible');
 	});
 
 	it('should render disabled', () => {

--- a/packages/design-system/src/components/Link/Link.stories.tsx
+++ b/packages/design-system/src/components/Link/Link.stories.tsx
@@ -44,7 +44,7 @@ export const Active = {
 
 export const WithIcon = {
 	render: (props: Story<LinkProps>) => (
-		<Link href="#" icon="talend-info-circle" {...props}>
+		<Link href="#" icon="information-filled" {...props}>
 			Link example
 		</Link>
 	),
@@ -52,7 +52,7 @@ export const WithIcon = {
 
 export const MultiLines = {
 	render: (props: Story<LinkProps>) => (
-		<Link href="https://www.talend.com" target="_blank" icon="talend-info-circle" {...props}>
+		<Link href="https://www.talend.com" target="_blank" icon="information-filled" {...props}>
 			Lorem ipsum dolor sit amet, consectetur adipiscing elit. Cras ac facilisis massa. Morbi et
 			massa nulla. Nulla vitae hendrerit diam. Aenean eu sem libero. Integer vitae quam rutrum orci
 			maximus imperdiet non sed lacus. Suspendisse ac est ac turpis luctus viverra. Proin tristique
@@ -67,7 +67,7 @@ export const MultiLines = {
 export const Disabled = {
 	render(props: Story<LinkProps>) {
 		return (
-			<Link href="#" icon="talend-info-circle" disabled {...props}>
+			<Link href="#" icon="information-filled" disabled {...props}>
 				Link example
 			</Link>
 		);
@@ -96,7 +96,7 @@ export const TargetBlank = {
 
 export const RouterLinkStory = () => (
 	<BrowserRouter>
-		<Link as={<RouterLink to="/documentation" />} icon="talend-info-circle">
+		<Link as={<RouterLink to="/documentation" />} icon="information-filled">
 			Documentation
 		</Link>
 	</BrowserRouter>

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -1,15 +1,15 @@
 import React, { forwardRef, ReactElement, Ref, useCallback, useMemo } from 'react';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { DeprecatedIconNames } from '../../types';
 import Linkable, { LinkableType, isBlank as targetCheck } from '../Linkable';
 
 import style from './Link.module.scss';
 
 export type LinkComponentProps = {
 	/** The icon to display before */
-	icon?: IconName | ReactElement;
+	icon?: DeprecatedIconNames | ReactElement;
 	/** if the link is disabled */
 	disabled?: boolean;
 };

--- a/packages/design-system/src/components/Linkable/Linkable.tsx
+++ b/packages/design-system/src/components/Linkable/Linkable.tsx
@@ -1,22 +1,25 @@
 import React, {
-	forwardRef,
-	Ref,
-	ReactElement,
-	ReactNode,
 	AnchorHTMLAttributes,
 	cloneElement,
+	forwardRef,
+	ReactElement,
+	ReactNode,
+	Ref,
 	useMemo,
 } from 'react';
 // eslint-disable-next-line @talend/import-depth
+import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
 import { DeprecatedIconNames } from '../../types';
-import { Icon } from '../Icon/Icon';
+import { SizedIcon } from '../Icon';
+
 import style from './LinkableStyles.module.scss';
+import { parseDeprecatedIcon } from '../Icon/DeprecatedIconHelper';
 
 export type LinkableType = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'style'> & {
 	as?: 'a' | ReactElement;
 	children: ReactNode | ReactNode[];
-	icon?: DeprecatedIconNames | ReactElement;
+	icon?: DeprecatedIconNames | ReactElement | IconNameWithSize<'M'>;
 	hideExternalIcon?: boolean;
 	isNaturallyAligned?: boolean;
 	withEllipsis?: boolean;
@@ -53,7 +56,9 @@ const Linkable = forwardRef(
 		const MaybeIcon =
 			icon &&
 			(typeof icon === 'string' ? (
-				<Icon className={style.link__icon} name={icon} data-test="link.icon.before" />
+				<span className={style.link__icon}>
+					{parseDeprecatedIcon({ iconSrc: icon, size: 'M', ['data-test']: 'link.icon.before' })}
+				</span>
 			) : (
 				cloneElement(icon, {
 					'data-test': 'link.icon.before',
@@ -62,11 +67,9 @@ const Linkable = forwardRef(
 			));
 
 		const MaybeExternal = isExternal && !hideExternalIcon && (
-			<Icon
-				className={style.link__iconExternal}
-				data-test="link.icon.external"
-				name="talend-link"
-			/>
+			<span className={style.link__iconExternal}>
+				<SizedIcon size="S" name="external-link" data-test="link.icon.external" />
+			</span>
 		);
 
 		const Element = (

--- a/packages/design-system/src/components/Linkable/Linkable.tsx
+++ b/packages/design-system/src/components/Linkable/Linkable.tsx
@@ -71,8 +71,8 @@ const Linkable = forwardRef(
 			));
 
 		const MaybeExternal = isExternal && !hideExternalIcon && (
-			<span className={style.link__iconExternal}>
-				<SizedIcon size="S" name="external-link" data-test="link.icon.external" />
+			<span className={style.link__iconExternal} data-test="link.icon.external">
+				<SizedIcon size="S" name="external-link" />
 			</span>
 		);
 

--- a/packages/design-system/src/components/Linkable/Linkable.tsx
+++ b/packages/design-system/src/components/Linkable/Linkable.tsx
@@ -2,22 +2,21 @@ import React, {
 	forwardRef,
 	Ref,
 	ReactElement,
-	ReactNodeArray,
 	ReactNode,
 	AnchorHTMLAttributes,
 	cloneElement,
 	useMemo,
 } from 'react';
 // eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
+import { DeprecatedIconNames } from '../../types';
 import { Icon } from '../Icon/Icon';
 import style from './LinkableStyles.module.scss';
 
 export type LinkableType = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'style'> & {
 	as?: 'a' | ReactElement;
-	children: ReactNode | ReactNodeArray;
-	icon?: IconName | ReactElement;
+	children: ReactNode | ReactNode[];
+	icon?: DeprecatedIconNames | ReactElement;
 	hideExternalIcon?: boolean;
 	isNaturallyAligned?: boolean;
 	withEllipsis?: boolean;

--- a/packages/design-system/src/components/Linkable/Linkable.tsx
+++ b/packages/design-system/src/components/Linkable/Linkable.tsx
@@ -14,7 +14,7 @@ import { DeprecatedIconNames } from '../../types';
 import { SizedIcon } from '../Icon';
 
 import style from './LinkableStyles.module.scss';
-import { parseDeprecatedIcon } from '../Icon/DeprecatedIconHelper';
+import { getIconWithDeprecatedSupport } from '../Icon/DeprecatedIconHelper';
 
 export type LinkableType = Omit<AnchorHTMLAttributes<HTMLAnchorElement>, 'style'> & {
 	as?: 'a' | ReactElement;
@@ -57,7 +57,11 @@ const Linkable = forwardRef(
 			icon &&
 			(typeof icon === 'string' ? (
 				<span className={style.link__icon}>
-					{parseDeprecatedIcon({ iconSrc: icon, size: 'M', ['data-test']: 'link.icon.before' })}
+					{getIconWithDeprecatedSupport({
+						iconSrc: icon,
+						size: 'M',
+						['data-test']: 'link.icon.before',
+					})}
 				</span>
 			) : (
 				cloneElement(icon, {

--- a/packages/design-system/src/components/Linkable/LinkableStyles.module.scss
+++ b/packages/design-system/src/components/Linkable/LinkableStyles.module.scss
@@ -1,22 +1,24 @@
 @use '~@talend/design-tokens/lib/tokens';
 
 $iconAlignmentOffsetM: -0.3rem;
-$iconAlignmentOffsetS: -0.1rem;
+$iconAlignmentOffsetS: 0.1rem;
 
 .linkable {
 	cursor: pointer;
 }
 
-svg.link__icon {
-	margin-bottom: $iconAlignmentOffsetM;
+.link__icon {
+	position: relative;
+	bottom: $iconAlignmentOffsetM;
 	height: tokens.$coral-sizing-xxxs;
 	width: tokens.$coral-sizing-xxxs;
 	margin-right: tokens.$coral-spacing-xxs;
 	flex-shrink: 0;
 }
 
-svg.link__iconExternal {
-	margin-bottom: $iconAlignmentOffsetS;
+.link__iconExternal {
+	position: relative;
+	top: $iconAlignmentOffsetS;
 	height: tokens.$coral-sizing-minimal;
 	width: tokens.$coral-sizing-minimal;
 	margin-left: tokens.$coral-spacing-xxs;

--- a/packages/design-system/src/components/Linkable/LinkableStyles.module.scss
+++ b/packages/design-system/src/components/Linkable/LinkableStyles.module.scss
@@ -23,6 +23,7 @@ $iconAlignmentOffsetS: 0.1rem;
 	width: tokens.$coral-sizing-minimal;
 	margin-left: tokens.$coral-spacing-xxs;
 	flex-shrink: 0;
+	display: inline-flex;
 }
 
 .naturally_aligned {

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -24,8 +24,8 @@ function ModalIcon(props: { icon: IconProp; 'data-test'?: string }): ReactElemen
 }
 
 type PrimaryActionPropsType =
-	| ButtonPrimaryPropsType
-	| ({ destructive: true } & ButtonDestructivePropsType);
+	| Omit<ButtonPrimaryPropsType<'M'>, 'size'>
+	| ({ destructive: true } & Omit<ButtonDestructivePropsType<'M'>, 'size'>);
 
 export type ModalPropsType = {
 	header: {
@@ -36,19 +36,19 @@ export type ModalPropsType = {
 	onClose?: () => void;
 	disclosure?: ReactElement;
 	primaryAction?: PrimaryActionPropsType;
-	secondaryAction?: ButtonSecondaryPropsType;
+	secondaryAction?: ButtonSecondaryPropsType<'M'>;
 	preventEscaping?: boolean;
 	children: ReactNode | ReactNode[];
 } & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'>;
 
 function PrimaryAction(props: PrimaryActionPropsType) {
 	if (!('destructive' in props) || !props.destructive) {
-		return <ButtonPrimary {...(props as ButtonPrimaryPropsType)} />;
+		return <ButtonPrimary {...(props as ButtonPrimaryPropsType<'M'>)} />;
 	}
 
 	const { destructive, ...buttonProps } = props;
 
-	return <ButtonDestructive {...(buttonProps as ButtonDestructivePropsType)} />;
+	return <ButtonDestructive {...(buttonProps as ButtonDestructivePropsType<'M'>)} />;
 }
 
 function Modal(props: ModalPropsType): ReactElement {

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -1,9 +1,8 @@
 import React, { HTMLAttributes, ReactElement, ReactNode, useEffect, useRef } from 'react';
 import i18n from 'i18next';
 import { Dialog, DialogBackdrop, DialogDisclosure, useDialogState } from 'reakit/Dialog';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
 
+import { DeprecatedIconNames } from '../../types';
 import { ButtonDestructive, ButtonPrimary, ButtonSecondary } from '../Button';
 import { Icon } from '../Icon';
 import { StackHorizontal, StackVertical } from '../Stack';
@@ -13,7 +12,7 @@ import { ButtonDestructivePropsType } from '../Button/variations/ButtonDestructi
 
 import styles from './Modal.scss';
 
-type IconProp = IconName | ReactElement;
+type IconProp = DeprecatedIconNames | ReactElement;
 
 function ModalIcon(props: { icon: IconProp; 'data-test'?: string }): ReactElement {
 	const { icon, 'data-test': dataTest } = props;

--- a/packages/design-system/src/components/Stepper/Step/Step.tsx
+++ b/packages/design-system/src/components/Stepper/Step/Step.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
-// eslint-disable-next-line @talend/import-depth
-import { IconName } from '@talend/icons/dist/typeUtils';
+import { DeprecatedIconNames } from '../../../types';
 import { Icon } from '../../Icon/Icon';
 import * as S from './Step.style';
 import Tooltip from '../../Tooltip';
@@ -13,7 +12,7 @@ export type StepProps = React.PropsWithRef<any> & {
 	/** The optional class name */
 	className?: string;
 	/** The icon element to display */
-	icon?: IconName;
+	icon?: DeprecatedIconNames;
 };
 
 /**

--- a/packages/design-system/src/types/index.ts
+++ b/packages/design-system/src/types/index.ts
@@ -1,5 +1,9 @@
+// eslint-disable-next-line @talend/import-depth
+import { IconName } from '@talend/icons/dist/typeUtils';
 export type DataAttributes = {
 	'data-feature'?: string;
 	'data-test'?: string;
 	'data-testid'?: string;
 };
+
+export type DeprecatedIconNames = IconName;

--- a/packages/icons/stories/Icon.tsx
+++ b/packages/icons/stories/Icon.tsx
@@ -344,7 +344,7 @@ const Icon = ({ name, size }: { name: string; size?: keyof typeof iconSizes }) =
 	const fullName = size ? name.split(':')[0] + ':' + size : name;
 	return (
 		<div className={className} style={style}>
-			<svg style={styleWithSize}>
+			<svg style={styleWithSize} shapeRendering="geometricPrecision">
 				<use xlinkHref={'#' + fullName} />
 			</svg>
 		</div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Components that used to rely on `Icon` were based in `IconName`, a type that lists several legacy icons but also takes `string`s without any actual check. 

The new component `Sizedicon` does not support this. It asks for a size and a name, and only accepts the name of icons available at the given size. 

Removing all uses of `Icon` would be the right way to go for the design-system, but it would also be a major breaking change for our consumers. 

**What is the chosen solution to this problem?**
Enable a mixture of `IconName` and the correct `IconNameWithSize` subset for the major `icon` props we could find (critical buttons etc...). This is a large compromise. Since `IconName` contains `string` in its union, TS will accept any string, which breaks the promise of a strongly-typed `SizedIcon` component. 

This PR also removes `<Icon />` components call where it's non-breaking.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
