### PR TITLE
feat(CDM-237) allow to customize subtitle tag

### DIFF
--- a/.changeset/twelve-kangaroos-carry.md
+++ b/.changeset/twelve-kangaroos-carry.md
@@ -1,0 +1,17 @@
+---
+'@talend/react-components': major
+---
+
+Allow to customize drawer's subtitle tag
+
+**Breaking change :**
+Props `subtitleTagLabel` and `subtitleTagTooltip` are replaced by a props `subtitleTag`.
+
+Props `subtitleTag` has following shape :
+```
+{
+    label: PropTypes.string,
+    tooltip: PropTypes.string,
+    component: PropTypes.element,
+}
+```

--- a/.changeset/twelve-kangaroos-carry.md
+++ b/.changeset/twelve-kangaroos-carry.md
@@ -12,6 +12,6 @@ Props `subtitleTag` has following shape :
 {
     label: PropTypes.string,
     tooltip: PropTypes.string,
-    component: PropTypes.element,
+    variant: PropTypes.oneOf(SubtitleTagVariants),
 }
 ```

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -5,7 +5,7 @@ import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import { Transition } from 'react-transition-group';
 import classnames from 'classnames';
-import { StackHorizontal, Tag, TagDefault, Tooltip } from '@talend/design-system';
+import { StackHorizontal, Tag, Tooltip } from '@talend/design-system';
 import ActionBar from '../ActionBar';
 import Action from '../Actions/Action';
 import TabBar from '../TabBar';
@@ -24,6 +24,15 @@ const STYLES = {
 	exiting: { transform: 'translateX(100%)' },
 	exited: { transform: 'translateX(100%)' },
 };
+
+export const SubtitleTagVariants = [
+	'default',
+	'information',
+	'success',
+	'warning',
+	'destructive',
+	'beta',
+];
 
 function DrawerAnimation(props) {
 	const { children, withTransition, ...rest } = props;
@@ -102,15 +111,11 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 	);
 }
 
-function renderSubtitleTag(
-	subtitleTagLabel,
-	subtitleTagTooltip,
-	subtitleTagComponent = TagDefault,
-) {
+function renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip, subtitleTagVariant = 'default') {
 	if (subtitleTagTooltip) {
 		return (
 			<Tooltip placement="top" title={subtitleTagTooltip}>
-				{React.createElement(subtitleTagComponent, null, subtitleTagLabel)}
+				<Tag variant={subtitleTagVariant}>{subtitleTagLabel}</Tag>
 			</Tooltip>
 		);
 	}
@@ -130,7 +135,7 @@ export function SubtitleComponent({ subtitle, ...rest }) {
 				<h2 title={subtitle}>{subtitle}</h2>
 				{subtitleTag &&
 					subtitleTag.label &&
-					renderSubtitleTag(subtitleTag.label, subtitleTag.tooltip, subtitleTag.component)}
+					renderSubtitleTag(subtitleTag.label, subtitleTag.tooltip, subtitleTag.variant)}
 			</StackHorizontal>
 		</div>
 	);
@@ -141,7 +146,7 @@ SubtitleComponent.propTypes = {
 	subtitleTag: PropTypes.shape({
 		label: PropTypes.string,
 		tooltip: PropTypes.string,
-		component: PropTypes.element,
+		variant: PropTypes.oneOf(SubtitleTagVariants),
 	}),
 };
 
@@ -233,7 +238,7 @@ DrawerTitle.propTypes = {
 	subtitleTag: PropTypes.shape({
 		label: PropTypes.string,
 		tooltip: PropTypes.string,
-		component: PropTypes.element,
+		variant: PropTypes.oneOf(SubtitleTagVariants),
 	}),
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -5,7 +5,7 @@ import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import { Transition } from 'react-transition-group';
 import classnames from 'classnames';
-import { TagDefault, StackHorizontal, Tooltip } from '@talend/design-system';
+import { StackHorizontal, Tag, TagDefault, Tooltip } from '@talend/design-system';
 import ActionBar from '../ActionBar';
 import Action from '../Actions/Action';
 import TabBar from '../TabBar';
@@ -102,28 +102,35 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 	);
 }
 
-function renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip) {
+function renderSubtitleTag(
+	subtitleTagLabel,
+	subtitleTagTooltip,
+	subtitleTagComponent = TagDefault,
+) {
 	if (subtitleTagTooltip) {
 		return (
 			<Tooltip placement="top" title={subtitleTagTooltip}>
-				<TagDefault>{subtitleTagLabel}</TagDefault>
+				{React.createElement(subtitleTagComponent, null, subtitleTagLabel)}
 			</Tooltip>
 		);
 	}
 
-	return <TagDefault>{subtitleTagLabel}</TagDefault>;
+	return <Tag>{subtitleTagLabel}</Tag>;
 }
 export function SubtitleComponent({ subtitle, ...rest }) {
 	if (!subtitle || !subtitle.length) {
 		return null;
 	}
 
-	const { subtitleTagLabel, subtitleTagTooltip } = rest;
+	const { subtitleTag } = rest;
+
 	return (
 		<div className={css('tc-drawer-header-subtitle')}>
 			<StackHorizontal gap="XS" align="center">
 				<h2 title={subtitle}>{subtitle}</h2>
-				{subtitleTagLabel && renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip)}
+				{subtitleTag &&
+					subtitleTag.label &&
+					renderSubtitleTag(subtitleTag.label, subtitleTag.tooltip, subtitleTag.component)}
 			</StackHorizontal>
 		</div>
 	);
@@ -131,8 +138,11 @@ export function SubtitleComponent({ subtitle, ...rest }) {
 
 SubtitleComponent.propTypes = {
 	subtitle: PropTypes.string,
-	subtitleTagLabel: PropTypes.string,
-	subtitleTagTooltip: PropTypes.string,
+	subtitleTag: PropTypes.shape({
+		label: PropTypes.string,
+		tooltip: PropTypes.string,
+		component: PropTypes.element,
+	}),
 };
 
 export function subtitleComponent(subtitle) {
@@ -148,8 +158,7 @@ function DrawerTitle({
 	getComponent,
 	editable,
 	inProgress,
-	subtitleTagLabel,
-	subtitleTagTooltip,
+	subtitleTag,
 	onEdit,
 	onSubmit,
 	onCancel,
@@ -200,13 +209,7 @@ function DrawerTitle({
 						/>
 					)}
 
-					{!isEditMode ? (
-						<SubtitleComponent
-							subtitle={subtitle}
-							subtitleTagLabel={subtitleTagLabel}
-							subtitleTagTooltip={subtitleTagTooltip}
-						/>
-					) : null}
+					{!isEditMode ? <SubtitleComponent subtitle={subtitle} subtitleTag={subtitleTag} /> : null}
 				</div>
 
 				{renderTitleActions()}
@@ -227,8 +230,11 @@ DrawerTitle.propTypes = {
 	renderTitleActions: PropTypes.func,
 	editable: PropTypes.bool,
 	inProgress: PropTypes.bool,
-	subtitleTagLabel: PropTypes.string,
-	subtitleTagTooltip: PropTypes.string,
+	subtitleTag: PropTypes.shape({
+		label: PropTypes.string,
+		tooltip: PropTypes.string,
+		component: PropTypes.element,
+	}),
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
 	onCancel: PropTypes.func,

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -2,14 +2,13 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import { Nav, NavItem, Tab } from '@talend/react-bootstrap';
 
-import Drawer from './Drawer.component';
+import Drawer, { SubtitleTagVariants } from './Drawer.component';
 
 import ActionBar from '../ActionBar';
 import HeaderBar from '../HeaderBar';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
 import { ActionButton } from '../Actions';
-import { TagWarning } from '@talend/design-system';
 
 const header = <HeaderBar brand={{ label: 'Example App Name' }} />;
 
@@ -631,30 +630,40 @@ export const _Interactive = () => {
 	);
 };
 
-export const WithSubtitleComponent = () => (
-	<Layout
-		header={header}
-		mode="OneColumn"
-		drawers={[
-			<Drawer key="drawer-1">
-				<Drawer.Title
-					title="Im drawer 1"
-					subtitle="Drawer subtitle"
-					subtitleTag={{
-						label: 'Preview',
-						tooltip: 'This is a preview',
-						component: TagWarning,
-					}}
-					renderTitleActions={titleActions}
-					onCancelAction={onCancelAction}
-					editable
-				/>
-				<h1>Hello drawer 1</h1>
-				<p>You should not being able to read this because I'm first</p>
-			</Drawer>,
-		]}
-	>
-		<span>zone with drawer</span>
-		{twentyRows}
-	</Layout>
-);
+export const WithSubtitleComponent = () => {
+	const [variant, setVariant] = React.useState('default');
+
+	return (
+		<Layout
+			header={header}
+			mode="OneColumn"
+			drawers={[
+				<Drawer key="drawer-1">
+					<Drawer.Title
+						title="Im drawer 1"
+						subtitle="Drawer subtitle"
+						subtitleTag={{
+							label: 'Preview',
+							tooltip: 'This is a preview',
+							variant,
+						}}
+						renderTitleActions={titleActions}
+						onCancelAction={onCancelAction}
+						editable
+					/>
+					<h1>Hello drawer 1</h1>
+					<p>You should not being able to read this because I'm first</p>
+				</Drawer>,
+			]}
+		>
+			<span>Select subtitle tag variants</span>
+			<select onChange={ev => setVariant(ev.target.value)} style={{ width: '250px' }}>
+				{SubtitleTagVariants.map(variant => (
+					<option key={variant} value={variant}>
+						{variant}
+					</option>
+				))}
+			</select>
+		</Layout>
+	);
+};

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -9,6 +9,7 @@ import HeaderBar from '../HeaderBar';
 import Layout from '../Layout';
 import SidePanel from '../SidePanel';
 import { ActionButton } from '../Actions';
+import { TagWarning } from '@talend/design-system';
 
 const header = <HeaderBar brand={{ label: 'Example App Name' }} />;
 
@@ -639,8 +640,11 @@ export const WithSubtitleComponent = () => (
 				<Drawer.Title
 					title="Im drawer 1"
 					subtitle="Drawer subtitle"
-					subtitleTagLabel="Preview"
-					subtitleTagTooltip="This is a preview"
+					subtitleTag={{
+						label: 'Preview',
+						tooltip: 'This is a preview',
+						component: TagWarning,
+					}}
 					renderTitleActions={titleActions}
 					onCancelAction={onCancelAction}
 					editable

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -392,7 +392,11 @@ const tagTitleProps = {
 	getComponent,
 	title: 'test',
 	subtitle: 'subtitle test',
-	subtitleTagLabel: 'BETA',
+	subtitleTag: {
+		label: 'BETA',
+		tooltip: 'This is a BETA tag',
+		variant: 'beta',
+	},
 };
 
 describe('Drawer title', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Drawer's subtitle tag is not customizable (style)

**What is the chosen solution to this problem?**
Allow to specify which component tag from DS we can use

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
