### PR TITLE
fix(cdn): do not copy the same assets multiple times

### DIFF
--- a/.changeset/shaggy-bees-matter.md
+++ b/.changeset/shaggy-bees-matter.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-cdn': patch
+---
+
+fix: do not copy the same lib multiple times

--- a/tools/scripts-config-cdn/cdn.js
+++ b/tools/scripts-config-cdn/cdn.js
@@ -41,7 +41,9 @@ function addToCopyConfig(info, config) {
 			to += '/';
 		}
 		if (fs.existsSync(from)) {
-			config.push({ from, to, info: { minimized: true } });
+			if (!config.find(c => c.from === from)) {
+				config.push({ from, to, info: { minimized: true } });
+			}
 		} else {
 			const found = findPackage(info);
 			if (!found) {
@@ -49,7 +51,9 @@ function addToCopyConfig(info, config) {
 			} else {
 				from = path.resolve(`${found}${info.path}`, '..');
 				if (fs.existsSync(from)) {
-					config.push({ from, to, info: { minimized: true } });
+					if (!config.find(c => c.from === from)) {
+						config.push({ from, to, info: { minimized: true } });
+					}
 				} else {
 					console.error(`cdn: ${from} path not found`);
 				}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

the copy has multiple time the same libs.

**What is the chosen solution to this problem?**

remove it

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
