### PR TITLE
fix(scripts/jest): expose jsdom as global variable in jest environment

### DIFF
--- a/.changeset/sour-readers-cough.md
+++ b/.changeset/sour-readers-cough.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': patch
+---
+
+expose jsdom as global variable in jest environment

--- a/tools/scripts-config-jest/jest.config.js
+++ b/tools/scripts-config-jest/jest.config.js
@@ -12,7 +12,7 @@ module.exports = {
 	},
 	rootDir: process.cwd(),
 	setupFilesAfterEnv: [path.join(__dirname, 'test-setup.js')],
-	testEnvironment: 'jsdom',
+	testEnvironment: 'jest-environment-jsdom-global',
 	testRegex: 'src/.*\\.test.(js|ts|tsx)$',
 	transform: {
 		...tsjestPreset.transform, // https://kulshekhar.github.io/ts-jest/user/config/#advanced


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In some of TMC's unit tests, we reference `jsdom` as global variable, it was working well but after upgrade to Jest 28, we need to config `testEnvironment: jest-environment-jsdom-global` for keep `jsdom` global.

**What is the chosen solution to this problem?**
Change jest config `testEnvironment` from 'jsdom' to 'jest-environment-jsdom-global'

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
