### PR TITLE
fix(TFD-14580): Fix DataViewer click on icons

### DIFF
--- a/.changeset/brown-mayflies-swim.md
+++ b/.changeset/brown-mayflies-swim.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TFD-14580): Fix DataViewer click on icons

--- a/packages/components/src/DataViewer/Core/Tree/Tree.scss
+++ b/packages/components/src/DataViewer/Core/Tree/Tree.scss
@@ -14,7 +14,7 @@
 
 	&-node-border {
 		border-left: 1px solid $alto;
-		margin-left: -12px;
+		margin-left: calc($svg-sm-size / 2);
 		&:hover {
 			border-left-color: $silver-chalice;
 		}

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.component.js
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.component.js
@@ -75,7 +75,6 @@ export class TreeBranchIcon extends React.PureComponent {
 					className={iconClassNames}
 					key="Icon"
 					name={icon.name}
-					onClick={this.onClick}
 					title={`${title} ${dataKey} (${jsonpath})`}
 				/>
 			</span>

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.scss
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.scss
@@ -1,13 +1,12 @@
 .tc-tree-branch-icon {
+	display: flex;
+	margin-right: $padding-smaller;
+
 	&-caret {
-		position: absolute;
-		left: 0;
-		top: 50%;
-		transform: translate(-150%, -50%);
 		height: $svg-sm-size;
 		width: $svg-sm-size;
 		&-right {
-			transform: translate(-150%, -50%) rotate(180deg);
+			transform: rotate(180deg);
 		}
 	}
 	:global(.tc-svg-anchor) {

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.test.js
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.test.js
@@ -55,23 +55,4 @@ describe('TreeBranchIcon', () => {
 		);
 		expect(wrapper.getElement()).toMatchSnapshot();
 	});
-	it('should trigger onClick', () => {
-		const event = {};
-		const index = 0;
-		const opened = true;
-		const jsonpath = 'myJsonPath';
-		const value = { value: 'myValue' };
-		const onToggle = jest.fn();
-		const wrapper = shallow(
-			<Component
-				index={index}
-				jsonpath={jsonpath}
-				onToggle={onToggle}
-				opened={opened}
-				value={value}
-			/>,
-		);
-		wrapper.find('Icon').simulate('click', event);
-		expect(onToggle).toHaveBeenCalledWith(event, { value, opened, jsonpath }, index);
-	});
 });

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/__snapshots__/TreeBranchIcon.test.js.snap
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/__snapshots__/TreeBranchIcon.test.js.snap
@@ -7,7 +7,6 @@ exports[`TreeBranchIcon should render an closed icon 1`] = `
   <Icon
     className="theme-tc-tree-branch-icon-caret tc-tree-branch-icon-caret theme-tc-tree-branch-icon-caret-right tc-tree-branch-icon-caret-right"
     name="talend-chevron-left"
-    onClick={[Function]}
     title="Expand myDataKey (myJsonPath)"
   />
 </span>
@@ -20,7 +19,6 @@ exports[`TreeBranchIcon should render an opened icon 1`] = `
   <Icon
     className="theme-tc-tree-branch-icon-caret tc-tree-branch-icon-caret"
     name="talend-caret-down"
-    onClick={[Function]}
     title="Collapse myDataKey (myJsonPath)"
   />
 </span>

--- a/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
+++ b/packages/components/src/DataViewer/RecordsViewer/Branch/RecordsViewerBranch.component.js
@@ -7,6 +7,7 @@ import Skeleton from '../../../Skeleton';
 import { LengthBadge } from '../../Badges';
 import { TreeBranchIcon } from '../../Icons';
 import theme from '../RecordsViewer.scss';
+import { Icon } from '@talend/design-system';
 
 /**
  * Used with the lazy loading to allow the render of the skeleton.

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.scss
@@ -75,6 +75,7 @@ $border-size: 0.1rem;
 	&-branch {
 		flex-direction: column;
 		justify-content: center;
+		margin-left: 12px;
 
 		&-highlighted::before {
 			@include selection($background-highlight);
@@ -106,10 +107,6 @@ $border-size: 0.1rem;
 		}
 
 		&-icon {
-			position: absolute;
-			left: 0;
-			top: 50%;
-			transform: translate(-150%, -50%);
 			color: $brand-primary;
 			height: $svg-sm-size;
 			width: $svg-sm-size;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Sub levels of hierarchical data rendered with the DataViewer component cannot be opened by clicking on the branch/leaf icon.
It was possible before.

https://jira.talendforge.org/browse/TFD-14580

**What is the chosen solution to this problem?**
Fix it.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
