### PR TITLE
fix(datagrid): Controlled selection is ignored on mount

### DIFF
--- a/.changeset/clean-dodos-teach.md
+++ b/.changeset/clean-dodos-teach.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Controlled seleciton is ignored on mount

--- a/packages/datagrid/src/components/DataGrid/DataGrid.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.tsx
@@ -24,10 +24,6 @@ export type DataGridProps = GridOptions &
 	GridColumnSelectionProps & {
 		/* Shows loader icons instead of grid */
 		loading?: boolean;
-		/* Controlled selection, handling only columns for now */
-		selection?: {
-			columnIds?: string[];
-		};
 		/* Key to use when persisting sizes to local storage */
 		sizesLocalStorageKey?: string;
 		onVerticalScroll?(
@@ -54,7 +50,6 @@ function DataGridSkeleton() {
 export default function DataGrid({
 	loading,
 	columnDefs,
-	selection,
 	sizesLocalStorageKey,
 	onVerticalScroll,
 	...props
@@ -83,14 +78,6 @@ export default function DataGrid({
 			},
 		}));
 	}, [columnDefs, onHeaderFocus, sizesLocalStorageKey]);
-
-	// Handle controlled selection
-	const controlledColumnIds = selection?.columnIds;
-	useEffect(() => {
-		if (controlledColumnIds) {
-			setSelectedColumns(controlledColumnIds);
-		}
-	}, [controlledColumnIds]);
 
 	// Add size persistence support
 	function onDragStopped(event: DragStoppedEvent) {

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -64,14 +64,23 @@ const Template: ComponentStory<typeof DataGrid> = args => <DataGrid {...args} />
 export const Default = () => <DataGrid {...defaultGridProps} />;
 
 export const Selection = Template.bind({});
-Selection.args = defaultGridProps;
+Selection.args = {
+	...defaultGridProps,
+	selection: {
+		columnIds: [sample.schema.fields[0].name],
+	},
+};
 Selection.play = async ({ canvasElement }) => {
 	const canvas = within(canvasElement);
-	await userEvent.click(
-		await canvas.findByText('field1', undefined, {
-			timeout: 10000,
-		}),
-	);
+	await expect(
+		(
+			await canvas.findByText('Nom de la gare', undefined, {
+				timeout: 10000,
+			})
+		).closest('.ag-header-cell'),
+	).toHaveClass(SELECTED_CELL_CLASS_NAME);
+	await sleep();
+	await userEvent.click(canvas.getByText('field1'));
 	await sleep();
 	await userEvent.click(await canvas.findByText('voyageurs 2016'), {
 		shiftKey: true,

--- a/packages/datagrid/src/components/DataGrid/useColumnSelection.hook.ts
+++ b/packages/datagrid/src/components/DataGrid/useColumnSelection.hook.ts
@@ -10,13 +10,17 @@ export interface GridColumnSelectionProps {
 	/* Enable ctrl/shift modifier on column header, default: 'single' */
 	columnSelection?: 'single' | 'multiple';
 	onColumnSelectionChanged?(params: { columnIds: string[] }): void;
+	/* Controlled selection, handling only columns for now */
+	selection?: {
+		columnIds?: string[];
+	};
 }
 
 export function useColumnSelection(
 	gridRef: RefObject<AgGridReact>,
-	{ columnSelection = 'single', onColumnSelectionChanged }: GridColumnSelectionProps,
+	{ columnSelection = 'single', onColumnSelectionChanged, selection }: GridColumnSelectionProps,
 ) {
-	const [selectedColumns, setSelectedColumns] = useState<string[]>([]);
+	const [selectedColumns, setSelectedColumns] = useState<string[]>(selection?.columnIds ?? []);
 
 	function updateSelectionOnCellFocus(event: CellFocusedEvent) {
 		// filter event triggered by clearFocusedCell
@@ -54,9 +58,17 @@ export function useColumnSelection(
 		[setSelectedColumns, columnSelection],
 	);
 
+	// Handle controlled selection
+	const controlledColumnIds = selection?.columnIds;
+	useEffect(() => {
+		if (controlledColumnIds) {
+			setSelectedColumns(controlledColumnIds);
+		}
+	}, [controlledColumnIds]);
+
 	// Force style update when selection changed
 	useEffect(() => {
-		if (gridRef.current) {
+		if (gridRef.current?.api) {
 			const previousSelection = gridRef.current.props.context.selectedColumns;
 			gridRef.current.props.context.selectedColumns = selectedColumns;
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When providing a column selection on mount. the column is not highlighted.
The selection is not provided as the default state value

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
