### PR TITLE
fix(datagrid): Controlled selection is ignored on mount

### DIFF
--- a/.changeset/lemon-turkeys-relax.md
+++ b/.changeset/lemon-turkeys-relax.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Wait for grid to be initialized before handling controlled selection

--- a/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
+++ b/packages/datagrid/src/components/DataGrid/DataGrid.test.tsx
@@ -8,7 +8,7 @@ import { Grid as agGrid } from 'ag-grid-community';
 import { AgGridReact, AgGridColumn } from 'ag-grid-react';
 
 import sample from '../../../mocks/sample.json';
-import { HIGHLIGHTED_CELL_CLASS_NAME } from '../../constants';
+import { HIGHLIGHTED_CELL_CLASS_NAME, SELECTED_CELL_CLASS_NAME } from '../../constants';
 import { getColumnDefs } from '../../serializers/datasetSerializer';
 import DataGrid from './DataGrid';
 import * as stories from './Datagrid.stories';
@@ -22,7 +22,7 @@ declare global {
 	}
 }
 
-const { Selection } = composeStories(stories);
+const { Selection, ControlledSelection } = composeStories(stories);
 
 jest.mock('ally.js');
 
@@ -85,5 +85,34 @@ describe('DataGrid', () => {
 		});
 
 		expect(getComputedStyle(cell.closest('.ag-header-cell')!).width).toEqual('789px');
+	});
+	it('should set controlled column selection', async () => {
+		const onColumnSelectionChanged = jest.fn();
+		const wrapper = render(
+			<ControlledSelection onColumnSelectionChanged={onColumnSelectionChanged} />,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText('field10').closest('.ag-header-cell')).toHaveClass(
+				SELECTED_CELL_CLASS_NAME,
+			);
+		});
+
+		wrapper.rerender(
+			<ControlledSelection
+				onColumnSelectionChanged={onColumnSelectionChanged}
+				selection={{
+					columnIds: ['field0'],
+				}}
+			/>,
+		);
+
+		await waitFor(() => {
+			expect(screen.getByText('Nom de la gare').closest('.ag-header-cell')).toHaveClass(
+				SELECTED_CELL_CLASS_NAME,
+			);
+		});
+
+		expect(onColumnSelectionChanged).not.toHaveBeenCalled();
 	});
 });

--- a/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
+++ b/packages/datagrid/src/components/DataGrid/Datagrid.stories.tsx
@@ -59,12 +59,13 @@ const defaultGridProps = {
 	onColumnSelectionChanged: action('onColumnSelectionChanged'),
 };
 
-const Template: ComponentStory<typeof DataGrid> = args => <DataGrid {...args} />;
+const Template: ComponentStory<typeof DataGrid> = args => (
+	<DataGrid {...defaultGridProps} {...args} />
+);
 
 export const Default = () => <DataGrid {...defaultGridProps} />;
 
 export const Selection = Template.bind({});
-Selection.args = defaultGridProps;
 Selection.play = async ({ canvasElement }) => {
 	const canvas = within(canvasElement);
 	await userEvent.click(
@@ -86,6 +87,13 @@ Selection.play = async ({ canvasElement }) => {
 };
 Selection.parameters = {
 	chromatic: { disableSnapshot: true },
+};
+
+export const ControlledSelection = Template.bind({});
+ControlledSelection.args = {
+	selection: {
+		columnIds: ['field10'],
+	},
 };
 
 export const CustomRenderer = () => (

--- a/packages/datagrid/src/types/index.ts
+++ b/packages/datagrid/src/types/index.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Column, ICellEditorParams } from 'ag-grid-community';
+import { Column, ColumnApi, GridApi, ICellEditorParams } from 'ag-grid-community';
 
 import { ButtonIcon } from '@talend/design-system';
 
@@ -84,6 +84,12 @@ export interface AgGridCellValue {
 
 export type GridContext = {
 	selectedColumns: string[];
+};
+
+export type GridRef = {
+	api: GridApi;
+	columnApi: ColumnApi;
+	context: GridContext;
 };
 
 export type { ColDef } from 'ag-grid-community';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Ag grid ref is not set directly on mount, meaning we can execute the effects and have an `undefined` api.

**What is the chosen solution to this problem?**

Use a state instead of a ref to get api objects, so we can react when they are set

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
