### PR TITLE
fix(ARCH-631/tools): remove sass data

### DIFF
--- a/.changeset/cuddly-pants-suffer.md
+++ b/.changeset/cuddly-pants-suffer.md
@@ -1,0 +1,17 @@
+---
+'@talend/scripts-config-react-webpack': major
+'@talend/scripts-preset-react': major
+'@talend/scripts-preset-react-lib': major
+---
+
+fix: No more implicit sass data injected in scss files
+
+This is BREAKING CHANGE:
+
+```diff
++++@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+```
+
+You have to
+* use `addSassData.js` from https://gist.github.com/jmfrancois/402c32c22fba98f1e35599f1e0dab2c2
+* rewrite your sass using @talend/design-tokens on the long and remove this bootstrap-theme guidelines from all your scss

--- a/.changeset/dull-squids-press.md
+++ b/.changeset/dull-squids-press.md
@@ -1,0 +1,5 @@
+---
+'@talend/bootstrap-theme': patch
+---
+
+fix: add sassdata to variations

--- a/packages/theme/src/theme/variations/_mdm.scss
+++ b/packages/theme/src/theme/variations/_mdm.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #5599d8 !default;
 	$brand-secondary-t7: #2975bb !default;

--- a/packages/theme/src/theme/variations/_portal.scss
+++ b/packages/theme/src/theme/variations/_portal.scss
@@ -1,3 +1,5 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+
 .t7 {
 	$brand-primary-t7: #0675c1 !default;
 	$brand-secondary-t7: #b6be00 !default;

--- a/packages/theme/src/theme/variations/_tdc.scss
+++ b/packages/theme/src/theme/variations/_tdc.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #5da288 !default;
 	$brand-secondary-t7: #508f8d !default;

--- a/packages/theme/src/theme/variations/_tdp.scss
+++ b/packages/theme/src/theme/variations/_tdp.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #00a1b3 !default;
 	$brand-secondary-t7: #168aa6 !default;

--- a/packages/theme/src/theme/variations/_tds.scss
+++ b/packages/theme/src/theme/variations/_tds.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #8c92ba !default;
 	$brand-secondary-t7: #6a83ab !default;

--- a/packages/theme/src/theme/variations/_tfd.scss
+++ b/packages/theme/src/theme/variations/_tfd.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #5d88aa !default;
 	$brand-secondary-t7: #4f7da2 !default;

--- a/packages/theme/src/theme/variations/_tic.scss
+++ b/packages/theme/src/theme/variations/_tic.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #009597 !default;
 	$brand-secondary-t7: #168396 !default;

--- a/packages/theme/src/theme/variations/_tmc.scss
+++ b/packages/theme/src/theme/variations/_tmc.scss
@@ -1,3 +1,4 @@
+@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 .t7 {
 	$brand-primary-t7: #009597 !default;
 	$brand-secondary-t7: #168396 !default;

--- a/tools/scripts-config-react-webpack/config/webpack.config.common.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.common.js
@@ -5,7 +5,7 @@ const { getBabelLoaderOptions } = require('@talend/scripts-utils/babel');
 const babelConfig = getBabelConfig();
 
 function getSassData(userSassData) {
-	let sassData = "@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;\n";
+	let sassData = '';
 
 	if (userSassData && userSassData.data) {
 		console.warn(


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

in  #4360 we have fixed our scss files but as mentionned in comment anyone can add a file without it and so introduce an issue. 

**What is the chosen solution to this problem?**

remove the implicit sass data injected by our talend-scripts.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
