### PR TITLE
chore: activate tree shaking on DS

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -4,6 +4,7 @@
   "description": "Talend Design System",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
+  "sideEffects": false,
   "scripts": {
     "build:lib": "talend-scripts build:ts:lib",
     "build:lib:umd": "talend-scripts build:lib:umd --dev",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

in #4411 I have seen we do not remove import of types from the bundle. 

**What is the chosen solution to this problem?**

let's activate tree shaking on ds to see the impact

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
