### PR TITLE
fix(cmf-router): history listener

### DIFF
--- a/.changeset/wicked-peas-destroy.md
+++ b/.changeset/wicked-peas-destroy.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-router': patch
+---
+
+fix(cmf-router): history listener

--- a/packages/cmf-router/src/UIRouter.js
+++ b/packages/cmf-router/src/UIRouter.js
@@ -93,7 +93,7 @@ export function getRouter(history, basename) {
 	function CMFRouter({ action, location, ...props }) {
 		// sync from history to redux
 		React.useEffect(() => {
-			return history.listen((location, action, isFirstRendering = false) => {
+			return history.listen(({ location, action, isFirstRendering = false }) => {
 				props.dispatch(onLocationChanged(location, action, isFirstRendering));
 			});
 		}, []);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Error in the api of history.listen

**What is the chosen solution to this problem?**
Fix it

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
