### PR TITLE
chore(eslint/ci): fix eslint false positive on imports

### DIFF
--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -25,7 +25,7 @@ jobs:
           cache: "yarn"
 
       - name: Install
-        run: yarn install --frozen-lockfile --ignore-scripts
+        run: yarn install --frozen-lockfile
 
       - name: eslint
         continue-on-error: true

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -27,7 +27,7 @@ const STYLES = {
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
-	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 1;
+	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
 
 	return (
 		<Transition in appear timeout={withTransition ? 500 : 0} {...rest}>

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -27,7 +27,7 @@ const STYLES = {
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
-	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 0;
+	const timeout = withTransition ? DEFAULT_TRANSITION_DURATION : 1;
 
 	return (
 		<Transition in appear timeout={withTransition ? 500 : 0} {...rest}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is some false positive warnings on imports for eslint

**What is the chosen solution to this problem?**

Add the build scripts to the yarn install command so import on /lib are resolved

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
