### PR TITLE
fix(datagrid): export parseRow from serializer

### DIFF
--- a/.changeset/cyan-poems-call.md
+++ b/.changeset/cyan-poems-call.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+fix(datagrid): export parseRow from serializer

--- a/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
+++ b/packages/datagrid/src/components/DatasetSerializer/datasetSerializer.js
@@ -100,24 +100,28 @@ export function getColumnDefs(sample) {
 	});
 }
 
-export function getRowData(sample, startIndex = 0) {
-	return (sample?.data ?? []).map((row, index) =>
-		Object.keys(row.value).reduce(
-			(rowData, key) => ({
-				...rowData,
-				[`${NAMESPACE_DATA}${key}`]: {
-					value: row.value[key].value,
-					quality: row.value[key].quality,
-					comments: [],
-					avro: {},
-				},
-			}),
-			{
-				[`${NAMESPACE_INDEX}${COLUMN_INDEX}`]: index + startIndex,
-				loaded: row.loaded,
+export function parseRow(row, index, startIndex = 1) {
+	const value = row && row.value ? row.value : {};
+
+	return Object.keys(value).reduce(
+		(rowData, key) => ({
+			...rowData,
+			[`${NAMESPACE_DATA}${key}`]: {
+				value: value[key].value,
+				quality: value[key].quality,
+				comments: [],
+				avro: {},
 			},
-		),
+		}),
+		{
+			[`${NAMESPACE_INDEX}${COLUMN_INDEX}`]: index + startIndex,
+			loaded: row?.loaded,
+		},
 	);
+}
+
+export function getRowData(sample, startIndex = 0) {
+	return (sample?.data ?? []).map((data, index) => parseRow(data, index, startIndex));
 }
 
 export function getPinnedColumnDefs(sample) {

--- a/packages/datagrid/src/components/DatasetSerializer/index.js
+++ b/packages/datagrid/src/components/DatasetSerializer/index.js
@@ -1,7 +1,14 @@
-import { getColumnDefs, getRowData, getPinnedColumnDefs, getCellValue } from './datasetSerializer';
+import {
+	getColumnDefs,
+	parseRow,
+	getRowData,
+	getPinnedColumnDefs,
+	getCellValue,
+} from './datasetSerializer';
 
 export default {
 	getColumnDefs,
+	parseRow,
 	getRowData,
 	getPinnedColumnDefs,
 	getCellValue,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

parseRow is not exported

**What is the chosen solution to this problem?**

export parseRow

**Please check if the PR fulfills these requirements**

- [ x The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
