### PR TITLE
fix(design-system/Conf): Restoring TS check in storybook watch mode

### DIFF
--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -53,6 +53,7 @@ module.exports = {
 	],
 	typescript: {
 		reactDocgen: false,
+		check: true,
 	},
 	core: {
 		builder: 'webpack5',

--- a/packages/design-system/.storybook/main.js
+++ b/packages/design-system/.storybook/main.js
@@ -11,12 +11,6 @@ module.exports = {
 		// storyStoreV7: true, // will break all work related to aggregated status in the next major version of Storybook
 	},
 	framework: '@storybook/react',
-	refs: {
-		'design-tokens': {
-			title: 'Design Tokens',
-			url: 'https://design.talend.com/design-tokens',
-		},
-	},
 	stories: [
 		'../src/Welcome.stories.@(js|tsx|mdx)',
 		'../src/GettingStarted.stories.@(js|tsx|mdx)',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some crucial options got removed during the webpack 5 config. 

**What is the chosen solution to this problem?**
Put them back in.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
