### PR TITLE
fix(webpack): css-loader filter url

### DIFF
--- a/.changeset/serious-apricots-refuse.md
+++ b/.changeset/serious-apricots-refuse.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix: do not handle css with url(/foo)

--- a/.changeset/serious-apricots-refuse.md
+++ b/.changeset/serious-apricots-refuse.md
@@ -3,3 +3,5 @@
 ---
 
 fix: do not handle css with url(/foo)
+
+breaking change: drop support for html-loader

--- a/tools/scripts-config-react-webpack/config/webpack.config.common.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.common.js
@@ -36,6 +36,15 @@ function getCommonStyleLoaders(enableModules, mode) {
 			importLoaders: 1,
 		};
 	}
+	// Don't handle images under root
+	//https://webpack.js.org/loaders/css-loader/#url
+	cssOptions.url = (url, resourcePath) => {
+		if (resourcePath.startsWith('/')) {
+			return false;
+		}
+
+		return true;
+	};
 	return [
 		{ loader: MiniCssExtractPlugin.loader, options: { esModule: false } },
 		{ loader: 'css-loader', options: cssOptions },

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -279,22 +279,6 @@ module.exports = ({ getUserConfig, mode }) => {
 						use: getJSAndTSLoader(env, useTypescript),
 					},
 					{
-						test: /\.html$/,
-						use: [
-							!process.env.NO_CACHE_LOADER && { loader: 'cache-loader' },
-							{
-								loader: 'html-loader',
-								options: {
-									minimize: {
-										removeComments: true,
-										collapseWhitespace: true,
-									},
-								},
-							},
-						].filter(Boolean),
-						exclude: indexTemplatePath,
-					},
-					{
 						test: /\.css$/,
 						use: getCommonStyleLoaders(false, mode),
 						exclude: /@talend/,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

if your css / scss rely on a file that is in your assets folder it fails

**What is the chosen solution to this problem?**

exclude the parsing of those url and let the current url be the final one

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
