### PR TITLE
chore(talend-scripts): disable storybook telemetry

### DIFF
--- a/.changeset/wild-garlics-marry.md
+++ b/.changeset/wild-garlics-marry.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+chore(talend-scripts): disable storybook telemetry

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -55,6 +55,8 @@ const defaultMain = {
 	],
 	core: {
 		builder: 'webpack5',
+		disableTelemetry: true,
+		enableCrashReports: false,
 	},
 	typescript: { reactDocgen: false },
 	webpackFinal: async (config) => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Storybook is now collecting some info.

<img width="965" alt="image" src="https://user-images.githubusercontent.com/1674329/189664441-14e3dfff-c60a-4583-80b8-0304bebd9393.png">

**What is the chosen solution to this problem?**

Disabled it from talend-scripts config following documentation.

https://storybook.js.org/docs/react/configure/telemetry#how-to-opt-out

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
