### PR TITLE
fix(datagrid/HeaderCellRenderer): DQ icon and 0 rules

### DIFF
--- a/.changeset/tricky-seas-beam.md
+++ b/.changeset/tricky-seas-beam.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+fix(datagrid/HeaderCellRenderer): DQ icon and 0 rules

--- a/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.component.tsx
+++ b/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.component.tsx
@@ -113,7 +113,7 @@ export default function HeaderCellRenderer({
 						)}
 					</div>
 
-					{nbAppliedDqRules && (
+					{!!nbAppliedDqRules && (
 						<IconWithTooltip
 							icon="law-hammer"
 							tooltip={t('HEADER_CELL_RENDERER_NB_APPLIED_DQ_RULES', {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In the grid header renderer, when `0` is provided as the number of DQ rules applied, current rendering code shows "0" (first value of conditional rendering is falsy but not null/undefined so the value is rendered).

**What is the chosen solution to this problem?**
Enforce value testing.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
