### PR TITLE
chore(ARCH-658): remove uuid dependency on components

### DIFF
--- a/.changeset/tender-cows-deliver.md
+++ b/.changeset/tender-cows-deliver.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat: remove uuid dependencies

--- a/.changeset/witty-apes-brake.md
+++ b/.changeset/witty-apes-brake.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': minor
+---
+
+mock crypto.randomUUID

--- a/packages/components/__mocks__/uuid.js
+++ b/packages/components/__mocks__/uuid.js
@@ -1,3 +1,0 @@
-const uuid = jest.genMockFromModule('uuid');
-uuid.v4 = () => '42';
-export default uuid;

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -66,8 +66,7 @@
     "recharts": "^2.1.13",
     "simplebar": "^5.3.8",
     "simplebar-react": "^2.4.1",
-    "styled-components": "^5.3.6",
-    "uuid": "^3.4.0"
+    "styled-components": "^5.3.6"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/components/src/Actions/ActionFile/ActionFile.component.js
+++ b/packages/components/src/Actions/ActionFile/ActionFile.component.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import uuid from 'uuid';
 
 import TooltipTrigger from '../../TooltipTrigger';
 import CircularProgress from '../../CircularProgress';
@@ -90,7 +89,7 @@ class ActionFile extends React.Component {
 		if (!available) {
 			return null;
 		}
-		const localId = id || uuid.v4();
+		const localId = id || crypto.randomUUID();
 		const iconInstance = inProgress ? (
 			<CircularProgress size="small" key="icon" />
 		) : (

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
@@ -3,7 +3,6 @@ import React from 'react';
 import classNames from 'classnames';
 import { SplitButton, MenuItem } from '@talend/react-bootstrap';
 import { useTranslation } from 'react-i18next';
-import uuid from 'uuid';
 import Icon from '../../Icon';
 import theme from './ActionSplitDropdown.module.scss';
 import wrapOnClick from '../wrapOnClick';
@@ -46,7 +45,7 @@ export default function ActionSplitDropdown(props) {
 		<SplitButton
 			onClick={wrapOnClick(props)}
 			title={Title}
-			id={uuid.v4()}
+			id={crypto.randomUUID()}
 			className={classNames(className, theme['tc-split-dropdown'])}
 			aria-label={label}
 			toggleLabel={t('ACTION_MENU_OPEN', { defaultValue: 'Open "{{label}}" menu', label })}

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import uuid from 'uuid';
 import { withTranslation } from 'react-i18next';
 
 import theme from './Breadcrumbs.module.scss';
@@ -164,7 +163,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 BreadcrumbsComponent.defaultProps = {
-	id: uuid.v4(),
+	id: crypto.randomUUID(),
 	items: [],
 	maxItems: DEFAULT_MAX_ITEMS,
 	t: getDefaultT(),

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
-import uuid from 'uuid';
 import classnames from 'classnames';
 import { usePopper } from 'react-popper';
 
@@ -34,7 +33,7 @@ function onMouseDown(event) {
 }
 
 export default function InputDatePicker(props) {
-	const popoverId = `date-picker-${props.id || uuid.v4()}`;
+	const popoverId = `date-picker-${props.id || crypto.randomUUID()}`;
 
 	const [referenceElement, setReferenceElement] = useState(null);
 	const [popperElement, setPopperElement] = useState(null);

--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.js
@@ -2,7 +2,6 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import omit from 'lodash/omit';
-import uuid from 'uuid';
 import { usePopper } from 'react-popper';
 
 import FocusManager from '../../FocusManager';
@@ -24,7 +23,7 @@ const PROPS_TO_OMIT_FOR_INPUT = [
 ];
 
 export default function InputTimePicker(props) {
-	const popoverId = `time-picker-${props.id || uuid.v4()}`;
+	const popoverId = `time-picker-${props.id || crypto.randomUUID()}`;
 
 	const containerRef = useRef(null);
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -3,7 +3,6 @@ import React, { useRef, useState } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import keycode from 'keycode';
-import uuid from 'uuid';
 import { usePopper } from 'react-popper';
 
 import FocusManager from '../../../FocusManager';
@@ -49,7 +48,7 @@ function InputDateTimePicker(props) {
 		placement: getPopperPlacement(),
 	});
 
-	const popoverId = `date-time-picker-${props.id || uuid.v4()}`;
+	const popoverId = `date-time-picker-${props.id || crypto.randomUUID()}`;
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define
 	const openPicker = isPicked => setPickerVisibility(true, isPicked);
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.component.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
-import uuid from 'uuid';
 import DebounceInput from 'react-debounce-input';
 import getDefaultT from '../../../../translate';
 import { DateTimeContext } from '../../DateTime/Context';
@@ -30,7 +29,7 @@ class TimePicker extends React.PureComponent {
 
 	constructor(props) {
 		super(props);
-		const id = uuid.v4();
+		const id = crypto.randomUUID();
 		this.hourId = `${id}-hour`;
 		this.minuteId = `${id}-minute`;
 		this.secondId = `${id}-second`;
@@ -57,14 +56,8 @@ class TimePicker extends React.PureComponent {
 		return (
 			<DateTimeContext.Consumer>
 				{({ errorManagement }) => {
-					const {
-						onInputFocus,
-						hasError,
-						formMode,
-						hoursErrorId,
-						minutesErrorId,
-						secondsErrorId,
-					} = errorManagement;
+					const { onInputFocus, hasError, formMode, hoursErrorId, minutesErrorId, secondsErrorId } =
+						errorManagement;
 
 					return (
 						<div className={classNames('tc-date-picker-time', theme['time-picker'])}>

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'uuid';
 import DisplayModeToggle, {
 	displayModesOptions as options,
 } from '../../Toolbar/DisplayModeToggle/DisplayModeToggle.component';
@@ -36,7 +35,7 @@ function ListDisplayMode({ children, displayModesOptions, id, onChange, selected
 }
 
 ListDisplayMode.defaultProps = {
-	id: uuid.v4(),
+	id: crypto.randomUUID(),
 	displayModesOptions: options,
 };
 ListDisplayMode.propTypes = {

--- a/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Navbar, MenuItem, NavDropdown, Nav, Button } from '@talend/react-bootstrap';
-import uuid from 'uuid';
 import Icon from '../../../Icon';
 
 import { useListContext } from '../context';
@@ -121,7 +120,7 @@ function SortBy({ id, options, onChange, value }) {
 }
 
 SortBy.defaultProps = {
-	id: uuid.v4(),
+	id: crypto.randomUUID(),
 	value: {},
 };
 

--- a/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React from 'react';
-import uuid from 'uuid';
 import { Nav, NavItem, NavDropdown, MenuItem } from '@talend/react-bootstrap';
 
 import Icon from '../../../Icon';
@@ -128,7 +127,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, t, .
 	return (
 		<Nav className={theme['tc-pagination']} onSelect={selectedKey => changePageTo(selectedKey)}>
 			<NavDropdown
-				id={id ? `${id}-size` : uuid.v4()}
+				id={id ? `${id}-size` : crypto.randomUUID()}
 				title={getItemsPerPageTitle(itemsPerPage)}
 				onSelect={onChangeItemsPerPage}
 			>

--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Nav, NavDropdown, MenuItem, Button } from '@talend/react-bootstrap';
-import uuid from 'uuid';
 import classNames from 'classnames';
 
 import getDefaultT from '../../../translate';
@@ -57,7 +56,7 @@ function SelectSortBy({ field, id, isDescending, onChange, options, t }) {
 				<li className="navbar-text">{options[0].name}</li>
 			) : (
 				<NavDropdown
-					id={id ? `${id}-by` : uuid.v4()}
+					id={id ? `${id}-by` : crypto.randomUUID()}
 					title={currentSortByLabel}
 					onSelect={onChangeField}
 					className={theme['sort-by-items']}

--- a/packages/components/src/Toggle/LabelToggle/LabelToggle.component.js
+++ b/packages/components/src/Toggle/LabelToggle/LabelToggle.component.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import uuid from 'uuid';
 import get from 'lodash/get';
 import { getTheme } from '../../theme';
 
@@ -26,7 +25,7 @@ const getAutoFocusValue = (autoFocus, values, value) => {
  * @param {function} onChange - callback that handle the state change
  */
 function LabelToggle({ id, values, name, value, onChange, disabled, autoFocus = false }) {
-	const localId = id || uuid.v4();
+	const localId = id || crypto.randomUUID();
 	const handleChange = e => {
 		onChange(e.target.value);
 	};

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import React, { cloneElement, useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
-import uuid from 'uuid';
 import classNames from 'classnames';
 import theme from './TooltipTrigger.module.scss';
 import useTooltipVisibility from './TooltipTrigger.hook';
@@ -112,7 +111,7 @@ function TooltipTrigger({
 
 	const [visible, show, hide] = useTooltipVisibility(tooltipDelay);
 
-	const [id] = useState(uuid.v4());
+	const [id] = useState(crypto.randomUUID());
 
 	const { props: childrenProps } = children;
 

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import React, { useMemo, useState } from 'react';
-import uuid from 'uuid';
 import classNames from 'classnames';
 import Autowhatever from 'react-autowhatever';
 import { useTranslation } from 'react-i18next';
@@ -281,7 +280,7 @@ Typeahead.displayName = 'Typeahead';
 Typeahead.defaultProps = {
 	autoFocus: false,
 	disabled: false,
-	id: uuid.v4().toString(),
+	id: crypto.randomUUID(),
 	items: null,
 	multiSection: true, // TODO this is for compat, see if we can do the reverse :(
 	position: 'left',

--- a/tools/scripts-config-jest/test-setup.js
+++ b/tools/scripts-config-jest/test-setup.js
@@ -56,6 +56,11 @@ const fetch = jest.fn(
 );
 global.fetch = fetch;
 
+global.crypto = {
+	...global.crypto,
+	randomUUID: () => '42',
+};
+
 // Mock session storage
 delete window.sessionStorage;
 Object.defineProperty(window, 'sessionStorage', {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

uuid is a tiny lib but there is a native API to do that: https://caniuse.com/mdn-api_crypto_randomuuid

as we use only v4 and v4 is using native when available it means uuid.v4 lib is not a lib but a polyfill.

**What is the chosen solution to this problem?**

remove it from components

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
