### PR TITLE
fix(ARCH-607/design-system): DS Tabs must be of type button

### DIFF
--- a/.changeset/real-pugs-run.md
+++ b/.changeset/real-pugs-run.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+DS Tabs button type should never be anything but "button"

--- a/packages/design-system/src/components/WIP/Tabs/Primitive/Tab.tsx
+++ b/packages/design-system/src/components/WIP/Tabs/Primitive/Tab.tsx
@@ -28,7 +28,7 @@ type TabTooltip = {
 };
 
 export type TabPropsTypesWithoutState = DataAttributes &
-	Omit<HTMLAttributes<HTMLButtonElement>, 'className' | 'style'> &
+	Omit<HTMLAttributes<HTMLButtonElement>, 'className' | 'style' | 'type'> &
 	TabSize &
 	TabTooltip &
 	TabChildren;
@@ -44,6 +44,7 @@ const Tab = forwardRef((props: TabPropsTypes, ref: Ref<HTMLButtonElement>) => {
 			return (
 				<ReakitTab
 					{...rest}
+					type="button"
 					ref={ref}
 					className={classnames(styles.tab, { [styles.tab_large]: size === 'L' })}
 				>
@@ -56,6 +57,7 @@ const Tab = forwardRef((props: TabPropsTypes, ref: Ref<HTMLButtonElement>) => {
 		return (
 			<ReakitTab
 				{...rest}
+				type="button"
 				ref={ref}
 				className={classnames(styles.tab, { [styles.tab_large]: size === 'L' })}
 			>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Tabs use a button element with no type, which defaults to "submit" in a form. 

**What is the chosen solution to this problem?**
Set it forever as "button" because ew.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
