### PR TITLE
fix(TDP-11258): get back tilde character for sass imports 

### DIFF
--- a/.changeset/four-items-train.md
+++ b/.changeset/four-items-train.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(TDP-11258): get back tilde character for sass imports for compatibility"

--- a/packages/design-system/src/components/WIP/Tabs/Primitive/TabStyles.module.scss
+++ b/packages/design-system/src/components/WIP/Tabs/Primitive/TabStyles.module.scss
@@ -1,4 +1,4 @@
-@use '@talend/design-tokens/lib/tokens';
+@use '~@talend/design-tokens/lib/tokens';
 
 .tab {
   font: tokens.$coral-heading-s;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We can't use `Tab` component from design-system v4 with Talend scripts because of this import : 

`@use '@talend/design-tokens/lib/tokens';`

This notation [requires sass-loader v11+ and webpack 5 to work](https://github.com/webpack-contrib/sass-loader/blob/master/CHANGELOG.md#1100-2021-02-05).

To be compatible with webpack 4, which is still used in our libs and apps, we have to keep the `~` character during sass imports to tell webpack to look into `node_modules` folder.  

Otherwise, it crashes with the following error : 

```
SassError: Can't find stylesheet to import.
  ╷
2 │ @use '@talend/design-tokens/lib/tokens';
  │ ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  ╵
```

**What is the chosen solution to this problem?**

Put back the `~` character in imports of components (not required in documentation components).

There is no risk to breaking things because this notation is still supported, just deprecated. 

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
