### PR TITLE
fix(ARCH-631): explicit use sass-data

### DIFF
--- a/.changeset/silly-fireants-run.md
+++ b/.changeset/silly-fireants-run.md
@@ -1,5 +1,9 @@
 ---
 '@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/react-dataviz': patch
+'@talend/react-faceted-search': patch
+'@talend/react-forms': patch
 ---
 
 fix: explicit import of sass-data

--- a/.changeset/silly-fireants-run.md
+++ b/.changeset/silly-fireants-run.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: explicit import of sass-data

--- a/packages/components/src/AboutDialog/AboutDialog.module.scss
+++ b/packages/components/src/AboutDialog/AboutDialog.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .about-dialog {
 	:global(.modal-body) {
 		text-align: center;

--- a/packages/components/src/ActionBar/ActionBar.module.scss
+++ b/packages/components/src/ActionBar/ActionBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-action-bar-background-color: $wild-sand !default;
 $tc-action-bar-margin: $padding-small $padding-large $padding-small 0 !default;
 

--- a/packages/components/src/ActionIntercom/Intercom.module.scss
+++ b/packages/components/src/ActionIntercom/Intercom.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-intercom {
 	position: relative;
 

--- a/packages/components/src/ActionList/ActionList.module.scss
+++ b/packages/components/src/ActionList/ActionList.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 
 ////

--- a/packages/components/src/Actions/ActionButton/ActionButton.module.scss
+++ b/packages/components/src/Actions/ActionButton/ActionButton.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-action-button-skeleton-circle {
 	margin-left: $padding-smaller;
 	margin-right: $padding-small;

--- a/packages/components/src/Actions/ActionButton/Button.stories.module.scss
+++ b/packages/components/src/Actions/ActionButton/Button.stories.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .storybook-wrapped-action {
 	margin-top: 200px;
 	margin-bottom: 250px;

--- a/packages/components/src/Actions/ActionDropdown/ActionDropdown.module.scss
+++ b/packages/components/src/Actions/ActionDropdown/ActionDropdown.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-dropdown-loader-padding: $padding-small !default;
 $tc-dropdown-button-right-padding: 0.8rem;
 

--- a/packages/components/src/Actions/ActionFile/ActionFile.module.scss
+++ b/packages/components/src/Actions/ActionFile/ActionFile.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 input[type='file'] {
 	&.action-file-input:focus + label {
 		@include tab-focus;

--- a/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.module.scss
+++ b/packages/components/src/Actions/ActionIconToggle/ActionIconToggle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-icon-toggle-size: 2.4rem !default;
 $tc-icon-toggle-icon-size: $svg-sm-size !default;
 $tc-icon-toggle-border: 1px solid $gray;

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.module.scss
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-split-dropdown {
 	li>a {
 		i,

--- a/packages/components/src/AppGuidedTour/DemoContentStep.module.scss
+++ b/packages/components/src/AppGuidedTour/DemoContentStep.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .info {
 	white-space: pre;
 }

--- a/packages/components/src/AppSwitcher/AppSwitcher.module.scss
+++ b/packages/components/src/AppSwitcher/AppSwitcher.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-app-switcher {
 	:global(.tc-svg-icon:first-child) {
 		height: $svg-lg-size;

--- a/packages/components/src/Badge/Badge.module.scss
+++ b/packages/components/src/Badge/Badge.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-badge-large-label-font-size: 1.4rem !default;
 $tc-badge-large-label-font-weight: normal !default;
 $tc-badge-large-label-with-categ-font-weight: $font-weight-semi-bold !default;

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.module.scss
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 ////
 /// Breadcrumb
 /// @group Custom widgets

--- a/packages/components/src/CircularProgress/CircularProgress.module.scss
+++ b/packages/components/src/CircularProgress/CircularProgress.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // CircularProgress styles
 $tc-circular-progress-light-fill: #eee !default;
 $tc-circular-progress-small: 1.2rem;

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.module.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-collapsible-panel-padding-smaller: $padding-smaller !default;
 $tc-collapsible-panel-padding-normal: $padding-normal !default;
 $tc-collapsible-panel-padding-larger: $padding-larger !default;

--- a/packages/components/src/DataViewer/Badges/LengthBadge/LengthBadge.module.scss
+++ b/packages/components/src/DataViewer/Badges/LengthBadge/LengthBadge.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-length-badge {
 	background-color: $gallery;
 	color: $dark-silver;

--- a/packages/components/src/DataViewer/Core/Tree/Tree.module.scss
+++ b/packages/components/src/DataViewer/Core/Tree/Tree.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 :global(.tc-model .tc-tree) {
 	overflow: auto;
 }

--- a/packages/components/src/DataViewer/Headers/TreeHeader/TreeHeader.module.scss
+++ b/packages/components/src/DataViewer/Headers/TreeHeader/TreeHeader.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $default-height: 4rem !default;
 
 .tc-tree-header {

--- a/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.module.scss
+++ b/packages/components/src/DataViewer/Icons/TreeBranchIcon/TreeBranchIcon.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-tree-branch-icon {
 	display: flex;
 	margin-right: $padding-smaller;

--- a/packages/components/src/DataViewer/ModelViewer/ModelViewer.module.scss
+++ b/packages/components/src/DataViewer/ModelViewer/ModelViewer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 $background-hover: rgba($dark-silver, 0.1) !default;

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.module.scss
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $background-hover: rgba($dark-silver, 0.1) !default;
 $background-highlight: rgba($scooter, 0.1) !default;
 $hightlight-height: 2.2rem !default;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.module.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/DefaultValueRenderer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .td-default-cell {
 	height: 100%;
 	white-space: nowrap;

--- a/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.module.scss
+++ b/packages/components/src/DataViewer/Text/SimpleTextKeyValue/SimpleTextKeyValue.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-simple-text {
 	display: flex;
 	min-width: 0;

--- a/packages/components/src/DataViewer/Virtualized/VirtualizedTree/VirtualizedTree.module.scss
+++ b/packages/components/src/DataViewer/Virtualized/VirtualizedTree/VirtualizedTree.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-virtualized-tree {
 	flex: 1 1 auto;
 }

--- a/packages/components/src/DataViewer/theme.module.scss
+++ b/packages/components/src/DataViewer/theme.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-layout-skeleton-width: 9.6rem !default;
 $tc-layout-skeleton-height: 9.6rem !default;
 

--- a/packages/components/src/Datalist/Datalist.module.scss
+++ b/packages/components/src/Datalist/Datalist.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-datalist-items-max-height: 32rem !default;
 $tc-datalist-item-height: 4rem !default;
 

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../shared/styles/mixins';
 
 .popper {

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../shared/styles/mixins';
 
 .popper {

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .date-time-picker {
 	display: flex;
 	flex-direction: row;

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../shared/styles/mixins';
 
 .range-picker {

--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-timepicker-width: 8rem !default;
 $tc-timepicker-height: 17rem !default;
 $tc-timepicker-box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2) !default;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .validation {
 	display: flex;
 	padding: $padding-small $padding-normal;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-datetimepicker-width: 31rem !default;
 $tc-datetimepicker-background: $white !default;
 $tc-datetimepicker-box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2) !default;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DatePicker/DatePicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DatePicker/DatePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/DateTimePicker/DateTimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 .container {

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 
 .time-picker {

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 
 .year-picker {

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/shared/styles/mixins.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @mixin nav-action {
 	padding: 0;
 	background: none;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/shared/styles/variables.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/shared/styles/variables.scss
@@ -1,1 +1,3 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $border-default: 0.1rem solid $gallery !default;

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/DateTimeView/DateTimeView.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/DateTimeView/DateTimeView.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/variables';
 
 .body {

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/HeaderTitle/HeaderTitle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 
 .common {

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/ViewLayout/ViewLayout.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/views/ViewLayout/ViewLayout.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .container {
 	height: 100%;
 	display: flex;

--- a/packages/components/src/DateTimePickers/Time/Input/Input.module.scss
+++ b/packages/components/src/DateTimePickers/Time/Input/Input.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .time-picker-input {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/DateTimePickers/TimeZone/TimeZone.module.scss
+++ b/packages/components/src/DateTimePickers/TimeZone/TimeZone.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .timezone-tooltip {
 	margin: 0 $padding-smaller;
 }

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 .container {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 @import '../../shared/styles/variables';
 

--- a/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .container {
 	padding: $padding-smaller 0;
 	background-color: $white;

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 
 .year-picker {

--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import './variables';
 
 @mixin nav-action {

--- a/packages/components/src/DateTimePickers/shared/styles/variables.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/variables.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $border-default: 0.1rem solid $gallery !default;
 
 $tc-datepicker-width: 31rem !default;

--- a/packages/components/src/DateTimePickers/views/DateView/DateView.module.scss
+++ b/packages/components/src/DateTimePickers/views/DateView/DateView.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/variables';
 
 .body {

--- a/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.module.scss
+++ b/packages/components/src/DateTimePickers/views/HeaderTitle/HeaderTitle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../../shared/styles/mixins';
 
 .common {

--- a/packages/components/src/DateTimePickers/views/ViewLayout/ViewLayout.module.scss
+++ b/packages/components/src/DateTimePickers/views/ViewLayout/ViewLayout.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .container {
 	height: 100%;
 	display: flex;

--- a/packages/components/src/Dialog/Dialog.scss
+++ b/packages/components/src/Dialog/Dialog.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 :global {
 	.modal-flex .modal-body {
 		display: flex;

--- a/packages/components/src/Drawer/Drawer.module.scss
+++ b/packages/components/src/Drawer/Drawer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-drawer-initial-offset: 1000px !default;
 $tc-drawer-bgcolor: white !default;
 $tc-drawer-transition-duration: 230ms !default;

--- a/packages/components/src/EditableText/EditableText.module.scss
+++ b/packages/components/src/EditableText/EditableText.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 @mixin ellipsis {

--- a/packages/components/src/Emphasis/Emphasis.module.scss
+++ b/packages/components/src/Emphasis/Emphasis.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .highlight {
 	font-weight: $font-weight-semi-bold;
 	font-style: normal;

--- a/packages/components/src/Enumeration/Enumeration.module.scss
+++ b/packages/components/src/Enumeration/Enumeration.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-enumeration-height: 50vh !default;
 $tc-enumeration-font-size: 1.4rem !default;
 

--- a/packages/components/src/Enumeration/Enumeration.stories.module.scss
+++ b/packages/components/src/Enumeration/Enumeration.stories.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .enum-with-class {
 	:global(.tc-enumeration-items) {
 		button.inactive > span {

--- a/packages/components/src/Enumeration/Header/Header.module.scss
+++ b/packages/components/src/Enumeration/Header/Header.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-enumeration-smaller-padding: $padding-smaller !default;
 $tc-enumeration-small-padding: $padding-small !default;
 $tc-enumeration-normal-padding: $padding-normal !default;

--- a/packages/components/src/Enumeration/Items/Item/Item.module.scss
+++ b/packages/components/src/Enumeration/Items/Item/Item.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-enumeration-normal-padding: $padding-normal !default;
 $tc-enumeration-smaller-padding: $padding-smaller !default;
 $tc-enumeration-small-padding: $padding-small !default;

--- a/packages/components/src/Enumeration/Items/Items.module.scss
+++ b/packages/components/src/Enumeration/Items/Items.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-enumeration-height: 40vh !default;
 
 .tc-enumeration-items {

--- a/packages/components/src/FilterBar/FilterBar.module.scss
+++ b/packages/components/src/FilterBar/FilterBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // Filter styles
 $tc-filter-bar-highlight-color: rgba($lightning-yellow, 0.75) !default;
 $tc-filter-bar-width: 250px !default;

--- a/packages/components/src/FormatValue/FormatValue.module.scss
+++ b/packages/components/src/FormatValue/FormatValue.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $svg-tab-width: 2.6rem !default;
 $svg-other-characters: 0.3rem !default;
 $svg-color: #ccc !default;

--- a/packages/components/src/GridLayout/Grid.module.scss
+++ b/packages/components/src/GridLayout/Grid.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .layout	{
 	:global(.react-grid-item) {
 		display: flex;

--- a/packages/components/src/GridLayout/Tile/Footer/TileFooter.module.scss
+++ b/packages/components/src/GridLayout/Tile/Footer/TileFooter.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-tile-footer {
 	display: flex;
 	height: 6.5rem;

--- a/packages/components/src/GridLayout/Tile/Header/TileHeader.module.scss
+++ b/packages/components/src/GridLayout/Tile/Header/TileHeader.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-tile-header {
 	display: flex;
 	height: 6.5rem;

--- a/packages/components/src/GridLayout/Tile/Tile.module.scss
+++ b/packages/components/src/GridLayout/Tile/Tile.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-tile-container {
 	display: flex;
 	flex-direction: column;

--- a/packages/components/src/GuidedTour/GuidedTour.module.scss
+++ b/packages/components/src/GuidedTour/GuidedTour.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-guidedtour-accent-color: $scooter !default;
 $tc-guidedtour-tooltip-padding: $padding-large !default;
 $tc-guidedtour-mask-opactiy: 0.25 !default;

--- a/packages/components/src/HeaderBar/HeaderBar.module.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-headerbar-logo-width: 6rem !default;
 $tc-headerbar-logo-full-width: 8.5rem !default;
 $background-color-on-hover: rgba(255, 255, 255, 0.2);

--- a/packages/components/src/HttpError/HttpError.module.scss
+++ b/packages/components/src/HttpError/HttpError.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-http-error-status-color: $scooter !default;
 $tc-http-error-title-color: $brand-primary !default;
 $tc-http-error-message-color: #888 !default;

--- a/packages/components/src/JSONSchemaRenderer/JSONSchemaRenderer.module.scss
+++ b/packages/components/src/JSONSchemaRenderer/JSONSchemaRenderer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .json-schema-renderer {
 	margin-top: $padding-large;
 	margin-left: $padding-large;

--- a/packages/components/src/Layout/Layout.module.scss
+++ b/packages/components/src/Layout/Layout.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 ////
 /// Layout
 /// @group Custom widgets

--- a/packages/components/src/Layout/OneColumn/OneColumn.module.scss
+++ b/packages/components/src/Layout/OneColumn/OneColumn.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // OneColumn styles
 
 .main {

--- a/packages/components/src/Layout/SkipLinks/SkipLinks.module.scss
+++ b/packages/components/src/Layout/SkipLinks/SkipLinks.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-skip-links {
 	position: absolute;
 	width: 0;

--- a/packages/components/src/Layout/TwoColumns/TwoColumns.module.scss
+++ b/packages/components/src/Layout/TwoColumns/TwoColumns.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 ////
 /// Layout
 /// @group Custom widgets

--- a/packages/components/src/List/List.module.scss
+++ b/packages/components/src/List/List.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // List styles
 
 .list {

--- a/packages/components/src/List/ListComposition/DisplayMode/DisplayModeToggle.scss
+++ b/packages/components/src/List/ListComposition/DisplayMode/DisplayModeToggle.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-display-button-icon-height: 2.4rem;
 
 .tc-display-mode-toggle {

--- a/packages/components/src/List/ListComposition/List.module.scss
+++ b/packages/components/src/List/ListComposition/List.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .list {
 	display: flex;
 	flex-direction: column;

--- a/packages/components/src/List/ListComposition/SortBy/SortBy.module.scss
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // SelectSortBy styles
 
 $tc-list-toolbar-display-color: $dove-gray !default;

--- a/packages/components/src/List/ListComposition/Toolbar/ListToolbar.module.scss
+++ b/packages/components/src/List/ListComposition/Toolbar/ListToolbar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-list-toolbar-display-color: $silver !default;
 $tc-list-toolbar-background-color: $wild-sand !default;
 

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.module.scss
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooser.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-popover-border-color: rgb(226, 226, 226) !default;
 $tc-popover-border-width: 0.1rem !default;
 $tc-icon-size: 1.2rem !default;

--- a/packages/components/src/List/Toolbar/Pagination/Pagination.module.scss
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-pagination {
 	:global(.tc-svg-icon) {
 		height: $svg-sm-size;

--- a/packages/components/src/List/Toolbar/SelectAll/SelectAll.module.scss
+++ b/packages/components/src/List/Toolbar/SelectAll/SelectAll.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-list-toolbar-background-color: $wild-sand !default;
 
 .container {

--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.module.scss
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // SelectSortBy styles
 
 $tc-list-toolbar-display-color: $dove-gray !default;

--- a/packages/components/src/List/Toolbar/Toolbar.module.scss
+++ b/packages/components/src/List/Toolbar/Toolbar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 
 // Toolbar styles

--- a/packages/components/src/ListView/Header/Header.module.scss
+++ b/packages/components/src/ListView/Header/Header.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-listview-header-height: 28px !default;
 $tc-listview-svg-color: #666 !default;
 $tc-listview-font-size: 1.4rem !default;

--- a/packages/components/src/ListView/Items/Items.module.scss
+++ b/packages/components/src/ListView/Items/Items.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-listview-height: 40vh !default;
 
 $row-height: 12px;

--- a/packages/components/src/ListView/ListView.module.scss
+++ b/packages/components/src/ListView/ListView.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-listview-svg-color: $dove-gray !default;
 $tc-listview-font-size: 1.4rem !default;
 

--- a/packages/components/src/Loader/Loader.module.scss
+++ b/packages/components/src/Loader/Loader.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-loader {
 	display: flex;
 }

--- a/packages/components/src/MultiSelect/Dropdown.module.scss
+++ b/packages/components/src/MultiSelect/Dropdown.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .dropdown {
 	z-index: 100;
 	position: absolute;

--- a/packages/components/src/MultiSelect/ItemOption.module.scss
+++ b/packages/components/src/MultiSelect/ItemOption.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .row {
 	padding-left: $padding-normal;
 	&:hover {

--- a/packages/components/src/MultiSelect/MultiSelect.module.scss
+++ b/packages/components/src/MultiSelect/MultiSelect.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // MultiSelect styles
 .container {
 	color: black;

--- a/packages/components/src/Notification/Notification.module.scss
+++ b/packages/components/src/Notification/Notification.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-notification-info-color: #3c763d !default;
 $tc-notification-info-bgcolor: #e8f2cc !default;
 

--- a/packages/components/src/ObjectViewer/JSONLike/JSONLike.module.scss
+++ b/packages/components/src/ObjectViewer/JSONLike/JSONLike.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @mixin chevron($color) {
 	border: 1px solid $scooter;
 	padding: 3px;

--- a/packages/components/src/ObjectViewer/List/List.module.scss
+++ b/packages/components/src/ObjectViewer/List/List.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // List styles
 .container {
 	> li {

--- a/packages/components/src/ObjectViewer/Table/Table.module.scss
+++ b/packages/components/src/ObjectViewer/Table/Table.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .table {
 	font-size: 12px;
 

--- a/packages/components/src/OverlayTrigger/OverlayTrigger.module.scss
+++ b/packages/components/src/OverlayTrigger/OverlayTrigger.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-action-button-positionned {
 	position: relative;
 	display: inline-block;

--- a/packages/components/src/PieChart/PieChart.module.scss
+++ b/packages/components/src/PieChart/PieChart.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 $tc-pie-chart-font-size: $font-size-large !default;
 $tc-pie-chart-loading-min-height-no-label: 20px !default;

--- a/packages/components/src/Progress/Progress.module.scss
+++ b/packages/components/src/Progress/Progress.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-progress-color: $brand-success !default;
 $infinite-indicator-ratio: 3;
 $infinite-indicator-width: calc(100% / $infinite-indicator-ratio);

--- a/packages/components/src/QualityBar/QualityRatioBar.module.scss
+++ b/packages/components/src/QualityBar/QualityRatioBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 $custom-quality-bar-placeholder-line-hover-height: 0.4rem;

--- a/packages/components/src/RadarChart/RadarChart.module.scss
+++ b/packages/components/src/RadarChart/RadarChart.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-radar-chart {
 	:global {
 		.recharts-polar-grid-concentric-polygon:not(:last-child) {

--- a/packages/components/src/RatioBar/RatioBar.module.scss
+++ b/packages/components/src/RatioBar/RatioBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 $custom-ratio-bar-height: 0.8rem;

--- a/packages/components/src/ResourceList/Resource/Resource.module.scss
+++ b/packages/components/src/ResourceList/Resource/Resource.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .resource-item {
 	padding-left: $padding-normal;
 	padding-right: $padding-normal;

--- a/packages/components/src/ResourceList/ResourceList.module.scss
+++ b/packages/components/src/ResourceList/ResourceList.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-resource-list-margin-top: 2rem !default;
 $tc-resource-list-height: 25rem !default;
 

--- a/packages/components/src/ResourceList/Toolbar/NameFilter/NameFilter.module.scss
+++ b/packages/components/src/ResourceList/Toolbar/NameFilter/NameFilter.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-resource-picker-name-filter {
 	flex: 1;
 	position: relative;

--- a/packages/components/src/ResourceList/Toolbar/SortOptions/OrderChooser/OrderChooser.module.scss
+++ b/packages/components/src/ResourceList/Toolbar/SortOptions/OrderChooser/OrderChooser.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-resource-picker-order-chooser-icon-size: 0.6rem !default;
 
 .tc-resource-picker-order-chooser {

--- a/packages/components/src/ResourceList/Toolbar/SortOptions/SortOptions.module.scss
+++ b/packages/components/src/ResourceList/Toolbar/SortOptions/SortOptions.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-resource-picker-sort-options {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/ResourceList/Toolbar/StateFilter/StateFilter.module.scss
+++ b/packages/components/src/ResourceList/Toolbar/StateFilter/StateFilter.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-resource-picker-toolbar-favorite-color: $lightning-yellow !default;
 $tc-resource-picker-toolbar-certified-color: $brand-primary !default;
 

--- a/packages/components/src/ResourceList/Toolbar/Toolbar.module.scss
+++ b/packages/components/src/ResourceList/Toolbar/Toolbar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-resource-list-toolbar {
 	display: flex;
 	background: $white;

--- a/packages/components/src/ResourcePicker/ResourcePicker.module.scss
+++ b/packages/components/src/ResourcePicker/ResourcePicker.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-resource-picker-toolbar-height: 3.5rem !default;
 $tc-resource-picker-height: 25rem !default;
 

--- a/packages/components/src/Rich/Error/RichError.module.scss
+++ b/packages/components/src/Rich/Error/RichError.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-rich-error-icon-size: 3.6rem !default;
 
 .wrapper {

--- a/packages/components/src/Rich/HeaderTitle/HeaderTitle.module.scss
+++ b/packages/components/src/Rich/HeaderTitle/HeaderTitle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-header-title-font-size: 1.6rem !default;
 $tc-header-title-font-weight: 700 !default;
 

--- a/packages/components/src/Rich/Layout/RichLayout.module.scss
+++ b/packages/components/src/Rich/Layout/RichLayout.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-popover-border-width: 0.1rem !default;
 $tc-popover-border-color: rgb(226, 226, 226) !default;
 $tc-popover-box-shadow: 0 0.1rem 0.3rem 0 rgba(0, 0, 0, 0.2) !default;

--- a/packages/components/src/SidePanel/SidePanel.module.scss
+++ b/packages/components/src/SidePanel/SidePanel.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 
 ////

--- a/packages/components/src/Skeleton/Skeleton.module.scss
+++ b/packages/components/src/Skeleton/Skeleton.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 $tc-skeleton-border-radius: 4px !default;

--- a/packages/components/src/Slider/Slider.module.scss
+++ b/packages/components/src/Slider/Slider.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 
 $tc-slider-thumb-shadow: 0 1px 2px 0 rgba(117, 132, 149, 0.5); //$slate-gray;

--- a/packages/components/src/Status/Status.module.scss
+++ b/packages/components/src/Status/Status.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-status-icon-size: $svg-md-size !default;
 $tc-status-action-min-size: 23px !default;
 $tc-status-space-btn-icon-label: 5px !default;

--- a/packages/components/src/Stepper/Stepper.component.module.scss
+++ b/packages/components/src/Stepper/Stepper.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $stepper-icon-size: $svg-md-size !default;
 
 .stepper {

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.module.scss
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @mixin input-icon($margin-left) {
 	margin-top: 1rem;
 	margin-left: $margin-left;

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 @mixin ellipsis {

--- a/packages/components/src/TabBar/TabBar.module.scss
+++ b/packages/components/src/TabBar/TabBar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @function str-replace($string, $search, $replace: '') {
 	$index: str-index($string, $search);
 	@return if($index, str-slice($string, 1, $index - 1) + $replace + str-replace(str-slice($string, $index + str-length($search)), $search, $replace), $string);

--- a/packages/components/src/Toggle/LabelToggle/LabelToggle.module.scss
+++ b/packages/components/src/Toggle/LabelToggle/LabelToggle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @mixin radio-toolbar-input($color, $opacity) {
 	transition: 0.2s ease-out;
 	color: $color;

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.module.scss
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-tooltip-max-width: 30rem !default;
 $tc-tooltip-font-size: 1.2rem !default;
 $tc-tooltip-color: $white !default;

--- a/packages/components/src/TreeView/TreeView.module.scss
+++ b/packages/components/src/TreeView/TreeView.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // TreeView styles
 
 .tc-treeview {

--- a/packages/components/src/TreeView/TreeViewItem/TreeViewItem.module.scss
+++ b/packages/components/src/TreeView/TreeViewItem/TreeViewItem.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // TreeView styles
 $item-height: 4rem;
 

--- a/packages/components/src/Typeahead/Typeahead.module.scss
+++ b/packages/components/src/Typeahead/Typeahead.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 $tc-typeahead-input-color: $black !default;

--- a/packages/components/src/VirtualizedList/CellActions/RowLargeCellActions.module.scss
+++ b/packages/components/src/VirtualizedList/CellActions/RowLargeCellActions.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // Large display specificities
 .row {
 	.tc-list-actions :global(.tc-actions) > button {

--- a/packages/components/src/VirtualizedList/CellActions/RowTableCellActions.module.scss
+++ b/packages/components/src/VirtualizedList/CellActions/RowTableCellActions.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // manage actions display on row hover
 .row {
 	.tc-list-actions button {

--- a/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.module.scss
+++ b/packages/components/src/VirtualizedList/CellBoolean/CellBoolean.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .cell-boolean-container {
 	display: flex;
 	width: 100%;

--- a/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.module.scss
+++ b/packages/components/src/VirtualizedList/CellCheckbox/CellCheckbox.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-list-checkbox {
 	:global(.checkbox) {
 		margin: 0;

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.module.scss
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .cell-icon-container {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/VirtualizedList/CellIconText/CellIconText.module.scss
+++ b/packages/components/src/VirtualizedList/CellIconText/CellIconText.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-icon-text {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.module.scss
+++ b/packages/components/src/VirtualizedList/CellTextIcon/CellWithIcon.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .cell-icon-container {
 	display: flex;
 	align-items: center;

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitle.module.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitle.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../colors';
 
 $tc-list-title-color: $black !default;

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.module.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../colors';
 
 $tc-list-title-actions-ellipsis: '\22ee';

--- a/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.module.scss
+++ b/packages/components/src/VirtualizedList/HeaderCheckbox/HeaderCheckbox.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-list-checkbox {
 	:global(.checkbox) {
 		margin: 0;

--- a/packages/components/src/VirtualizedList/HeaderIcon/HeaderIcon.module.scss
+++ b/packages/components/src/VirtualizedList/HeaderIcon/HeaderIcon.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-list-header-icon-margin-top: 3px !default;
 
 .tc-header-icon {

--- a/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.module.scss
+++ b/packages/components/src/VirtualizedList/HeaderResizable/HeaderResizable.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $drag-element-width: $padding-smaller;
 
 .tc-header-cell-resizable {

--- a/packages/components/src/VirtualizedList/ListGrid/ListGrid.module.scss
+++ b/packages/components/src/VirtualizedList/ListGrid/ListGrid.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-list-list {
 	padding: $padding-normal;
 }

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.module.scss
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 @import '../colors';
 

--- a/packages/components/src/VirtualizedList/NoRows/NoRows.module.scss
+++ b/packages/components/src/VirtualizedList/NoRows/NoRows.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-virtualizedlist-no-result,
 :global(.tc-virtualizedlist-no-result) {
 	display: flex;

--- a/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.module.scss
+++ b/packages/components/src/VirtualizedList/RowCollapsiblePanel/RowCollapsiblePanel.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 :global(.tc-collapsible-row) {
 	:global(.panel[class*='collapsible-panel']) {
 		margin-bottom: $padding-small;

--- a/packages/components/src/VirtualizedList/RowLarge/RowLarge.module.scss
+++ b/packages/components/src/VirtualizedList/RowLarge/RowLarge.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-list-large-hover-bg: $white !default;
 $tc-list-large-field-value-color: $dove-gray !default;
 

--- a/packages/components/src/VirtualizedList/RowSelection/RowSelection.module.scss
+++ b/packages/components/src/VirtualizedList/RowSelection/RowSelection.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../colors';
 
 :global(.tc-list-table) {

--- a/packages/components/src/VirtualizedList/VirtualizedList.module.scss
+++ b/packages/components/src/VirtualizedList/VirtualizedList.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 :global(.tc-virtualizedlist-default-cell) {
 	min-width: 0;
 	text-overflow: ellipsis;

--- a/packages/components/src/VirtualizedList/_colors.scss
+++ b/packages/components/src/VirtualizedList/_colors.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-list-row-hover-bg: $wild-sand !default;
 $tc-list-row-selected-bg: tint($scooter, 85%) !default;
 $tc-list-row-selected-hover-bg: shade($tc-list-row-selected-bg, 5%) !default;

--- a/packages/components/src/WithDrawer/withDrawer.module.scss
+++ b/packages/components/src/WithDrawer/withDrawer.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-with-drawer {
 	height: 100%;
 	position: initial;

--- a/packages/containers/src/SelectObject/SelectObject.scss
+++ b/packages/containers/src/SelectObject/SelectObject.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .wrapper {
 	min-height: 300px;
 	max-width: 500px;

--- a/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.module.scss
+++ b/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../bar-chart';
 
 $module: colored-bar;

--- a/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.module.scss
+++ b/packages/dataviz/src/components/BarChart/HorizontalBarChart/HorizontalBarChart.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../bar-chart';
 
 .horizontal-bar-chart {

--- a/packages/dataviz/src/components/BarChart/TooltipCursor/TooltipCursor.component.module.scss
+++ b/packages/dataviz/src/components/BarChart/TooltipCursor/TooltipCursor.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tooltip-cursor {
 	pointer-events: all;
 	cursor: pointer;

--- a/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.module.scss
+++ b/packages/dataviz/src/components/BarChart/VerticalBarChart/VerticalBarChart.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '../bar-chart';
 
 .vertical-bar-chart {

--- a/packages/dataviz/src/components/BarChart/_bar-chart.scss
+++ b/packages/dataviz/src/components/BarChart/_bar-chart.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $pattern-bar-primary-color: tint($jaffa, 70%);
 $pattern-bar-secondary-color: shade($jaffa, 30%);
 

--- a/packages/dataviz/src/components/BoxPlot/BoxPlot.component.module.scss
+++ b/packages/dataviz/src/components/BoxPlot/BoxPlot.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // Imported (almost) as-is from TDP
 
 .box-plot {

--- a/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.module.scss
+++ b/packages/dataviz/src/components/ChartPanel/VerticalChartFilter/VerticalChartFilter.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $module: vertical-chart-panel;
 
 .#{$module} {

--- a/packages/dataviz/src/components/GeoChart/GeoChart.module.scss
+++ b/packages/dataviz/src/components/GeoChart/GeoChart.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 :export {
 	scaleMinColor: tint($regal-blue, 80%); /* stylelint-disable-line property-no-unknown */
 	scaleMaxColor: shade($regal-blue, 30%); /* stylelint-disable-line property-no-unknown */

--- a/packages/dataviz/src/components/KeyValueTooltip/KeyValueTooltip.component.module.scss
+++ b/packages/dataviz/src/components/KeyValueTooltip/KeyValueTooltip.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $module: key-value-tooltip;
 
 .#{$module} {

--- a/packages/dataviz/src/components/LineChart/LineChart.module.scss
+++ b/packages/dataviz/src/components/LineChart/LineChart.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss' as tokens;
 
 $module: line-chart;

--- a/packages/dataviz/src/components/RangeFilter/RangeFilter.component.module.scss
+++ b/packages/dataviz/src/components/RangeFilter/RangeFilter.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $module: range-filter;
 
 .#{$module} {

--- a/packages/dataviz/src/components/RangeFilter/handlers/DateTimeRangeHandler/DateTimeInputField.component.module.scss
+++ b/packages/dataviz/src/components/RangeFilter/handlers/DateTimeRangeHandler/DateTimeInputField.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .date-time-input-field {
 	input {
 		width: 100% !important;

--- a/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberInputField.component.module.scss
+++ b/packages/dataviz/src/components/RangeFilter/handlers/NumberRangeHandler/NumberInputField.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .number-input-field {
 	width: 100px;
 }

--- a/packages/dataviz/src/components/Tooltip/Tooltip.component.module.scss
+++ b/packages/dataviz/src/components/Tooltip/Tooltip.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/_tokens.scss';
 
 .dataviz-tooltip {

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.module.scss
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopover.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 $popover-screen-width: tokens.$coral-sizing-maximal;

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopoverHeader/AddFacetPopoverHeader.module.scss
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopoverHeader/AddFacetPopoverHeader.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 .tc-add-facet-popover-header:not(:empty) {

--- a/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopoverRow/AddFacetPopoverRowButton/AddFacetPopoverRowButton.module.scss
+++ b/packages/faceted-search/src/components/AddFacetPopover/AddFacetPopoverRow/AddFacetPopoverRowButton/AddFacetPopoverRowButton.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 .tc-add-facet-popover-row-button {

--- a/packages/faceted-search/src/components/AdvancedSearch/AdvancedSearch.module.scss
+++ b/packages/faceted-search/src/components/AdvancedSearch/AdvancedSearch.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 $search-icon-offset: 1.8rem;

--- a/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .fs-badge-checkbox-form {
 	:global(.tc-tooltip-body) {
 		margin: 0;

--- a/packages/faceted-search/src/components/Badges/BadgeDate/BadgeDate.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeDate/BadgeDate.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $padding: 2rem;
 
 .tc-badge-date-form {

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 // stylelint-disable scss/selector-no-redundant-nesting-selector

--- a/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumber.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeNumber/BadgeNumber.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-badge-number-form {
 	:global(.tc-tooltip-body) {
 		margin: 0;

--- a/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeOperator/BadgeOperator.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $circle-size-large: 2.2rem !default;
 $circle-size-small: 1.8rem !default;
 

--- a/packages/faceted-search/src/components/Badges/BadgeOverlay/BadgeOverlay.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeOverlay/BadgeOverlay.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-badge-format-value {
 	display: inline-flex;
 

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/BadgeSlider.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // stylelint-disable property-no-vendor-prefix
 
 .tc-badge-slider-form {

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .fs-badge-tags-form {
 	:global(.tc-tooltip-body) {
 		margin: $padding-normal 0 0;

--- a/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeText/BadgeText.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // stylelint-disable selector-no-qualifying-type
 .tc-badge-text-form {
 	:global(.tc-tooltip-body) {

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.module.scss
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 .tc-basic-search {

--- a/packages/faceted-search/src/components/FacetedToolbar/FacetedToolbar.module.scss
+++ b/packages/faceted-search/src/components/FacetedToolbar/FacetedToolbar.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 // stylelint-disable order/order
 $toolbar-height: 5.5rem;
 

--- a/packages/forms/src/FormSkeleton.module.scss
+++ b/packages/forms/src/FormSkeleton.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @use '~@talend/design-tokens/lib/tokens';
 
 $tc-drawer-content-max-width: 65rem !default;

--- a/packages/forms/src/UIForm/UIForm.module.scss
+++ b/packages/forms/src/UIForm/UIForm.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tc-drawer-content-max-width: 65rem !default;
 $tc-drawer-padding: $padding-large !default;
 

--- a/packages/forms/src/UIForm/Widget/Widget.component.module.scss
+++ b/packages/forms/src/UIForm/Widget/Widget.component.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tooltip {
 	display: block;
 }

--- a/packages/forms/src/UIForm/fields/Button/Buttons.module.scss
+++ b/packages/forms/src/UIForm/fields/Button/Buttons.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-buttons {
 	display: flex;
 	justify-content: space-between;

--- a/packages/forms/src/UIForm/fields/CheckBox/displayMode/TextMode.module.scss
+++ b/packages/forms/src/UIForm/fields/CheckBox/displayMode/TextMode.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .checkbox {
 	display: flex;
 	flex-direction: row-reverse;

--- a/packages/forms/src/UIForm/fields/Comparator/Comparator.module.scss
+++ b/packages/forms/src/UIForm/fields/Comparator/Comparator.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tf-comparator-operator-height: 3.2rem !default;
 $tf-comparator-operator-width: 5rem !default;
 $tf-comparator-operator-top: 2.4rem !default;

--- a/packages/forms/src/UIForm/fields/Datalist/displayMode/TextMode.module.scss
+++ b/packages/forms/src/UIForm/fields/Datalist/displayMode/TextMode.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 .loading {

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 .template:global(.required) {

--- a/packages/forms/src/UIForm/fields/File/File.module.scss
+++ b/packages/forms/src/UIForm/fields/File/File.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .file {
 	display: flex;
 

--- a/packages/forms/src/UIForm/fields/KeyValue/KeyValue.module.scss
+++ b/packages/forms/src/UIForm/fields/KeyValue/KeyValue.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .key-value {
 	display: flex;
 	margin-bottom: 0;

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.module.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 $tf-datalist-items-background-color: $white !default;
 $tf-datalist-items-shadow-color: $shadow !default;
 $tf-typeahead-input-width: 135px !default;

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/displayMode/TextMode.module.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/displayMode/TextMode.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tc-badge-list {
 	display: flex;
 	flex-wrap: wrap;

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.module.scss
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .nested-list-view {
 	// Temporary hide list count with CSS, should be done properly
 	// once ListView UX/UI specifications have been finished

--- a/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-array-item {
 	display: flex;
 	background: $wild-sand;

--- a/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Array/DefaultArrayTemplate.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-array-fieldset {
 	margin-bottom: $padding-normal;
 

--- a/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-array-text-mode {
 	ol {
 		list-style: none;

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .collapsible-panel {
   :global(.panel-heading) {
     font-weight: 600;

--- a/packages/forms/src/UIForm/fieldsets/Columns/Columns.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Columns/Columns.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-columns {
 	.items {
 		display: flex;

--- a/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Tabs/Tabs.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .tf-tabs {
 	li.has-error {
 		> button {

--- a/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/forms/src/widgets/templates/FieldTemplate/FieldTemplate.module.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
 .inProgress {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

our current tools add sass-data so scss file rely on defined variables, but developer write variables without include them.
This block us to use tools like create-react-app

**What is the chosen solution to this problem?**

* create script to do that: https://gist.github.com/jmfrancois/402c32c22fba98f1e35599f1e0dab2c2
* explicitly add use of the sass data

to test it, I have applied it in /lib folder of create-react-app and did the job to fix all build errors.

![image](https://user-images.githubusercontent.com/19857479/192749014-8a4282e8-86ec-4abc-9f5c-44084d21a988.png)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
