### PR TITLE
fix(dataviz): render dot in LineChart when there is only one value

### DIFF
--- a/.changeset/beige-kings-deliver.md
+++ b/.changeset/beige-kings-deliver.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+fix(dataviz): render dot in LineChart when there is only one value

--- a/packages/dataviz/src/components/LineChart/LineChart.component.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.component.tsx
@@ -53,8 +53,12 @@ function LineChart({
 
 	const [activeLine, setActiveLine] = React.useState<string | null>(null);
 	const [selectedLines, setSelectedLines] = React.useState<string[]>(initialSelectedLines);
+	const hasOnlyOneValue = data?.length === 1;
 
 	const getLineStyleFromStatus = (status: LineStatus, key: string) => {
+		const defaultDotSize = hasOnlyOneValue ? 2 : 0;
+		const defaultDotStrokeWidth = hasOnlyOneValue ? 4 : 0;
+
 		const styleByStatus = {
 			light: {
 				strokeWidth: 1,
@@ -80,7 +84,7 @@ function LineChart({
 
 		if (hasLineSelection && selectedLines.length > 0) {
 			return {
-				dot: { r: 0 },
+				dot: { r: defaultDotSize, strokeWidth: defaultDotStrokeWidth },
 				...styleByStatus[status],
 				strokeOpacity: selectedLines.includes(key) ? 1 : 0.25,
 			};
@@ -88,14 +92,14 @@ function LineChart({
 
 		if (activeLine !== null) {
 			return {
-				dot: { r: 0 },
+				dot: { r: defaultDotSize, strokeWidth: defaultDotStrokeWidth },
 				...styleByStatus[status],
 				strokeOpacity: activeLine === key ? 1 : 0.25,
 			};
 		}
 
 		return {
-			dot: { r: 0 },
+			dot: { r: defaultDotSize, strokeWidth: defaultDotStrokeWidth },
 			...styleByStatus[status],
 		};
 	};

--- a/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
@@ -408,24 +408,24 @@ export const WithOnlyOneDot = {
 		},
 		lines: [
 			{
-				key: 'S Romain',
+				key: 'User1',
 				color: tokens.coralColorChartsColor01,
 			},
 			{
-				key: 'Sébastien Romain',
+				key: 'User2',
 				color: tokens.coralColorChartsColor02,
 			},
 			{
-				key: 'Sebastien Semanji',
+				key: 'User3',
 				color: tokens.coralColorChartsColor04,
 			},
 		],
 		data: [
 			{
 				xLabel: 'W41 2022',
-				'S Romain': 3024000000,
-				'Sébastien Romain': 5702400000,
-				'Sebastien Semanji': 8380800000,
+				User1: 3024000000,
+				User2: 5702400000,
+				User3: 8380800000,
 			},
 		],
 	},

--- a/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
@@ -388,6 +388,12 @@ export const CustomXAxisDomainLineChart = {
 	},
 };
 
+const tickFormatter = (value: number) => {
+	const durationByMonth = value / 2678400000;
+	const months = Math.floor(durationByMonth);
+	return `${months} months`;
+};
+
 export const WithOnlyOneDot = {
 	args: {
 		hasLineSelection: true,
@@ -396,33 +402,30 @@ export const WithOnlyOneDot = {
 			xAxisOptions: '{verticalOffset: 5}',
 			leftYAxisOptions: {
 				horizontalOffset: 4,
-				manualTicks: [22378905872, 22382505872, 22386105872, 22389705872],
-				// formatter: 'ƒ tickFormatter() {}',
+				manualTicks: [3024000000, 5702400000, 8380800000, 11059200000],
+				formatter: tickFormatter,
 			},
 		},
 		lines: [
 			{
 				key: 'S Romain',
 				color: tokens.coralColorChartsColor01,
-				// tooltipFormatter: 'ƒ labelFormatter() {}',
 			},
 			{
 				key: 'Sébastien Romain',
 				color: tokens.coralColorChartsColor02,
-				// tooltipFormatter: 'ƒ labelFormatter() {}',
 			},
 			{
 				key: 'Sebastien Semanji',
 				color: tokens.coralColorChartsColor04,
-				// tooltipFormatter: 'ƒ labelFormatter() {}',
 			},
 		],
 		data: [
 			{
 				xLabel: 'W41 2022',
-				'S Romain': 22378905872,
-				'Sébastien Romain': 22379612230,
-				'Sebastien Semanji': 22379081790,
+				'S Romain': 3024000000,
+				'Sébastien Romain': 5702400000,
+				'Sebastien Semanji': 8380800000,
 			},
 		],
 	},

--- a/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
+++ b/packages/dataviz/src/components/LineChart/LineChart.stories.tsx
@@ -387,3 +387,43 @@ export const CustomXAxisDomainLineChart = {
 		],
 	},
 };
+
+export const WithOnlyOneDot = {
+	args: {
+		hasLineSelection: true,
+		chartOptions: {
+			showGridLines: true,
+			xAxisOptions: '{verticalOffset: 5}',
+			leftYAxisOptions: {
+				horizontalOffset: 4,
+				manualTicks: [22378905872, 22382505872, 22386105872, 22389705872],
+				// formatter: 'ƒ tickFormatter() {}',
+			},
+		},
+		lines: [
+			{
+				key: 'S Romain',
+				color: tokens.coralColorChartsColor01,
+				// tooltipFormatter: 'ƒ labelFormatter() {}',
+			},
+			{
+				key: 'Sébastien Romain',
+				color: tokens.coralColorChartsColor02,
+				// tooltipFormatter: 'ƒ labelFormatter() {}',
+			},
+			{
+				key: 'Sebastien Semanji',
+				color: tokens.coralColorChartsColor04,
+				// tooltipFormatter: 'ƒ labelFormatter() {}',
+			},
+		],
+		data: [
+			{
+				xLabel: 'W41 2022',
+				'S Romain': 22378905872,
+				'Sébastien Romain': 22379612230,
+				'Sebastien Semanji': 22379081790,
+			},
+		],
+	},
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Currently, nothing is displayed as it's only the "Line" that is displayed

<img width="639" alt="CleanShot 2022-11-03 at 14 48 12@2x" src="https://user-images.githubusercontent.com/2909671/199738164-584e8f1e-7e5e-4a28-a5b0-823d3d79694a.png">

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
