### PR TITLE
fix(script-config): fallback and polyfills

### DIFF
--- a/.changeset/angry-plums-crash.md
+++ b/.changeset/angry-plums-crash.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix: fallback and polyfills

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -262,6 +262,7 @@ module.exports = ({ getUserConfig, mode }) => {
 			resolve: {
 				extensions: ['.js', useTypescript && '.ts', useTypescript && '.tsx'].filter(Boolean),
 				fallback: {
+					path: false,
 					url: false,
 				},
 			},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Webpack does not load nodejs polyfills automatically now 👀 
![image](https://user-images.githubusercontent.com/2909671/192472934-17a8a85c-5a7a-48c4-9afb-646b184dda83.png)

**What is the chosen solution to this problem?**
Add path to false 
https://webpack.js.org/configuration/resolve/#resolvefallback

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
