### PR TITLE
fix(TDP-11342): do not reset Datalist filter on titleMap change

### DIFF
--- a/.changeset/odd-horses-wonder.md
+++ b/.changeset/odd-horses-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDP-11342): do not reset Datalist filter on titleMap change

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -147,7 +147,7 @@ function Datalist(props) {
 			setEntry(entry);
 		}
 		// Update the input value only if user did not change it
-		if (!name || name === filterValue) {
+		if ((!name && !filterValue) || name === filterValue) {
 			setFilterValue(entry.name);
 		}
 		// eslint-disable-next-line react-hooks/exhaustive-deps

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -43,9 +43,7 @@ describe('Datalist component', () => {
 
 	it('should show all suggestions on focus (even with a value)', () => {
 		// given
-		render(
-			<Datalist autoFocus id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />,
-		);
+		render(<Datalist id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />);
 
 		// when
 		fireEvent.click(screen.getByRole('textbox'));
@@ -60,9 +58,7 @@ describe('Datalist component', () => {
 
 	it('should show all suggestions on down press (even with a value)', () => {
 		// given
-		render(
-			<Datalist autoFocus id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />,
-		);
+		render(<Datalist id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />);
 
 		// when
 		userEvent.type(screen.getByRole('textbox'), '{down}');
@@ -77,9 +73,7 @@ describe('Datalist component', () => {
 
 	it('should show all suggestions on up press (even with a value)', () => {
 		// given
-		render(
-			<Datalist autoFocus id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />,
-		);
+		render(<Datalist id="my-datalist" isValid onChange={jest.fn()} {...props} value="foo" />);
 
 		// when
 		userEvent.type(screen.getByRole('textbox'), '{up}');
@@ -94,7 +88,7 @@ describe('Datalist component', () => {
 
 	it('should show suggestions that match filter', () => {
 		// given
-		render(<Datalist autoFocus id="my-datalist" isValid onChange={jest.fn()} {...props} />);
+		render(<Datalist id="my-datalist" isValid onChange={jest.fn()} {...props} />);
 
 		// when
 		userEvent.type(screen.getByRole('textbox'), 'foo');
@@ -276,11 +270,29 @@ describe('Datalist component', () => {
 		expect(screen.getByRole('textbox')).toHaveValue('My foo updated');
 	});
 
-	it('should keep filter when titleMap is updated', async () => {
+	it('should keep filter when titleMap is updated', () => {
 		// given
 		const testProps = {
 			id: 'my-datalist',
 			value: 'foo',
+			onChange: jest.fn(),
+			...props,
+		};
+		const { rerender } = render(<Datalist {...testProps} />);
+
+		// when
+		userEvent.type(screen.getByRole('textbox'), 'a');
+		rerender(<Datalist {...testProps} titleMap={[...props.titleMap]} />);
+
+		// then
+		expect(screen.getByRole('textbox')).toHaveValue('a');
+	});
+
+	it('should keep filter when titleMap is updated and value is empty', () => {
+		// given
+		const testProps = {
+			id: 'my-datalist',
+			value: '',
 			onChange: jest.fn(),
 			...props,
 		};
@@ -322,9 +334,7 @@ describe('Datalist component', () => {
 		expect(screen.getByRole('textbox')).toHaveValue(testProps.value);
 
 		// when data list is rendered one more time with value from new title map
-		rerender(
-			<Datalist {...testProps} titleMap={newTitleMap} value={newTitleMap[0].value} />,
-		);
+		rerender(<Datalist {...testProps} titleMap={newTitleMap} value={newTitleMap[0].value} />);
 
 		// then entry is updated and filter value is new entry name
 		expect(screen.getByRole('textbox')).toHaveValue(newTitleMap[0].name);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

When titleMap is updated asynchronously AND input has no value set, you lost filter value on promise resolved. 
![before](https://user-images.githubusercontent.com/6088236/190616056-4f4fc86a-5a17-448e-89d1-1a0242e3f3ce.gif) 

This bug causes E2E instabilities with cypress. 

**What is the chosen solution to this problem?**

Simply test if there is a filter before updating it with empty value.

Now your filter is not changed after titleMap has been updated 
![after](https://user-images.githubusercontent.com/6088236/190616253-17b73db0-5ab6-44fb-8d0d-38141c686694.gif)


**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
