### PR TITLE
fix(cmf-router): router saga do not catch events

### DIFF
--- a/.changeset/moody-dryers-switch.md
+++ b/.changeset/moody-dryers-switch.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': patch
+---
+
+fix(cmf-router): router saga do not catch location change

--- a/packages/cmf-router/src/index.js
+++ b/packages/cmf-router/src/index.js
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { routerMiddleware, connectRouter } from 'connected-react-router';
 import cmf from '@talend/react-cmf';
-import { fork, takeLatest } from 'redux-saga/effects';
+import { spawn, takeLatest } from 'redux-saga/effects';
 import { create as createBrowserHistory } from './history';
 import { getRouter } from './UIRouter';
 import expressions from './expressions';
@@ -32,17 +32,17 @@ function getModule(...args) {
 
 	function* saga() {
 		let routerStarted = false;
-		yield fork(documentTitle);
+		yield spawn(documentTitle);
 		if (options.sagaRouterConfig) {
 			if (options.startOnAction) {
 				yield takeLatest(options.startOnAction, function* startRouter() {
 					if (!routerStarted) {
-						yield fork(sagaRouter, history, options.sagaRouterConfig);
+						yield spawn(sagaRouter, history, options.sagaRouterConfig);
 						routerStarted = true;
 					}
 				});
 			} else {
-				yield fork(sagaRouter, history, options.sagaRouterConfig);
+				yield spawn(sagaRouter, history, options.sagaRouterConfig);
 			}
 		}
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
As designed, the rooter saga has a while(true) loop and is triggered to start and stop the sagas with the current location.
I don't get why but the saga router using fork do not catch any redux event (using take/takeevery/takelatest etc), so, the while loop is just trigger one time at bootstrap and while we are navigating through the application, nothing happened.

With a spawn, the saga is registered at the root level, and i don't get why, all redux event are well catched...
I don't find any regression/issue using a spawn instead of a fork, so i propose this change.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
