### PR TITLE
fix(UIForm): keep defaultProps created by withTranslation

### DIFF
--- a/.changeset/tender-candles-hunt.md
+++ b/.changeset/tender-candles-hunt.md
@@ -2,4 +2,4 @@
 '@talend/react-forms': patch
 ---
 
-keep defaultProps created by withTranslation
+fix(UIForm): keep defaultProps created by withTranslation

--- a/.changeset/tender-candles-hunt.md
+++ b/.changeset/tender-candles-hunt.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+keep defaultProps created by withTranslation

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -425,6 +425,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 I18NUIForm.defaultProps = {
+	...I18NUIForm.defaultProps,
 	noHtml5Validate: true,
 	buttonBlockClass: 'form-actions',
 	properties: {},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When running test with React Test library, it throws the error " t is not function",  the "t" prop is injected with jest mock, but it is overwrited in the https://github.com/Talend/ui/blob/d6fe79807fb51e5897a9a9cdb8e758508ac93ac5/packages/forms/src/UIForm/UIForm.component.js#L427
This cause when calling CustomFormats function, the "t" is undefined. 
The fix only affect the unit test, for the webapp, there is no defaultProp for the I18NUIForm
**What is the chosen solution to this problem?**
append defaultProps for the I18NUIForm.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
