### PR TITLE
fix: apply transform style from props

### DIFF
--- a/.changeset/rude-pets-fix.md
+++ b/.changeset/rude-pets-fix.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: apply transform style from props

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -107,9 +107,10 @@ export const Icon = React.forwardRef(
 			}
 		}, [border, safeRef]);
 
-		const classname = classnames('tc-icon', style.svg, className, transform, {
+		const classname = classnames('tc-icon', style.svg, className, {
 			[`tc-icon-name-${name}`]: !(isImg || isRemote),
 			[style.border]: border,
+			[style[transform]]: !!transform,
 		});
 
 		if (isImg) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Regression found in webapp on treeview component. Arrows were always `>` but not `v` when oppened.

Legacy Icons transform property wasn't applied as class name.

This regression came after styled component removal (https://github.com/Talend/ui/pull/4390/files#diff-a810449a35ffd5558225ed3b3eb27f608cdf5e961cc298a5930e344115898e13R6)
I don't know if this was a warning https://github.com/Talend/ui/pull/4390/files#r995527175

**What is the chosen solution to this problem?**

applied transform property as a classname if exists

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
