### PR TITLE
feat(datagrid): Add cell context to editor onSubmit callback

### DIFF
--- a/.changeset/warm-horses-tap.md
+++ b/.changeset/warm-horses-tap.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': minor
+---
+
+Add cell context to editor onSubmit callback

--- a/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
@@ -123,7 +123,12 @@ function PlaygroundCellEditor(
 							onCancel={onCancel}
 							onSubmit={(applyToValues: boolean) => {
 								stopEditing();
-								onSubmit(state, applyToValues);
+								onSubmit(state, applyToValues, {
+									rowIndex: props.rowIndex,
+									data: props.data,
+									column: props.column,
+									value,
+								});
 							}}
 						/>
 					</div>

--- a/packages/datagrid/src/types/index.ts
+++ b/packages/datagrid/src/types/index.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Column } from 'ag-grid-community';
+import { Column, ICellEditorParams } from 'ag-grid-community';
 
 import { ButtonIcon } from '@talend/design-system';
 
@@ -52,7 +52,11 @@ export type SemanticType = {
 export type CellEditorParams = {
 	getSemanticType(semanticType: string): Promise<SemanticType>;
 	getSemanticTypeSuggestions(event: Event, search: string): Promise<string[]>;
-	onSubmit(value: string, applyToAll: boolean): void;
+	onSubmit(
+		value: string,
+		applyToAll: boolean,
+		cellParams: Pick<ICellEditorParams, 'data' | 'rowIndex' | 'column' | 'value'>,
+	): void;
 };
 
 export type HeaderClickParams = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When submitting a new cell value, we don't have direct access to it's rowIndex, we need to get the focused column.

**What is the chosen solution to this problem?**

Add a third param with the context

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
