### PR TITLE
fix(TDS-6837): not using submit button

### DIFF
--- a/.changeset/happy-wombats-dance.md
+++ b/.changeset/happy-wombats-dance.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDS-6837): not using submit type button in legacy date picker

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
@@ -60,7 +60,7 @@ function Validation({ t }) {
 			<button
 				name="action-datepicker-validate"
 				className="btn btn-primary"
-				type="button
+				type="button"
 				aria-label={t('DATEPICKER_VALIDATE_DESC', {
 					defaultValue: 'Validate the date picker value',
 				})}

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
@@ -11,15 +11,9 @@ import Error from './Error.component';
 import theme from './Validation.scss';
 
 function Validation({ t }) {
-	const { errorManagement } = useContext(DateTimeContext);
-	const {
-		errors,
-		focusedInput,
-		hoursErrorId,
-		minutesErrorId,
-		secondsErrorId,
-		inputErrorId,
-	} = errorManagement;
+	const { errorManagement, formManagement } = useContext(DateTimeContext);
+	const { errors, focusedInput, hoursErrorId, minutesErrorId, secondsErrorId, inputErrorId } =
+		errorManagement;
 
 	const errorsOrder = [inputErrorId, hoursErrorId, minutesErrorId, secondsErrorId];
 	const errorsMapping = {
@@ -66,10 +60,10 @@ function Validation({ t }) {
 			<button
 				name="action-datepicker-validate"
 				className="btn btn-primary"
-				type="submit"
 				aria-label={t('DATEPICKER_VALIDATE_DESC', {
 					defaultValue: 'Validate the date picker value',
 				})}
+				onClick={formManagement.onSubmit}
 			>
 				{t('DATEPICKER_VALIDATE', { defaultValue: 'Done' })}
 			</button>

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.js
@@ -60,6 +60,7 @@ function Validation({ t }) {
 			<button
 				name="action-datepicker-validate"
 				className="btn btn-primary"
+				type="button
 				aria-label={t('DATEPICKER_VALIDATE_DESC', {
 					defaultValue: 'Validate the date picker value',
 				})}

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.test.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/Validation.component.test.js
@@ -29,6 +29,9 @@ describe('DateTime.Validation', () => {
 				minutesErrorId: 'my-custom-minutes-error',
 				secondsErrorId: 'my-custom-seconds-error',
 			},
+			formManagement: {
+				onSubmit: jest.fn(),
+			},
 		};
 
 		// when
@@ -57,6 +60,9 @@ describe('DateTime.Validation', () => {
 				minutesErrorId: 'my-custom-minutes-error',
 				secondsErrorId: 'my-custom-seconds-error',
 				focusedInput: 'my-custom-hours-error',
+			},
+			formManagement: {
+				onSubmit: jest.fn(),
 			},
 		};
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/__snapshots__/Validation.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/__snapshots__/Validation.component.test.js.snap
@@ -68,6 +68,7 @@ exports[`DateTime.Validation should render 1`] = `
       className="btn btn-primary"
       name="action-datepicker-validate"
       onClick={[MockFunction]}
+      type="button"
     >
       Done
     </button>

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/__snapshots__/Validation.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/DateTime/Validation/__snapshots__/Validation.component.test.js.snap
@@ -67,7 +67,7 @@ exports[`DateTime.Validation should render 1`] = `
       aria-label="Validate the date picker value"
       className="btn btn-primary"
       name="action-datepicker-validate"
-      type="submit"
+      onClick={[MockFunction]}
     >
       Done
     </button>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Having submit button when two form are encapsulated results in a weird redirect.
So when having the date picker in a form and clicking on "done" a submit is done and the page reloaded ...
**What is the chosen solution to this problem?**
remove the submit type and use onclick
**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
