### PR TITLE
fix(design-system): Allow additional bundles for IconsProvider

### DIFF
--- a/.changeset/unlucky-trees-look.md
+++ b/.changeset/unlucky-trees-look.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): Allow additional bundles for IconsProvider

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.spec.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.spec.tsx
@@ -56,4 +56,12 @@ context('<IconsProvider />', () => {
 		);
 		cy.getByTestId('wrapper').find('symbol').should('have.length', 2);
 	});
+	it('should support additionalBundles props', () => {
+		const additionalBundles = ['/some/other/icons', '/more/icons/is/better'];
+		cy.intercept('/some/other/icons', '<svg data-test="other-icons"></svg>').as('getOtherBundle');
+		cy.intercept('/more/icons/is/better', '<svg data-test="more-icons"></svg>').as('getMoreBundle');
+		cy.mount(<IconsProvider bundles={[]} additionalBundles={additionalBundles} />);
+		cy.getByTest('other-icons').should('to.exist');
+		cy.getByTest('more-icons').should('to.exist');
+	});
 });

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
@@ -119,10 +119,12 @@ function isRootProvider(ref: RefObject<any>) {
  */
 export function IconsProvider({
 	bundles = DEFAULT_BUNDLES,
+	additionalBundles = [],
 	defaultIcons = {},
 	icons = {},
 }: {
-	bundles?: string[] | [];
+	bundles?: string[];
+	additionalBundles?: string[];
 	defaultIcons?: Record<string, ReactElement>;
 	icons?: Record<string, ReactElement>;
 }) {
@@ -131,10 +133,12 @@ export function IconsProvider({
 	const [shouldRender, setShouldRender] = useState(true);
 
 	useEffect(() => {
-		if (!Array.isArray(bundles)) {
+		if (!Array.isArray(bundles) || !Array.isArray(additionalBundles)) {
 			return;
 		}
+
 		bundles
+			.concat(additionalBundles)
 			.filter(url => !hasBundle(url))
 			.forEach(url => {
 				FETCHING_BUNDLES[url] = fetch(url)
@@ -143,7 +147,7 @@ export function IconsProvider({
 						delete FETCHING_BUNDLES[url];
 					});
 			});
-	}, [bundles]);
+	}, [bundles, additionalBundles]);
 
 	useEffect(() => {
 		if (!isRootProvider(ref)) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In Pipeline Designer (at least), we load additional icons bundles. We should not declare default bundle anymore, but if we only keep additional ones, it overrides the default config and we lost default icons.

**What is the chosen solution to this problem?**
Add a new `additionalBundles` props to the `IconsProvider` component and concat it with the `bundle` props.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
