### PR TITLE
fix(SubHeaderBar): replace EditableText to InlineEditing

### DIFF
--- a/.changeset/large-radios-pretend.md
+++ b/.changeset/large-radios-pretend.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+feat(InlineEditing): add new `onToggle` optional props to get notify from edition mode changes

--- a/.changeset/large-radios-pretend2.md
+++ b/.changeset/large-radios-pretend2.md
@@ -1,0 +1,9 @@
+---
+'@talend/react-components': major
+---
+
+feat(SubHeaderBar): replace `EditableText` legacy component by `InlineEditing` Coral component.
+
+Breaking:
+- `onEdit` and `onCancel` props has been removed. They are now directly handled by the `InlineEditing` component.
+- `onSubmit` callback signature changed from `onSubmit(event: JSEvent, { value: string })` to `onSubmit(event: JSEvent, value: string)` the returned value from the `InlineEditing` component is not wrapped within an object containing only one `value` property. You now have the `value` directly.

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -95,6 +95,12 @@ export const WithSubtitle = () => (
 	</div>
 );
 
+export const WithEditableSubtitle = () => (
+	<div>
+		<SubHeaderBar {...viewProps} onGoBack={backAction} editable subTitle="mySubTitle" />
+	</div>
+);
+
 export const WithLoadingSubtitle = () => (
 	<div>
 		<SubHeaderBar {...viewProps} subTitleLoading onGoBack={backAction} />

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -78,7 +78,7 @@ function TitleSubHeader({
 		return <Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />;
 	}
 
-	const InjectedInlineEditingText = Inject.get(getComponent, 'InlineEditing', InlineEditing);
+	const InjectedInlineEditingText = Inject.get(getComponent, 'InlineEditing', InlineEditing.Text);
 
 	return (
 		<div
@@ -94,6 +94,7 @@ function TitleSubHeader({
 							required={true}
 							renderValueAs="h1"
 							label=""
+							placeholder=""
 							defaultValue={title}
 							loading={loading}
 							onToggle={setIsEditMode}

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.component.js
@@ -1,7 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+
+import { InlineEditing } from '@talend/design-system';
+
 import Skeleton from '../../Skeleton';
-import EditableText from '../../EditableText';
 import titleSubHeaderCssModule from './TitleSubHeader.module.scss';
 import Icon from '../../Icon';
 import Inject from '../../Inject';
@@ -11,81 +13,12 @@ import { getTheme } from '../../theme';
 
 const theme = getTheme(titleSubHeaderCssModule);
 
-function TitleSubHeader({
-	title,
-	iconId,
-	loading,
-	inProgress,
-	editable,
-	getComponent,
-	onEdit,
-	onCancel,
-	onSubmit,
-	...rest
-}) {
-	const [isEditMode, setIsEditMode] = React.useState(false);
-	function handleEdit(...args) {
-		setIsEditMode(true);
-		if (onEdit) {
-			onEdit(...args);
-		}
-	}
-
-	function handleCancel(...args) {
-		setIsEditMode(false);
-		if (onCancel) {
-			onCancel(...args);
-		}
-	}
-
-	function handleSubmit(...args) {
-		setIsEditMode(false);
-		if (onSubmit) {
-			onSubmit(...args);
-		}
-	}
-
-	if (loading) {
-		return <Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />;
-	}
-
-	const InjectedEditableText = Inject.get(getComponent, 'EditableText', EditableText);
-
-	return (
-		<div
-			className={theme('tc-subheader-details', {
-				'tc-subheader-details-blink': inProgress,
-			})}
-		>
-			{iconId && <Icon name={iconId} className={theme('tc-subheader-details-icon')} />}
-			<div className={theme('tc-subheader-details-text')}>
-				<div className={theme('tc-subheader-details-text-title')}>
-					{editable ? (
-						<InjectedEditableText
-							text={title}
-							inProgress={inProgress}
-							feature="subheaderbar.rename"
-							componentClass="h1"
-							onEdit={handleEdit}
-							onCancel={handleCancel}
-							onSubmit={handleSubmit}
-							editMode={isEditMode}
-							{...rest}
-						/>
-					) : (
-						<TooltipTrigger label={title} tooltipPlacement="bottom">
-							<h1 className={theme('tc-subheader-details-text-title-wording')} {...rest.titleProps}>{title}</h1>
-						</TooltipTrigger>
-					)}
-				</div>
-				{!isEditMode ? <SubTitle {...rest} /> : null}
-			</div>
-		</div>
-	);
-}
-
 function DefaultSubTitle({ subTitle, subTitleProps }) {
-	return <small className={theme('tc-subheader-details-text-subtitle')} {...subTitleProps}>{subTitle}</small>;
+	return (
+		<small className={theme('tc-subheader-details-text-subtitle')} {...subTitleProps}>
+			{subTitle}
+		</small>
+	);
 }
 
 DefaultSubTitle.propTypes = {
@@ -93,7 +26,12 @@ DefaultSubTitle.propTypes = {
 	subTitleProps: PropTypes.object,
 };
 
-function SubTitle({ subTitleLoading, subTitle, subTitleAs: SubTitleAs = DefaultSubTitle, ...rest }) {
+function SubTitle({
+	subTitleLoading,
+	subTitle,
+	subTitleAs: SubTitleAs = DefaultSubTitle,
+	...rest
+}) {
 	if (subTitleLoading) {
 		return (
 			<Skeleton
@@ -117,6 +55,66 @@ SubTitle.propTypes = {
 	subTitleAs: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
 };
 
+function TitleSubHeader({
+	title,
+	iconId,
+	loading,
+	inProgress,
+	editable,
+	getComponent,
+	onCancel,
+	onSubmit,
+	...rest
+}) {
+	const [isEditMode, setIsEditMode] = React.useState(false);
+
+	function handleSubmit(...args) {
+		if (onSubmit) {
+			onSubmit(...args);
+		}
+	}
+
+	if (loading) {
+		return <Skeleton type={Skeleton.TYPES.text} size={Skeleton.SIZES.large} />;
+	}
+
+	const InjectedInlineEditingText = Inject.get(getComponent, 'InlineEditing', InlineEditing);
+
+	return (
+		<div
+			className={theme('tc-subheader-details', {
+				'tc-subheader-details-blink': inProgress,
+			})}
+		>
+			{iconId && <Icon name={iconId} className={theme('tc-subheader-details-icon')} />}
+			<div className={theme('tc-subheader-details-text')}>
+				<div className={theme('tc-subheader-details-text-title')}>
+					{editable ? (
+						<InjectedInlineEditingText
+							required={true}
+							renderValueAs="h1"
+							label=""
+							defaultValue={title}
+							loading={loading}
+							onToggle={setIsEditMode}
+							onEdit={handleSubmit}
+							data-feature="subheaderbar.rename"
+							{...rest}
+						/>
+					) : (
+						<TooltipTrigger label={title} tooltipPlacement="bottom">
+							<h1 className={theme('tc-subheader-details-text-title-wording')} {...rest.titleProps}>
+								{title}
+							</h1>
+						</TooltipTrigger>
+					)}
+				</div>
+				{!isEditMode ? <SubTitle {...rest} /> : null}
+			</div>
+		</div>
+	);
+}
+
 TitleSubHeader.propTypes = {
 	title: PropTypes.string.isRequired,
 	iconId: PropTypes.string,
@@ -124,9 +122,7 @@ TitleSubHeader.propTypes = {
 	inProgress: PropTypes.bool,
 	editable: PropTypes.bool,
 	subTitle: PropTypes.node,
-	onEdit: PropTypes.func,
 	onSubmit: PropTypes.func,
-	onCancel: PropTypes.func,
 	t: PropTypes.func,
 	...Inject.PropTypes,
 };

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
@@ -10,6 +10,7 @@
 
 $tc-input-subheader-size-large: 2.4rem !default;
 $tc-input-subheader-size-medium: 1.4rem !default;
+$header-title-max-width: 90rem;
 
 :global(.tc-subheader-details-blink) {
 	@include heartbeat(object-blink);
@@ -35,13 +36,18 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 		overflow: hidden;
 		flex: 1 auto;
 		margin-right: 110px;
-		max-width: 90rem;
+		max-width: $header-title-max-width;
 		align-items: flex-start;
 
 		&-title {
 			display: inline-flex;
 			align-items: center;
 			width: 100%;
+
+			// force InlineEditing max space to allow ellipsis
+			> * {
+				max-width: $header-title-max-width;
+			}
 
 			&-wording,
 			&-wording-button {

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
@@ -49,40 +49,6 @@ $tc-input-subheader-size-medium: 1.4rem !default;
 				line-height: unset;
 				margin: 0;
 			}
-
-			:global {
-				.tc-editable-text-wording {
-					line-height: unset;
-					margin: 0;
-				}
-
-				.tc-editable-text-form-input {
-					width: 30rem;
-				}
-
-				.tc-editable-text-form-buttons-submit:hover {
-					background: $scooter;
-
-					& svg {
-						background: $scooter;
-					}
-				}
-
-				.tc-editable-text-pencil {
-					opacity: 0;
-
-					&:focus,
-					&:active {
-						opacity: 1;
-					}
-				}
-
-				:hover {
-					.tc-editable-text-pencil {
-						opacity: 1;
-					}
-				}
-			}
 		}
 
 		&-subtitle {

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -1,10 +1,12 @@
 import React from 'react';
 import { shallow, mount } from 'enzyme';
+
+import { InlineEditing } from '@talend/design-system';
+
 import Skeleton from '../../Skeleton';
 import Icon from '../../Icon';
 import Action from '../../Actions/Action';
 import Tag from '../../Tag';
-import EditableText from '../../EditableText';
 import TitleSubHeader, { SubTitle } from './TitleSubHeader.component';
 
 describe('TitleSubHeader', () => {
@@ -13,7 +15,6 @@ describe('TitleSubHeader', () => {
 	beforeEach(() => {
 		defaultProps = {
 			title: 'myTitle',
-			onEdit: jest.fn(),
 			onSubmit: jest.fn(),
 		};
 	});
@@ -49,10 +50,10 @@ describe('TitleSubHeader', () => {
 		expect(wrapper.find('h1')).toHaveLength(1);
 	});
 
-	it('should render EditableText', () => {
+	it('should render InlineEditing', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
-		expect(wrapper.find(EditableText)).toHaveLength(1);
-		expect(wrapper.find(EditableText).get(0).props.feature).toBe('subheaderbar.rename');
+		expect(wrapper.find(InlineEditing)).toHaveLength(1);
+		expect(wrapper.find(InlineEditing).get(0).props['data-feature']).toBe('subheaderbar.rename');
 		expect(wrapper.find('h1')).toHaveLength(0);
 	});
 
@@ -66,19 +67,6 @@ describe('TitleSubHeader', () => {
 		expect(wrapper.props().className).toEqual(
 			'tc-subheader-details theme-tc-subheader-details tc-subheader-details-blink theme-tc-subheader-details-blink',
 		);
-	});
-
-	it('should go in edit mode', () => {
-		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
-		const findEditableText = () => wrapper.find('[feature="subheaderbar.rename"]');
-
-		findEditableText().props().onEdit();
-
-		expect(findEditableText().props().editMode).toEqual(true);
-
-		findEditableText().props().onCancel();
-
-		expect(findEditableText().props().editMode).toEqual(false);
 	});
 
 	it('should render pass extra props to the title', () => {
@@ -130,6 +118,6 @@ describe('SubTitle', () => {
 		const wrapper = mount(<SubTitle {...defaultProps} subTitleProps={subTitleProps} />);
 
 		// then
-		expect(wrapper.find(('[data-test="345"]'))).toHaveLength(1);
+		expect(wrapper.find('[data-test="345"]')).toHaveLength(1);
 	});
 });

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.test.js
@@ -52,8 +52,10 @@ describe('TitleSubHeader', () => {
 
 	it('should render InlineEditing', () => {
 		const wrapper = shallow(<TitleSubHeader {...defaultProps} editable />);
-		expect(wrapper.find(InlineEditing)).toHaveLength(1);
-		expect(wrapper.find(InlineEditing).get(0).props['data-feature']).toBe('subheaderbar.rename');
+		expect(wrapper.find(InlineEditing.Text)).toHaveLength(1);
+		expect(wrapper.find(InlineEditing.Text).get(0).props['data-feature']).toBe(
+			'subheaderbar.rename',
+		);
 		expect(wrapper.find('h1')).toHaveLength(0);
 	});
 

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.stories.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.stories.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Story } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
 
 import InlineEditing from '.';
 
@@ -120,6 +121,7 @@ export const InUse = (props: Story) => {
 				loading={loading}
 				defaultValue={data}
 				hasError={error}
+				onToggle={action('onToggle')}
 				onEdit={onEdit}
 				onCancel={onCancel}
 				aria-describedby="inlinemessage-id"

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -32,6 +32,7 @@ export type InlineEditingPrimitiveProps = {
 	loading?: boolean;
 	onEdit?: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent, newValue: string) => void;
 	onCancel?: () => void;
+	onToggle?: (isEditionMode: boolean) => void;
 	defaultValue?: string;
 	label: string;
 	required?: boolean;
@@ -50,6 +51,7 @@ const InlineEditingPrimitive = forwardRef(
 			mode,
 			onEdit = () => {},
 			onCancel = () => {},
+			onToggle = () => {},
 			required = false,
 			defaultValue,
 			label,
@@ -62,11 +64,15 @@ const InlineEditingPrimitive = forwardRef(
 		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 		const [isEditing, setEditing] = useState<boolean>(false);
 		const [value, setValue] = React.useState<string | undefined>(defaultValue);
+		const toggleEditionMode = (isEditionMode: boolean) => {
+			setEditing(isEditionMode);
+			onToggle(isEditionMode);
+		};
 
 		// Errors should set InlineEditing into editing mode
 		useEffect(() => {
 			if (hasError) {
-				setEditing(hasError);
+				toggleEditionMode(hasError);
 			}
 		}, [hasError]);
 
@@ -76,14 +82,14 @@ const InlineEditingPrimitive = forwardRef(
 				const sentValue = value || '';
 				onEdit(event, sentValue);
 			}
-			setEditing(false);
+			toggleEditionMode(false);
 		};
 
 		const handleCancel = () => {
 			if (isEditing) {
 				setValue(defaultValue);
 			}
-			setEditing(false);
+			toggleEditionMode(false);
 			onCancel();
 		};
 
@@ -186,7 +192,7 @@ const InlineEditingPrimitive = forwardRef(
 						})}
 						onDoubleClick={() => {
 							if (!loading) {
-								setEditing(true);
+								toggleEditionMode(true);
 							}
 						}}
 					>
@@ -194,7 +200,7 @@ const InlineEditingPrimitive = forwardRef(
 						<span className={styles.inlineEditor__content__button}>
 							<ButtonIcon
 								data-test="inlineediting.button.edit"
-								onClick={() => setEditing(true)}
+								onClick={() => toggleEditionMode(true)}
 								aria-label={ariaLabel || label}
 								icon="pencil"
 								disabled={loading}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In the context of https://jira.talendforge.org/browse/TDS-6839 we had issues with the `EditableText` and to fix the problem and to move forward with DS usage I choose to replace the `EditableText` by the `InlineEditing` component.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
