### PR TITLE
fix(ARCH-537/storybook): add ThemeProvider import

### DIFF
--- a/.changeset/honest-houses-wave.md
+++ b/.changeset/honest-houses-wave.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: add ThemeProvider import

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import { I18nextProvider } from 'react-i18next';
-import { IconsProvider } from '@talend/design-system';
+import { IconsProvider, ThemeProvider } from '@talend/design-system';
 import { merge } from 'lodash';
 import { initialize, mswDecorator } from 'msw-storybook-addon';
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

ThemeProvider is undefined
![image](https://user-images.githubusercontent.com/19857479/176389983-09d00078-85a1-419f-97da-6d3cf1e0feb7.png)

Bad merge happens on webpack 5 PR

**What is the chosen solution to this problem?**

import ThemeProvider

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
