### PR TITLE
fix(dataviz): Range filter marks are overflowing

### DIFF
--- a/.changeset/olive-bats-sparkle.md
+++ b/.changeset/olive-bats-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+Range filter marks are overflowing

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.scss
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.scss
@@ -6,20 +6,20 @@ $module: range-filter;
 	}
 
 	&__slider-mark {
-		position: absolute;
+		position: relative;
+		display: block;
 		width: 100%;
 		white-space: nowrap;
 
 		&--top {
-			transform: translateX(-50%);
 			top: -36px;
 		}
 		&--bottom-left {
+			position: absolute;
 			text-align: left;
 		}
 		&--bottom-right {
-			right: 0;
-			text-align: right;
+			transform: translateX(50%);
 		}
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Range filter marks are not properly placed

![Screenshot 2022-09-05 at 12 39 48](https://user-images.githubusercontent.com/58977230/188430449-00997d0f-7b47-4918-b234-6ca038908b05.png)

**What is the chosen solution to this problem?**

![Screenshot 2022-09-05 at 12 40 02](https://user-images.githubusercontent.com/58977230/188430506-d9b0db54-386d-44b8-b73b-23565a65872c.png)

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
