### PR TITLE
feat: addToIgnorePatterns

### DIFF
--- a/.changeset/stale-carpets-wait.md
+++ b/.changeset/stale-carpets-wait.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': minor
+---
+
+feat: addToIgnorePatterns to extend the config

--- a/.changeset/stale-carpets-wait.md
+++ b/.changeset/stale-carpets-wait.md
@@ -2,4 +2,4 @@
 '@talend/scripts-config-jest': minor
 ---
 
-feat: addToIgnorePatterns to extend the config
+feat: add applyBabelTransformOn support to extend the jest config

--- a/tools/scripts-config-jest/README.md
+++ b/tools/scripts-config-jest/README.md
@@ -24,7 +24,7 @@ Since d3 7.x library use ECMAPScriptModules in it's package.json as main entry p
 
 ```
 
-You may encounter in your project the neeed to add other modules than just d3. To do so we provide to you the following API:
+You may encounter in your project the need to add other modules than just d3. To do so we provide to you the following API:
 
 ```javascript
 // your project's jest.config.js

--- a/tools/scripts-config-jest/README.md
+++ b/tools/scripts-config-jest/README.md
@@ -15,7 +15,7 @@ module.exports = {
 };
 ```
 
-## how stop ignore transform over node_modules
+## how stop ignore transform over packages in node_modules
 
 because jest support of [ECMAPScriptModules](https://github.com/facebook/jest/blob/64de4d7361367fd711a231d25c37f3be89564264/docs/ECMAScriptModules.md) is experiemental we have added possibilities to apply transforms on modules.
 Since d3 7.x library use ECMAPScriptModules in it's package.json as main entry point it break jest with this kind of errors:
@@ -31,7 +31,7 @@ You may encounter in your project the neeed to add other modules than just d3. T
 const config = require('@talend/scripts-config-jest/jest.config.js');
 const testUtils = require('@talend/scripts-config-jest/utils');
 
-testUtils.addToIgnorePatterns(config, ['dexie']);
+testUtils.applyBabelTransformOn(config, ['dexie']);
 
 module.exports = config;
 ```

--- a/tools/scripts-config-jest/README.md
+++ b/tools/scripts-config-jest/README.md
@@ -21,7 +21,10 @@ because jest support of [ECMAPScriptModules](https://github.com/facebook/jest/bl
 Since d3 7.x library use ECMAPScriptModules in it's package.json as main entry point it break jest with this kind of errors:
 
 ```
-
+node_modules/d3-scale/src/index.js:1
+export {
+^
+ParseError: 'import' and 'export' may appear only with 'sourceType: module'
 ```
 
 You may encounter in your project the need to add other modules than just d3. To do so we provide to you the following API:

--- a/tools/scripts-config-jest/README.md
+++ b/tools/scripts-config-jest/README.md
@@ -14,3 +14,24 @@ module.exports = {
 	// add/change default config here
 };
 ```
+
+## how stop ignore transform over node_modules
+
+because jest support of [ECMAPScriptModules](https://github.com/facebook/jest/blob/64de4d7361367fd711a231d25c37f3be89564264/docs/ECMAScriptModules.md) is experiemental we have added possibilities to apply transforms on modules.
+Since d3 7.x library use ECMAPScriptModules in it's package.json as main entry point it break jest with this kind of errors:
+
+```
+
+```
+
+You may encounter in your project the neeed to add other modules than just d3. To do so we provide to you the following API:
+
+```javascript
+// your project's jest.config.js
+const config = require('@talend/scripts-config-jest/jest.config.js');
+const testUtils = require('@talend/scripts-config-jest/utils');
+
+testUtils.addToIgnorePatterns(config, ['dexie']);
+
+module.exports = config;
+```

--- a/tools/scripts-config-jest/jest.config.js
+++ b/tools/scripts-config-jest/jest.config.js
@@ -60,6 +60,9 @@ module.exports = {
 	transformIgnorePatterns: [
 		// option 2, stop ignore transform on es6 packages
 		`/node_modules/(?!${d3Pkgs.join('|')}|internmap|d3-delaunay|delaunator|robust-predicates)`,
+		// we can't have it twice (double negative patterns cancel each other),
+		// so you can import addToIgnorePatterns from './utils' to add more pkgs
+
 		// option 3, stop ignore transform on all node_modules
 		// `/node_modules/(?!.*)`,
 	],

--- a/tools/scripts-config-jest/jest.config.js
+++ b/tools/scripts-config-jest/jest.config.js
@@ -59,7 +59,9 @@ module.exports = {
 	// stop ignore node_modules transform since d3 and others start to put es6 as main of packages
 	transformIgnorePatterns: [
 		// option 2, stop ignore transform on es6 packages
-		`/node_modules/(?!${d3Pkgs.join('|')}|internmap|d3-delaunay|delaunator|robust-predicates)`,
+		`/node_modules/(?!${d3Pkgs.join(
+			'|',
+		)}|internmap|d3-delaunay|delaunator|robust-predicates|@talend/tql/index)`,
 		// we can't have it twice (double negative patterns cancel each other),
 		// so you can import addToIgnorePatterns from './utils' to add more pkgs
 

--- a/tools/scripts-config-jest/utils.js
+++ b/tools/scripts-config-jest/utils.js
@@ -1,4 +1,4 @@
-function addToIgnorePatterns(config, pkgs) {
+function applyBabelTransformOn(config, pkgs) {
 	config.transformIgnorePatterns[0] = config.transformIgnorePatterns[0].replace(
 		')',
 		`|${pkgs.join('|')})`,
@@ -6,5 +6,5 @@ function addToIgnorePatterns(config, pkgs) {
 }
 
 module.exports = {
-	addToIgnorePatterns,
+	applyBabelTransformOn,
 };

--- a/tools/scripts-config-jest/utils.js
+++ b/tools/scripts-config-jest/utils.js
@@ -1,0 +1,10 @@
+function addToIgnorePatterns(config, pkgs) {
+	config.transformIgnorePatterns[0] = config.transformIgnorePatterns[0].replace(
+		')',
+		`|${pkgs.join('|')})`,
+	);
+}
+
+module.exports = {
+	addToIgnorePatterns,
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

this configuration in your jest.config will break config related to d3

```javascript
       transformIgnorePatterns: [
               '/node_modules/(?!PKG_NAME)$',
       ],
 ```

because it is a double negation (ignore !d3 || ignore !PKG_NAME) so this one will make d3 ignored!

**What is the chosen solution to this problem?**

add API to be able to concat pkgs to that DO NOT ignore pattern

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
