### PR TITLE
chore(presets): add breaking change for talend scripts presets

### DIFF
--- a/.changeset/large-days-breaking.md
+++ b/.changeset/large-days-breaking.md
@@ -1,0 +1,8 @@
+---
+'@talend/scripts-preset-react': major
+'@talend/scripts-preset-react-lib': major
+---
+
+fix(talend-scripts): update common webpack config for ng config compatibility and bump to postcss v8
+
+Breaking: html-loader has been removed and its webpack config too which means no automatic support of html import in webapp


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Latest changes on talend scripts are breaking and we want to make the app updates them when they want.

**What is the chosen solution to this problem?**

Add a major bump for breaking change for the presets

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
