### PR TITLE
chore(storybook-lib): Broken Windows filepath

### DIFF
--- a/.changeset/smart-suns-think.md
+++ b/.changeset/smart-suns-think.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+chore(storybook-lib): Broken Windows filepath

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -4,6 +4,8 @@ const path = require('path');
 const CDNPlugin = require('@talend/dynamic-cdn-webpack-plugin');
 const { getAllModules } = require('@talend/module-to-cdn');
 
+const { fixWindowsPaths } = require('./utils');
+
 const cwd = process.cwd();
 
 function getFolderGlob(folderName) {
@@ -67,21 +69,13 @@ const defaultMain = {
 
 const userMain = <%  if(userFilePath) { %> require(String.raw`<%= userFilePath %>`); <% } else { %> {}; <% } %>
 
-// Temporary fix until Storybook handles well Windows path
-// Waiting for a release https://github.com/storybookjs/storybook/pull/17641
-function fixWindowsPath(paths){
-	return process.platform === 'win32'
-		? paths.map(p => p.replace(/\\/g, '/'))
-		: paths;
-}
-
 module.exports = {
 	...defaultMain,
 	features: merge(defaultMain.features, userMain.features),
-	stories: fixWindowsPath([...defaultMain.stories, ...(userMain.stories || [])]),
+	stories: fixWindowsPaths([...defaultMain.stories, ...(userMain.stories || [])]),
 	addons: [...defaultMain.addons, ...(userMain.addons || [])],
 	core: merge(defaultMain.core, userMain.core),
-	staticDirs: fixWindowsPath([...(defaultMain.staticDirs|| []), ...(userMain.staticDirs || [])]),
+	staticDirs: fixWindowsPaths([...(defaultMain.staticDirs|| []), ...(userMain.staticDirs || [])]),
 	webpackFinal: async (config) => {
 		let finalConfig = await defaultMain.webpackFinal(config);
 		if(userMain.webpackFinal) {

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -17,7 +17,7 @@ const i18n = initI18n(userI18n);
 // cmf
 let cmfLoader;
 let cmfDecorator;
-if(cmf) {
+if (cmf) {
 	const cmfPreview = require('./cmf').configureCmfModules(cmf.modules, cmf.settings);
 	cmfLoader = cmfPreview.loader;
 	cmfDecorator = cmfPreview.decorator;

--- a/tools/scripts-config-storybook-lib/.storybook-templates/utils.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/utils.js
@@ -1,0 +1,11 @@
+// Temporary fixes until Storybook handles well Windows path
+// Waiting for a release https://github.com/storybookjs/storybook/pull/17641
+function fixWindowsPath(path) {
+    return process.platform === 'win32' ? path.replace(/\\/g, '/') : path;
+}
+
+function fixWindowsPaths(paths){
+    return paths.map(fixWindowsPath);
+}
+
+module.exports = { fixWindowsPath, fixWindowsPaths };

--- a/tools/scripts-config-storybook-lib/index.js
+++ b/tools/scripts-config-storybook-lib/index.js
@@ -3,6 +3,8 @@ const fse = require('fs-extra');
 const path = require('path');
 const { template } = require('lodash');
 
+const { fixWindowsPath } = require('./.storybook-templates/utils');
+
 const CWD = process.cwd();
 const TMP_PATH = path.join(CWD, 'node_modules', '.cache', '.talend-storybook');
 const TEMPLATE_SB_PATH = path.join(__dirname, '.storybook-templates');
@@ -29,7 +31,7 @@ function copyFile(fileName) {
 			const fileAsString = fs.readFileSync(defaultFilePath).toString();
 			const compiledTemplate = template(fileAsString);
 			const content = compiledTemplate({
-				userFilePath: userFileExists ? userFilePath : undefined,
+				userFilePath: userFileExists ? fixWindowsPath(userFilePath) : undefined,
 				userFileContent: userFileExists ? fs.readFileSync(userFilePath) : '',
 			});
 			fs.writeFileSync(targetPath, content);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Storybook doesn't start on Windows with this config because of unresolved backslashed paths.

**What is the chosen solution to this problem?**
Prevent Windows paths with backslashes to be used.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
