### PR TITLE
fix(datagrid): Header menu icon not rendering on firefox

### DIFF
--- a/.changeset/fresh-items-pull.md
+++ b/.changeset/fresh-items-pull.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+Header menu icon not rendering on firefox

--- a/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.component.tsx
+++ b/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.component.tsx
@@ -87,9 +87,7 @@ export default function HeaderCellRenderer({
 					</div>
 				</div>
 				{menuProps && (
-					<div className={theme['header-cell__menu-button']}>
-						<ButtonIcon icon="talend-ellipsis" size="XS" disabled={isLoading} {...menuProps} />
-					</div>
+					<ButtonIcon icon="dots-vertical" size="XS" disabled={isLoading} {...menuProps} />
 				)}
 			</StackHorizontal>
 			{quality && <QualityBar {...quality} {...qualityBarProps} />}

--- a/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.scss
+++ b/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.scss
@@ -51,10 +51,6 @@
 		height: tokens.$coral-sizing-minimal;
 	}
 
-	&__menu-button svg {
-		transform: rotate(90deg);
-	}
-
 	&--loading {
 		animation: tokens.$coral-animation-heartbeat;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Firefox does not display the burger menu icon
http://talend.surge.sh/datagrid/?path=/story/components-headercellrenderer--with-menus

**What is the chosen solution to this problem?**

Use the new DS icon

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
