### PR TITLE
chore(TDS-6666): disable split

### DIFF
--- a/.changeset/eighty-crabs-work.md
+++ b/.changeset/eighty-crabs-work.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+chore(TDS-6666): disabled split

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -49,11 +49,9 @@ class EnumerationForm extends React.Component {
 		return ITEMS_DEFAULT_HEIGHT;
 	}
 
-	static parseStringValueToArray(values, skipCommas) {
-		if (skipCommas) {
-			return values
-				.match(/(\\.|[^,])+/g)
-				.map(value => value.trim().replace(/\\,/g, ',').replace(/\\./g, '\\'));
+	static parseStringValueToArray(values, disableSplit) {
+		if (disableSplit) {
+			return [values];
 		}
 		return values.split(',').map(value => value.trim());
 	}
@@ -439,7 +437,7 @@ class EnumerationForm extends React.Component {
 			}));
 			const formattedValue = EnumerationForm.parseStringValueToArray(
 				value.value,
-				this.props.schema?.skipCommas || false,
+				this.props.schema?.disableSplit || false,
 			);
 			this.props
 				.onTrigger(event, {
@@ -480,7 +478,7 @@ class EnumerationForm extends React.Component {
 			if (value.value && !valueExist) {
 				item.values = EnumerationForm.parseStringValueToArray(
 					value.value,
-					this.props.schema?.skipCommas || false,
+					this.props.schema?.disableSplit || false,
 				);
 			}
 			if (valueExist) {
@@ -716,7 +714,7 @@ class EnumerationForm extends React.Component {
 					trigger: {
 						value: EnumerationForm.parseStringValueToArray(
 							value.value,
-							this.props.schema?.skipCommas || false,
+							this.props.schema?.disableSplit || false,
 						),
 						action: ENUMERATION_ADD_ACTION,
 					},
@@ -743,7 +741,7 @@ class EnumerationForm extends React.Component {
 					{
 						values: EnumerationForm.parseStringValueToArray(
 							value.value,
-							this.props.schema?.skipCommas || false,
+							this.props.schema?.disableSplit || false,
 						),
 					},
 				]),
@@ -1069,6 +1067,7 @@ if (process.env.NODE_ENV !== 'production') {
 		onTrigger: PropTypes.func.isRequired,
 		properties: PropTypes.object,
 		schema: PropTypes.object,
+		disableSplit: PropTypes.bool,
 		t: PropTypes.func,
 		value: PropTypes.arrayOf(
 			PropTypes.shape({

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -262,6 +262,10 @@ class EnumerationForm extends React.Component {
 		}
 	}
 
+	getDisableSplit() {
+		return this.props.schema?.disableSplit || false;
+	}
+
 	onBlur(event) {
 		const { schema, onFinish } = this.props;
 		onFinish(event, { schema });
@@ -437,7 +441,7 @@ class EnumerationForm extends React.Component {
 			}));
 			const formattedValue = EnumerationForm.parseStringValueToArray(
 				value.value,
-				this.props.schema?.disableSplit || false,
+				this.getDisableSplit(),
 			);
 			this.props
 				.onTrigger(event, {
@@ -476,10 +480,7 @@ class EnumerationForm extends React.Component {
 
 			// if the value is empty, no value update is done
 			if (value.value && !valueExist) {
-				item.values = EnumerationForm.parseStringValueToArray(
-					value.value,
-					this.props.schema?.disableSplit || false,
-				);
+				item.values = EnumerationForm.parseStringValueToArray(value.value, this.getDisableSplit());
 			}
 			if (valueExist) {
 				item.error = this.props.t('ENUMERATION_WIDGET_DUPLICATION_ERROR', {
@@ -712,10 +713,7 @@ class EnumerationForm extends React.Component {
 			this.props
 				.onTrigger(event, {
 					trigger: {
-						value: EnumerationForm.parseStringValueToArray(
-							value.value,
-							this.props.schema?.disableSplit || false,
-						),
+						value: EnumerationForm.parseStringValueToArray(value.value, this.getDisableSplit()),
 						action: ENUMERATION_ADD_ACTION,
 					},
 					schema,
@@ -739,10 +737,7 @@ class EnumerationForm extends React.Component {
 				schema,
 				value: this.state.items.concat([
 					{
-						values: EnumerationForm.parseStringValueToArray(
-							value.value,
-							this.props.schema?.disableSplit || false,
-						),
+						values: EnumerationForm.parseStringValueToArray(value.value, this.getDisableSplit()),
 					},
 				]),
 			};
@@ -1067,7 +1062,6 @@ if (process.env.NODE_ENV !== 'production') {
 		onTrigger: PropTypes.func.isRequired,
 		properties: PropTypes.object,
 		schema: PropTypes.object,
-		disableSplit: PropTypes.bool,
 		t: PropTypes.func,
 		value: PropTypes.arrayOf(
 			PropTypes.shape({

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
@@ -258,7 +258,7 @@ describe('EnumerationWidget', () => {
 		// then
 		expect(onTrigger).toBeCalledWith(expect.anything(), {
 			schema: {
-				skipCommas: true,
+				disableSplit: true,
 			},
 			trigger: {
 				action: 'ENUMERATION_ADD_ACTION',

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
@@ -236,7 +236,7 @@ describe('EnumerationWidget', () => {
 		});
 	});
 
-	it('should call add trigger with skip commas', () => {
+	it('should call add trigger with disableSplit', () => {
 		// given
 		const onTrigger = jest.fn(() => Promise.resolve([]));
 		render(
@@ -245,14 +245,14 @@ describe('EnumerationWidget', () => {
 				onChange={jest.fn()}
 				onFinish={jest.fn()}
 				onTrigger={onTrigger}
-				schema={{ skipCommas: true }}
+				schema={{ disableSplit: true }}
 				properties={{ connectedMode: true }}
 			/>,
 		);
 
 		// when
 		userEvent.click(screen.queryByRole('link', { name: 'Add item' }));
-		userEvent.type(screen.queryByRole('textbox', { name: 'Enter new entry name' }), 'foo\\, tata');
+		userEvent.type(screen.queryByRole('textbox', { name: 'Enter new entry name' }), 'foo, tata');
 		userEvent.click(screen.queryByRole('link', { name: 'Validate' }));
 
 		// then


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The split feature of the enumeration component needs to be disable for some use cases
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
