### PR TITLE
fix(datagrid): Cell value is persisted when canceling edition

### DIFF
--- a/.changeset/spicy-beds-study.md
+++ b/.changeset/spicy-beds-study.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Cell value is persisted when canceling edition

--- a/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
+++ b/packages/datagrid/src/components/PlaygroundCellEditor/PlaygroundCellEditor.component.tsx
@@ -15,15 +15,8 @@ function PlaygroundCellEditor(
 	props: ICellEditorParams & CellEditorParams,
 	ref: React.Ref<HTMLElement>,
 ) {
-	const {
-		eGridCell,
-		value,
-		colDef,
-		stopEditing,
-		getSemanticType,
-		getSemanticTypeSuggestions,
-		onSubmit,
-	} = props;
+	const { eGridCell, value, colDef, api, getSemanticType, getSemanticTypeSuggestions, onSubmit } =
+		props;
 	const {
 		cellEditorPopup,
 		cellRendererParams: { semanticTypeId },
@@ -94,7 +87,7 @@ function PlaygroundCellEditor(
 	const hasSuggestions = semanticType?.type === 'DICT';
 
 	const onCancel = () => {
-		stopEditing(true);
+		api.stopEditing(true);
 	};
 
 	return (
@@ -123,7 +116,7 @@ function PlaygroundCellEditor(
 							onCancel={onCancel}
 							editorType={hasSuggestions ? 'datalist' : 'textarea'}
 							onSubmit={(applyToValues: boolean) => {
-								stopEditing();
+								api.stopEditing();
 								onSubmit(state, applyToValues, {
 									rowIndex: props.rowIndex,
 									data: props.data,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Grid data is mutated when cancelling cell edition,
`stopEditing` provided in props does not behave as the one from API

https://github.com/ag-grid/ag-grid/blob/latest/community-modules/core/src/ts/rendering/cell/cellCtrl.ts#L560

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
