### PR TITLE
chore(ARCH-658): simplify webpack from sb

### DIFF
--- a/.changeset/loud-dolphins-drum.md
+++ b/.changeset/loud-dolphins-drum.md
@@ -1,0 +1,7 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+feat: simplify configuration as part of the current changes in all talend-scripts.
+
+Now talend-scripts only work with mainstream approach of file names.

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -1,13 +1,8 @@
 const fs = require('fs');
 const { merge } = require('lodash');
 const path = require('path');
-const getTalendWebpackConfig = require('@talend/scripts-core/config/webpack.config');
 const CDNPlugin = require('@talend/dynamic-cdn-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const { getAllModules } = require('@talend/module-to-cdn');
-const HtmlWebpackPlugin = require('html-webpack-plugin');
-const { DuplicatesPlugin } = require('inspectpack/plugin');
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 
 const cwd = process.cwd();
 
@@ -23,14 +18,6 @@ function getStoriesFolders() {
 	}
 	return storiesFolders;
 }
-
-const excludedPlugins = [
-	CDNPlugin, // will be overridden without @talend modules
-	DuplicatesPlugin, BundleAnalyzerPlugin, // slow
-	MiniCssExtractPlugin, // blocker for optimization
-	HtmlWebpackPlugin, // use SB index.html, not app's
-]
-
 
 const defaultMain = {
 	features: {
@@ -60,48 +47,13 @@ const defaultMain = {
 	},
 	typescript: { reactDocgen: false },
 	webpackFinal: async (config) => {
-		process.env.TALEND_SCRIPTS_CONFIG = JSON.stringify(require(path.join(cwd, 'talend-scripts.json')));
-		process.env.TALEND_MODE = 'development';
-		const talendWebpackConfig = await getTalendWebpackConfig();
-
-		const presetHasStyleRules = talendWebpackConfig.module.rules.some(rule => rule.test.toString().match(/scss|css/))
-		const presetHasSVGRules = talendWebpackConfig.module.rules.some(rule => rule.test.toString().match(/svg/))
-
 		const mergedConfig = {
 			...config,
-			module: {
-				...config.module,
-				rules: [
-					// there are rules on svg and sass/css that overlap with the talend/scripts preset config.
-					// remove those in SB config
-					...config.module.rules
-					// remove all sass/scss/css rules if handled by preset webpack rules
-					.filter(rule => !presetHasStyleRules || !rule.test.toString().match(/\.(s\[ca\]ss|scss|css)/))
-					// remove svg rule if handled by preset webpack rules
-					.map(rule => {
-						if (presetHasSVGRules && rule.test && rule.test.toString().match(/svg/)) {
-							return {
-								...rule,
-								// remove extra slashes surrounding the regex.toString() /regex/, then remove the "svg" from test
-								test: new RegExp(rule.test.toString().slice(1, -1).replace('svg|', '')),
-							};
-						}
-						return rule;
-					}),
-					...talendWebpackConfig.module.rules,
-				],
-			},
 			plugins: [
 				...config.plugins,
-				...talendWebpackConfig.plugins
-					.filter(plugin => !excludedPlugins.some(excludedPlugin => plugin instanceof excludedPlugin)),
 				// use dynamic-cdn-webpack-plugin with default modules
 				new CDNPlugin({
 					exclude: Object.keys(getAllModules()).filter(name => name.match(/^(@talend\/|angular)/))
-				}),
-				new MiniCssExtractPlugin({
-					filename: `[name].css`,
-					chunkFilename: `[name].css`,
 				}),
 			],
 			resolve: {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

I have the following error this morning:

```
Generated code for /home/.../node_modules/css-loader/dist/cjs.js??ruleSet[1].rules[11].use[1]!/home/.../node_modules/postcss-loader/dist/cjs.js??ruleSet[1].rules[11].use[2]!/home/.../node_modules/typeface-source-sans-pro/index.css
1 | throw new Error("Module build failed (from ./node_modules/postcss-loader/dist/cjs.js):\nError: PostCSS plugin autoprefixer requires PostCSS 8.\nMigration guide for end-users:\nhttps://github.com/postcss/postcss/wiki/PostCSS-8-for-end-users\n    at Processor.normalize (/home/.../node_modules/postcss/lib/processor.js:153:15)\n    at new Processor (/home/.../node_modules/postcss/lib/processor.js:56:25)\n    at postcss (/home/.../node_modules/postcss/lib/postcss.js:55:10)\n    at Object.loader (/home/.../node_modules/postcss-loader/dist/index.js:94:17)");
```

This came from a mix of your webpack config and storybook.
Since we have simplified and aligned our way to work with mainstream tool this is not required anymore.

**What is the chosen solution to this problem?**

* remove most of the merge webpack configuration.
* keep only cdn plugin as it make the build faster and let our storybook way much light to publish

We will remove the cdn plugin once we will have only one storybook per repository

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
