### PR TITLE
fix(datagrid):  Unnecessary css important rule use

### DIFF
--- a/.changeset/old-rockets-smell.md
+++ b/.changeset/old-rockets-smell.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Unnecessary css important rule used

--- a/packages/datagrid/src/components/DataGrid/DataGrid.module.scss
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.module.scss
@@ -65,13 +65,13 @@ $td-datagrid-skeleton-height: 9.6rem !default;
 
 	:global(.column-focus),
 	:global(.ag-row-selected) :global(.ag-cell) {
-		// stylelint-disable-next-line
-		background-color: tokens.$coral-color-accent-background-selected !important;
+		--ag-header-cell-hover-background-color: #{tokens.$coral-color-accent-background-selected};
+		--ag-header-cell-moving-background-color: #{tokens.$coral-color-accent-background-selected};
+		background-color: tokens.$coral-color-accent-background-selected;
 	}
 
 	:global(.ag-row-selected) :global(.column-focus) {
-		// stylelint-disable-next-line
-		background-color: tokens.$coral-color-neutral-background !important;
+		background-color: tokens.$coral-color-neutral-background;
 		// stylelint-disable-next-line
 		outline: tokens.$coral-border-m-solid tokens.$coral-color-accent-border !important;
 		outline-offset: -2px;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

CSS used `!important` to override hover color, which makes custom styling difficult on app side, use css variable instead

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
