### PR TITLE
fix: use flex-start

### DIFF
--- a/.changeset/slow-swans-approve.md
+++ b/.changeset/slow-swans-approve.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-components': patch
+'@talend/design-system': patch
+---
+
+fix: use flex-start instead of start

--- a/packages/components/src/SidePanel/SidePanel.scss
+++ b/packages/components/src/SidePanel/SidePanel.scss
@@ -52,7 +52,7 @@ $large-docked-width: 7rem;
 			.btn.btn-link {
 				display: flex;
 				align-items: center;
-				justify-content: start;
+				justify-content: flex-start;
 				font-size: 1.6rem;
 				height: $list-item-height;
 				margin: $padding-smaller $padding-small;

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/CompositionList/CompositionListItem.module.scss
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/CompositionList/CompositionListItem.module.scss
@@ -14,7 +14,7 @@
   width: 100%;
   grid-template-columns: repeat(2, 1fr);
   gap: tokens.$coral-spacing-m;
-  align-items: start;
+  align-items: flex-start;
 }
 
 .title {

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/ColorScale/ColorScale.module.scss
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/ColorScale/ColorScale.module.scss
@@ -6,7 +6,7 @@
   overflow: auto;
   gap: tokens.$coral-spacing-m;
   justify-content: space-between;
-  align-items: start;
+  align-items: flex-start;
   list-style-type: none;
   max-width: 100%;
 

--- a/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/SizingScale/SizingScale.module.scss
+++ b/packages/design-system/.storybook/docs/tokensDocHelpers/components/DefinitionList/SizingScale/SizingScale.module.scss
@@ -5,8 +5,8 @@
   flex-flow: row nowrap;
   overflow: auto;
   gap: tokens.$coral-spacing-m;
-  justify-content: start;
-  align-items: start;
+  justify-content: flex-start;
+  align-items: flex-start;
   list-style-type: none;
   max-width: 100%;
 

--- a/packages/design-system/src/components/Form/Primitives/Checkbox/Checkbox.module.scss
+++ b/packages/design-system/src/components/Form/Primitives/Checkbox/Checkbox.module.scss
@@ -7,7 +7,7 @@ $checkbox-size: tokens.$coral-sizing-xxxs;
 .checkbox {
   display: flex;
   gap: tokens.$coral-spacing-xs;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   position: relative;
 

--- a/packages/design-system/src/components/Form/Primitives/Radio/Radio.module.scss
+++ b/packages/design-system/src/components/Form/Primitives/Radio/Radio.module.scss
@@ -6,7 +6,7 @@ $mark-size: calc(#{tokens.$coral-sizing-xxs} / 2);
 .radio {
   display: inline-flex;
   gap: tokens.$coral-spacing-xs;
-  justify-content: start;
+  justify-content: flex-start;
   align-items: center;
   position: relative;
 

--- a/packages/design-system/src/components/InlineMessage/Primitive/InlineMessagePrimitive.module.scss
+++ b/packages/design-system/src/components/InlineMessage/Primitive/InlineMessagePrimitive.module.scss
@@ -43,8 +43,8 @@
     display: inline-flex;
     padding: tokens.$coral-spacing-xxs tokens.$coral-spacing-xs;
     border-radius: tokens.$coral-radius-s;
-    justify-content: start;
-    align-items: start;
+    justify-content: flex-start;
+    align-items: flex-start;
 
     .icon {
       // Visually align icon in inline-flex mode

--- a/packages/design-system/src/components/WIP/Tabs/Primitive/TabStyles.module.scss
+++ b/packages/design-system/src/components/WIP/Tabs/Primitive/TabStyles.module.scss
@@ -6,8 +6,8 @@
   color: tokens.$coral-color-neutral-text-weak;
   position: relative;
   display: inline-flex;
-  justify-content: start;
-  align-items: start;
+  justify-content: flex-start;
+  align-items: flex-start;
   background: transparent;
   border: 0;
   padding: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

I see many logs during build: 
```
(35:3) start value has mixed support, consider using flex-start instead
```

**What is the chosen solution to this problem?**

use flex-start

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
