### PR TITLE
chore: fix ds deploy ci master

### DIFF
--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -32,7 +32,7 @@ jobs:
           yarn workspace @talend/assets-api run build:lib
           yarn workspace @talend/icons run build:lib
           yarn workspace @talend/design-tokens run build:lib
-          yarn workspace @talend/design-tokens run build-storybook
+          yarn workspace @talend/design-tokens run test:demo
 
       - name: Build Storybook of the design system
         run: yarn workspace @talend/design-system run build-storybook

--- a/.github/workflows/design-system-deploy.yml
+++ b/.github/workflows/design-system-deploy.yml
@@ -32,10 +32,12 @@ jobs:
           yarn workspace @talend/assets-api run build:lib
           yarn workspace @talend/icons run build:lib
           yarn workspace @talend/design-tokens run build:lib
+          yarn workspace @talend/design-system run build:lib
+          yarn workspace @talend/storybook-docs run build:lib
           yarn workspace @talend/design-tokens run test:demo
 
       - name: Build Storybook of the design system
-        run: yarn workspace @talend/design-system run build-storybook
+        run: yarn workspace @talend/design-system run test:demo
         env:
           STORYBOOK_FIGMA_ACCESS_TOKEN: ${{ secrets.STORYBOOK_FIGMA_ACCESS_TOKEN }}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

ci master fails to deploy ds

**What is the chosen solution to this problem?**

we have to assume a circular dependency with storybook-docs which is here:

storybook-docs need build:lib of design-system and design-tokens
storybook-docs is a dependency to build test:demo of both

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
