### PR TITLE
feat(dataviz): allow to build custom legend

### DIFF
--- a/.changeset/quick-lizards-yawn.md
+++ b/.changeset/quick-lizards-yawn.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': minor
+---
+
+feat(dataviz): allow to build custom legend for linechart

--- a/packages/dataviz/src/components/LineChart/LineChart.scss
+++ b/packages/dataviz/src/components/LineChart/LineChart.scss
@@ -26,6 +26,11 @@ $module: line-chart;
 		gap: tokens.$coral-spacing-m;
 		list-style: none;
 
+		&-item {
+			display: flex;
+			align-items: center;
+		}
+
 		&--align-left {
 			justify-content: flex-start;
 		}

--- a/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
@@ -7,7 +7,6 @@ import {
 	StackHorizontal,
 	StackItem,
 	Tooltip,
-	StackVertical,
 } from '@talend/design-system';
 import LineChart, { LineChartProps } from './LineChart.component';
 

--- a/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { Meta } from '@storybook/react';
 import tokens from '@talend/design-tokens';
+import {
+	TagInformation,
+	SizedIcon,
+	StackHorizontal,
+	StackItem,
+	Tooltip,
+	StackVertical,
+} from '@talend/design-system';
 import LineChart, { LineChartProps } from './LineChart.component';
 
 export default {
@@ -72,8 +80,18 @@ export const FullyCustomisedLineChart = {
 			{
 				key: 'validity',
 				color: tokens.coralColorChartsColor00Strong,
+				legendLabel: (
+					<StackHorizontal gap="XS" align="center">
+						<StackItem>Validity</StackItem>
+						<Tooltip title="Validity refer to your sample quality">
+							<StackHorizontal gap={0}>
+								<SizedIcon name="information-stroke" size="S" />
+							</StackHorizontal>
+						</Tooltip>
+						<TagInformation>Well</TagInformation>
+					</StackHorizontal>
+				),
 				tooltipLabel: 'Validity',
-				legendLabel: 'Validity',
 				axis: 'left',
 				status: 'highlighted',
 			},

--- a/packages/dataviz/src/components/LineChart/LineChart.types.ts
+++ b/packages/dataviz/src/components/LineChart/LineChart.types.ts
@@ -9,7 +9,7 @@ export type LineOptions = {
 	key: string;
 	color: string;
 	tooltipLabel?: string;
-	legendLabel?: string;
+	legendLabel?: string | React.ReactElement;
 	axis?: 'left' | 'right';
 	dashed?: boolean;
 	tooltipFormatter?: (value: any) => string;

--- a/packages/dataviz/src/components/LineChart/LineChartLegend.component.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChartLegend.component.tsx
@@ -42,7 +42,7 @@ export const CustomLegend = ({
 					<li key={config.key}>
 						<div
 							data-testid={`legend_item_${config.key}`}
-							className={classNames({
+							className={classNames(styles['line-chart-custom-legend-item'], {
 								[styles['line-chart-custom-legend__button--inactive']]:
 									config?.status === 'inactive',
 							})}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
<img width="622" alt="CleanShot 2022-08-30 at 17 08 33@2x" src="https://user-images.githubusercontent.com/2909671/187477133-f8be9c7d-188c-48b3-96af-c58b274b1dd3.png">

It's a bit broken if we try to insert JSX

**What is the chosen solution to this problem?**
Use the Design System
<img width="652" alt="CleanShot 2022-08-30 at 17 25 36@2x" src="https://user-images.githubusercontent.com/2909671/187477319-fd267aa0-2010-4233-baaf-46ce5cdeb2e6.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
