### PR TITLE
feat(design-system): set switch font to prevent inheritance

### DIFF
--- a/.changeset/tame-gorillas-drive.md
+++ b/.changeset/tame-gorillas-drive.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(design-system): set switch font to prevent inheritance

--- a/packages/design-system/src/components/Switch/Switch.style.ts
+++ b/packages/design-system/src/components/Switch/Switch.style.ts
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import { shade } from 'polished';
+import dsTokens from '@talend/design-tokens';
 
 import tokens from '../../tokens';
 
@@ -19,14 +20,14 @@ export const SwitchIndicator = styled.span`
 export const Switch = styled.div<{ disabled: boolean; readOnly: boolean }>`
 	div {
 		position: relative;
-    	display: inline-flex;
+		display: inline-flex;
 		background: ${({ theme }) => theme.colors.inputRadioBackgroundColor};
 		border-radius: 10rem;
-		box-shadow: inset 0 .1rem .3rem 0 rgba(0, 0, 0, .25);
+		box-shadow: inset 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.25);
 		overflow: hidden;
-    	${({ disabled }) => (disabled ? `opacity: ${tokens.opacity.disabled};` : '')}
+		${({ disabled }) => (disabled ? `opacity: ${tokens.opacity.disabled};` : '')}
 	}
-	
+
 	button {
 		position: relative;
 		display: flex;
@@ -34,46 +35,46 @@ export const Switch = styled.div<{ disabled: boolean; readOnly: boolean }>`
 		justify-content: space-around;
 		margin: 0;
 		padding: 0 1rem;
-		color: ${({ theme }) => theme.colors.textColor}
-		font-size: ${tokens.fontSizes.small};
-    	opacity: ${tokens.opacity.disabled};
-		user-select: none; 		
+		color: ${({ theme }) => theme.colors.textColor};
+		font: ${dsTokens.coralParagraphMBold};
+		opacity: ${tokens.opacity.disabled};
+		user-select: none;
 		cursor: pointer;
 		background: none;
 		border: none;
 		z-index: ${tokens.zIndices.onTop};
 	}
-	
+
 	${SwitchIndicator} em {
-  		position: absolute;
-  		top: .2rem;
-		right: .2rem;
-  		bottom: .2rem;
-  		left: .2rem;
-		transition: background .3s;
-		background: ${({ theme }) => theme.colors.activeColor[500]};    
-    	border-radius: 100px;
-  	}
+		position: absolute;
+		top: 0.2rem;
+		right: 0.2rem;
+		bottom: 0.2rem;
+		left: 0.2rem;
+		transition: background 0.3s;
+		background: ${({ theme }) => theme.colors.activeColor[500]};
+		border-radius: 100px;
+	}
 
 	div:hover ${SwitchIndicator} em {
 		background: ${({ readOnly, theme }) =>
 			!readOnly ? shade(0.25, theme.colors.activeColor[500]) : 'none'};
 	}
-  
+
 	[aria-selected] {
 		transition: color ${tokens.transitions.normal};
 	}
-	
-	[aria-selected="true"] {
+
+	[aria-selected='true'] {
 		color: ${({ theme }) => theme.colors.inputBackgroundColor};
 		opacity: ${tokens.opacity.opaque};
 	}
-		
+
 	[aria-selected] ~ ${SwitchIndicator} {
 		visibility: hidden;
 	}
-	
-	[aria-selected="true"] ~ ${SwitchIndicator} {
+
+	[aria-selected='true'] ~ ${SwitchIndicator} {
 		visibility: visible;
 	}
 `;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When you use switch component in multiple containers, switch font inherits from parent, leading to inconsistent UI. 

**What is the chosen solution to this problem?**

Set a `paragraph-m-bold` font on switch label to prevent inheritance.

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
