### PR TITLE
fix(config/storybook): add scss and cdn config

### DIFF
--- a/.changeset/fluffy-otters-smile.md
+++ b/.changeset/fluffy-otters-smile.md
@@ -1,0 +1,7 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: add CDN, css, scss and assets config to storybook
+
+stop try to merge two config together.

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -1,7 +1,6 @@
 const fs = require('fs');
 const { merge } = require('lodash');
 const path = require('path');
-const getTalendWebpackConfig = require('@talend/scripts-core/config/webpack.config');
 const CDNPlugin = require('@talend/dynamic-cdn-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { getAllModules } = require('@talend/module-to-cdn');

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -68,7 +68,7 @@ const defaultMain = {
 					.filter(rule => !rule.test.toString().match(/\.(s\[ca\]ss|scss|css)/))
 					// remove svg rule if handled by preset webpack rules
 					.map(rule => {
-						if (true && rule.test && rule.test.toString().match(/svg/)) {
+						if (rule.test && rule.test.toString().match(/svg/)) {
 							return {
 								...rule,
 								// remove extra slashes surrounding the regex.toString() /regex/, then remove the "svg" from test


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

storybook do not work with react preset but it work with lib preset.
the current status is our config try to merge two webpack config, both are really big.

current error I have is:
```
WARN Force closed manager build
ModuleParseError: Module parse failed: Assigning to rvalue (1:1)
You may need an appropriate loader to handle this file type, currently no loaders are configured to process this file. See https://webpack.js.org/concepts#loaders
> [data-theme=light]{--coral-color-neutral-text: hsla(0, 0%, 13%, 1);
keyframes coral-dark-keyframes-blink{0%,100%{opacity:1}50%{opacity:.5}}
| 
| /*# sourceMappingURL=TalendDesignTokens.css.map*/
    at handleParseError (/home/jean/github/talend/ui-ee/node_modules/webpack/lib/NormalModule.js:976:19)
    at /home/jean/github/talend/ui-ee/node_modules/webpack/lib/NormalModule.js:1095:5
    at processResult (/home/jean/github/talend/ui-ee/node_modules/webpack/lib/NormalModule.js:800:11)
    at /home/jean/github/talend/ui-ee/node_modules/webpack/lib/NormalModule.js:860:5
```
![image](https://user-images.githubusercontent.com/19857479/178005644-24c32d77-1c67-48a3-8b6b-e1383abcecda.png)



**What is the chosen solution to this problem?**

simplification: just remove few conflicting rules from storybook webpack and add our rules.

Note: we are discussing of incoming simplification which will have side effect to remove this need:

* use .module.scss syntax to active css module
* remove the auto import of bootstrap scss variables

both will be breaking changes

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
