### PR TITLE
fix(preset-storybook): angular xlts packages can't be fetched from unpkg.com

### DIFF
--- a/.changeset/neat-birds-sleep.md
+++ b/.changeset/neat-birds-sleep.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+angular xlts packages can't be fetched from unpkg.com

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -95,7 +95,7 @@ const defaultMain = {
 					.filter(plugin => !excludedPlugins.some(excludedPlugin => plugin instanceof excludedPlugin)),
 				// use dynamic-cdn-webpack-plugin with default modules
 				new CDNPlugin({
-					exclude: Object.keys(getAllModules()).filter(name => name.startsWith('@talend/'))
+					exclude: Object.keys(getAllModules()).filter(name => name.match(/^(@talend\/|angular)/))
 				}),
 				new MiniCssExtractPlugin({
 					filename: `[name].css`,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

 angular xlts packages can't be fetched from unpkg.com

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
