### PR TITLE
feat(no ticket): Action in EmptyState size M

### DIFF
--- a/.changeset/twelve-apricots-end.md
+++ b/.changeset/twelve-apricots-end.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Enabling `action` prop on EmptyState component size M.

--- a/packages/design-system/src/components/EmptyState/EmptyState.stories.mdx
+++ b/packages/design-system/src/components/EmptyState/EmptyState.stories.mdx
@@ -1,4 +1,4 @@
-import { ArgsTable, Meta, Canvas, Story } from '@storybook/addon-docs';
+import { ArgsTable, Canvas, Meta, Story } from '@storybook/addon-docs';
 import { FigmaImage, Use } from '~docs';
 
 import EmptyStatePrimitive from './primitive/EmptyStatePrimitive';
@@ -69,7 +69,7 @@ Use large empty states when the empty content area on screen takes up at least 5
 #### EmptyStateMedium (with Icon illustration)
 
 <Canvas>
-	<Story story={Stories.Medium} />
+	<Story story={Stories.MediumWithAction} />
 </Canvas>
 
 **Content guidelines**
@@ -81,6 +81,7 @@ Use medium empty states when the empty content area on screen takes up less than
 - Use body text to:
   - (Informative empty states) tell users what will display here, with no direct actions from them
   - (Actionable empty states) guide users towards taking the next step when there's an action the user can take
+- (Only actionable empty states) Give a call-to-action (CTA) button when users can resolve the empty state
 - (Optional but preferred) Include a "Learn more" link to the documentation if the feature is documented
 
 #### EmptyStateSmall (with no Icon illustration)

--- a/packages/design-system/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/design-system/src/components/EmptyState/EmptyState.stories.tsx
@@ -16,7 +16,7 @@ export const Large = () => (
 		action={{
 			children: 'Create a dataset',
 			onClick: () => sbAction('clicked'),
-			icon: 'talend-plus',
+			icon: 'plus',
 			actionType: 'button',
 		}}
 		link={{ href: 'https://talend.com' }}
@@ -30,7 +30,7 @@ export const LargeWithLinkButton = () => (
 			description="Add a preparation to clean, format, and transform data prior to processing."
 			action={{
 				children: 'Create a preparation',
-				icon: 'talend-plus',
+				icon: 'plus',
 				actionType: 'link',
 				as: <Link to="/preparation/new" />,
 				'data-feature': 'Preparation empty state clicked',
@@ -40,10 +40,16 @@ export const LargeWithLinkButton = () => (
 	</BrowserRouter>
 );
 
-export const Medium = () => (
+export const MediumWithAction = () => (
 	<EmptyStateMedium
-		title="No preparations yet"
+		title="No dataset yet"
 		description="Add a preparation to clean, format, and transform data prior to processing."
+		action={{
+			children: 'Create a dataset',
+			onClick: () => sbAction('clicked'),
+			icon: 'plus',
+			actionType: 'button',
+		}}
 		link={{ href: 'https://talend.com' }}
 	/>
 );
@@ -79,7 +85,7 @@ export const Usage = (args: EmptyStateProps) => {
 		}
 
 		case 'M': {
-			const { action, ...rest } = args;
+			const { ...rest } = args;
 			return <EmptyState {...rest} />;
 		}
 

--- a/packages/design-system/src/components/EmptyState/EmptyState.stories.tsx
+++ b/packages/design-system/src/components/EmptyState/EmptyState.stories.tsx
@@ -130,7 +130,7 @@ Usage.argTypes = {
 			actionType: 'button',
 			'data-feature': 'Feature name',
 		},
-		description: 'Optional for Large. Unavailable for Medium and Small',
+		description: 'Optional for Large and Medium. Unavailable for Small',
 	},
 	illustration: {
 		table: {

--- a/packages/design-system/src/components/EmptyState/variants/EmptyStateMedium.tsx
+++ b/packages/design-system/src/components/EmptyState/variants/EmptyStateMedium.tsx
@@ -4,7 +4,6 @@ import EmptyStatePrimitive, { EmptyStatePrimitiveProps } from '../primitive/Empt
 import IconDefault from '../illustrations/IconDefault';
 
 export type EmptyStateMediumProps = Omit<EmptyStatePrimitiveProps, 'illustration'> & {
-	action?: never;
 	description: string;
 };
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The EmptyState component in its medium size does not expect a CTA.
However in some cases designer found out it could offer a better layout than having a CTA and underneath an action-less EmptyState. 

**What is the chosen solution to this problem?**
Opening up the action prop from the Primitive to the EmptyStateMedium component.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
