### PR TITLE
fix(datagrid): Lazy loading use case

### DIFF
--- a/.changeset/slow-mirrors-help.md
+++ b/.changeset/slow-mirrors-help.md
@@ -17,11 +17,10 @@ __API changes:__
 3. [Props] `selection.columnIds`: controlled column selection
 
 __API breaking changes:__
-1. [Props] `avroRenderer` and `onVerticalScroll` removed (not used)
+1. [Props] `avroRenderer` removed (not used)
 2. [Props] `data` and `getRowDataFn` removed: use `rowData` instead (less parsing + cleaner API)
 3. [Props] `cellRenderer`, `headerRenderer`, `pinHeaderRenderer` removed: set `columnDef.cellRenderer` and `columnDef.headerComponent` instead
 4. [Props] `getPinnedColumnDefsFn`, `getColumnDefsFn`, `getValueByCellFn` removed: use `columnDefs` instead
-5. [Export] `DatasetSerializer.parseRow` removed, mapping data is expensive, use `columnDef.valueGetter` instead
 6. [Export] `DatasetSerializer` is no longer export as `Datagrid.components.DatasetSerializer`, use `import { DatasetSerializer } from '@talend/react-datagrid'`
 
 __Deprecations:__

--- a/packages/datagrid/README.md
+++ b/packages/datagrid/README.md
@@ -49,6 +49,7 @@ Here are the main ones:
 | rowSelection  | set the type of selection (single or multiple) | string        | single  |
 | rowData       | pass the row data straight right to ag-grid    | Array         |         |
 | columnsDef    | definition of the columns                      | Array<ColDef> |         |
+| getRowId      | return row identifier, used when updating rows | function      |         |
 
 To support new use cases, new props were added:
 
@@ -59,6 +60,7 @@ To support new use cases, new props were added:
 | loading                  |                                                   | boolean                   | false   |
 | selection                | controlled selection                              | { rowIndexes, columnIds } |         |
 | sizesLocalStorageKey     | Key to use when persisting sizes to local storage | string                    |         |
