### PR TITLE
feat(datagrid): Add column size persistence to local storage

### DIFF
--- a/.changeset/clean-chefs-clap.md
+++ b/.changeset/clean-chefs-clap.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': minor
+---
+
+Allow column size persistence to local storage

--- a/packages/datagrid/README.md
+++ b/packages/datagrid/README.md
@@ -21,16 +21,17 @@ import DataGrid from '@talend/react-datagrid';
 The dataGrid component is used to show datagrid on all Talend projects. This library uses [Ag-Grid](http://ag-grid.com) to show the grid.
 Grid is composed like this :
 
-| colDef[0].headerComponent | colDef[1].headerComponent   | colDef[2].headerComponent |
-|---------------------------|-----------------------------|---------------------------|
-| raw ag-grid renderer      | colDef[1].cellRenderer      | colDef[2].cellRenderer   |
-| raw ag-grid renderer      | colDef[1].cellRenderer      | colDef[2].cellRenderer    |
-| raw ag-grid renderer      | colDef[1].cellRenderer      | colDef[2].cellRenderer    |
-| raw ag-grid renderer      | colDef[1].cellRenderer      | colDef[2].cellRenderer    |
+| colDef[0].headerComponent | colDef[1].headerComponent | colDef[2].headerComponent |
+| ------------------------- | ------------------------- | ------------------------- |
+| raw ag-grid renderer      | colDef[1].cellRenderer    | colDef[2].cellRenderer    |
+| raw ag-grid renderer      | colDef[1].cellRenderer    | colDef[2].cellRenderer    |
+| raw ag-grid renderer      | colDef[1].cellRenderer    | colDef[2].cellRenderer    |
+| raw ag-grid renderer      | colDef[1].cellRenderer    | colDef[2].cellRenderer    |
 
 ## Data sources
 
 A serializer is provided to handle dataset sample format:
+
 ```
 import { DatasetSerializer } from '@talend/react-datagrid`;
 const columnDefs = DatasetSerializer.getColumnDefs(sample);
@@ -41,23 +42,23 @@ const columnDefs = DatasetSerializer.getColumnDefs(sample);
 All ag-grid props can be provided (https://www.ag-grid.com/react-data-grid/grid-options/).
 Here are the main ones:
 
-| property        | description                                    | type          | default |
-|-----------------|------------------------------------------------|---------------|---------|
-| headerHeight    | height of the header                           | int           | 69      |
-| onCellFocused   | callback when one cell is focused              | function      |         |
-| rowSelection    | set the type of selection (single or multiple) | string        | single  |
-| rowData         | pass the row data straight right to ag-grid    | Array         |         |
-| columnsDef      | definition of the columns                      | Array<ColDef> |         |
+| property      | description                                    | type          | default |
+| ------------- | ---------------------------------------------- | ------------- | ------- |
+| headerHeight  | height of the header                           | int           | 69      |
+| onCellFocused | callback when one cell is focused              | function      |         |
+| rowSelection  | set the type of selection (single or multiple) | string        | single  |
+| rowData       | pass the row data straight right to ag-grid    | Array         |         |
+| columnsDef    | definition of the columns                      | Array<ColDef> |         |
 
 To support new use cases, new props were added:
 
-| property                 | description                                    | type                      | default |
-|--------------------------|------------------------------------------------|---------------------------|---------|
-| columnSelection          | set the type of selection (single or multiple) | string                    | single  |
-| onColumnSelectionChanged | callback selected column(s) changed            | function                  |         |
-| loading                  |                                                | boolean                   | false   |
-| selection                | controlled selection                           | { rowIndexes, columnIds } |         |
-
+| property                 | description                                       | type                      | default |
+| ------------------------ | ------------------------------------------------- | ------------------------- | ------- |
+| columnSelection          | set the type of selection (single or multiple)    | string                    | single  |
+| onColumnSelectionChanged | callback selected column(s) changed               | function                  |         |
+| loading                  |                                                   | boolean                   | false   |
+| selection                | controlled selection                              | { rowIndexes, columnIds } |         |
+| sizesLocalStorageKey     | Key to use when persisting sizes to local storage | string                    |         |
 
 ## Issue solved with ag-grid
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-// import all stories from the stories file
 import { composeStories } from '@storybook/testing-react';
 import { render, screen } from '@testing-library/react';
 import ReactDOM from 'react-dom';
@@ -48,5 +47,28 @@ describe('DataGrid', () => {
 	it('should add class on selected columns', async () => {
 		const wrapper = render(<Selection />);
 		await Selection.play({ canvasElement: wrapper.baseElement });
+	});
+	it('should use persisted column sizes', async () => {
+		const LOCAL_STORAGE_KEY = 'key';
+		window.localStorage.setItem(
+			LOCAL_STORAGE_KEY,
+			JSON.stringify({
+				[sample.schema.fields[0].name]: 789,
+			}),
+		);
+
+		render(
+			<DataGrid
+				sizesLocalStorageKey={LOCAL_STORAGE_KEY}
+				columnDefs={getColumnDefs(sample)}
+				rowData={sample.data}
+			/>,
+		);
+
+		const cell = await screen.findByText('Nom de la gare', undefined, {
+			timeout: 10000,
+		});
+
+		expect(getComputedStyle(cell.closest('.ag-header-cell')!).width).toEqual('789px');
 	});
 });

--- a/packages/datagrid/src/components/DataGrid/DataGrid.utils.ts
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.utils.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { GridApi, NavigateToNextCellParams, TabToNextCellParams } from 'ag-grid-community';
+import { Column, GridApi, NavigateToNextCellParams, TabToNextCellParams } from 'ag-grid-community';
 
 import { SELECTED_CELL_CLASS_NAME } from '../../constants';
 
@@ -55,4 +55,29 @@ export function refreshHeader(
 			?.classList.toggle(SELECTED_CELL_CLASS_NAME, selection.includes(colId));
 	});
 	// END QUICKFIX
+}
+
+/**
+ * Return column sizes saved in local storage
+ */
+export function getColumnSizes(localStorageKey?: string) {
+	try {
+		const sizesStr = localStorageKey ? localStorage.getItem(localStorageKey) : null;
+		if (sizesStr) {
+			return JSON.parse(sizesStr);
+		}
+	} catch (e) {
+		console.error('local storage seems corrupted', e);
+	}
+	return null;
+}
+
+/*
+ * Save column size to local storage
+ */
+export function saveColumnSizes(localStorageKey: string, columns: Column[] | null) {
+	if (columns) {
+		const sizes = columns.map(col => [col.getColId(), col.getActualWidth()]);
+		localStorage.setItem(localStorageKey, JSON.stringify(Object.fromEntries(sizes)));
+	}
 }

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -50,6 +50,7 @@ export default {
 } as Meta;
 
 const defaultGridProps = {
+	sizesLocalStorageKey: 'sb-grid-sizes',
 	columnSelection: 'multiple' as DataGridProps['columnSelection'],
 	rowData: sample.data,
 	columnDefs: getColumnDefs(sample),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We want to be able to persist the column sizes to local storage, so the user don't have to resize it's every time

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
