### PR TITLE
test: add cdn config tests

### DIFF
--- a/.changeset/fluffy-weeks-wave.md
+++ b/.changeset/fluffy-weeks-wave.md
@@ -1,0 +1,5 @@
+---
+'@talend/module-to-cdn': minor
+---
+
+feat: expose test helpers to check cdn config

--- a/fork/module-to-cdn/index.test.js
+++ b/fork/module-to-cdn/index.test.js
@@ -1,6 +1,7 @@
 const modules = require('./modules.json');
 const fn = require('.');
 const {parseToSemverIfPossible} = require('./version');
+const helpers = require('@talend/module-to-cdn/test-helpers');
 
 /* eslint-disable no-param-reassign */
 /* eslint-disable no-console */
@@ -34,7 +35,9 @@ describe('module-to-cdn', () => {
             styleUrl: undefined
         });
     });
-
+    it('should respect style patterns', () => {
+        helpers.assertStyleVersionPatterns(modules);
+    });
     it('getAllModules', () => {
         t.deepEqual(fn.getAllModules(), modules);
     });

--- a/fork/module-to-cdn/test-helpers.js
+++ b/fork/module-to-cdn/test-helpers.js
@@ -1,7 +1,7 @@
 function assertStyleVersionPatterns(config) {
     Object.keys(config)
         .filter(importPath => config[importPath].hasOwnProperty('style-versions'))
-        .reduce((acc, importPath) => {
+        .forEach((acc, importPath) => {
             const patterns = Object.keys(config[importPath].versions);
             const stylePatterns = Object.keys(config[importPath]['style-versions']);
             expect(patterns).toEqual(expect.arrayContaining(stylePatterns));

--- a/fork/module-to-cdn/test-helpers.js
+++ b/fork/module-to-cdn/test-helpers.js
@@ -1,0 +1,13 @@
+function assertStyleVersionPatterns(config) {
+    Object.keys(config)
+        .filter(importPath => config[importPath].hasOwnProperty('style-versions'))
+        .reduce((acc, importPath) => {
+            const patterns = Object.keys(config[importPath].versions);
+            const stylePatterns = Object.keys(config[importPath]['style-versions']);
+            expect(patterns).toEqual(expect.arrayContaining(stylePatterns));
+        }, true);
+}
+
+module.exports = {
+    assertStyleVersionPatterns
+};

--- a/fork/module-to-cdn/test-helpers.js
+++ b/fork/module-to-cdn/test-helpers.js
@@ -1,7 +1,7 @@
 function assertStyleVersionPatterns(config) {
     Object.keys(config)
         .filter(importPath => config[importPath].hasOwnProperty('style-versions'))
-        .forEach((acc, importPath) => {
+        .forEach(importPath => {
             const patterns = Object.keys(config[importPath].versions);
             const stylePatterns = Object.keys(config[importPath]['style-versions']);
             expect(patterns).toEqual(expect.arrayContaining(stylePatterns));

--- a/tools/scripts-config-cdn/modules.test.js
+++ b/tools/scripts-config-cdn/modules.test.js
@@ -1,0 +1,8 @@
+const config = require('./modules.json');
+const helpers = require('@talend/module-to-cdn/test-helpers');
+
+describe('modules.json is ok', () => {
+	it('should respect style patterns', () => {
+		helpers.assertStyleVersionPatterns(config);
+	});
+});

--- a/tools/scripts-config-cdn/package.json
+++ b/tools/scripts-config-cdn/package.json
@@ -4,10 +4,13 @@
   "description": "Provide a simple API to inject CDN config into existing webpack configuration",
   "main": "cdn.js",
   "scripts": {
-    "test": "echo \"Nothing to test\""
+    "test": "jest"
   },
   "author": "Talend Frontend <frontend@talend.com> (http://www.talend.com)",
   "license": "Apache-2.0",
+  "devDependencies": {
+    "jest": "^28.1.3"
+  },
   "dependencies": {
     "@talend/dynamic-cdn-webpack-plugin": "^13.0.0",
     "@talend/module-to-cdn": "^9.8.3",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

I have introduced a regression in #4232. Because at webpack bundle time the check over style-versions is done with the same range. This is a constraints and nothing indicate it.

**What is the chosen solution to this problem?**

add test to ensure if you add a style-versions the range has to be aligned.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
