### PR TITLE
feat(TDOPS-3184): add --watch support on build:lib and build:ts:lib

### DIFF
--- a/.changeset/lovely-trainers-yell.md
+++ b/.changeset/lovely-trainers-yell.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-core': minor
+---
+
+add support for --watch option on build:lib and build:ts:lib command

--- a/tools/scripts-core/scripts/build-lib.js
+++ b/tools/scripts-core/scripts/build-lib.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const path = require('path');
 const spawn = require('cross-spawn');
 const rimraf = require('rimraf');
@@ -18,32 +19,66 @@ module.exports = function build(env, presetApi, options) {
 	const srcFolder = path.join(process.cwd(), 'src');
 	const targetFolder = path.join(process.cwd(), 'lib');
 
-	console.log(`Removing target folder (${targetFolder})...`);
-	rimraf.sync(targetFolder);
+	if (!options.includes('--watch')) {
+		console.log(`Removing target folder (${targetFolder})...`);
+		rimraf.sync(targetFolder);
+	}
+	const babelPromise = () =>
+		new Promise((resolve, reject) => {
+			console.log('Compiling with babel...');
+			const babelSpawn = spawn(
+				babel,
+				[
+					'--config-file',
+					babelConfigPath,
+					'-d',
+					targetFolder,
+					srcFolder,
+					'--source-maps',
+					'--ignore',
+					'**/*.test.js,**/*.stories.js',
+					...options,
+				],
+				{
+					stdio: 'inherit',
+					env,
+				},
+			);
+			babelSpawn.on('exit', status => {
+				if (parseInt(status, 10) !== 0) {
+					console.error(`Babel exit error: ${status}`);
+					reject(new Error(status));
+				} else {
+					console.log(`Babel exit: ${status}`);
+					resolve({ status });
+				}
+			});
+		});
 
-	console.log('Compiling with babel...');
-	spawn.sync(
-		babel,
-		[
-			'--config-file',
-			babelConfigPath,
-			'-d',
-			targetFolder,
-			srcFolder,
-			'--source-maps',
-			'--ignore',
-			'**/*.test.js,**/*.stories.js',
-			...options,
-		],
-		{
-			stdio: 'inherit',
-			env,
-		},
-	);
+	const copyPromise = () =>
+		new Promise((resolve, reject) => {
+			if (options.includes('--watch')) {
+				const evtEmitter = cpx.watch(`${srcFolder}/**/*.{scss,json}`, targetFolder);
+				evtEmitter.on('watch-error', err => {
+					reject(err);
+				});
+				evtEmitter.on('copy', e => {
+					console.log('copy', e.srcPath, e.dstPath);
+				});
+			} else {
+				console.log('Copying assets...');
+				cpx.copy(`${srcFolder}/**/*.{scss,json}`, targetFolder, err => {
+					if (err) {
+						console.error(err);
+						reject(error);
+					} else {
+						resolve();
+					}
+				});
+			}
+		});
 
-	console.log('Copying assets...');
-	cpx.copySync(`${srcFolder}/**/*.{scss,json}`, targetFolder);
-
-	console.log('🎉 Build complete');
-	return { status: 0 };
+	return Promise.all([babelPromise(), copyPromise()]).then(() => {
+		console.log('🎉 Build complete');
+	});
 };

--- a/tools/scripts-core/scripts/build-ts-lib.js
+++ b/tools/scripts-core/scripts/build-ts-lib.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const fs = require('fs');
 const path = require('path');
 const spawn = require('cross-spawn');
