### PR TITLE
fix(playground): display playground icons

### DIFF
--- a/.changeset/olive-taxis-joke.md
+++ b/.changeset/olive-taxis-joke.md
@@ -1,0 +1,5 @@
+---
+'@talend/ui-playground': patch
+---
+
+fix(playground): display playground icons

--- a/packages/playground/package.json
+++ b/packages/playground/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "build": "cross-env BASENAME='/playground' talend-scripts build",
     "test": "echo nothing to test in playground",
-    "test:demo:umd": "cross-env BASENAME='/playground' INITIATOR_URL='/playground/inject.js' talend-scripts build --prod",
+    "test:demo:umd": "cross-env BASENAME='/playground/' INITIATOR_URL='/playground/inject.js' talend-scripts build --prod",
     "start": "cross-env BASENAME='/' INITIATOR_URL='/inject.js' talend-scripts start --open http://localhost:3000",
     "start-dist": "talend-scripts build && node serve-dist"
   },


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Playground icons is broken:

<img width="768" alt="image" src="https://user-images.githubusercontent.com/1674329/190597134-cf7edff0-3ec1-49b0-a48e-e87c5dcde90f.png">

`/playgroundassets/svg/logo-645fcf40b9b6e3f25843.svg`
missing backslash
`/playground/assets/svg/logo-645fcf40b9b6e3f25843.svg`

**What is the chosen solution to this problem?**

Fix it

<img width="813" alt="image" src="https://user-images.githubusercontent.com/1674329/190597214-fb6c10f2-0a7a-4545-ac10-b9e631fde748.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
