### PR TITLE
fix(ARCH-658): add missing dep

### DIFF
--- a/.changeset/slimy-moles-move.md
+++ b/.changeset/slimy-moles-move.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: add missing dependency on @storybook/preset-scss

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -25,6 +25,7 @@
     "@storybook/builder-webpack5": "^6.5.10",
     "@storybook/jest": "^0.0.10",
     "@storybook/manager-webpack5": "^6.5.10",
+    "@storybook/preset-scss": "^6.5.10",
     "@storybook/react": "^6.5.10",
     "@storybook/testing-library": "^0.0.13",
     "@talend/dynamic-cdn-webpack-plugin": "^13.0.0",

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -25,7 +25,7 @@
     "@storybook/builder-webpack5": "^6.5.10",
     "@storybook/jest": "^0.0.10",
     "@storybook/manager-webpack5": "^6.5.10",
-    "@storybook/preset-scss": "^6.5.10",
+    "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.5.10",
     "@storybook/testing-library": "^0.0.13",
     "@talend/dynamic-cdn-webpack-plugin": "^13.0.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

our storybook doc rely on a preset which is not in a dependency

**What is the chosen solution to this problem?**

Usage create the following error:
```
info => Loading presets
WARN   Failed to load preset: {"options":{"cssLoaderOptions":{"modules":true}},"type":"presets"} on level 1
ERR! TypeError: The "id" argument must be of type string. Received an instance of Object
ERR!     at new NodeError (node:internal/errors:372:5)
ERR!     at validateString (node:internal/validators:120:11)
ERR!     at Module.require (node:internal/modules/cjs/loader:998:3)
ERR!     at require (node:internal/modules/cjs/helpers:102:18)
ERR!     at interopRequireDefault (/home/jean/github/talend/ui-dataset/node_modules/@storybook/core-common/dist/cjs/presets.js:178:16)
```

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
