### PR TITLE
fix: missing fonts in exposed bundle

### DIFF
--- a/.changeset/modern-rocks-arrive.md
+++ b/.changeset/modern-rocks-arrive.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: missing fonts in exported bundle

--- a/.changeset/purple-pugs-share.md
+++ b/.changeset/purple-pugs-share.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+feat: add id on bootstrap.css link tag

--- a/packages/design-system/.storybook/preview-head.html
+++ b/packages/design-system/.storybook/preview-head.html
@@ -3,7 +3,6 @@
 	href="https://fonts.googleapis.com/css2?family=Gelasio:ital,wght@0,400;0,500;0,600;0,700;1,400;1,500;1,600;1,700&display=swap"
 	rel="stylesheet"
 />
-<link id="bootstrap-theme" href="https://talend.surge.sh/theme/bootstrap.css" rel="stylesheet" />
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@algolia/autocomplete-theme-classic" />
 <script type="text/javascript">

--- a/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
@@ -4,6 +4,10 @@ import './ThemeProvider.module.scss';
 import '@talend/design-tokens/dist/TalendDesignTokens.css';
 import React, { PropsWithChildren, useContext, useState } from 'react';
 
+import 'typeface-source-sans-pro/index.css';
+import 'typeface-inconsolata/index.css';
+import 'modern-css-reset/dist/reset.min.css';
+
 export type ThemeProviderProps = PropsWithChildren<{
 	theme: string;
 }>;

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview-head.html
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview-head.html
@@ -1,4 +1,4 @@
-<link href="https://talend.surge.sh/theme/bootstrap.css" rel="stylesheet" />
+<link id="bootstrap-theme" href="https://talend.surge.sh/theme/bootstrap.css" rel="stylesheet" />
 <script type="text/javascript">
 	// add this because of badly built https://unpkg.com/hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.min.js
 	window.process = window.process || { env: { NODE_ENV: 'production' } };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Bundle wasn't exporting app fonts anymore, leading to CORS errors in chromatic and font not loaded. 
https://www.chromatic.com/build?appId=62022f03c6654e003a637b65&number=714

**What is the chosen solution to this problem?**

Get back font import

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
