### PR TITLE
feat(design-system): add isFullWidth to StackH

### DIFF
--- a/.changeset/cool-socks-repeat.md
+++ b/.changeset/cool-socks-repeat.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(design-system): add isFullWidth to StackHorizontal

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.module.scss
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.module.scss
@@ -400,6 +400,10 @@
 		}
 	}
 
+	&.fullWidth {
+		width: 100%;
+	}
+
 	&.height {
 		&-100 {
 			height: 100%;

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
@@ -106,6 +106,7 @@ export type StackPrimitiveProps = {
 	role?: string;
 	relative?: boolean;
 	height?: keyof typeof heightOptions;
+	isFullWidth?: boolean;
 	noShrink?: boolean;
 	noGrow?: boolean;
 };
@@ -127,6 +128,7 @@ const StackPrimitive = forwardRef(function StackPrimitive(
 		height,
 		noShrink = false,
 		noGrow = false,
+		isFullWidth,
 		...props
 	}: StackPrimitiveProps,
 	ref: React.Ref<any>,
@@ -221,6 +223,7 @@ const StackPrimitive = forwardRef(function StackPrimitive(
 				styles[direction],
 				styles[display],
 				height && styles[`height-${heightOptions[height]}`],
+				isFullWidth && styles.fullWidth,
 				{ [styles.relative]: relative },
 				{ [styles.noShrink]: noShrink },
 				{ [styles.noGrow]: noGrow },

--- a/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
+++ b/packages/design-system/src/components/Stack/StackHorizontal.stories.tsx
@@ -48,6 +48,7 @@ export const manualStackArgs = {
 		control: { type: 'select' },
 		defaultValue: 'nowrap',
 	},
+	isFullWidth: { control: { type: 'boolean' }, defaultValue: false },
 	height: {
 		options: Object.keys(heightOptions),
 		control: { type: 'select' },

--- a/packages/design-system/src/components/Stack/StackVertical.tsx
+++ b/packages/design-system/src/components/Stack/StackVertical.tsx
@@ -1,7 +1,7 @@
 import React, { forwardRef } from 'react';
 import StackPrimitive, { StackPrimitiveProps } from './Primitive/StackPrimitive';
 
-export type StackVerticalProps = Omit<StackPrimitiveProps, 'direction'>;
+export type StackVerticalProps = Omit<StackPrimitiveProps, 'direction' | 'isFullWidth'>;
 
 export const StackVertical = forwardRef((props: StackVerticalProps, ref: React.Ref<any>) => {
 	return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
For some layout, we find the need to wrap this component with a container that have a width of 100%

**What is the chosen solution to this problem?**
Have the size to 100% available in the stack horizontal component

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
