### PR TITLE
fix(component): don't pass rowdata to cell title

### DIFF
--- a/.changeset/pink-gorillas-hug.md
+++ b/.changeset/pink-gorillas-hug.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(component): don't spread row data to cellTitle action

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
@@ -40,7 +40,6 @@ function CellTitleSelector(props) {
 		return (
 			<Action
 				{...columnData}
-				{...rowData}
 				id={id && `${id}-btn`}
 				icon={undefined}
 				className={className}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
RowData can contain children prop 🙄 
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
