### PR TITLE
feat: Support .mjs files transform

### DIFF
--- a/.changeset/big-zoos-relate.md
+++ b/.changeset/big-zoos-relate.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': minor
+---
+
+feat: Support .mjs files transform

--- a/tools/scripts-config-jest/jest.config.js
+++ b/tools/scripts-config-jest/jest.config.js
@@ -17,6 +17,7 @@ module.exports = {
 	transform: {
 		...tsjestPreset.transform, // https://kulshekhar.github.io/ts-jest/user/config/#advanced
 		'^.+\\.jsx?$': ['babel-jest', { configFile: getBabelConfigPath() }],
+		'^.+\\.mjs?$': ['babel-jest', { configFile: getBabelConfigPath() }],
 	},
 	snapshotSerializers: ['jest-serializer-html'],
 	modulePathIgnorePatterns: ['<rootDir>/dist/cdn'],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some libs are now exposing `.mjs` files and we currently don't apply transformations on them.

**What is the chosen solution to this problem?**
Add a configuration to now transform those files.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
