### PR TITLE
fix(ci): build storybook docs for visual testing github action

### DIFF
--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -69,8 +69,8 @@ jobs:
         run: |
           yarn workspace @talend/assets-api run build:lib
           yarn workspace @talend/icons run build:lib
-          yarn workspace @talend/storybook-docs run build:lib
           yarn workspace @talend/design-tokens run build:lib
+          yarn workspace @talend/storybook-docs run build:lib
 
       - name: Build @talend/*
         if: matrix.package != 'design-system'

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -69,17 +69,13 @@ jobs:
         run: |
           yarn workspace @talend/assets-api run build:lib
           yarn workspace @talend/icons run build:lib
+          yarn workspace @talend/storybook-docs run build:lib
           yarn workspace @talend/design-tokens run build:lib
-
-      - name: Build @talend/icons
-        if: matrix.package == 'design-system'
-        run: |
-          yarn workspace @talend/icons run build:lib
 
       - name: Build @talend/*
         if: matrix.package != 'design-system'
         run: |
-          # We need to build all dependencies (cmf, coponents...)
+          # We need to build all dependencies (cmf, components...)
           yarn postinstall
 
       - name: Publish PR to DS Chromatic

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -11,7 +11,17 @@ const Accordion = React.forwardRef(
 	({ selectedId, children, ...rest }: AccordionProps, ref: React.Ref<ReakitCompositeProps>) => {
 		const composite = useCompositeState({});
 
-		return null;
+		return (
+			<S.Accordion {...composite} ref={ref} {...rest}>
+				{children.map((child: React.ReactElement, key: number) =>
+					React.cloneElement(child, {
+						id: `${composite.baseId}-${key + 1}`,
+						...composite,
+						...child.props,
+					}),
+				)}
+			</S.Accordion>
+		);
 	},
 );
 

--- a/packages/design-system/src/components/Accordion/Accordion.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.tsx
@@ -11,17 +11,7 @@ const Accordion = React.forwardRef(
 	({ selectedId, children, ...rest }: AccordionProps, ref: React.Ref<ReakitCompositeProps>) => {
 		const composite = useCompositeState({});
 
-		return (
-			<S.Accordion {...composite} ref={ref} {...rest}>
-				{children.map((child: React.ReactElement, key: number) =>
-					React.cloneElement(child, {
-						id: `${composite.baseId}-${key + 1}`,
-						...composite,
-						...child.props,
-					}),
-				)}
-			</S.Accordion>
-		);
+		return null;
 	},
 );
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Visual testing github actions is failing due to storybook-docs package.

<img width="1215" alt="image" src="https://user-images.githubusercontent.com/1674329/187919626-fc5aa6c3-a9f0-4d61-85e7-4868c2c6da8f.png">

See https://github.com/Talend/ui/runs/8135110867?check_suite_focus=true

**What is the chosen solution to this problem?**

Build the package alongside the other while running the action.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
