### PR TITLE
feat(components): possibility to add icon in HeaderBar

### DIFF
--- a/.changeset/nine-adults-play.md
+++ b/.changeset/nine-adults-play.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat: add HeaderBar and AppSwitcher icon props

--- a/packages/components/src/AppSwitcher/AppSwitcher.component.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.js
@@ -12,13 +12,14 @@ import { getTheme } from '../theme';
 
 const theme = getTheme(AppSwitcherCSSModule);
 
-export default function AppSwitcher({ label, isSeparated, onClick, getComponent, ...props }) {
+export default function AppSwitcher({ label, isSeparated, onClick, getComponent, icon, ...props }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
 	const Renderers = Inject.getAll(getComponent, { Action, ActionDropdown });
 
 	const className = theme('tc-app-switcher-action', {
 		separated: isSeparated,
+		hasIcon: !!icon,
 	});
 
 	let ActionComponent;
@@ -37,7 +38,15 @@ export default function AppSwitcher({ label, isSeparated, onClick, getComponent,
 
 	return (
 		<li role="presentation" className={className}>
-			<span role="heading">
+			{icon && (
+				<style>
+					{`.tc-app-switcher-action [role='heading'] span:first-child:before {
+						-webkit-mask-image: url('${icon}');
+						mask-image: url('${icon}');
+				}`}
+				</style>
+			)}
+			<span role="heading" aria-level="1">
 				<ActionComponent
 					bsStyle="link"
 					className={theme('tc-app-switcher')}
@@ -56,6 +65,7 @@ AppSwitcher.propTypes = {
 	label: PropTypes.string,
 	isSeparated: PropTypes.bool,
 	items: PropTypes.arrayOf(PropTypes.object),
+	icon: PropTypes.string,
 	onClick: PropTypes.func,
 	getComponent: PropTypes.func,
 };

--- a/packages/components/src/AppSwitcher/AppSwitcher.component.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.js
@@ -12,14 +12,21 @@ import { getTheme } from '../theme';
 
 const theme = getTheme(AppSwitcherCSSModule);
 
-export default function AppSwitcher({ label, isSeparated, onClick, getComponent, icon, ...props }) {
+export default function AppSwitcher({
+	label,
+	isSeparated,
+	onClick,
+	getComponent,
+	iconUrl,
+	...props
+}) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
 	const Renderers = Inject.getAll(getComponent, { Action, ActionDropdown });
 
 	const className = theme('tc-app-switcher-action', {
 		separated: isSeparated,
-		hasIcon: !!icon,
+		hasIcon: !!iconUrl,
 	});
 
 	let ActionComponent;
@@ -38,11 +45,11 @@ export default function AppSwitcher({ label, isSeparated, onClick, getComponent,
 
 	return (
 		<li role="presentation" className={className}>
-			{icon && (
+			{iconUrl && (
 				<style>
 					{`.tc-app-switcher-action [role='heading'] span:first-child:before {
-						-webkit-mask-image: url('${icon}');
-						mask-image: url('${icon}');
+						-webkit-mask-image: url('${iconUrl}');
+						mask-image: url('${iconUrl}');
 				}`}
 				</style>
 			)}
@@ -65,7 +72,7 @@ AppSwitcher.propTypes = {
 	label: PropTypes.string,
 	isSeparated: PropTypes.bool,
 	items: PropTypes.arrayOf(PropTypes.object),
-	icon: PropTypes.string,
+	iconUrl: PropTypes.string,
 	onClick: PropTypes.func,
 	getComponent: PropTypes.func,
 };

--- a/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
@@ -69,7 +69,7 @@ describe('AppSwitcher', () => {
 			id: 'brand',
 			label: 'My App',
 			onClick: jest.fn(),
-			icon: 'test.jpg',
+			iconUrl: 'test.jpg',
 		};
 		const wrapper = mount(<AppSwitcher {...brand} />);
 

--- a/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
+++ b/packages/components/src/AppSwitcher/AppSwitcher.component.test.js
@@ -63,4 +63,16 @@ describe('AppSwitcher', () => {
 
 		expect(wrapper.find('li').prop('className').includes('separated')).toBeTruthy();
 	});
+
+	it('should render an icon', () => {
+		const brand = {
+			id: 'brand',
+			label: 'My App',
+			onClick: jest.fn(),
+			icon: 'test.jpg',
+		};
+		const wrapper = mount(<AppSwitcher {...brand} />);
+
+		expect(wrapper.find('li').prop('className').includes('hasIcon')).toBeTruthy();
+	});
 });

--- a/packages/components/src/AppSwitcher/AppSwitcher.scss
+++ b/packages/components/src/AppSwitcher/AppSwitcher.scss
@@ -12,7 +12,7 @@
 	height: 100%;
 	white-space: nowrap;
 
-	&.separated:not(:last-child):after {
+	&.separated:not(:last-child)::after {
 		content: ' ';
 		display: block;
 		width: 1px;
@@ -26,10 +26,10 @@
 				display: inline-flex;
 				align-items: center;
 
-				&:before {
+				&::before {
 					display: block;
 					content: '';
-					margin-right: $padding-small;
+					margin-right: $padding-smaller;
 					height: $navbar-brand-logo-height;
 					width: $navbar-brand-logo-height;
 					background-repeat: no-repeat;
@@ -38,7 +38,7 @@
 			}
 
 			svg + span:first-child {
-				&:before {
+				&::before {
 					display: none;
 				}
 			}

--- a/packages/components/src/AppSwitcher/AppSwitcher.scss
+++ b/packages/components/src/AppSwitcher/AppSwitcher.scss
@@ -19,4 +19,29 @@
 		height: $font-size-large;
 		background-color: $white;
 	}
+
+	&.hasIcon {
+		[role='heading'] {
+			span:first-child {
+				display: inline-flex;
+				align-items: center;
+
+				&:before {
+					display: block;
+					content: '';
+					margin-right: $padding-small;
+					height: $navbar-brand-logo-height;
+					width: $navbar-brand-logo-height;
+					background-repeat: no-repeat;
+					background-color: white;
+				}
+			}
+
+			svg + span:first-child {
+				&:before {
+					display: none;
+				}
+			}
+		}
+	}
 }

--- a/packages/components/src/AppSwitcher/__snapshots__/AppSwitcher.component.test.js.snap
+++ b/packages/components/src/AppSwitcher/__snapshots__/AppSwitcher.component.test.js.snap
@@ -4,7 +4,9 @@ exports[`AppSwitcher should render the products 1`] = `
 <li role="presentation"
     class="tc-app-switcher-action theme-tc-app-switcher-action"
 >
-  <span role="heading">
+  <span role="heading"
+        aria-level="1"
+  >
     <div class="dropdown btn-group btn-group-link">
       <button aria-label="Switch to another application. Current application: My App"
               id="brand"

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -249,12 +249,7 @@ function HeaderBar(props) {
 				{props.logo && (
 					<Components.Logo getComponent={props.getComponent} {...props.logo} t={props.t} />
 				)}
-				<AppSwitcherComponent
-					{...props.brand}
-					{...props.products}
-					icon={props.appSwitcherIcon}
-					isSeparated={!!props.env}
-				/>
+				<AppSwitcherComponent {...props.brand} {...props.products} isSeparated={!!props.env} />
 				{props.env && <Components.Environment getComponent={props.getComponent} {...props.env} />}
 			</ul>
 			<ul className={theme('tc-header-bar-actions', 'navbar-nav', 'right')}>
@@ -395,8 +390,9 @@ if (process.env.NODE_ENV !== 'production') {
 			renderers: PropTypes.shape({
 				Action: PropTypes.func,
 			}),
+			icon: PropTypes.string,
+			iconUrl: PropTypes.string,
 		}),
-		appSwitcherIcon: PropTypes.string,
 		env: PropTypes.shape(Environment.propTypes),
 		callToAction: PropTypes.shape(CallToAction.propTypes),
 		search: PropTypes.shape(Search.propTypes),

--- a/packages/components/src/HeaderBar/HeaderBar.component.js
+++ b/packages/components/src/HeaderBar/HeaderBar.component.js
@@ -249,7 +249,12 @@ function HeaderBar(props) {
 				{props.logo && (
 					<Components.Logo getComponent={props.getComponent} {...props.logo} t={props.t} />
 				)}
-				<AppSwitcherComponent {...props.brand} {...props.products} isSeparated={!!props.env} />
+				<AppSwitcherComponent
+					{...props.brand}
+					{...props.products}
+					icon={props.appSwitcherIcon}
+					isSeparated={!!props.env}
+				/>
 				{props.env && <Components.Environment getComponent={props.getComponent} {...props.env} />}
 			</ul>
 			<ul className={theme('tc-header-bar-actions', 'navbar-nav', 'right')}>
@@ -391,6 +396,7 @@ if (process.env.NODE_ENV !== 'production') {
 				Action: PropTypes.func,
 			}),
 		}),
+		appSwitcherIcon: PropTypes.string,
 		env: PropTypes.shape(Environment.propTypes),
 		callToAction: PropTypes.shape(CallToAction.propTypes),
 		search: PropTypes.shape(Search.propTypes),

--- a/packages/components/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/components/src/HeaderBar/HeaderBar.stories.js
@@ -7,7 +7,7 @@ import Immutable from 'immutable'; // eslint-disable-line import/no-extraneous-d
 import Icon from '../Icon';
 import HeaderBar from './HeaderBar.component';
 import AppSwitcher from '../AppSwitcher';
-import Layout from '../Layout';
+import assetsApi from '@talend/assets-api';
 
 const props = {
 	brand: {
@@ -144,6 +144,19 @@ export const WithoutProducts = () => {
 
 WithoutProducts.story = {
 	name: 'without products',
+	parameters: { info: { styles: infoStyle } },
+};
+
+export const WithAppSwitcherIcon = () => {
+	const headerProps = Immutable.fromJS({
+		...props,
+		appSwitcherIcon: assetsApi.getURL('/src/svg/products/tmc-negative.svg', '@talend/icons'),
+	}).toJS();
+	return <HeaderBar {...headerProps} />;
+};
+
+WithAppSwitcherIcon.story = {
+	name: 'with app switcher icon',
 	parameters: { info: { styles: infoStyle } },
 };
 

--- a/packages/components/src/HeaderBar/HeaderBar.stories.js
+++ b/packages/components/src/HeaderBar/HeaderBar.stories.js
@@ -147,16 +147,35 @@ WithoutProducts.story = {
 	parameters: { info: { styles: infoStyle } },
 };
 
-export const WithAppSwitcherIcon = () => {
+export const WithBrandIcon = () => {
 	const headerProps = Immutable.fromJS({
 		...props,
-		appSwitcherIcon: assetsApi.getURL('/src/svg/products/tmc-negative.svg', '@talend/icons'),
+		brand: {
+			...props.brand,
+			icon: 'talend-tmc-positive',
+		},
 	}).toJS();
 	return <HeaderBar {...headerProps} />;
 };
 
-WithAppSwitcherIcon.story = {
-	name: 'with app switcher icon',
+WithBrandIcon.story = {
+	name: 'with brand icon',
+	parameters: { info: { styles: infoStyle } },
+};
+
+export const WithBrandIconUrl = () => {
+	const headerProps = Immutable.fromJS({
+		...props,
+		brand: {
+			...props.brand,
+			iconUrl: assetsApi.getURL('/src/svg/products/tmc-negative.svg', '@talend/icons'),
+		},
+	}).toJS();
+	return <HeaderBar {...headerProps} />;
+};
+
+WithBrandIconUrl.story = {
+	name: 'with brand icon url',
 	parameters: { info: { styles: infoStyle } },
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Following the removal of theme scss styles from webpack , we need the possibility to add icons in SidePanel and HeaderBar components

**What is the chosen solution to this problem?**
Add an `appSwitcherIcon` props to HeaderBar component

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
