### PR TITLE
fix: ThemeProvider optional theme property

### DIFF
--- a/.changeset/fifty-lemons-beam.md
+++ b/.changeset/fifty-lemons-beam.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: ThemeProvider optional theme property

--- a/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
@@ -9,7 +9,7 @@ import 'typeface-inconsolata/index.css';
 import 'modern-css-reset/dist/reset.min.css';
 
 export type ThemeProviderProps = PropsWithChildren<{
-	theme: string;
+	theme?: string;
 }>;
 
 const ThemeProvider = ({ theme = 'light', children }: ThemeProviderProps) => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`ThemeProvider` theme property has been set as mandatory here https://github.com/Talend/ui/pull/4403/files#diff-f0f2d9658ff5eabd7c9296a2c246e54ad0b76c6cffdb3bb673b560f9273d0f56R8
But it has a default value in its implementation (https://github.com/Talend/ui/pull/4403/files#diff-f0f2d9658ff5eabd7c9296a2c246e54ad0b76c6cffdb3bb673b560f9273d0f56R11)

**What is the chosen solution to this problem?**

Switch prop to optional

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
