### PR TITLE
fix(design-system/buttonIcon): SVG in ButtonIcon does not register click anymore

### DIFF
--- a/.changeset/odd-bobcats-jump.md
+++ b/.changeset/odd-bobcats-jump.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+SVGs in ButtonIcon should not register clicks

--- a/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIcon.module.scss
+++ b/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIcon.module.scss
@@ -20,6 +20,10 @@
 		align-items: center;
 		width: tokens.$coral-sizing-xxxs;
 		height: tokens.$coral-sizing-xxxs;
+
+		svg {
+			pointer-events: none;
+		}
 	}
 
 	&.size_S {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In Mapper, clicking on the Icon does not actually fire the button's onClick event.

**What is the chosen solution to this problem?**|
Remove pointer events from the SVGs

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
