### PR TITLE
feat(CDM-237) Allow to customize drawer's subtitle tag

### DIFF
--- a/.changeset/twelve-kangaroos-carry.md
+++ b/.changeset/twelve-kangaroos-carry.md
@@ -1,10 +1,11 @@
 ---
-'@talend/react-components': major
+'@talend/react-components': minor
 ---
 
 Allow to customize drawer's subtitle tag
 
 **Breaking change :**
+
 Props `subtitleTagLabel` and `subtitleTagTooltip` are replaced by a props `subtitleTag`.
 
 Props `subtitleTag` has following shape :
@@ -15,3 +16,5 @@ Props `subtitleTag` has following shape :
     variant: PropTypes.oneOf(TagVariantsNames),
 }
 ```
+
+_NOTE: While this props are only used by TPD this breaking change is passed as minor change to avoid waiting dataset release_

--- a/.changeset/twelve-kangaroos-carry.md
+++ b/.changeset/twelve-kangaroos-carry.md
@@ -1,0 +1,17 @@
+---
+'@talend/react-components': major
+---
+
+Allow to customize drawer's subtitle tag
+
+**Breaking change :**
+Props `subtitleTagLabel` and `subtitleTagTooltip` are replaced by a props `subtitleTag`.
+
+Props `subtitleTag` has following shape :
+```
+{
+    label: PropTypes.string,
+    tooltip: PropTypes.string,
+    variant: PropTypes.oneOf(TagVariantsNames),
+}
+```

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -71,7 +71,7 @@
   "devDependencies": {
     "@storybook/addon-actions": "^6.5.9",
     "@talend/bootstrap-theme": "^6.39.0",
-    "@talend/design-system": "^4.0.0",
+    "@talend/design-system": "^4.1.1",
     "@talend/icons": "^6.47.0",
     "@talend/locales-design-system": "^1.12.2",
     "@talend/locales-tui-components": "^6.44.11",

--- a/packages/components/src/Drawer/Drawer.component.js
+++ b/packages/components/src/Drawer/Drawer.component.js
@@ -5,7 +5,7 @@ import omit from 'lodash/omit';
 import noop from 'lodash/noop';
 import { Transition } from 'react-transition-group';
 import classnames from 'classnames';
-import { TagDefault, StackHorizontal, Tooltip } from '@talend/design-system';
+import { StackHorizontal, Tag, TagVariantsNames, Tooltip } from '@talend/design-system';
 import ActionBar from '../ActionBar';
 import Action from '../Actions/Action';
 import TabBar from '../TabBar';
@@ -102,28 +102,31 @@ export function cancelActionComponent(onCancelAction, getComponent) {
 	);
 }
 
-function renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip) {
+function renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip, subtitleTagVariant = 'default') {
 	if (subtitleTagTooltip) {
 		return (
 			<Tooltip placement="top" title={subtitleTagTooltip}>
-				<TagDefault>{subtitleTagLabel}</TagDefault>
+				<Tag variant={subtitleTagVariant}>{subtitleTagLabel}</Tag>
 			</Tooltip>
 		);
 	}
 
-	return <TagDefault>{subtitleTagLabel}</TagDefault>;
+	return <Tag>{subtitleTagLabel}</Tag>;
 }
 export function SubtitleComponent({ subtitle, ...rest }) {
 	if (!subtitle || !subtitle.length) {
 		return null;
 	}
 
-	const { subtitleTagLabel, subtitleTagTooltip } = rest;
+	const { subtitleTag } = rest;
+
 	return (
 		<div className={css('tc-drawer-header-subtitle')}>
 			<StackHorizontal gap="XS" align="center">
 				<h2 title={subtitle}>{subtitle}</h2>
-				{subtitleTagLabel && renderSubtitleTag(subtitleTagLabel, subtitleTagTooltip)}
+				{subtitleTag &&
+					subtitleTag.label &&
+					renderSubtitleTag(subtitleTag.label, subtitleTag.tooltip, subtitleTag.variant)}
 			</StackHorizontal>
 		</div>
 	);
@@ -131,8 +134,11 @@ export function SubtitleComponent({ subtitle, ...rest }) {
 
 SubtitleComponent.propTypes = {
 	subtitle: PropTypes.string,
-	subtitleTagLabel: PropTypes.string,
-	subtitleTagTooltip: PropTypes.string,
+	subtitleTag: PropTypes.shape({
+		label: PropTypes.string,
+		tooltip: PropTypes.string,
+		variant: PropTypes.oneOf(TagVariantsNames),
+	}),
 };
 
 export function subtitleComponent(subtitle) {
@@ -148,8 +154,7 @@ function DrawerTitle({
 	getComponent,
 	editable,
 	inProgress,
-	subtitleTagLabel,
-	subtitleTagTooltip,
+	subtitleTag,
 	onEdit,
 	onSubmit,
 	onCancel,
@@ -200,13 +205,7 @@ function DrawerTitle({
 						/>
 					)}
 
-					{!isEditMode ? (
-						<SubtitleComponent
-							subtitle={subtitle}
-							subtitleTagLabel={subtitleTagLabel}
-							subtitleTagTooltip={subtitleTagTooltip}
-						/>
-					) : null}
+					{!isEditMode ? <SubtitleComponent subtitle={subtitle} subtitleTag={subtitleTag} /> : null}
 				</div>
 
 				{renderTitleActions()}
@@ -227,8 +226,11 @@ DrawerTitle.propTypes = {
 	renderTitleActions: PropTypes.func,
 	editable: PropTypes.bool,
 	inProgress: PropTypes.bool,
-	subtitleTagLabel: PropTypes.string,
-	subtitleTagTooltip: PropTypes.string,
+	subtitleTag: PropTypes.shape({
+		label: PropTypes.string,
+		tooltip: PropTypes.string,
+		variant: PropTypes.oneOf(TagVariantsNames),
+	}),
 	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
 	onCancel: PropTypes.func,

--- a/packages/components/src/Drawer/Drawer.stories.js
+++ b/packages/components/src/Drawer/Drawer.stories.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { action } from '@storybook/addon-actions';
+import { TagVariantsNames } from '@talend/design-system';
 import { Nav, NavItem, Tab } from '@talend/react-bootstrap';
 
 import Drawer from './Drawer.component';
@@ -630,27 +631,40 @@ export const _Interactive = () => {
 	);
 };
 
-export const WithSubtitleComponent = () => (
-	<Layout
-		header={header}
-		mode="OneColumn"
-		drawers={[
-			<Drawer key="drawer-1">
-				<Drawer.Title
-					title="Im drawer 1"
-					subtitle="Drawer subtitle"
-					subtitleTagLabel="Preview"
-					subtitleTagTooltip="This is a preview"
-					renderTitleActions={titleActions}
-					onCancelAction={onCancelAction}
-					editable
-				/>
-				<h1>Hello drawer 1</h1>
-				<p>You should not being able to read this because I'm first</p>
-			</Drawer>,
-		]}
-	>
-		<span>zone with drawer</span>
-		{twentyRows}
-	</Layout>
-);
+export const WithSubtitleComponent = () => {
+	const [variant, setVariant] = React.useState('default');
+
+	return (
+		<Layout
+			header={header}
+			mode="OneColumn"
+			drawers={[
+				<Drawer key="drawer-1">
+					<Drawer.Title
+						title="Im drawer 1"
+						subtitle="Drawer subtitle"
+						subtitleTag={{
+							label: 'Preview',
+							tooltip: 'This is a preview',
+							variant,
+						}}
+						renderTitleActions={titleActions}
+						onCancelAction={onCancelAction}
+						editable
+					/>
+					<h1>Hello drawer 1</h1>
+					<p>You should not being able to read this because I'm first</p>
+				</Drawer>,
+			]}
+		>
+			<span>Select subtitle tag variants</span>
+			<select onChange={ev => setVariant(ev.target.value)} style={{ width: '250px' }}>
+				{TagVariantsNames.map(variant => (
+					<option key={variant} value={variant}>
+						{variant}
+					</option>
+				))}
+			</select>
+		</Layout>
+	);
+};

--- a/packages/components/src/Drawer/Drawer.test.js
+++ b/packages/components/src/Drawer/Drawer.test.js
@@ -392,7 +392,11 @@ const tagTitleProps = {
 	getComponent,
 	title: 'test',
 	subtitle: 'subtitle test',
-	subtitleTagLabel: 'BETA',
+	subtitleTag: {
+		label: 'BETA',
+		tooltip: 'This is a BETA tag',
+		variant: 'beta',
+	},
 };
 
 describe('Drawer title', () => {

--- a/packages/datagrid/package.json
+++ b/packages/datagrid/package.json
@@ -47,7 +47,7 @@
     "lodash": "^4.17.21"
   },
   "devDependencies": {
-    "@talend/design-system": "^4.0.0",
+    "@talend/design-system": "^4.1.1",
     "@talend/icons": "^6.48.0",
     "@talend/locales-tui-datagrid": "^6.36.5",
     "@talend/scripts-core": "^12.0.0",

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -48,7 +48,7 @@
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/testing-library": "^0.0.13",
     "@talend/bootstrap-theme": "^6.39.0",
-    "@talend/design-system": "^4.1.0",
+    "@talend/design-system": "^4.1.1",
     "@talend/icons": "^6.47.0",
     "@talend/locales-tui-components": "^6.44.11",
     "@talend/locales-tui-faceted-search": "^4.0.2",

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -61,7 +61,7 @@
     "@storybook/addon-actions": "^6.5.9",
     "@storybook/addon-controls": "^6.5.9",
     "@talend/bootstrap-theme": "^6.39.0",
-    "@talend/design-system": "^4.0.0",
+    "@talend/design-system": "^4.1.1",
     "@talend/icons": "^6.47.0",
     "@talend/locales-tui-forms": "^6.41.3",
     "@talend/react-components": "^7.7.0",

--- a/packages/storybook-docs/package.json
+++ b/packages/storybook-docs/package.json
@@ -28,7 +28,7 @@
     "access": "public"
   },
   "dependencies": {
-    "@talend/design-system": "^4.0.0",
+    "@talend/design-system": "^4.1.1",
     "@talend/design-tokens": "^2.7.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,6 +3563,21 @@
   resolved "https://registry.yarnpkg.com/@talend/daikon-tql-client/-/daikon-tql-client-1.3.1.tgz#75a764ec14b06355af3924f3b2d65ff8e61db4f0"
   integrity sha512-trwueNzgISaN2jSNBxuiHw76jWX2G/vtSrCtlTaoeS3NzsCIVUlGryqKZnuBLfZWJyVWeImx9xm34mBOHITMIQ==
 
+"@talend/design-system@^4.1.1":
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/@talend/design-system/-/design-system-4.1.1.tgz#91b4ce2539327a33e602b12799e4494cb29b826f"
+  integrity sha512-bTrWaCrpHlsf497H4FDJRRMkonOHGL+5x60DeLlcO910ZjBFzuqeP97Hg3B6JsjNCUiL8b9tmup6/WMZTNffUw==
+  dependencies:
+    "@talend/assets-api" "^1.2.2"
+    "@talend/design-tokens" "^2.7.0"
+    classnames "^2.3.1"
+    modern-css-reset "^1.4.0"
+    polished "^4.2.2"
+    react-use "^17.4.0"
+    reakit "^1.3.11"
+    typeface-inconsolata "^1.1.13"
+    typeface-source-sans-pro "^1.1.13"
+
 "@talend/locales-design-system@^1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@talend/locales-design-system/-/locales-design-system-1.12.2.tgz#ed4f5412f052479c920f6baf6995cd4d84db7eb4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3563,21 +3563,6 @@
   resolved "https://registry.yarnpkg.com/@talend/daikon-tql-client/-/daikon-tql-client-1.3.1.tgz#75a764ec14b06355af3924f3b2d65ff8e61db4f0"
   integrity sha512-trwueNzgISaN2jSNBxuiHw76jWX2G/vtSrCtlTaoeS3NzsCIVUlGryqKZnuBLfZWJyVWeImx9xm34mBOHITMIQ==
 
-"@talend/design-system@^4.1.1":
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/@talend/design-system/-/design-system-4.1.1.tgz#91b4ce2539327a33e602b12799e4494cb29b826f"
-  integrity sha512-bTrWaCrpHlsf497H4FDJRRMkonOHGL+5x60DeLlcO910ZjBFzuqeP97Hg3B6JsjNCUiL8b9tmup6/WMZTNffUw==
-  dependencies:
-    "@talend/assets-api" "^1.2.2"
-    "@talend/design-tokens" "^2.7.0"
-    classnames "^2.3.1"
-    modern-css-reset "^1.4.0"
-    polished "^4.2.2"
-    react-use "^17.4.0"
-    reakit "^1.3.11"
-    typeface-inconsolata "^1.1.13"
-    typeface-source-sans-pro "^1.1.13"
-
 "@talend/locales-design-system@^1.12.2":
   version "1.12.2"
   resolved "https://registry.yarnpkg.com/@talend/locales-design-system/-/locales-design-system-1.12.2.tgz#ed4f5412f052479c920f6baf6995cd4d84db7eb4"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Drawer's subtitle tag is not customizable (style)

**What is the chosen solution to this problem?**
Allow to specify which component tag from DS we can use

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
