### PR TITLE
fix(design-system): Link from ReactElement in ErrorState

### DIFF
--- a/.changeset/tiny-cooks-stare.md
+++ b/.changeset/tiny-cooks-stare.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): Link from ReactElement in ErrorState

--- a/packages/design-system/src/components/WIP/ErrorState/ErrorState.tsx
+++ b/packages/design-system/src/components/WIP/ErrorState/ErrorState.tsx
@@ -1,4 +1,4 @@
-import React, { ReactElement } from 'react';
+import React, { ReactElement, isValidElement } from 'react';
 
 import { ButtonPrimary } from '../../Button';
 import { ButtonPrimaryPropsType } from '../../Button/variations/ButtonPrimary';
@@ -30,7 +30,7 @@ function ErrorState({ title, description, action, link }: ErrorStatePropTypes) {
 
 				{action && <ButtonPrimary {...action} />}
 
-				{link && (React.isValidElement(link) ? link : <Link {...(link as LinkProps)} />)}
+				{link && (isValidElement(link) ? link : <Link {...(link as LinkProps)} />)}
 			</StackVertical>
 		</article>
 	);

--- a/packages/design-system/src/components/WIP/ErrorState/ErrorState.tsx
+++ b/packages/design-system/src/components/WIP/ErrorState/ErrorState.tsx
@@ -30,7 +30,7 @@ function ErrorState({ title, description, action, link }: ErrorStatePropTypes) {
 
 				{action && <ButtonPrimary {...action} />}
 
-				{link && (typeof link === 'object' ? <Link {...(link as LinkProps)} /> : link)}
+				{link && (React.isValidElement(link) ? link : <Link {...(link as LinkProps)} />)}
 			</StackVertical>
 		</article>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
ErrorState doesn't render "link" prop when it is provided as a React element

**What is the chosen solution to this problem?**
Fix the test in the component

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
