### PR TITLE
fix(TDOPS-1735/designSystem) - use DS namespace for translations

### DIFF
--- a/.changeset/calm-poets-talk.md
+++ b/.changeset/calm-poets-talk.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Use DS namespace for DS translations

--- a/packages/design-system/src/components/Breadcrumbs/Breadcrumbs.tsx
+++ b/packages/design-system/src/components/Breadcrumbs/Breadcrumbs.tsx
@@ -9,6 +9,7 @@ import { ButtonTertiary } from '../Button';
 import { StackHorizontal } from '../Stack';
 import Divider from '../Divider';
 import VisuallyHidden from '../VisuallyHidden';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 type BreadcrumbsLink = {
 	label: string;
@@ -61,7 +62,7 @@ function BreadcrumbLink({
 }
 
 const Breadcrumbs = forwardRef(({ items, ...rest }: BreadCrumbsProps, ref: Ref<HTMLElement>) => {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	const buildEntries = () => {
 		if (items.length > maxBreadcrumbsItemLength) {
 			const origin = items[0];

--- a/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
+++ b/packages/design-system/src/components/EmptyState/primitive/EmptyStatePrimitive.tsx
@@ -9,6 +9,7 @@ import { ButtonPrimaryPropsType } from '../../Button/variations/ButtonPrimary';
 import { ButtonPrimaryAsLinkPropsType } from '../../ButtonAsLink/variations/ButtonPrimaryAsLink';
 
 import styles from './EmptyStatePrimitive.module.scss';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 type CallbackTypes =
 	| (Omit<ButtonPrimaryPropsType<'M'>, 'size'> & { actionType: 'button' })
@@ -40,7 +41,7 @@ function buildAction(action: CallbackTypes) {
 
 const EmptyStatePrimitive = forwardRef((props: EmptyStatePrimitiveProps, ref: Ref<HTMLElement>) => {
 	const { title, description, link, illustration, action, ...commonProps } = props;
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 	return (
 		<article {...commonProps} ref={ref} className={styles.emptyState}>

--- a/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.Copy.tsx
@@ -5,6 +5,7 @@ import FieldGroup from '../../FieldGroup';
 import Text from './Input.Text';
 import { InputProps } from './Input';
 import { AffixButton, AffixReadOnly } from '../../FieldGroup/Affix';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../../constants';
 
 const InputCopy = React.forwardRef(
 	(
@@ -16,7 +17,7 @@ const InputCopy = React.forwardRef(
 		const [{ value: clipboardValue, error: clipboardError }, copyToClipboard] =
 			useCopyToClipboard();
 		const inputRef = React.useRef<HTMLInputElement | null>(null);
-		const { t } = useTranslation();
+		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 		const inputValue = value || defaultValue;
 
 		useEffect(() => {

--- a/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.File.tsx
@@ -13,6 +13,7 @@ import VisuallyHidden from '../../../VisuallyHidden';
 import Input, { InputProps } from './Input';
 import tokens from '../../../../deprecatedTokens';
 import Field from '../Field';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../../constants';
 
 const FileField = styled.div`
 	width: 100%;
@@ -142,7 +143,7 @@ const InputFile = React.forwardRef((props: FileProps, ref: React.Ref<HTMLInputEl
 	const [files, setFiles] = React.useState<FileList | null>(props.files);
 
 	const inputRef = React.useRef<HTMLInputElement | null>(null);
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 	function handleChange() {
 		const input = inputRef.current;

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
@@ -4,11 +4,12 @@ import { useTranslation } from 'react-i18next';
 import Clickable from '../../../../Clickable';
 import Tooltip from '../../../../Tooltip';
 import { SizedIcon } from '../../../../Icon';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../../../constants';
 
 export default function useRevealPassword() {
 	const [revealed, setRevealed] = useState(false);
 	const currentType = revealed ? 'text' : 'password';
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	const showMsg = t('FORM_PASSWORD_SHOW', { defaultValue: 'Show password' });
 	const hideMsg = t('FORM_PASSWORD_HIDE', { defaultValue: 'Hide password' });
 

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.tsx
@@ -8,6 +8,7 @@ import Form from '../Form';
 
 import * as S from './InlineEditing.style';
 import { StackHorizontal } from '../Stack';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 export enum Mode {
 	Single,
@@ -60,7 +61,7 @@ const InlineEditing = React.forwardRef(
 		}: StyledInlineEditing,
 		ref,
 	) => {
-		const { t } = useTranslation();
+		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 		const [isEditing, setEditMode] = React.useState(false);
 		const [value, setValue] = React.useState(defaultValue);
 

--- a/packages/design-system/src/components/Layout/Footer.tsx
+++ b/packages/design-system/src/components/Layout/Footer.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement } from 'react';
 import styled from 'styled-components';
 import { useTranslation } from 'react-i18next';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 export type FooterProps = React.PropsWithChildren<any>;
 
@@ -10,7 +11,7 @@ const SFooter = styled.div`
 `;
 
 const Footer = React.forwardRef(({ children, ...rest }: FooterProps, ref: React.Ref<any>) => {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	return (
 		<SFooter {...rest} ref={ref}>
 			<ul className="footer__links">

--- a/packages/design-system/src/components/Layout/SkipLinks/SkipLinks.tsx
+++ b/packages/design-system/src/components/Layout/SkipLinks/SkipLinks.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import Link from '../../Link';
 
 import * as S from './SkipLinks.style';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 export type SkipLinksProps = {
 	nav?: boolean;
@@ -11,7 +12,7 @@ export type SkipLinksProps = {
 };
 
 const SkipLinks = ({ nav, main }: SkipLinksProps) => {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	return (
 		<S.SkipLinks className="skip-links">
 			{/* eslint-disable-next-line jsx-a11y/no-redundant-roles */}

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -6,6 +6,7 @@ import { DeprecatedIconNames } from '../../types';
 import Linkable, { LinkableType, isBlank as targetCheck } from '../Linkable';
 
 import style from './Link.module.scss';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 export type LinkComponentProps = {
 	/** The icon to display before */
@@ -21,7 +22,7 @@ const Link = forwardRef(
 		{ children, disabled, href, target, title, hideExternalIcon, ...rest }: LinkProps,
 		ref: Ref<HTMLAnchorElement>,
 	) => {
-		const { t } = useTranslation();
+		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 		const isBlank: boolean = useMemo(() => targetCheck(target), [target]);
 
 		const getTitle = useCallback(() => {

--- a/packages/design-system/src/components/LinkAsButton/LinkAsButton.tsx
+++ b/packages/design-system/src/components/LinkAsButton/LinkAsButton.tsx
@@ -7,6 +7,7 @@ import { LinkComponentProps } from '../Link';
 
 import sharedLinkableStyles from '../Linkable/LinkableStyles.module.scss';
 import linkStyles from '../Link/Link.module.scss';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 type LinkAsButtonProps = Omit<ClickableProps, 'className'> &
 	Omit<LinkComponentProps, 'hideExternalIcon'>;
@@ -16,7 +17,7 @@ const LinkAsButton = forwardRef(
 		{ disabled, title, icon, children, ...rest }: LinkAsButtonProps,
 		ref: Ref<HTMLButtonElement>,
 	) => {
-		const { t } = useTranslation();
+		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 		const getTitle = () => {
 			if (disabled && title) {

--- a/packages/design-system/src/components/Stepper/Progress/Progress.tsx
+++ b/packages/design-system/src/components/Stepper/Progress/Progress.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import VisuallyHidden from '../../VisuallyHidden';
 
 import * as S from './Progress.style';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 type StepperOrientation = 'vertical' | 'horizontal';
 
@@ -15,7 +16,7 @@ export type ProgressProps = React.PropsWithChildren<any> & {
 };
 
 const Progress = ({ min = 1, value, max, orientation, children, ...rest }: ProgressProps) => {
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	const size = `${(value - 1) * (100 / (max - 1))}%`;
 	return (
 		<S.Progress

--- a/packages/design-system/src/components/ThemeProvider/ThemeSwitcher/ThemeSwitcher.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemeSwitcher/ThemeSwitcher.tsx
@@ -5,11 +5,12 @@ import { ButtonIconToggle } from '../../ButtonIcon';
 import ThemeContext from '../ThemeContext';
 
 import { dark, light } from '../../../themes';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 const ThemeSwitcher = () => {
 	const { switchTheme, theme } = useContext(ThemeContext);
 	const [hasDarkMode, setDarkMode] = useState(false);
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 	React.useEffect(() => {
 		setDarkMode(theme === dark);

--- a/packages/design-system/src/components/WIP/FormPrimitives/Input/Input.tsx
+++ b/packages/design-system/src/components/WIP/FormPrimitives/Input/Input.tsx
@@ -20,6 +20,7 @@ type InputProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> &
 	Omit<FieldStatusProps, 'errorMessage'>;
 
 import styles from './Input.module.scss';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../../constants';
 
 const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) => {
 	const {
@@ -38,7 +39,7 @@ const Input = forwardRef((props: InputProps, ref: Ref<HTMLInputElement | null>) 
 	const [isClear, setClear] = useState<boolean>(type !== 'password');
 	const inputType = type === 'password' && isClear ? 'text' : type;
 	const inputRef = useRef<HTMLInputElement | null>(null);
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	const showMsg = t('FORM_PASSWORD_SHOW', 'Show password');
 	const hideMsg = t('FORM_PASSWORD_HIDE', 'Hide password');
 

--- a/packages/design-system/src/components/WIP/HeaderBar/HeaderBar.tsx
+++ b/packages/design-system/src/components/WIP/HeaderBar/HeaderBar.tsx
@@ -6,6 +6,7 @@ import { useTranslation } from 'react-i18next';
 import * as S from './HeaderBar.style';
 
 import tokens from '../../../deprecatedTokens';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 const HeaderBar = S.HeaderBar;
 
@@ -16,7 +17,7 @@ const Content: React.FC<ContentProps> = ({ children }: ContentProps) => {
 	const disclosure = useDisclosureState({
 		animated: 250,
 	});
-	const { t } = useTranslation();
+	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 	return isWide ? (
 		children
 	) : (

--- a/packages/design-system/src/components/WIP/Menu/Menu.tsx
+++ b/packages/design-system/src/components/WIP/Menu/Menu.tsx
@@ -7,6 +7,7 @@ import * as S from './Menu.style';
 import tokens from '../../../deprecatedTokens';
 import Tooltip from '../../Tooltip';
 import { Icon } from '../../Icon/Icon';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
 
 export type MenuProps = React.PropsWithChildren<any> & {
 	/**
@@ -20,7 +21,7 @@ export type MenuProps = React.PropsWithChildren<any> & {
 const Menu = React.forwardRef(
 	({ children, hasToggle = true, ...rest }: MenuProps, ref: React.Ref<HTMLElement>) => {
 		const [isCollapsed, collapse] = React.useState(false);
-		const { t } = useTranslation();
+		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 		const isWide = useMedia(`(min-width: ${tokens.breakpoints.l})`);
 

--- a/packages/design-system/src/components/constants.ts
+++ b/packages/design-system/src/components/constants.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export const I18N_DOMAIN_DESIGN_SYSTEM = 'design-system';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
DS components are not localised
https://jira.talendforge.org/browse/TDOPS-1735

**What is the chosen solution to this problem?**
use DS namespace for translations

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
