### PR TITLE
feat(StackVertical): Add a height prop

### DIFF
--- a/.changeset/unlucky-ghosts-add.md
+++ b/.changeset/unlucky-ghosts-add.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+StackVertical: add height prop

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.module.scss
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.module.scss
@@ -390,4 +390,31 @@
 			}
 		}
 	}
+
+	&.height {
+		&-100 {
+			height: 100%;
+		}
+		&-XXXS {
+			height: tokens.$coral-sizing-xxxs;
+		}
+		&-XXS {
+			height: tokens.$coral-sizing-xxs;
+		}
+		&-XS {
+			height: tokens.$coral-sizing-xs;
+		}
+		&-S {
+			height: tokens.$coral-sizing-s;
+		}
+		&-M {
+			height: tokens.$coral-sizing-m;
+		}
+		&-L {
+			height: tokens.$coral-sizing-l;
+		}
+		&-XXXL {
+			height: tokens.$coral-sizing-xxxl;
+		}
+	}
 }

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
@@ -1,6 +1,6 @@
-import React, { forwardRef, ReactNode } from 'react';
-import classnames from 'classnames';
 import styles from './StackPrimitive.module.scss';
+import classnames from 'classnames';
+import React, { forwardRef, ReactNode } from 'react';
 
 export const justifyOptions = {
 	start: 'justify-start',
@@ -36,6 +36,17 @@ export const sizeOptions = {
 	M: 'M',
 	L: 'L',
 	XL: 'XL',
+};
+
+export const heightOptions = {
+	'100%': '100',
+	XXXS: 'XXXS',
+	XXS: 'XXS',
+	XS: 'XS',
+	S: 'S',
+	M: 'M',
+	L: 'L',
+	XXXL: 'XXXL',
 };
 
 export const sizeOptionsWithAuto = {
@@ -94,6 +105,7 @@ export type StackPrimitiveProps = {
 	display?: 'block' | 'inline';
 	role?: string;
 	relative?: boolean;
+	height?: keyof typeof heightOptions;
 };
 
 const StackPrimitive = forwardRef(function StackPrimitive(
@@ -110,6 +122,7 @@ const StackPrimitive = forwardRef(function StackPrimitive(
 		padding,
 		margin,
 		role,
+		height,
 		...props
 	}: StackPrimitiveProps,
 	ref: React.Ref<any>,
@@ -203,6 +216,7 @@ const StackPrimitive = forwardRef(function StackPrimitive(
 				styles[wrap],
 				styles[direction],
 				styles[display],
+				height && styles[`height-${heightOptions[height]}`],
 				{ [styles.relative]: relative },
 				getAlignContent(),
 				...getGap(),

--- a/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
+++ b/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
@@ -6,6 +6,7 @@ import { StackHorizontal } from '.';
 import {
 	alignContentOptions,
 	alignOptions,
+	heightOptions,
 	justifyOptions,
 	possibleAsTypes,
 	sizeOptions,
@@ -46,6 +47,10 @@ export const manualStackArgs = {
 		options: ['nowrap', 'wrap', 'wrapReverse'],
 		control: { type: 'select' },
 		defaultValue: 'nowrap',
+	},
+	height: {
+		options: Object.keys(heightOptions),
+		control: { type: 'select' },
 	},
 	alignContent: { options: Object.keys(alignContentOptions), control: { type: 'select' } },
 	display: { options: ['block', 'inline'], control: { type: 'select' }, defaultValue: 'block' },

--- a/packages/design-system/src/components/Stack/StackHorizontal.tsx
+++ b/packages/design-system/src/components/Stack/StackHorizontal.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import StackPrimitive, { StackPrimitiveProps } from './Primitive/StackPrimitive';
 
-export type StackHorizontalProps = Omit<StackPrimitiveProps, 'direction'>;
+export type StackHorizontalProps = Omit<StackPrimitiveProps, 'direction' | 'height'>;
 
 export const StackHorizontal = forwardRef((props: StackHorizontalProps, ref: React.Ref<any>) => {
 	return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Would be nice to be able to provide a height to the `StackVertical` component

**What is the chosen solution to this problem?**

Add a prop allowing only tokens + 100%

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
