### PR TITLE
fix(react-forms): remove build-utils.js from .npmignore

### DIFF
--- a/packages/forms/.npmignore
+++ b/packages/forms/.npmignore
@@ -59,5 +59,4 @@ talend-scripts.json
 tsconfig.build.json
 tsconfig.json
 webpack.ace.config.js
-build-utils.js
 talend-i18n.json


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
build-utils.js has been added into the .npmignore file.

**What is the chosen solution to this problem?**
remove build-utils.js into .npmignore.js


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
