### PR TITLE
feat(datagrid): Highlight cells with the same values

### DIFF
--- a/.changeset/great-cycles-hope.md
+++ b/.changeset/great-cycles-hope.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': minor
+---
+
+Highlight cells with same values

--- a/packages/datagrid/jest.setup.js
+++ b/packages/datagrid/jest.setup.js
@@ -1,2 +1,3 @@
 // DS is mocked by ui-scripts, preventing us to use testing-library getByLabelText & others selectors
 jest.unmock('@talend/design-system');
+jest.setTimeout(10000);

--- a/packages/datagrid/src/components/DataGrid/DataGrid.module.scss
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.module.scss
@@ -29,6 +29,10 @@ $td-datagrid-skeleton-height: 9.6rem !default;
 		}
 	}
 
+	:global(.ag-cell.highlighted) {
+		font: tokens.$coral-data-m-bold;
+	}
+
 	/* ==== HEADER ==== */
 	:global(.ag-header-cell-resize) {
 		cursor: col-resize;

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -22,7 +22,6 @@ declare global {
 	}
 }
 
-jest.mock('ally.js');
 const { Selection } = composeStories(stories);
 
 jest.mock('ally.js');

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -62,7 +62,7 @@ describe('DataGrid', () => {
 				HIGHLIGHTED_CELL_CLASS_NAME,
 			);
 		});
-
+	});
 	it('should use persisted column sizes', async () => {
 		const LOCAL_STORAGE_KEY = 'key';
 		window.localStorage.setItem(

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -1,13 +1,14 @@
 import React from 'react';
-
-// import all stories from the stories file
-import { composeStories } from '@storybook/testing-react';
-import { render, screen } from '@testing-library/react';
 import ReactDOM from 'react-dom';
+
+import { composeStories } from '@storybook/testing-react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { Grid as agGrid } from 'ag-grid-community';
 import { AgGridReact, AgGridColumn } from 'ag-grid-react';
 
 import sample from '../../../mocks/sample.json';
+import { HIGHLIGHTED_CELL_CLASS_NAME } from '../../constants';
 import { getColumnDefs } from '../../serializers/datasetSerializer';
 import DataGrid from './DataGrid';
 import * as stories from './Datagrid.stories';
@@ -23,6 +24,8 @@ declare global {
 
 jest.mock('ally.js');
 const { Selection } = composeStories(stories);
+
+jest.mock('ally.js');
 
 describe('DataGrid', () => {
 	beforeAll(() => {
@@ -48,5 +51,17 @@ describe('DataGrid', () => {
 	it('should add class on selected columns', async () => {
 		const wrapper = render(<Selection />);
 		await Selection.play({ canvasElement: wrapper.baseElement });
+	});
+	it('should highlight cell with the same values', async () => {
+		render(<DataGrid columnDefs={getColumnDefs(sample)} rowData={sample.data} />);
+		await screen.findByText('Segmentation', undefined, {
+			timeout: 10000,
+		});
+		await userEvent.click(screen.getAllByText('c')[0]);
+		await waitFor(() => {
+			expect(screen.getAllByText('c')[1].closest('.ag-cell')).toHaveClass(
+				HIGHLIGHTED_CELL_CLASS_NAME,
+			);
+		});
 	});
 });

--- a/packages/datagrid/src/components/DataGrid/useColumnSelection.hook.ts
+++ b/packages/datagrid/src/components/DataGrid/useColumnSelection.hook.ts
@@ -25,6 +25,11 @@ export function useColumnSelection(
 			// Column selection changed
 			if (selectedColumns.length > 1 || selectedColumns[0] !== update[0]) {
 				setSelectedColumns(update);
+			} else {
+				// Only row changed
+				event.api.refreshCells({
+					columns: [event.column],
+				});
 			}
 		}
 	}

--- a/packages/datagrid/src/constants/column-definition.constants.ts
+++ b/packages/datagrid/src/constants/column-definition.constants.ts
@@ -44,8 +44,8 @@ export const DefaultColDef: Partial<ColDef> = {
 			if (focusedCell) {
 				// For each cell, check if it's the same value as the focused cell
 				const focusedRow = api.getDisplayedRowAtIndex(focusedCell.rowIndex);
-				const focusedValue = api.getValue(focusedCell.column, focusedRow!).value;
-				return value.value === focusedValue && colDef === focusedCell.column.getColDef();
+				const focusedValue = api.getValue(focusedCell.column, focusedRow!)?.value;
+				return value?.value === focusedValue && colDef === focusedCell.column.getColDef();
 			}
 			return false;
 		},

--- a/packages/datagrid/src/constants/column-definition.constants.ts
+++ b/packages/datagrid/src/constants/column-definition.constants.ts
@@ -5,7 +5,12 @@ import DefaultCellRenderer from '../components/DefaultCellRenderer';
 import DefaultHeaderRenderer from '../components/HeaderCellRenderer';
 import DefaultPinHeaderRenderer from '../components/PinHeaderRenderer';
 import PlaygroundCellEditor from '../components/PlaygroundCellEditor';
-import { COLUMN_MIN_WIDTH, CELL_WIDTH, SELECTED_CELL_CLASS_NAME } from './datagrid.constants';
+import {
+	COLUMN_MIN_WIDTH,
+	CELL_WIDTH,
+	SELECTED_CELL_CLASS_NAME,
+	HIGHLIGHTED_CELL_CLASS_NAME,
+} from './datagrid.constants';
 
 function isSelectedColumn(params: CellClassParams | HeaderClassParams) {
 	return params.context.selectedColumns?.includes((params.colDef as ColDef).field);
@@ -34,5 +39,15 @@ export const DefaultColDef: Partial<ColDef> = {
 		}),
 	cellClassRules: {
 		[SELECTED_CELL_CLASS_NAME]: isSelectedColumn,
+		[HIGHLIGHTED_CELL_CLASS_NAME]: ({ api, colDef, value }: CellClassParams) => {
+			const focusedCell = api.getFocusedCell();
+			if (focusedCell) {
+				// For each cell, check if it's the same value as the focused cell
+				const focusedRow = api.getDisplayedRowAtIndex(focusedCell.rowIndex);
+				const focusedValue = api.getValue(focusedCell.column, focusedRow!).value;
+				return value.value === focusedValue && colDef === focusedCell.column.getColDef();
+			}
+			return false;
+		},
 	},
 };

--- a/packages/datagrid/src/constants/datagrid.constants.ts
+++ b/packages/datagrid/src/constants/datagrid.constants.ts
@@ -7,3 +7,4 @@ export const COLUMN_MIN_WIDTH = 30;
 export const ROW_HEIGHT = 39;
 export const CELL_WIDTH = 150;
 export const SELECTED_CELL_CLASS_NAME = 'column-focus';
+export const HIGHLIGHTED_CELL_CLASS_NAME = 'highlighted';

--- a/packages/datagrid/src/serializers/__snapshots__/datasetSerializer.test.ts.snap
+++ b/packages/datagrid/src/serializers/__snapshots__/datasetSerializer.test.ts.snap
@@ -12,6 +12,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -64,6 +65,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -100,6 +102,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -152,6 +155,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -204,6 +208,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -256,6 +261,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -308,6 +314,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -344,6 +351,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -396,6 +404,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),
@@ -448,6 +457,7 @@ Array [
   Object {
     "cellClassRules": Object {
       "column-focus": [Function],
+      "highlighted": [Function],
     },
     "cellEditor": Object {
       "$$typeof": Symbol(react.forward_ref),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When focusing a cell, other cell in the same column with the same values should be highlighted

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
