### PR TITLE
fix(cmf-router): wrong convertion from settings to routes for simple parent routes

### DIFF
--- a/.changeset/short-needles-wave.md
+++ b/.changeset/short-needles-wave.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': patch
+---
+
+fix(cmf-router): wrong convertion from settings to routes for simple parent routes

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ bin/
 *.iml
 *.iws
 out/
+.vscode/
 
 # JavaScript/NodeJS files #
 .npm/

--- a/packages/cmf-router/src/UIRouter.js
+++ b/packages/cmf-router/src/UIRouter.js
@@ -39,7 +39,11 @@ if (process.env.NODE_ENV === 'development') {
 }
 
 function getRouteProps({ path, indexRoute, childRoutes, ...props }, currentpath, isIndex) {
-	const injectProps = { ...props };
+	// Outlet is the children renderer of react-router v6
+	let element = <Outlet key="outlet" />;
+	if (props.component) {
+		element = <Inject {...props}>{childRoutes ? [<Outlet key="outlet" />] : null}</Inject>;
+	}
 	let absPath;
 	// some route has no path (indexRoute for example)
 	if (path) {
@@ -51,15 +55,11 @@ function getRouteProps({ path, indexRoute, childRoutes, ...props }, currentpath,
 			absPath = `${currentpath === '/' ? '' : currentpath}/${path}`;
 		}
 	}
-	if (childRoutes) {
-		// Outlet is the children renderer of react-router v6
-		injectProps.children = [<Outlet key="outlet" />];
-	}
 
 	const routeProps = {
 		path,
 		key: absPath || `${currentpath}index`,
-		element: <Inject {...injectProps} />,
+		element,
 		children: [indexRoute && <Route {...getRouteProps(indexRoute, currentpath, true)} />]
 			.filter(Boolean)
 			.concat(


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`cmf-router` takes all routes and set an `Inject`, but if a route is juste a route that groupe sub-routes, with no components, it will display a banner with non-found component `undefined` in registry.

**What is the chosen solution to this problem?**

We don't put the Inject automatically, but only if we have a component property.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
