### PR TITLE
feat(CDM-237) Add const to export Tag variations through string array

### DIFF
--- a/.changeset/popular-schools-remember.md
+++ b/.changeset/popular-schools-remember.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Add const to export Tag variations through string array

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -19,6 +19,9 @@ export enum TagVariant {
 	beta = 'beta',
 }
 
+// This const allows JS component to type props with restricted list of tag variations
+export const TagVariants = Object.values(TagVariant);
+
 type TagProps = Omit<PrimitiveTagProps, 'className'> & {
 	/**
 	 * Tag variation depending on its semantic

--- a/packages/design-system/src/components/Tag/Tag.tsx
+++ b/packages/design-system/src/components/Tag/Tag.tsx
@@ -20,7 +20,7 @@ export enum TagVariant {
 }
 
 // This const allows JS component to type props with restricted list of tag variations
-export const TagVariants = Object.values(TagVariant);
+export const TagVariantsNames = Object.values(TagVariant);
 
 type TagProps = Omit<PrimitiveTagProps, 'className'> & {
 	/**

--- a/packages/design-system/src/components/Tag/index.ts
+++ b/packages/design-system/src/components/Tag/index.ts
@@ -1,4 +1,4 @@
-import Tag, { TagVariants } from './Tag';
+import Tag, { TagVariantsNames } from './Tag';
 
 import {
 	TagDefault,

--- a/packages/design-system/src/components/Tag/index.ts
+++ b/packages/design-system/src/components/Tag/index.ts
@@ -1,4 +1,4 @@
-import Tag from './Tag';
+import Tag, { TagVariants } from './Tag';
 
 import {
 	TagDefault,
@@ -9,4 +9,13 @@ import {
 	TagBeta,
 } from './variations';
 
-export { Tag, TagDefault, TagInformation, TagSuccess, TagWarning, TagDestructive, TagBeta };
+export {
+	Tag,
+	TagDefault,
+	TagInformation,
+	TagSuccess,
+	TagWarning,
+	TagDestructive,
+	TagBeta,
+	TagVariants,
+};

--- a/packages/design-system/src/components/Tag/index.ts
+++ b/packages/design-system/src/components/Tag/index.ts
@@ -17,5 +17,5 @@ export {
 	TagWarning,
 	TagDestructive,
 	TagBeta,
-	TagVariants,
+	TagVariantsNames,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
To allow JS component to add customizable Tag as part of it, it requires to be able to define available tag variations in component prop type definition

**What is the chosen solution to this problem?**
Export available tag variations as string array

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
