### PR TITLE
feat(design-system):message component

### DIFF
--- a/packages/design-system/src/.vscode/settings.json
+++ b/packages/design-system/src/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "mdx-preview.preview.useVscodeMarkdownStyles": false
+}

--- a/packages/design-system/src/components/WIP/Message/docs/message.stories.mdx
+++ b/packages/design-system/src/components/WIP/Message/docs/message.stories.mdx
@@ -3,7 +3,7 @@ import { Meta } from '@storybook/addon-docs';
 import { FigmaImage } from '~docs';
 
 <Meta
-	title="Components/Message"
+	title="[WIP] Components/Message"
 	parameters={{
 		status: { figma: 'wip', storybook: 'wip', react: 'wip', i18n: 'na' },
 		figmaLink: 'https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/?node-id=122%3A42331',
@@ -19,7 +19,7 @@ Messages have one of these semantic values: informative, success, warning or err
 Its core text content is mandatory. Other elements are optional. The hyperlink element is only available on the Message, never on MessageCollection.
 
 <FigmaImage
-	src="[https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A45189](https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A45189)"
+	src="https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A45189"
 	alt="Message"
 />
 
@@ -52,7 +52,7 @@ Only one “MainAction” is available. All other actions must be in a dropdown.
 Decorative elements in the background do not count in the Message’s box size. Use absolute elements or shadows to replicate.
 
 <FigmaImage
-	src="[https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A44927](https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A44927)"
+	src="https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=252%3A44927"
 	alt="MessageCollection"
 />
 
@@ -85,20 +85,22 @@ _add figma link_
 ## States
 
 ### Message action behavior
-_add link to this Figma file_
-// https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=243%3A45449
+
+[add link to this Figma file](https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=243%3A45449)
 
 ### MessageCollection action behavior
 
-_add link to this Figma file_
-// https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=243%3A44883
+[add link to this Figma file](https://www.figma.com/file/MSrfT0wzGwQSL8GuyG3UE7/Messages?node-id=243%3A44883)
 
 ## Content
+
 Titles should be kept short, but to be accessible we understand they can reflow.
 Description text should also be kept short, but should also reflow at will.
 Links need to be short and descriptive enough to see where it leads.
 Main action button are only displaying one action. Text has to be short, based on content defined on Button guideline.
+
 _add do don't_
+
 Do use sentence case in title.
 Don’t use more than 3 words on a button: keep it short and simple.
 Don't use technical error as a descriptive element.


### PR DESCRIPTION
Init message component documentation

**What is the problem this PR is trying to solve?**
Creation of documentation for the message component
**What is the chosen solution to this problem?**
Doing it 
**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