@@ -25,77 +26,103 @@ module.exports = function build(env, presetApi, options) {
 	const srcFolder = path.join(process.cwd(), 'src');
 	const targetFolder = path.join(process.cwd(), 'lib');
 
-	console.log(`Removing target folder (${targetFolder})...`);
-	rimraf.sync(targetFolder);
+	if (!options.includes('--watch')) {
+		console.log(`Removing target folder (${targetFolder})...`);
+		rimraf.sync(targetFolder);
+	}
 
-	console.log('Building with babel, generating definition types with tsc...');
-	const babelPromise = new Promise((resolve, reject) => {
-		const babelSpawn = spawn(
-			babel,
-			[
-				'--config-file',
-				babelConfigPath,
-				'-d',
-				targetFolder,
-				srcFolder,
-				'--source-maps',
-				'--ignore',
-				// @see https://github.com/babel/babel/issues/12008
-				'**/*.test.js,**/*.test.ts,**/*.test.tsx,**/*.spec.js,**/*.spec.ts,**/*.spec.tsx,**/*.stories.js,**/*.stories.ts,**/*.stories.tsx',
-				'--extensions',
-				'.js,.ts,.tsx,.jsx',
-				...options,
-			],
-			{ stdio: 'inherit', env },
-		);
+	const babelPromise = () =>
+		new Promise((resolve, reject) => {
+			console.log('Building with babel, generating definition types with tsc...');
+			const babelSpawn = spawn(
+				babel,
+				[
+					'--config-file',
+					babelConfigPath,
+					'-d',
+					targetFolder,
+					srcFolder,
+					'--source-maps',
+					'--ignore',
+					// @see https://github.com/babel/babel/issues/12008
+					'**/*.test.js,**/*.test.ts,**/*.test.tsx,**/*.spec.js,**/*.spec.ts,**/*.spec.tsx,**/*.stories.js,**/*.stories.ts,**/*.stories.tsx',
+					'--extensions',
+					'.js,.ts,.tsx,.jsx',
+					...options,
+				],
+				{ stdio: 'inherit', env },
+			);
 
-		babelSpawn.on('exit', status => {
-			if (parseInt(status, 10) !== 0) {
-				console.error(`Babel exit error: ${status}`);
-				reject(new Error(status));
-			} else {
-				console.log('Copying assets...');
-				cpx.copySync(`${srcFolder}/**/*.{scss,json}`, targetFolder);
-
-				console.log(`Babel exit: ${status}`);
-				resolve({ status });
-			}
-		});
-	});
-	const tscPromise = new Promise((resolve, reject) => {
-		const tscSpawn = spawn(
-			tsc,
-			['--emitDeclarationOnly', '--project', tscConfigPath, '--outDir', targetFolder, ...options],
-			{ stdio: 'inherit', env },
-		);
-
-		tscSpawn.on('exit', status => {
-			if (parseInt(status, 10) !== 0) {
-				console.error(`TSC exit error: ${status}`);
-				reject(new Error(status));
-			} else {
-				console.log(`TSC exit: ${status}`);
-				const pkgPath = path.join(process.cwd(), 'package.json');
-				const types = JSON.parse(fs.readFileSync(pkgPath))?.types;
-				if (!types) {
-					const msg = `Entry "types", referencing your declaration file (index.d.ts), must be defined in ${pkgPath}`;
-					console.error(msg);
-					reject(new Error(msg));
+			babelSpawn.on('exit', status => {
+				if (parseInt(status, 10) !== 0) {
+					console.error(`Babel exit error: ${status}`);
+					reject(new Error(status));
 				} else {
-					const absoluteTypes = path.join(process.cwd(), types);
-					if (!fs.existsSync(absoluteTypes)) {
-						const msg = `Declaration file, referenced in package.json, not found ${absoluteTypes}`;
+					console.log(`Babel exit: ${status}`);
+					resolve({ status });
+				}
+			});
+		});
+
+	const tscPromise = () =>
+		new Promise((resolve, reject) => {
+			const tscSpawn = spawn(
+				tsc,
+				['--emitDeclarationOnly', '--project', tscConfigPath, '--outDir', targetFolder, ...options],
+				{ stdio: 'inherit', env },
+			);
+
+			tscSpawn.on('exit', status => {
+				if (parseInt(status, 10) !== 0) {
+					console.error(`TSC exit error: ${status}`);
+					reject(new Error(status));
+				} else {
+					console.log(`TSC exit: ${status}`);
+					const pkgPath = path.join(process.cwd(), 'package.json');
+					const types = JSON.parse(fs.readFileSync(pkgPath))?.types;
+					if (!types) {
+						const msg = `Entry "types", referencing your declaration file (index.d.ts), must be defined in ${pkgPath}`;
 						console.error(msg);
 						reject(new Error(msg));
 					} else {
-						resolve({ status });
+						const absoluteTypes = path.join(process.cwd(), types);
+						if (!fs.existsSync(absoluteTypes)) {
+							const msg = `Declaration file, referenced in package.json, not found ${absoluteTypes}`;
+							console.error(msg);
+							reject(new Error(msg));
+						} else {
+							resolve({ status });
+						}
 					}
 				}
+			});
+		});
+
+	const copyPromise = () =>
+		new Promise((resolve, reject) => {
+			if (options.includes('--watch')) {
+				const evtEmitter = cpx.watch(`${srcFolder}/**/*.{scss,json}`, targetFolder);
+				evtEmitter.on('watch-error', err => {
+					reject(err);
+				});
+				evtEmitter.on('copy', e => {
+					console.log('copy', e.srcPath, e.dstPath);
+				});
+			} else {
+				console.log('Copying assets...');
+
+				cpx.copy(`${srcFolder}/**/*.{scss,json}`, targetFolder, err => {
+					if (err) {
+						console.error(err);
+						reject(error);
+					} else {
+						resolve();
+					}
+				});
 			}
 		});
-	});
 
-	return Promise.all([babelPromise, tscPromise]).then(() => {
+	return Promise.all([babelPromise(), tscPromise(), copyPromise()]).then(() => {
 		console.log('🎉 Build complete');
 	});
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In the context of #4445 we need to watch and rebuild libraries.
But `talend-scripts build:ts:lib --watch` doesn't work.

As babel do not exit copy never happens.

Same for `talend-scripts build:lib` it will not work.

**What is the chosen solution to this problem?**

* add the --watch option support in build:ts:lib.
* align build-lib.js script to use same patterns as in build-ts-lib so it supports --watch

The main difference is the copy is happening in parallel of babel and typescript

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
