### PR TITLE
chore(ARCH-658): pin react router

### DIFF
--- a/.changeset/empty-maps-swim.md
+++ b/.changeset/empty-maps-swim.md
@@ -1,0 +1,7 @@
+---
+'@talend/react-cmf-router': patch
+'@talend/design-system': patch
+'@talend/router-bridge': patch
+---
+
+fix: pin react-router to 6.3.0

--- a/packages/cmf-router/package.json
+++ b/packages/cmf-router/package.json
@@ -25,8 +25,8 @@
     "path-to-regexp": "^6.2.1",
     "prop-types": "^15.8.1",
     "react-redux": "^7.2.8",
-    "react-router": "^6.3.0",
-    "react-router-dom": "^6.3.0",
+    "react-router": "~6.3.0",
+    "react-router-dom": "~6.3.0",
     "redux-saga": "^1.1.3"
   },
   "peerDependencies": {

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -92,7 +92,7 @@
     "react-hook-form": "^7.33.1",
     "react-i18next": "^11.18.1",
     "react-is": "^16.13.1",
-    "react-router-dom": "^6.3.0",
+    "react-router-dom": "~6.3.0",
     "storybook-addon-mdx-embed": "^1.0.0",
     "storybook-docs-toc": "^1.7.0",
     "styled-components": "^5.3.5",

--- a/packages/router-bridge/package.json
+++ b/packages/router-bridge/package.json
@@ -24,11 +24,11 @@
     "connected-react-router": "^6.9.3",
     "history": "^5.3.0",
     "react": "^17.0.2",
-    "react-router-dom": "^6.3.0"
+    "react-router-dom": "~6.3.0"
   },
   "peerDependencies": {
     "connected-react-router": "^6.9.2",
-    "react-router-dom": "^6.2.1"
+    "react-router-dom": "~6.3.0"
   },
   "peerDependenciesMeta": {
     "connected-react-router": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -16459,7 +16459,7 @@ react-resize-detector@^7.1.2:
   dependencies:
     lodash "^4.17.21"
 
-react-router-dom@^6.3.0, react-router-dom@~6.3.0:
+react-router-dom@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
   integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -16459,7 +16459,7 @@ react-resize-detector@^7.1.2:
   dependencies:
     lodash "^4.17.21"
 
-react-router-dom@^6.3.0:
+react-router-dom@^6.3.0, react-router-dom@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.3.0.tgz#a0216da813454e521905b5fa55e0e5176123f43d"
   integrity sha512-uaJj7LKytRxZNQV8+RbzJWnJ8K2nPsOOEuX7aQstlMZKQT0164C+X2w6bnkqU3sjtLvpd5ojrezAyfZ1+0sStw==
@@ -16467,7 +16467,7 @@ react-router-dom@^6.3.0:
     history "^5.2.0"
     react-router "6.3.0"
 
-react-router@6.3.0, react-router@^6.3.0:
+react-router@6.3.0, react-router@~6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.3.0.tgz#3970cc64b4cb4eae0c1ea5203a80334fdd175557"
   integrity sha512-7Wh1DzVQ+tlFjkeo+ujvjSqSJmkt1+8JO+T5xklPlgrh70y7ogx75ODRW0ThWhY7S+6yEDks8TYrtQe/aoboBQ==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we spot a change in exposed internals of react-router in latest release. 
![image](https://user-images.githubusercontent.com/19857479/198548584-c457a7a0-6c39-4981-b8ed-755e7d71155d.png)

**What is the chosen solution to this problem?**

in the doubt for the moment I prefer to pin it to 6.3


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
