### PR TITLE
feat(storybook-preset): Disable bundle-analyzer plugin

### DIFF
--- a/.changeset/neat-tigers-melt.md
+++ b/.changeset/neat-tigers-melt.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+Disable bundle-analyze-plugin to speed up build

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -7,6 +7,7 @@ const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { getAllModules } = require('@talend/module-to-cdn');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const { DuplicatesPlugin } = require('inspectpack/plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const cwd = process.cwd();
 
@@ -24,11 +25,12 @@ function getStoriesFolders() {
 }
 
 const excludedPlugins = [
-	CDNPlugin, // will be overrided without @talend modules
-	DuplicatesPlugin, // slow
+	CDNPlugin, // will be overridden without @talend modules
+	DuplicatesPlugin, BundleAnalyzerPlugin, // slow
 	MiniCssExtractPlugin, // blocker for optimization
 	HtmlWebpackPlugin, // use SB index.html, not app's
 ]
+
 
 const defaultMain = {
 	features: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Storybook preset is using the preset-react config, with all its slow plugins.

**What is the chosen solution to this problem?**

Add a slow plugin to exclude list

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
