### PR TITLE
feat(TFD-14361) Use data-testid attribute instead of data-test

### DIFF
--- a/.changeset/red-carpets-leave.md
+++ b/.changeset/red-carpets-leave.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Change data-test attribute for data-testid

--- a/packages/design-system/src/components/Modal/Modal.spec.tsx
+++ b/packages/design-system/src/components/Modal/Modal.spec.tsx
@@ -1,3 +1,6 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+// => Not relevant because we use Cypress
+
 import React from 'react';
 import { composeStories } from '@storybook/testing-react';
 
@@ -8,21 +11,21 @@ const { NoDisclosure, WithDisclosure, WithNonClosingBackdrop } = composeStories(
 context('<Modal />', () => {
 	it('should render and focus on the modal', () => {
 		cy.mount(<NoDisclosure />);
-		cy.getByTest('open-modal').click();
-		cy.getByTest('modal').should('be.visible');
-		cy.focused().should('have.attr', 'data-test', 'modal');
+		cy.getByTestId('open-modal').click();
+		cy.getByTestId('modal').should('be.visible');
+		cy.focused().should('have.attr', 'data-testid', 'modal');
 	});
 
 	it('should support custom disclosure', () => {
 		cy.mount(<WithDisclosure />);
-		cy.getByTest('modal-disclosure').click();
-		cy.getByTest('modal').should('be.visible');
+		cy.getByTestId('modal-disclosure').click();
+		cy.getByTestId('modal').should('be.visible');
 	});
 
 	it('should close the modal on cancel/close action', () => {
 		// when
 		cy.mount(<NoDisclosure />);
-		cy.getByTest('open-modal').click();
+		cy.getByTestId('open-modal').click();
 		cy.getByTestId('modal.buttons.close')
 			.click()
 			.then(() => {
@@ -34,24 +37,24 @@ context('<Modal />', () => {
 	it('should close the modal on ESC key', () => {
 		// when
 		cy.mount(<NoDisclosure />);
-		cy.getByTest('open-modal').click();
-		cy.getByTest('modal')
+		cy.getByTestId('open-modal').click();
+		cy.getByTestId('modal')
 			.type('{esc}')
 			.then(() => {
 				// then
-				cy.getByTest('modal').should('not.exist');
+				cy.getByTestId('modal').should('not.exist');
 			});
 	});
 
 	it('should not close the modal on ESC key', () => {
 		// when
 		cy.mount(<WithNonClosingBackdrop />);
-		cy.getByTest('open-modal').click();
-		cy.getByTest('modal')
+		cy.getByTestId('open-modal').click();
+		cy.getByTestId('modal')
 			.type('{esc}')
 			.then(() => {
 				// then
-				cy.getByTest('modal').should('exist');
+				cy.getByTestId('modal').should('exist');
 			});
 	});
 });

--- a/packages/design-system/src/components/Modal/Modal.stories.tsx
+++ b/packages/design-system/src/components/Modal/Modal.stories.tsx
@@ -14,20 +14,21 @@ function ModalStory(props: Partial<ModalPropsType>) {
 
 	return (
 		<>
-			<ButtonPrimary onClick={() => setModalOpen(true)} data-test="open-modal">
+			<ButtonPrimary onClick={() => setModalOpen(true)} data-testid="open-modal">
 				See
 			</ButtonPrimary>
 
 			{modalOpen && (
 				<Modal
 					header={{ title: '(Default story title)' }}
-					children="(Default story child)"
 					onClose={() => {
 						action('onClose');
 						setModalOpen(false);
 					}}
 					{...props}
-				/>
+				>
+					(Default story child)
+				</Modal>
 			)}
 		</>
 	);
@@ -146,7 +147,7 @@ export const WithDisclosure: ComponentStory<typeof Modal> = props => (
 		{...props}
 		header={{ title: 'With disclosure' }}
 		disclosure={
-			<ButtonPrimary data-test="modal-disclosure" onClick={() => {}}>
+			<ButtonPrimary data-testid="modal-disclosure" onClick={() => {}}>
 				Open the modal
 			</ButtonPrimary>
 		}

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -14,10 +14,10 @@ import styles from './Modal.module.scss';
 
 type IconProp = DeprecatedIconNames | ReactElement;
 
-function ModalIcon(props: { icon: IconProp; 'data-test'?: string }): ReactElement {
-	const { icon, 'data-test': dataTest } = props;
+function ModalIcon(props: { icon: IconProp; 'data-testid'?: string }): ReactElement {
+	const { icon, 'data-testid': dataTest } = props;
 	return (
-		<div className={styles['modal-icon']} data-test={dataTest}>
+		<div className={styles['modal-icon']} data-testid={dataTest}>
 			{typeof icon === 'string' ? <Icon name={icon} /> : icon}
 		</div>
 	);
@@ -83,30 +83,34 @@ function Modal(props: ModalPropsType): ReactElement {
 				</DialogDisclosure>
 			)}
 			{dialog.visible && (
-				<DialogBackdrop {...dialog} className={styles['modal-backdrop']} data-test="modal.backdrop">
+				<DialogBackdrop
+					{...dialog}
+					className={styles['modal-backdrop']}
+					data-testid="modal.backdrop"
+				>
 					<div className={styles['modal-container']}>
 						<Dialog
 							{...dialog}
 							{...rest}
-							data-test="modal"
+							data-testid="modal"
 							className={styles.modal}
 							hide={preventEscaping ? undefined : () => onCloseHandler()}
 							ref={ref}
 						>
 							<StackVertical gap={0}>
 								<div className={styles.modal__header}>
-									{header.icon && <ModalIcon icon={header.icon} data-test="modal.header.icon" />}
+									{header.icon && <ModalIcon icon={header.icon} data-testid="modal.header.icon" />}
 									<div className={styles['modal-header-text']}>
 										<span
 											className={styles['modal-header-text__title']}
-											data-test="modal.header.title"
+											data-testid="modal.header.title"
 										>
 											{header.title}
 										</span>
 										{header.description && (
 											<span
 												className={styles['modal-header-text__description']}
-												data-test="modal.header.description"
+												data-testid="modal.header.description"
 											>
 												{header.description}
 											</span>
@@ -114,11 +118,11 @@ function Modal(props: ModalPropsType): ReactElement {
 									</div>
 								</div>
 
-								<div className={styles.modal__content} data-test="modal.content">
+								<div className={styles.modal__content} data-testid="modal.content">
 									{children}
 								</div>
 
-								<div className={styles.modal__buttons} data-test="modal.buttons">
+								<div className={styles.modal__buttons} data-testid="modal.buttons">
 									<StackHorizontal gap="XS" justify="end">
 										<span className={styles['close-button']}>
 											<ButtonSecondary


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**Proposal** : change use of data-test attribute for cypress' unit test for data-testid, so QA on TPD can use them to do their automatic tests

**What is the chosen solution to this problem?**

Rename "data-test" for "data-testid"

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
