### PR TITLE
feat(CDM-237) export TagVariantsNames from global module

### DIFF
--- a/.changeset/pink-days-brush.md
+++ b/.changeset/pink-days-brush.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Export TagVariantsNames from DS module

--- a/packages/design-system/src/index.ts
+++ b/packages/design-system/src/index.ts
@@ -70,6 +70,7 @@ import {
 	TagDestructive,
 	TagInformation,
 	TagSuccess,
+	TagVariantsNames,
 	TagWarning,
 } from './components/Tag';
 import ThemeProvider from './components/ThemeProvider';
@@ -147,6 +148,7 @@ export {
 	TagDestructive,
 	TagInformation,
 	TagSuccess,
+	TagVariantsNames,
 	TagWarning,
 	ThemeProvider,
 	Tooltip,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**
export TagVariantsNames from global module

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
