### PR TITLE
fix(cmf-router): no history listener unregister on new action

### DIFF
--- a/.changeset/beige-bottles-arrive.md
+++ b/.changeset/beige-bottles-arrive.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': patch
+---
+
+fix(cmf-router): no history listener unregister on new action

--- a/packages/cmf-router/src/UIRouter.js
+++ b/packages/cmf-router/src/UIRouter.js
@@ -93,12 +93,10 @@ export function getRouter(history, basename) {
 	function CMFRouter({ action, location, ...props }) {
 		// sync from history to redux
 		React.useEffect(() => {
-			return history.listen(opts => {
-				if (isDifferent(opts, { action, location })) {
-					props.dispatch(onLocationChanged(opts.location, opts.action));
-				}
+			return history.listen((location, action, isFirstRendering = false) => {
+				props.dispatch(onLocationChanged(location, action, isFirstRendering));
 			});
-		}, [location, action]);
+		}, []);
 
 		if (props.routes.path && props.routes.component) {
 			const routeProps = getRouteProps(props.routes, props.routes.path);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In cmf router, there is a useEffect that register a listener on history to sync with redux.
But it unregister at action and location change. So everytime there is a new history push/replace change or location change, it unregister, rerender and register again.

But everything is not synchronous and we end up with time without listener.
A problematic usecase: we go to a route, and the component useEffect triggers an action (redux) that replaces the route, injecting an id. After the url replacement, the component rerenders and uses the id in parameter.
What happens:
- push action to go on the route
- cmf-router useEffect unregisters the history listener because action changed
- route component useEffect triggers the route replace
- the history replace is called but no listener to trigger
- the route component is not rerendered by redux

**What is the chosen solution to this problem?**
Do not unregister the history listener.
It was done like that to compare if the route has "really" changed, but not sure that's a real usecase.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
