### PR TITLE
fix(playground): Handle datagrid breaking changes

### DIFF
--- a/.changeset/lucky-birds-study.md
+++ b/.changeset/lucky-birds-study.md
@@ -1,0 +1,5 @@
+---
+'@talend/ui-playground': patch
+---
+
+Handle datagrid breaking changes

--- a/packages/playground/src/app/components/DataGrid.js
+++ b/packages/playground/src/app/components/DataGrid.js
@@ -1,16 +1,17 @@
 import React from 'react';
-// eslint-disable-next-line @talend/import-depth
-import data from '@talend/react-datagrid/mocks/sample.json';
-import DataGrid from '@talend/react-datagrid';
+
 import Layout from '@talend/react-components/lib/Layout';
-import SidePanel from '@talend/react-containers/lib/SidePanel';
 import HeaderBar from '@talend/react-containers/lib/HeaderBar';
+import SidePanel from '@talend/react-containers/lib/SidePanel';
+import DataGrid, { DatasetSerializer } from '@talend/react-datagrid';
+// eslint-disable-next-line @talend/import-depth
+import sample from '@talend/react-datagrid/mocks/sample.json';
 
 export function DataGridPlayground() {
 	return (
 		<Layout mode="TwoColumns" one={<SidePanel />} header={<HeaderBar />}>
 			<div style={{ height: '100%' }}>
-				<DataGrid data={data} />
+				<DataGrid columnDefs={DatasetSerializer.getColumnDefs(sample)} rowData={sample.data} />
 			</div>
 		</Layout>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Datagrid props changed in the last version

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
