### PR TITLE
fix(APIC-827): reset input copy state when input value change

### DIFF
--- a/.changeset/modern-ladybugs-sell.md
+++ b/.changeset/modern-ladybugs-sell.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+fix(APIC-827): reset inputCopy state when input value changes

--- a/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import { useCopyToClipboard } from 'react-use';
 import { useTranslation } from 'react-i18next';
 import FieldGroup from '../../FieldGroup';
@@ -11,10 +11,28 @@ const InputCopy = React.forwardRef(
 		{ label, disabled, readOnly, value, defaultValue, prefix, ...rest }: InputProps,
 		ref: React.Ref<HTMLInputElement | null>,
 	) => {
-		const [{ value: copiedValue, error: copyError }, copyToClipboard] = useCopyToClipboard();
+		const [copiedValue, setCopiedValue] = useState('');
+		const [copyError, setCopyError] = useState<Error | undefined | null>(null);
+		const [{ value: clipboardValue, error: clipboardError }, copyToClipboard] =
+			useCopyToClipboard();
 		const inputRef = React.useRef<HTMLInputElement | null>(null);
 		const { t } = useTranslation();
 		const inputValue = value || defaultValue;
+
+		useEffect(() => {
+			if (inputValue !== copiedValue) {
+				setCopiedValue('');
+				setCopyError(null);
+			}
+		}, [inputValue, copiedValue]);
+
+		useEffect(() => {
+			setCopiedValue(clipboardValue as string);
+		}, [clipboardValue]);
+
+		useEffect(() => {
+			setCopyError(clipboardError);
+		}, [clipboardError]);
 
 		React.useImperativeHandle(ref, () => inputRef.current);
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the inputValue of the inputCopy change, the state of the hook `useCopyToClipboard` is not reset.
Preventing errors and copy message to be hidden.

**What is the chosen solution to this problem?**
Since we cannot reset the state of the hook manualy, the solution is to transfer the state of the hook to a custom local state.
Se we can reset this state when the value of the input change.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
