### PR TITLE
feat(ARCH-661): add typings to react-components

### DIFF
--- a/.changeset/blue-dodos-impress.md
+++ b/.changeset/blue-dodos-impress.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat: add typings

--- a/.changeset/gold-waves-drum.md
+++ b/.changeset/gold-waves-drum.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+fix: do not pass t props to FormatValue

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -3,12 +3,13 @@
   "description": "Set of react components.",
   "main": "lib/index.js",
   "mainSrc": "src/index.js",
+  "types": "lib/index.d.ts",
   "license": "Apache-2.0",
   "scripts": {
     "build:dev": "talend-scripts build:lib:umd --dev",
     "build:prod": "talend-scripts build:lib:umd --prod",
     "pre-release": "yarn build:dev && yarn build:prod",
-    "build:lib": "talend-scripts build:lib",
+    "build:lib": "talend-scripts build:ts:lib",
     "test": "cross-env TZ=Europe/Paris talend-scripts test",
     "test:watch": "cross-env TZ=Europe/Paris talend-scripts test --watch",
     "test:cov": "cross-env TZ=Europe/Paris talend-scripts test --coverage",
@@ -80,6 +81,13 @@
     "@testing-library/jest-dom": "^5.16.4",
     "@testing-library/react": "^12.1.5",
     "@testing-library/user-event": "^13.5.0",
+    "@types/classnames": "^2.3.1",
+    "@types/d3": "^7.4.0",
+    "@types/date-fns": "^0.0.2",
+    "@types/enzyme": "^3.10.12",
+    "@types/lodash": "^4.14.182",
+    "@types/prop-types": "^15.7.5",
+    "@types/react": "^17.0.47",
     "cross-env": "^7.0.3",
     "enzyme": "^3.11.0",
     "enzyme-to-json": "^3.6.2",
@@ -92,7 +100,8 @@
     "react-dom": "^17.0.2",
     "react-i18next": "^11.18.1",
     "react-storybook-addon-props-combinations": "^1.1.0",
-    "react-test-renderer": "^17.0.2"
+    "react-test-renderer": "^17.0.2",
+    "typescript": "^4.6.4"
   },
   "peerDependencies": {
     "@talend/design-system": ">= 3.0.0",

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -427,37 +427,37 @@ Datalist.defaultProps = {
 	titleMap: [],
 };
 
-if (process.env.NODE_ENV !== 'production') {
-	Datalist.propTypes = {
-		className: PropTypes.string,
-		onBlur: PropTypes.func,
-		onChange: PropTypes.func.isRequired,
-		onFocus: PropTypes.func,
-		onClick: PropTypes.func,
-		onLiveChange: PropTypes.func,
-		disabled: PropTypes.bool,
-		multiSection: PropTypes.bool,
-		readOnly: PropTypes.bool,
-		restricted: PropTypes.bool,
-		titleMap: PropTypes.arrayOf(
-			PropTypes.oneOfType([
-				PropTypes.shape({
-					name: PropTypes.string.isRequired,
-					value: PropTypes.string.isRequired,
-				}),
-				PropTypes.shape({
-					title: PropTypes.string,
-					suggestions: PropTypes.arrayOf(
-						PropTypes.shape({
-							name: PropTypes.string,
-							value: PropTypes.string,
-						}),
-					),
-				}),
-			]),
-		),
-		value: PropTypes.string,
-	};
-}
+Datalist.propTypes = {
+	autoFocus: PropTypes.bool,
+	isLoading: PropTypes.bool,
+	className: PropTypes.string,
+	onBlur: PropTypes.func,
+	onChange: PropTypes.func.isRequired,
+	onFocus: PropTypes.func,
+	onClick: PropTypes.func,
+	onLiveChange: PropTypes.func,
+	disabled: PropTypes.bool,
+	multiSection: PropTypes.bool,
+	readOnly: PropTypes.bool,
+	restricted: PropTypes.bool,
+	titleMap: PropTypes.arrayOf(
+		PropTypes.oneOfType([
+			PropTypes.shape({
+				name: PropTypes.string.isRequired,
+				value: PropTypes.string.isRequired,
+			}),
+			PropTypes.shape({
+				title: PropTypes.string,
+				suggestions: PropTypes.arrayOf(
+					PropTypes.shape({
+						name: PropTypes.string,
+						value: PropTypes.string,
+					}),
+				),
+			}),
+		]),
+	),
+	value: PropTypes.string,
+};
 
 export default Datalist;

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -41,7 +41,7 @@ function InputDateTimePicker({
 				{({ date, time, onDateChange, onTimeChange }) => (
 					<div className={theme['date-time-picker']}>
 						<InputDatePicker
-							id={`${props.id}-date-picker`}
+							id={`${id}-date-picker`}
 							readOnly={props.readOnly}
 							disabled={props.disabled}
 							onBlur={props.onBlur}

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -10,8 +10,18 @@ import { DateTimeContext } from '../DateTime/Context';
 
 import theme from './InputDateTimePicker.module.scss';
 
-function InputDateTimePicker(props) {
-	if (props.selectedDateTime) {
+function InputDateTimePicker({
+	id,
+	value,
+	selectedDateTime,
+	useSeconds,
+	useUTC,
+	timezone,
+	onChange,
+	defaultTimeValue,
+	...props
+}) {
+	if (selectedDateTime) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			'Warning: "selectedDateTime" is deprecated and will be removed in the next major version. Use "value" instead please.',
@@ -19,13 +29,13 @@ function InputDateTimePicker(props) {
 	}
 	return (
 		<DateTime.Manager
-			id={props.id}
-			value={props.value || props.selectedDateTime}
-			useSeconds={props.useSeconds}
-			useUTC={props.useUTC}
-			timezone={props.timezone}
-			onChange={props.onChange}
-			defaultTimeValue={props.defaultTimeValue}
+			id={id}
+			value={value || selectedDateTime}
+			useSeconds={useSeconds}
+			useUTC={useUTC}
+			timezone={timezone}
+			onChange={onChange}
+			defaultTimeValue={defaultTimeValue}
 		>
 			<DateTimeContext.Consumer>
 				{({ date, time, onDateChange, onTimeChange }) => (
@@ -44,14 +54,14 @@ function InputDateTimePicker(props) {
 							isDisabledChecker={props.isDisabledChecker}
 						/>
 						<InputTimePicker
-							id={`${props.id}-time-picker`}
+							id={`${id}-time-picker`}
 							readOnly={props.readOnly}
 							disabled={props.disabled}
 							onBlur={props.onBlur}
 							onChange={onTimeChange}
 							value={time}
-							useSeconds={props.useSeconds}
-							timezone={props.timezone}
+							useSeconds={useSeconds}
+							timezone={timezone}
 							minWidth={props.minWidthTime}
 						/>
 					</div>
@@ -105,6 +115,7 @@ function InputDateTimePickerSwitch(props) {
 }
 InputDateTimePickerSwitch.propTypes = {
 	formMode: PropTypes.bool,
+	...InputDatePicker.propTypes,
 };
 
 export default InputDateTimePickerSwitch;

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -10,18 +10,8 @@ import { DateTimeContext } from '../DateTime/Context';
 
 import theme from './InputDateTimePicker.module.scss';
 
-function InputDateTimePicker({
-	id,
-	value,
-	selectedDateTime,
-	useSeconds,
-	useUTC,
-	timezone,
-	onChange,
-	defaultTimeValue,
-	...props
-}) {
-	if (selectedDateTime) {
+function InputDateTimePicker(props) {
+	if (props.selectedDateTime) {
 		// eslint-disable-next-line no-console
 		console.warn(
 			'Warning: "selectedDateTime" is deprecated and will be removed in the next major version. Use "value" instead please.',
@@ -29,19 +19,19 @@ function InputDateTimePicker({
 	}
 	return (
 		<DateTime.Manager
-			id={id}
-			value={value || selectedDateTime}
-			useSeconds={useSeconds}
-			useUTC={useUTC}
-			timezone={timezone}
-			onChange={onChange}
-			defaultTimeValue={defaultTimeValue}
+			id={props.id}
+			value={props.value || props.selectedDateTime}
+			useSeconds={props.useSeconds}
+			useUTC={props.useUTC}
+			timezone={props.timezone}
+			onChange={props.onChange}
+			defaultTimeValue={props.defaultTimeValue}
 		>
 			<DateTimeContext.Consumer>
 				{({ date, time, onDateChange, onTimeChange }) => (
 					<div className={theme['date-time-picker']}>
 						<InputDatePicker
-							id={`${id}-date-picker`}
+							id={`${props.id}-date-picker`}
 							readOnly={props.readOnly}
 							disabled={props.disabled}
 							onBlur={props.onBlur}
@@ -54,14 +44,14 @@ function InputDateTimePicker({
 							isDisabledChecker={props.isDisabledChecker}
 						/>
 						<InputTimePicker
-							id={`${id}-time-picker`}
+							id={`${props.id}-time-picker`}
 							readOnly={props.readOnly}
 							disabled={props.disabled}
 							onBlur={props.onBlur}
 							onChange={onTimeChange}
 							value={time}
-							useSeconds={useSeconds}
-							timezone={timezone}
+							useSeconds={props.useSeconds}
+							timezone={props.timezone}
 							minWidth={props.minWidthTime}
 						/>
 					</div>

--- a/packages/components/tsconfig.json
+++ b/packages/components/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@talend/scripts-config-typescript/tsconfig.json",
+  "include": ["src/*"],
+  "exclude": ["node_modules"],
+  "files": [],
+  "compilerOptions": {
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "noEmit": false
+  }
+}

--- a/packages/datagrid/src/types/types.d.ts
+++ b/packages/datagrid/src/types/types.d.ts
@@ -3,5 +3,4 @@ declare module '*.scss' {
 	export default content;
 }
 
-declare module '@talend/react-components';
 declare module '@talend/react-bootstrap';

--- a/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.tsx
+++ b/packages/dataviz/src/components/BarChart/ColoredBar/ColoredBar.component.tsx
@@ -72,7 +72,6 @@ function ColoredBarLabel({ focusedBarIndex, payload, chartStyle, ...props }: Col
 							styles['colored-bar__label'],
 						)}
 						value={payload?.value || t('EMPTY', 'Empty')}
-						t={t}
 					/>
 				</foreignObject>
 			)}

--- a/packages/dataviz/src/types/types.d.ts
+++ b/packages/dataviz/src/types/types.d.ts
@@ -3,4 +3,5 @@ declare module '*.scss' {
 	export default content;
 }
 
+// FIXME: add the needed types to react-components to remove this
 declare module '@talend/react-components';

--- a/packages/forms/stories/Playground.stories.tsx
+++ b/packages/forms/stories/Playground.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { action } from '@storybook/addon-actions';
 import isEqual from 'lodash/isEqual';
 
-import { FormDefinition } from '../lib';
+import { FormDefinition } from '../src/types';
 import Form from '../src/FormSwitcher';
 
 const DEFAULT_DATA = { jsonSchema: {}, uiSchema: [], properties: {} };

--- a/packages/jsfc/package.json
+++ b/packages/jsfc/package.json
@@ -42,7 +42,6 @@
     "@talend/scripts-core": "^12.0.0",
     "@talend/scripts-preset-react-lib": "^14.0.0",
     "@types/chai": "^3.5.2",
-    "@types/mocha": "^2.2.48",
     "@types/node": "^6.14.13",
     "json-refs": "^3.0.15",
     "rimraf": "^3.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3966,6 +3966,11 @@
     "@types/d3-transition" "*"
     "@types/d3-zoom" "*"
 
+"@types/date-fns@^0.0.2":
+  version "0.0.2"
+  resolved "https://registry.yarnpkg.com/@types/date-fns/-/date-fns-0.0.2.tgz#a71d2e0b2ab57bb8de81c843e5ecf6e161779b8c"
+  integrity sha512-oaNPSNlQvNmenCWCw5fHBpRUpltjZCBw3hwZkYKgSyNuCuD2w60jpIgMUa1h/BrKuw4L+0BvoiXhwmNKUFQLHw==
+
 "@types/debug@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/debug/-/debug-4.1.7.tgz#7cc0ea761509124709b8b2d1090d8f6c17aadb82"
@@ -4196,11 +4201,6 @@
   resolved "https://registry.yarnpkg.com/@types/minimist/-/minimist-1.2.2.tgz#ee771e2ba4b3dc5b372935d549fd9617bf345b8c"
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
-"@types/mocha@^2.2.48":
-  version "2.2.48"
-  resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-2.2.48.tgz#3523b126a0b049482e1c3c11877460f76622ffab"
-  integrity sha512-nlK/iyETgafGli8Zh9zJVCTicvU3iajSkRwOh3Hhiva598CMqNJ4NcVCGMTGKpGpTYj/9R8RLzS9NAykSSCqGw==
-
 "@types/ms@*":
   version "0.7.31"
   resolved "https://registry.yarnpkg.com/@types/ms/-/ms-0.7.31.tgz#31b7ca6407128a3d2bbc27fe2d21b345397f6197"
@@ -4274,7 +4274,7 @@
   resolved "https://registry.yarnpkg.com/@types/pretty-hrtime/-/pretty-hrtime-1.0.1.tgz#72a26101dc567b0d68fd956cf42314556e42d601"
   integrity sha512-VjID5MJb1eGKthz2qUerWT8+R4b9N+CHvGCzg9fn4kWZgaF9AhdYikQio3R7wV8YY1NsQKPaCwKz1Yff+aHNUQ==
 
-"@types/prop-types@*":
+"@types/prop-types@*", "@types/prop-types@^15.7.5":
   version "15.7.5"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.5.tgz#5f19d2b85a98e9558036f6a3cacc8819420f05cf"
   integrity sha512-JCB8C6SnDoQf0cNycqd/35A7MjcnK+ZTqE7judS6o7utxUCg6imJg3QK2qzHKszlTjcj2cn+NwMB2i96ubpj7w==
@@ -19534,7 +19534,7 @@ typescript-tuple@^2.2.1:
   dependencies:
     typescript-compare "^0.0.2"
 
-typescript@>=4.6.3, typescript@^3.0.0, typescript@^4.6.2, typescript@^4.7.4:
+typescript@>=4.6.3, typescript@^3.0.0, typescript@^4.6.2, typescript@^4.6.4, typescript@^4.7.4:
   version "4.8.4"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we use more and more TS but react-components do not expose typings

**What is the chosen solution to this problem?**

* add the bare minimum configuration and tools to generate typings in `@talend/react-components` package.

It means from this release react-components will contains a lib/index.d.ts in the release.

You can still use `declare module '@talend/react-components';` in your package but you should try to remove it to see if current typings are working well. Here it has been possible for datagrid but not for dataviz.

This came from the fact the new types are inferred by typescript from the javascript code so this is far from perfect.
But with this we will be now able to use ts and tsx files in place of javascript files and so be able to create correct typings.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
