### PR TITLE
fix(ARCH-607/DS): add react-18 as possible usage

### DIFF
--- a/.changeset/hip-cars-invite.md
+++ b/.changeset/hip-cars-invite.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat: add react-18 as possible peerDependency

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -70,7 +70,7 @@
     "@types/classnames": "^2.3.1",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
-    "@types/react-is": "^16.7.2",
+    "@types/react-is": "^17.0.2",
     "@types/styled-components": "^5.1.25",
     "algoliasearch": "^4.14.0",
     "babel-plugin-styled-components": "^1.13.3",
@@ -91,7 +91,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.33.1",
     "react-i18next": "^11.18.1",
-    "react-is": "^16.13.1",
+    "react-is": "^17.0.2",
     "react-router-dom": "^6.3.0",
     "storybook-addon-mdx-embed": "^1.0.0",
     "storybook-docs-toc": "^1.7.0",
@@ -100,13 +100,13 @@
   },
   "peerDependencies": {
     "@talend/icons": "^6.42.0",
-    "@talend/locales-design-system": "^1.4.0",
+    "@talend/locales-design-system": "^4.0.0",
     "focus-outline-manager": "^1.0.2",
     "i18next": "^20.1.0",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-i18next": "^11.8.13",
-    "react-is": "^16.13.1",
+    "react-is": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "styled-components": "^5.2.1"
   }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -70,7 +70,7 @@
     "@types/classnames": "^2.3.1",
     "@types/react": "^17.0.47",
     "@types/react-dom": "^17.0.17",
-    "@types/react-is": "^17.0.2",
+    "@types/react-is": "^16.7.2",
     "@types/styled-components": "^5.1.25",
     "algoliasearch": "^4.14.0",
     "babel-plugin-styled-components": "^1.13.3",
@@ -91,7 +91,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.33.1",
     "react-i18next": "^11.18.1",
-    "react-is": "^16.7.2",
+    "react-is": "^16.13.1",
     "react-router-dom": "^6.3.0",
     "storybook-addon-mdx-embed": "^1.0.0",
     "storybook-docs-toc": "^1.7.0",
@@ -106,7 +106,7 @@
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-i18next": "^11.8.13",
-    "react-is": "^16.7.2 || ^17.0.0 || ^18.0.0",
+    "react-is": "^16.13.1",
     "styled-components": "^5.2.1"
   }
 }

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -91,7 +91,7 @@
     "react-helmet": "^6.1.0",
     "react-hook-form": "^7.33.1",
     "react-i18next": "^11.18.1",
-    "react-is": "^17.0.2",
+    "react-is": "^16.7.2",
     "react-router-dom": "^6.3.0",
     "storybook-addon-mdx-embed": "^1.0.0",
     "storybook-docs-toc": "^1.7.0",
@@ -106,7 +106,7 @@
     "react": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-dom": "^16.14.0 || ^17.0.0 || ^18.0.0",
     "react-i18next": "^11.8.13",
-    "react-is": "^16.14.0 || ^17.0.0 || ^18.0.0",
+    "react-is": "^16.7.2 || ^17.0.0 || ^18.0.0",
     "styled-components": "^5.2.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -16370,7 +16370,7 @@ react-is@17.0.2, react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.7.2, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4295,12 +4295,12 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react-is@^16.7.2":
-  version "16.7.2"
-  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.2.tgz#8c2862013d00d741be189ceb71da8e8d21e8fa7d"
-  integrity sha512-rdQUu9J+RUz4Vcr768UyTzv+fZGzKBy1/PPhaxTfzAfaHSW4+b0olA6czXLZv7PO7/ktbHu41kcpAG7Z46kvDQ==
+"@types/react-is@^17.0.2":
+  version "17.0.3"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
+  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
   dependencies:
-    "@types/react" "^16"
+    "@types/react" "*"
 
 "@types/react-redux@^7.1.20", "@types/react-redux@^7.1.24":
   version "7.1.24"
@@ -4319,7 +4319,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@>=16.9.11", "@types/react@^16", "@types/react@^17", "@types/react@^17.0.2", "@types/react@^17.0.47":
+"@types/react@*", "@types/react@>=16.9.11", "@types/react@^17", "@types/react@^17.0.2", "@types/react@^17.0.47":
   version "17.0.50"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.50.tgz#39abb4f7098f546cfcd6b51207c90c4295ee81fc"
   integrity sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4295,12 +4295,12 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react-is@^17.0.2":
-  version "17.0.3"
-  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-17.0.3.tgz#2d855ba575f2fc8d17ef9861f084acc4b90a137a"
-  integrity sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==
+"@types/react-is@^16.7.2":
+  version "16.7.2"
+  resolved "https://registry.yarnpkg.com/@types/react-is/-/react-is-16.7.2.tgz#8c2862013d00d741be189ceb71da8e8d21e8fa7d"
+  integrity sha512-rdQUu9J+RUz4Vcr768UyTzv+fZGzKBy1/PPhaxTfzAfaHSW4+b0olA6czXLZv7PO7/ktbHu41kcpAG7Z46kvDQ==
   dependencies:
-    "@types/react" "*"
+    "@types/react" "^16"
 
 "@types/react-redux@^7.1.20", "@types/react-redux@^7.1.24":
   version "7.1.24"
@@ -4319,7 +4319,7 @@
   dependencies:
     "@types/react" "^17"
 
-"@types/react@*", "@types/react@>=16.9.11", "@types/react@^17", "@types/react@^17.0.2", "@types/react@^17.0.47":
+"@types/react@*", "@types/react@>=16.9.11", "@types/react@^16", "@types/react@^17", "@types/react@^17.0.2", "@types/react@^17.0.47":
   version "17.0.50"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-17.0.50.tgz#39abb4f7098f546cfcd6b51207c90c4295ee81fc"
   integrity sha512-ZCBHzpDb5skMnc1zFXAXnL3l1FAdi+xZvwxK+PkglMmBrwjpp9nKaWuEvrGnSifCJmBFGxZOOFuwC6KH/s0NuA==
@@ -16370,7 +16370,7 @@ react-is@17.0.2, react-is@^17.0.0, react-is@^17.0.1, react-is@^17.0.2:
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
-react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.7.2, react-is@^16.8.1, react-is@^16.8.6:
+react-is@^16.10.2, react-is@^16.12.0, react-is@^16.13.1, react-is@^16.3.2, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

I am on a POC where I work with create-react-app which is react 18.

**What is the chosen solution to this problem?**

I think we can open the DS to be used with it.

NOte: react-is is part of react mono repository it should be possible to align it to react.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
