### PR TITLE
fix(cmf-router): no routes from config

### DIFF
--- a/.changeset/happy-moons-switch.md
+++ b/.changeset/happy-moons-switch.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': patch
+---
+
+fix: saga documentTitle do not fail if no routes from config

--- a/packages/cmf-router/src/sagas/documentTitle.js
+++ b/packages/cmf-router/src/sagas/documentTitle.js
@@ -23,6 +23,9 @@ export function formatPath(path, parentPath) {
  * @param {string} parentPath
  */
 export function buildMapFromRoutes(routes, mapRoutes, parentPath) {
+	if (!routes || !routes.path) {
+		return mapRoutes;
+	}
 	const path = formatPath(routes.path, parentPath);
 	if (routes.documentTitle) {
 		mapRoutes.set(path, routes.documentTitle);
@@ -69,7 +72,6 @@ export function* handleDocumentTitle({ settings }) {
 	const mapRoutes = buildMapFromRoutes(settings.routes, new Map());
 	const defaultDocTitle = mapRoutes.get('/');
 	assignDocTitle(defaultDocTitle);
-
 	for (;;) {
 		const router = yield take('@@router/LOCATION_CHANGE');
 		const docTitle = getTitleFromRoutes(mapRoutes, router.payload.pathname, defaultDocTitle);

--- a/packages/cmf-router/src/sagas/documentTitle.test.js
+++ b/packages/cmf-router/src/sagas/documentTitle.test.js
@@ -128,6 +128,15 @@ describe('assignDocTitle', () => {
 });
 
 describe('buildMapFromRoutes', () => {
+	it('should handle empty path', () => {
+		// Given
+		const data = { documentTitle: 'docTitleRoot' };
+		// When
+		const testMap = buildMapFromRoutes(data, new Map());
+		// Then
+		const myMap = new Map();
+		expect(testMap).toEqual(myMap);
+	});
 	it('should return a map (path: docTitle) from an object', () => {
 		// Given
 		const child2 = { documentTitle: 'child2', path: 'child2' };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

documentTitle saga fails and make all the sagarouter fail

**What is the chosen solution to this problem?**

handle the case where no routes.path from the config

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
