### PR TITLE
fix(TDOPS-2998): Replace globalObject value to self

### DIFF
--- a/.changeset/loud-cameras-smile.md
+++ b/.changeset/loud-cameras-smile.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix(TDOPS-2998): Replace globalObject value to self

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -256,7 +256,7 @@ module.exports = ({ getUserConfig, mode }) => {
 				filename: getFileNameForExtension('js', jsPrefix),
 				chunkFilename: getFileNameForExtension('js', jsPrefix),
 				publicPath: '/',
-				globalObject: 'this',
+				globalObject: 'self',
 			},
 			devtool: 'source-map',
 			resolve: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
globalObject has been set by mistake to this instead of self

**What is the chosen solution to this problem?**
Follow webpack documentation: this for lib and self for web app
https://webpack.js.org/configuration/output/#outputglobalobject

> When targeting a library, especially when libraryTarget is 'umd', this option indicates what global object will be used to mount the library. To make UMD build available on both browsers and Node.js, set output.globalObject option to 'this'. Defaults to self for Web-like targets.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