+| onVerticalScroll         | callback when the grid scroll vertical            | function                  |         |
 
 ## Issue solved with ag-grid
 

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -40,7 +40,7 @@ describe('DataGrid', () => {
 		delete window.AgGridReact;
 	});
 	it('should render a sample', async () => {
-		render(<DataGrid columnDefs={getColumnDefs(sample)} rowData={sample.data} />);
+		render(<DataGrid columnDefs={getColumnDefs(sample.schema)} rowData={sample.data} />);
 		expect(
 			await screen.findByText('Code postal', undefined, {
 				timeout: 10000,
@@ -52,7 +52,7 @@ describe('DataGrid', () => {
 		await Selection.play({ canvasElement: wrapper.baseElement });
 	});
 	it('should highlight cell with the same values', async () => {
-		render(<DataGrid columnDefs={getColumnDefs(sample)} rowData={sample.data} />);
+		render(<DataGrid columnDefs={getColumnDefs(sample.schema)} rowData={sample.data} />);
 		await screen.findByText('Segmentation', undefined, {
 			timeout: 10000,
 		});
@@ -75,7 +75,7 @@ describe('DataGrid', () => {
 		render(
 			<DataGrid
 				sizesLocalStorageKey={LOCAL_STORAGE_KEY}
-				columnDefs={getColumnDefs(sample)}
+				columnDefs={getColumnDefs(sample.schema)}
 				rowData={sample.data}
 			/>,
 		);

--- a/packages/datagrid/src/components/DataGrid/DataGrid.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 
-import { CellFocusedEvent, GridOptions, ColDef, DragStoppedEvent } from 'ag-grid-community';
+import {
+	CellFocusedEvent,
+	GridOptions,
+	ColDef,
+	DragStoppedEvent,
+	BodyScrollEvent,
+} from 'ag-grid-community';
 import { AgGridReact as AgGridReactType } from 'ag-grid-react';
 import classNames from 'classnames';
 
@@ -24,6 +30,10 @@ export type DataGridProps = GridOptions &
 		};
 		/* Key to use when persisting sizes to local storage */
 		sizesLocalStorageKey?: string;
+		onVerticalScroll?(
+			event: BodyScrollEvent,
+			indexes: { firstDisplayedRowIndex: number; lastDisplayedRowIndex: number },
+		): void;
 	};
 
 const AgGridReact = React.lazy(() =>
@@ -46,6 +56,7 @@ export default function DataGrid({
 	columnDefs,
 	selection,
 	sizesLocalStorageKey,
+	onVerticalScroll,
 	...props
 }: DataGridProps): JSX.Element {
 	const gridRef = useRef<AgGridReactType>(null);
@@ -91,6 +102,18 @@ export default function DataGrid({
 		}
 	}
 
+	function onBodyScroll(event: BodyScrollEvent) {
+		if (event.direction === 'vertical' && onVerticalScroll) {
+			onVerticalScroll(event, {
+				firstDisplayedRowIndex: event.api.getFirstDisplayedRow(),
+				lastDisplayedRowIndex: event.api.getLastDisplayedRow(),
+			});
+		}
+		if (props.onBodyScroll) {
+			props.onBodyScroll(event);
+		}
+	}
+
 	return (
 		<div className={classNames(theme['td-grid'])}>
 			{loading ? (
@@ -112,6 +135,7 @@ export default function DataGrid({
 						onCellFocused={onCellFocused}
 						context={context.current}
 						onDragStopped={onDragStopped}
+						onBodyScroll={onBodyScroll}
 					/>
 				</React.Suspense>
 			)}

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -53,7 +53,7 @@ const defaultGridProps = {
 	sizesLocalStorageKey: 'sb-grid-sizes',
 	columnSelection: 'multiple' as DataGridProps['columnSelection'],
 	rowData: sample.data.map(parseRow),
-	columnDefs: getColumnDefs(sample),
+	columnDefs: getColumnDefs(sample.schema),
 	onCellFocused: action('onCellFocused'),
 	onSelectionChanged: action('onSelectionChanged'),
 	onColumnSelectionChanged: action('onColumnSelectionChanged'),

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { expect } from '@storybook/jest';
@@ -6,10 +6,11 @@ import { Meta, ComponentStory } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import { ColDef, ICellRendererParams, IHeaderParams } from 'ag-grid-community';
 import cloneDeep from 'lodash/cloneDeep';
+import debounce from 'lodash/debounce';
 
 import sourceSample from '../../../mocks/sample.json';
 import { SELECTED_CELL_CLASS_NAME } from '../../constants';
-import { getColumnDefs } from '../../serializers/datasetSerializer';
+import { getColumnDefs, getRowId, parseRow } from '../../serializers/datasetSerializer';
 import DataGrid, { DataGridProps } from './DataGrid';
 
 // eslint-disable-next-line no-irregular-whitespace
@@ -52,7 +53,7 @@ export default {
 const defaultGridProps = {
 	sizesLocalStorageKey: 'sb-grid-sizes',
 	columnSelection: 'multiple' as DataGridProps['columnSelection'],
-	rowData: sample.data,
+	rowData: sample.data.map(parseRow),
 	columnDefs: getColumnDefs(sample),
 	onCellFocused: action('onCellFocused'),
 	onSelectionChanged: action('onSelectionChanged'),
@@ -118,6 +119,43 @@ export const NoQuality = () => (
 		headerHeight={55}
 	/>
 );
+
+export const LazyLoading = () => {
+	const [state, setState] = useState(defaultGridProps.rowData.slice(0, 50));
+
+	function updateLoadedRow(i: number) {
+		setState(prev => {
+			const updated = [...prev];
+			updated[i] = parseRow({ ...defaultGridProps.rowData[0] }, i);
+			return updated;
+		});
+	}
+
+	return (
+		<DataGrid
+			{...defaultGridProps}
+			rowData={state}
+			getRowId={getRowId}
+			onVerticalScroll={(event, { firstDisplayedRowIndex, lastDisplayedRowIndex }) => {
+				setState(prev => {
+					const updated = [...prev];
+					for (let i = firstDisplayedRowIndex; i < lastDisplayedRowIndex + 9; i++) {
+						if (!updated[i]) {
+							updated[i] = parseRow(
+								{
+									loaded: false,
+								},
+								i,
+							);
+							setTimeout(() => updateLoadedRow(i), 1000);
+						}
+					}
+					return updated;
+				});
+			}}
+		/>
+	);
+};
 
 export const NoRowSpecificMessage = () => (
 	<DataGrid {...defaultGridProps} rowData={[]} overlayNoRowsTemplate="Custom message" />

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { expect } from '@storybook/jest';
@@ -6,7 +6,6 @@ import { Meta, ComponentStory } from '@storybook/react';
 import { within, userEvent } from '@storybook/testing-library';
 import { ColDef, ICellRendererParams, IHeaderParams } from 'ag-grid-community';
 import cloneDeep from 'lodash/cloneDeep';
-import debounce from 'lodash/debounce';
 
 import sourceSample from '../../../mocks/sample.json';
 import { SELECTED_CELL_CLASS_NAME } from '../../constants';

--- a/packages/datagrid/src/serializers/__snapshots__/datasetSerializer.test.ts.snap
+++ b/packages/datagrid/src/serializers/__snapshots__/datasetSerializer.test.ts.snap
@@ -59,7 +59,7 @@ Array [
     "headerName": "Nom de la gare",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field0",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -96,7 +96,7 @@ Array [
     "headerName": "field1",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field1",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -149,7 +149,7 @@ Array [
     "headerName": "Code postal",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field2",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -202,7 +202,7 @@ Array [
     "headerName": "Segmentation",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field3",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -255,7 +255,7 @@ Array [
     "headerName": "voyageurs 2016",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field4",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -308,7 +308,7 @@ Array [
     "headerName": "volume total d'usagers 2016 (voyageurs+ non voyageurs)",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field5",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -345,7 +345,7 @@ Array [
     "headerName": "voyageurs 2015",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field6",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -398,7 +398,7 @@ Array [
     "headerName": "volume total d'usagers 2015 (voyageurs+ non voyageurs)",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field7",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -451,7 +451,7 @@ Array [
     "headerName": "voyageurs 2014",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field8",
+    "valueGetter": [Function],
     "width": 150,
   },
   Object {
@@ -504,7 +504,7 @@ Array [
     "headerName": "volume total d'usagers 2014 (voyageurs+ non voyageurs)",
     "minWidth": 30,
     "resizable": true,
-    "valueGetter": "data.value.field9",
+    "valueGetter": [Function],
     "width": 150,
   },
 ]

--- a/packages/datagrid/src/serializers/datasetSerializer.test.ts
+++ b/packages/datagrid/src/serializers/datasetSerializer.test.ts
@@ -3,7 +3,7 @@ import { getColumnDefs } from './datasetSerializer';
 
 describe('getColumnDefs', () => {
 	it('should returns the columns definitions', () => {
-		const columnDefs = getColumnDefs(sample);
+		const columnDefs = getColumnDefs(sample.schema);
 
 		expect(columnDefs).toMatchSnapshot();
 	});

--- a/packages/datagrid/src/serializers/datasetSerializer.ts
+++ b/packages/datagrid/src/serializers/datasetSerializer.ts
@@ -90,7 +90,8 @@ export const getRowId: GetRowIdFunc = params => params.data.id;
  */
 export const parseRow = (data: any, index: number) => ({
 	...data,
-	id: index,
+	// getRowId needs a string
+	id: index.toString(),
 });
 
 /**

--- a/packages/datagrid/src/serializers/datasetSerializer.ts
+++ b/packages/datagrid/src/serializers/datasetSerializer.ts
@@ -1,4 +1,4 @@
-import { ColDef } from 'ag-grid-community';
+import { ColDef, GetRowIdFunc, ValueGetterFunc } from 'ag-grid-community';
 
 import {
 	QUALITY_EMPTY_KEY,
@@ -78,9 +78,23 @@ export function getQualityValue(type: AvroField['type']) {
 	return type?.[QUALITY_KEY];
 }
 
+const valueGetter: ValueGetterFunc = ({ data, colDef }) => data.value?.[colDef.field!];
+
+/**
+ * Return row identifier, used when updating data
+ */
+export const getRowId: GetRowIdFunc = params => params.data.id;
+
+/**
+ * Add a row identifier
+ */
+export const parseRow = (data: any, index: number) => ({
+	...data,
+	id: index,
+});
+
 /**
  * Return column definitions for a dataset sample
- * @param sample
  */
 export function getColumnDefs(sample: Sample): ColDef[] {
 	return [
@@ -90,7 +104,7 @@ export function getColumnDefs(sample: Sample): ColDef[] {
 			const quality = avroField.type && getQualityValue(avroField.type);
 			return {
 				...DefaultColDef,
-				valueGetter: `data.value.${avroField.name}`,
+				valueGetter: valueGetter,
 				field: avroField.name,
 				headerName: avroField.doc || avroField.name,
 				cellRendererParams: {

--- a/packages/datagrid/src/serializers/datasetSerializer.ts
+++ b/packages/datagrid/src/serializers/datasetSerializer.ts
@@ -7,7 +7,7 @@ import {
 	QUALITY_VALID_KEY,
 } from '../constants';
 import { DefaultColDef, DefaultPinnedColDef } from '../constants/column-definition.constants';
-import { AvroField, Sample } from '../types';
+import { AvroField, Schema } from '../types';
 
 /**
  * check if the type is null
@@ -97,10 +97,10 @@ export const parseRow = (data: any, index: number) => ({
 /**
  * Return column definitions for a dataset sample
  */
-export function getColumnDefs(sample: Sample): ColDef[] {
+export function getColumnDefs(schema: Schema): ColDef[] {
 	return [
 		DefaultPinnedColDef,
-		...sample.schema.fields.map(avroField => {
+		...schema.fields.map(avroField => {
 			const type = sanitizeAvro(avroField);
 			const quality = avroField.type && getQualityValue(avroField.type);
 			return {

--- a/packages/datagrid/src/types/index.ts
+++ b/packages/datagrid/src/types/index.ts
@@ -6,11 +6,14 @@ import { ButtonIcon } from '@talend/design-system';
 
 import { QUALITY_EMPTY_KEY, QUALITY_INVALID_KEY, QUALITY_VALID_KEY } from '../constants';
 
-// Yeah, I know
+// Will get typed later on?
+
+export type Schema = {
+	fields: any[];
+};
+
 export type Sample = {
-	schema: {
-		fields: any[];
-	};
+	schema: Schema;
 	data: any[];
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Lazy loading requires a row identifier, which was missing.
Add it and document use case

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
