### PR TITLE
fix(scripts/sentry): fix inconsistent sentry release version

### DIFF
--- a/.changeset/lucky-insects-kiss.md
+++ b/.changeset/lucky-insects-kiss.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix(scripts/sentry): fix inconsistent sentry release version

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -345,7 +345,7 @@ module.exports = ({ getUserConfig, mode }) => {
 						// see https://docs.sentry.io/platforms/node/guides/aws-lambda/sourcemaps/uploading/webpack/
 						org: sentryConfig.org || process.env.SENTRY_ORG || 'talend-0u',
 						project: sentryConfig.project || process.env.SENTRY_PROJECT,
-						release: VERSIONS.version,
+						release: `${meta['app-id']}@${VERSIONS.version}`,
 						include: sentryConfig.include || ['dist/'],
 						ignore: sentryConfig.ignore || ['cdn/'],
 					}),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
the sentry release version is not same with the one in initiator

**What is the chosen solution to this problem?**
use the same release version when build release.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
