### PR TITLE
fix(TFD-14627): jest config

### DIFF
--- a/.changeset/twenty-horses-brush.md
+++ b/.changeset/twenty-horses-brush.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': patch
+---
+
+fix: do not use option1 which fails if d3 is not installed

--- a/tools/scripts-config-jest/jest.config.js
+++ b/tools/scripts-config-jest/jest.config.js
@@ -36,10 +36,10 @@ const d3Pkgs = [
 ];
 
 // option 1 map module to an bundled version of the package which is es5
-const moduleNameMapper = d3Pkgs.reduce((acc, pkg) => {
-	acc[`^${pkg}$`] = path.join(require.resolve(pkg), `../../dist/${pkg}.min.js`);
-	return acc;
-}, {});
+// const moduleNameMapper = d3Pkgs.reduce((acc, pkg) => {
+// 	acc[`^${pkg}$`] = path.join(require.resolve(pkg), `../../dist/${pkg}.min.js`);
+// 	return acc;
+// }, {});
 
 module.exports = {
 	moduleNameMapper: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We have the following error on a project without d3:
` Error: Cannot find module 'd3'`

**What is the chosen solution to this problem?**

remove require.resolve on d3 pkgs

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
