### PR TITLE
fix(components): quality bar in split mode

### DIFF
--- a/.changeset/cold-toys-tickle.md
+++ b/.changeset/cold-toys-tickle.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(components): QualityBar in split mode

--- a/packages/components/src/QualityBar/QualityBar.component.js
+++ b/packages/components/src/QualityBar/QualityBar.component.js
@@ -62,7 +62,14 @@ QualityBarRatioBars.propTypes = {
  * @param {number} naRaw number of not applicable raw
  * @param {number} digits number of digits we want to keep
  */
-function getQualityPercentagesRounded(invalid, empty, valid, na, placeholder, digits) {
+function getQualityPercentagesRounded(
+	invalid = 0,
+	empty = 0,
+	valid = 0,
+	na = 0,
+	placeholder = 0,
+	digits,
+) {
 	const output = {};
 
 	let sumValues = 0;
@@ -94,31 +101,29 @@ function getQualityPercentagesRounded(invalid, empty, valid, na, placeholder, di
 }
 
 function SplitQualityBar({ empty, getDataFeature, invalid, na, onClick, valid, percentages }) {
-	const totalValues = empty + invalid + na + valid;
+	const totalValues = (empty || 0) + (invalid || 0) + (na || 0) + (valid || 0);
 	const usedValues = { empty, invalid, na, valid };
 	const fwd = { getDataFeature, onClick };
 
 	return (
 		<StackHorizontal gap="M">
-			{[QualityType.INVALID, QualityType.EMPTY, QualityType.NOTAPPLICABLE, QualityType.VALID].map(
-				type => {
-					const currentTypePercentage = percentages[type];
-					const currentTypeValue = usedValues[type];
+			{[QualityType.INVALID, QualityType.EMPTY, QualityType.NA, QualityType.VALID].map(type => {
+				const currentTypePercentage = percentages[type];
+				const currentTypeValue = usedValues[type];
 
-					return currentTypePercentage ? (
-						<StackHorizontal gap="XXS" key={type}>
-							<span>{currentTypePercentage}%</span>
+				return currentTypeValue !== undefined ? (
+					<StackHorizontal gap="XXS" key={type}>
+						<span>{currentTypePercentage}%</span>
 
-							<QualityBarRatioBars
-								{...fwd}
-								{...{ [type]: currentTypeValue }} // Spread needed for the dynamic "type" key
-								placeholder={totalValues - currentTypeValue}
-								percentages={{ ...percentages, placeholder: 100 - currentTypePercentage }}
-							/>
-						</StackHorizontal>
-					) : null;
-				},
-			)}
+						<QualityBarRatioBars
+							{...fwd}
+							{...{ [type]: currentTypeValue }} // Spread needed for the dynamic "type" key
+							placeholder={totalValues - currentTypeValue}
+							percentages={{ ...percentages, placeholder: 100 - currentTypePercentage }}
+						/>
+					</StackHorizontal>
+				) : null;
+			})}
 		</StackHorizontal>
 	);
 }
@@ -146,10 +151,5 @@ QualityBar.propTypes = {
 
 QualityBar.defaultProps = {
 	digits: 1,
-	empty: 0,
-	invalid: 0,
-	na: 0,
-	placeholder: 0,
-	valid: 0,
 	split: false,
 };

--- a/packages/components/src/QualityBar/QualityBar.stories.js
+++ b/packages/components/src/QualityBar/QualityBar.stories.js
@@ -59,6 +59,31 @@ export const _QualityBar = () => (
 				getDataFeature={qualityType => `data-feature.${qualityType}`}
 				split
 			/>
+			<QualityBar
+				invalid={0}
+				valid={100}
+				empty={0}
+				onClick={action('onSplitQualityBarAction')}
+				getDataFeature={qualityType => `data-feature.${qualityType}`}
+				split
+			/>
+			<QualityBar
+				invalid={40}
+				valid={60}
+				empty={0}
+				onClick={action('onSplitQualityBarAction')}
+				getDataFeature={qualityType => `data-feature.${qualityType}`}
+				split
+			/>
+			<QualityBar
+				invalid={40}
+				valid={30}
+				empty={15}
+				na={15}
+				onClick={action('onSplitQualityBarAction')}
+				getDataFeature={qualityType => `data-feature.${qualityType}`}
+				split
+			/>
 		</div>
 	</section>
 );


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the current split mode, if the result of the percentage for a given category is 0, we will not have the representation for it.
We would like to have the quality bar telling that the indicator is set to 0 instead of having maybe only 1 or 2 splited part

<img width="483" alt="CleanShot 2022-10-12 at 12 15 00@2x" src="https://user-images.githubusercontent.com/2909671/195316642-b8468264-bbee-4326-9408-d140ecd0bdf5.png">

**What is the chosen solution to this problem?**
<img width="497" alt="CleanShot 2022-10-12 at 12 11 26@2x" src="https://user-images.githubusercontent.com/2909671/195315874-fb96aaa4-d3ab-4d36-9e44-31e03a8152df.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
