### PR TITLE
fix(sidepanel): reversed mode

### DIFF
--- a/.changeset/short-hats-visit.md
+++ b/.changeset/short-hats-visit.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(components): sidepanel reversed color in gray

--- a/packages/components/src/SidePanel/SidePanel.module.scss
+++ b/packages/components/src/SidePanel/SidePanel.module.scss
@@ -69,7 +69,7 @@ $large-docked-width: 7rem;
 				width: $tc-side-panel-icons-size;
 				height: $tc-side-panel-icons-size;
 			}
-			:global(svg){
+			:global(svg) {
 				margin-left: $padding-smaller;
 			}
 
@@ -209,7 +209,7 @@ $large-docked-width: 7rem;
 		}
 	}
 
-	&.reverse[role='navigation'][aria-expanded] {
+	&.reverse[role='navigation'] {
 		background: $wild-sand !important; // sass-lint:disable-line no-important
 
 		&:before {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
<img width="633" alt="CleanShot 2022-10-03 at 10 42 45@2x" src="https://user-images.githubusercontent.com/2909671/193535992-c759da56-1223-4117-9010-4714243bf4eb.png">
**What is the chosen solution to this problem?**
<img width="527" alt="CleanShot 2022-10-03 at 10 41 36@2x" src="https://user-images.githubusercontent.com/2909671/193536035-d0eade66-51bc-4c1a-be2d-b2a56fbe79fa.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
