### PR TITLE
feat(design-system/TUX-1175): Use a single hook for every ClickToCopy element

### DIFF
--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/BreakpointScale/BreakpointScale.tsx
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/BreakpointScale/BreakpointScale.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useRef } from 'react';
 import classnames from 'classnames';
 import { useOverflow } from 'use-overflow';
 
@@ -7,34 +7,12 @@ import { getScssName } from '../../../TokenFormatter';
 import { SizedIcon, Tooltip } from '../../../../../../src';
 
 import styles from './BreakpointScale.module.scss';
+import useCopyValue from '../DefinitionListItem/useCopyValue';
 
 function BreakpointBlock({ token }: { token: Token }) {
-	const [isCopied, setIsCopied] = useState(false);
+	const { copy, isCopied } = useCopyValue();
 	const horizontalRef = useRef(null);
 	const { refXOverflowing, refXScrollBegin, refXScrollEnd } = useOverflow(horizontalRef);
-	console.log({ refXOverflowing, refXScrollBegin, refXScrollEnd });
-
-	const handleCopy = useCallback(() => {
-		if (navigator.clipboard) {
-			navigator.clipboard
-				.writeText(getScssName(token?.name))
-				.then(() => {
-					setIsCopied(true);
-				})
-				.catch(err => {
-					// eslint-disable-next-line no-console
-					console.log('Something went wrong', err);
-				});
-		}
-	}, [getScssName(token?.name)]);
-
-	useEffect(() => {
-		if (isCopied) {
-			setTimeout(() => {
-				setIsCopied(false);
-			}, 5000);
-		}
-	}, [isCopied]);
 
 	return (
 		<>
@@ -45,7 +23,7 @@ function BreakpointBlock({ token }: { token: Token }) {
 				}
 			>
 				<button
-					onClick={handleCopy}
+					onClick={() => copy(getScssName(token?.name))}
 					className={classnames(styles.breakpointScale_element, {
 						[styles.breakpointScale_element__overflowRight]: refXOverflowing && !refXScrollEnd,
 						[styles.breakpointScale_element__overflowLeft]: refXOverflowing && !refXScrollBegin,

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/ColorScale/ColorScale.tsx
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/ColorScale/ColorScale.tsx
@@ -1,35 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import classnames from 'classnames';
 import { ColorToken, Token } from '../../../../../../src/tokens/types';
 import { getScssName } from '../../../TokenFormatter';
 import { SizedIcon, Tooltip } from '../../../../../../src';
 
 import styles from './ColorScale.module.scss';
+import useCopyValue from '../DefinitionListItem/useCopyValue';
 
 function ColorBlock({ token }: { token: Token }) {
-	const [isCopied, setIsCopied] = useState(false);
-
-	const handleCopy = useCallback(() => {
-		if (navigator.clipboard) {
-			navigator.clipboard
-				.writeText(getScssName(token?.name))
-				.then(() => {
-					setIsCopied(true);
-				})
-				.catch(err => {
-					// eslint-disable-next-line no-console
-					console.log('Something went wrong', err);
-				});
-		}
-	}, [getScssName(token?.name)]);
-
-	useEffect(() => {
-		if (isCopied) {
-			setTimeout(() => {
-				setIsCopied(false);
-			}, 5000);
-		}
-	}, [isCopied]);
+	const { copy, isCopied } = useCopyValue();
 
 	return (
 		<>
@@ -38,7 +17,7 @@ function ColorBlock({ token }: { token: Token }) {
 				title={<span className={styles.colorScale_tooltip}>Copy {getScssName(token?.name)}</span>}
 			>
 				<button
-					onClick={handleCopy}
+					onClick={() => copy(getScssName(token?.name))}
 					className={styles.colorScale_element}
 					style={{ backgroundColor: token.value }}
 				>

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/DefinitionListItem/CopyValue.tsx
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/DefinitionListItem/CopyValue.tsx
@@ -1,35 +1,15 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { SizedIcon } from '../../../../../../src/components/Icon';
 import classnames from 'classnames';
 
 import styles from './CopyValue.module.scss';
+import useCopyValue from './useCopyValue';
 
 function CopyValue({ children }: { children: string }) {
-	const [isCopied, setIsCopied] = useState(false);
-	const handleCopy = useCallback(() => {
-		if (navigator.clipboard) {
-			navigator.clipboard
-				.writeText(children)
-				.then(() => {
-					setIsCopied(true);
-				})
-				.catch(err => {
-					// eslint-disable-next-line no-console
-					console.error('Something went wrong', err);
-				});
-		}
-	}, [children]);
-
-	useEffect(() => {
-		if (isCopied) {
-			setTimeout(() => {
-				setIsCopied(false);
-			}, 5000);
-		}
-	}, [isCopied]);
+	const { copy, isCopied } = useCopyValue();
 
 	return (
-		<button onClick={handleCopy} className={styles.copyButton}>
+		<button onClick={() => copy(children)} className={styles.copyButton}>
 			<span className={styles.icons}>
 				<span className={classnames(styles.copyIcon, { [styles.copyIcon_hidden]: isCopied })}>
 					<SizedIcon size="S" name="copy" />

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/DefinitionListItem/useCopyValue.tsx
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/DefinitionListItem/useCopyValue.tsx
@@ -1,0 +1,29 @@
+import React, { useEffect, useState } from 'react';
+
+export default function useCopyValue() {
+	const [isCopied, setIsCopied] = useState(false);
+
+	useEffect(() => {
+		if (isCopied) {
+			setTimeout(() => {
+				setIsCopied(false);
+			}, 5000);
+		}
+	}, [isCopied]);
+
+	const copy = (value: string) => {
+		if (navigator.clipboard) {
+			navigator.clipboard
+				.writeText(value)
+				.then(() => {
+					setIsCopied(true);
+				})
+				.catch(err => {
+					// eslint-disable-next-line no-console
+					console.error('Something went wrong', err);
+				});
+		}
+	};
+
+	return { copy, isCopied };
+}

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/SizingScale/SizingScale.tsx
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/SizingScale/SizingScale.tsx
@@ -1,35 +1,14 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import { Token } from '../../../../../../src/tokens/types';
 
 import styles from './SizingScale.module.scss';
 import { getScssName } from '../../../TokenFormatter';
 import classnames from 'classnames';
 import { SizedIcon, Tooltip } from '../../../../../../src';
+import useCopyValue from '../DefinitionListItem/useCopyValue';
 
 function SizeBlock({ token }: { token: Token }) {
-	const [isCopied, setIsCopied] = useState(false);
-
-	const handleCopy = useCallback(() => {
-		if (navigator.clipboard) {
-			navigator.clipboard
-				.writeText(getScssName(token?.name))
-				.then(() => {
-					setIsCopied(true);
-				})
-				.catch(err => {
-					// eslint-disable-next-line no-console
-					console.log('Something went wrong', err);
-				});
-		}
-	}, [getScssName(token?.name)]);
-
-	useEffect(() => {
-		if (isCopied) {
-			setTimeout(() => {
-				setIsCopied(false);
-			}, 5000);
-		}
-	}, [isCopied]);
+	const { copy, isCopied } = useCopyValue();
 
 	return (
 		<>
@@ -38,7 +17,7 @@ function SizeBlock({ token }: { token: Token }) {
 				title={<span className={styles.sizingScale_tooltip}>Copy {getScssName(token?.name)}</span>}
 			>
 				<button
-					onClick={handleCopy}
+					onClick={() => copy(getScssName(token?.name))}
 					className={styles.sizingScale_element}
 					style={{ width: token.value, height: token.value }}
 				>

--- a/packages/storybook-docs/src/globalStyles.scss
+++ b/packages/storybook-docs/src/globalStyles.scss
@@ -221,6 +221,7 @@ html {
 
   .sbdocs-hr {
     border-top: tokens.$coral-border-s-solid tokens.$coral-color-neutral-border-weak;
+    margin: 0 0 tokens.$coral-spacing-m 0;
   }
 
   .sbdocs-h1,
@@ -288,7 +289,11 @@ html {
   }
 
   .sbdocs-p {
-    margin-bottom: tokens.$coral-spacing-xs;
+    margin-bottom: tokens.$coral-spacing-m;
+
+    + .sbdocs-p {
+      margin-top: calc(#{tokens.$coral-spacing-xs} * -1);
+    }
 
     code {
       font: tokens.$coral-data-m;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Copy behavior was duplicated in the tokens doc pages

**What is the chosen solution to this problem?**
Write it as a single hook

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
