### PR TITLE
fix(forms): move code to let tsc build correct types

### DIFF
--- a/.changeset/spicy-clocks-cry.md
+++ b/.changeset/spicy-clocks-cry.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+fix: move exported values of UIForm into the class as static values

--- a/packages/forms/src/UIForm/UIForm.container.js
+++ b/packages/forms/src/UIForm/UIForm.container.js
@@ -4,6 +4,16 @@ import React from 'react';
 
 import UIFormTranslatedComponent from './UIForm.component';
 import { formPropTypes } from './utils/propTypes';
+import * as FormTemplate from './FormTemplate';
+import FieldTemplate, { TextModeTemplate } from './fields/FieldTemplate';
+import Message from './Message';
+import callTrigger from './trigger';
+import utils from './utils';
+import Widget from './Widget';
+
+import customFormats from './customFormats';
+import lang from './lang';
+import merge from './merge';
 
 /**
  * add error object on a formSchema if it doesn't exist
@@ -73,6 +83,26 @@ const setInitialStateAsLiveState = prevState => ({
 
 export default class UIForm extends React.Component {
 	static displayName = 'Container(UIForm)';
+
+	static FormTemplate = FormTemplate;
+
+	static TextModeTemplate = TextModeTemplate;
+
+	static FieldTemplate = FieldTemplate;
+
+	static Message = Message;
+
+	static callTrigger = callTrigger;
+
+	static utils = utils;
+
+	static Widget = Widget;
+
+	static customFormats = customFormats;
+
+	static lang = lang;
+
+	static merge = merge;
 
 	constructor(props) {
 		super(props);

--- a/packages/forms/src/UIForm/index.js
+++ b/packages/forms/src/UIForm/index.js
@@ -1,30 +1,7 @@
-import * as FormTemplate from './FormTemplate';
-import FieldTemplate, { TextModeTemplate } from './fields/FieldTemplate';
-import Message from './Message';
-import callTrigger from './trigger';
-import utils from './utils';
-import Widget from './Widget';
-
-import customFormats from './customFormats';
-import lang from './lang';
-import merge from './merge';
 import UIForm from './UIForm.container';
 
 // TODO Remove for 6.0
 import * as triggers from './utils/triggers';
 
-export { UIForm, triggers };
-
-UIForm.FormTemplate = FormTemplate;
-UIForm.TextModeTemplate = TextModeTemplate;
-UIForm.FieldTemplate = FieldTemplate;
-UIForm.Message = Message;
-UIForm.callTrigger = callTrigger;
-UIForm.utils = utils;
-UIForm.Widget = Widget;
-
-UIForm.customFormats = customFormats;
-UIForm.lang = lang;
-UIForm.merge = merge;
-
 export default UIForm;
+export { UIForm, triggers };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

On project side, tsc complains on 
`const Code = Forms.UIForm.utils.widgets.code;`
that
`Property 'utils' does not exist on type 'typeof UIForm'.ts(2339)`

this is because it is attached dynamically to the UIForm and so it can't be discovered by typescript compiler

**What is the chosen solution to this problem?**
Attach it properly: statically.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
