### PR TITLE
chore(ARCH-658): remove uuid

### DIFF
--- a/.changeset/famous-toys-look.md
+++ b/.changeset/famous-toys-look.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: use randomUUID from talend/utils

--- a/.changeset/giant-geckos-draw.md
+++ b/.changeset/giant-geckos-draw.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': minor
+---
+
+feat: add randomUUID function based on crypto

--- a/.changeset/sixty-fishes-smile.md
+++ b/.changeset/sixty-fishes-smile.md
@@ -1,0 +1,9 @@
+---
+'@talend/react-cmf': patch
+'@talend/react-containers': patch
+'@talend/react-datagrid': patch
+'@talend/react-faceted-search': patch
+'@talend/react-forms': patch
+---
+
+chore: remove uuid

--- a/.changeset/sixty-fishes-smile.md
+++ b/.changeset/sixty-fishes-smile.md
@@ -6,4 +6,4 @@
 '@talend/react-forms': patch
 ---
 
-chore: remove uuid
+chore: remove uuid dependencies. use randomUUID from @talend/utils

--- a/packages/cmf/__tests__/cmfConnect.test.js
+++ b/packages/cmf/__tests__/cmfConnect.test.js
@@ -16,8 +16,6 @@ import cmfConnect, {
 } from '../src/cmfConnect';
 import component from '../src/component';
 
-jest.mock('uuid', () => ({ v4: () => '42' }));
-
 describe('cmfConnect', () => {
 	describe('#getComponentName', () => {
 		it('should return displayName', () => {

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -51,8 +51,7 @@
     "redux-storage-decorator-filter": "^1.1.8",
     "redux-storage-decorator-immutablejs": "^1.0.4",
     "redux-storage-engine-localstorage": "^1.1.4",
-    "redux-thunk": "^2.4.1",
-    "uuid": "^3.4.0"
+    "redux-thunk": "^2.4.1"
   },
   "devDependencies": {
     "@redux-saga/testing-utils": "^1.1.3",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@talend/scripts-cmf": "^1.0.1",
+    "@talend/utils": "^2.4.0",
     "hoist-non-react-statics": "^3.3.2",
     "immutable": "^3.8.2",
     "invariant": "^2.2.4",

--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -26,6 +26,7 @@ import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect, useStore } from 'react-redux';
+import { randomUUID } from '@talend/utils';
 import actions from './actions';
 import actionCreator from './actionCreator';
 import component from './component';
@@ -234,7 +235,7 @@ export default function cmfConnect({
 		}
 
 		function CMFContainer(props, ref) {
-			const [instanceId] = React.useState(crypto.randomUUID());
+			const [instanceId] = React.useState(randomUUID());
 			const registry = React.useContext(RegistryContext);
 			const store = useStore();
 
@@ -333,7 +334,7 @@ export default function cmfConnect({
 		};
 		CMFContainer.WrappedComponent = WrappedComponent;
 		CMFContainer.getState = getState;
-
+		// eslint-disable-next-line @typescript-eslint/default-param-last
 		CMFContainer.setStateAction = function setStateAction(state, id = 'default', type) {
 			if (typeof state !== 'function') {
 				return getSetStateAction(state, id, type);

--- a/packages/cmf/src/cmfConnect.js
+++ b/packages/cmf/src/cmfConnect.js
@@ -26,7 +26,6 @@ import React from 'react';
 import hoistStatics from 'hoist-non-react-statics';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect, useStore } from 'react-redux';
-import { v4 as uuidv4 } from 'uuid';
 import actions from './actions';
 import actionCreator from './actionCreator';
 import component from './component';
@@ -235,7 +234,7 @@ export default function cmfConnect({
 		}
 
 		function CMFContainer(props, ref) {
-			const [instanceId] = React.useState(uuidv4());
+			const [instanceId] = React.useState(crypto.randomUUID());
 			const registry = React.useContext(RegistryContext);
 			const store = useStore();
 

--- a/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.js
+++ b/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.js
@@ -1,8 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { v4 } from 'uuid';
 import { start, stop } from '../../actions/saga';
+
+function v4() {
+	return crypto.randomUUID();
+}
 
 export function CmfRegisteredSagaComponent({
 	sagaId,

--- a/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.js
+++ b/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.js
@@ -1,11 +1,8 @@
 import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { randomUUID } from '@talend/utils';
 import { start, stop } from '../../actions/saga';
-
-function v4() {
-	return crypto.randomUUID();
-}
 
 export function CmfRegisteredSagaComponent({
 	sagaId,
@@ -15,7 +12,7 @@ export function CmfRegisteredSagaComponent({
 	componentId = 'default',
 	children = null,
 }) {
-	const id = useMemo(v4, []);
+	const id = useMemo(randomUUID, []);
 	// If we pass the sagaId, we use the cmf registry
 	useEffect(() => {
 		if (sagaId) {

--- a/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.test.js
+++ b/packages/cmf/src/components/Saga/CmfRegisteredSaga.component.test.js
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 import { CmfRegisteredSagaComponent } from './CmfRegisteredSaga.component';
 
 const defaultMockUuid = '42';
-jest.mock('uuid', () => ({ v4: () => defaultMockUuid }));
 
 describe('CmfRegisteredSagaComponent', () => {
 	it('should dispatch actions', () => {

--- a/packages/cmf/src/components/Saga/Saga.component.js
+++ b/packages/cmf/src/components/Saga/Saga.component.js
@@ -1,8 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { v4 } from 'uuid';
 import { actions } from './Saga.saga';
+
+function v4() {
+	return crypto.randomUUID();
+}
 
 export function SagaComponent({ startSaga, stopSaga, saga, sagaAttributes, children = null }) {
 	const id = useMemo(v4, []);

--- a/packages/cmf/src/components/Saga/Saga.component.js
+++ b/packages/cmf/src/components/Saga/Saga.component.js
@@ -1,14 +1,11 @@
 import { useEffect, useMemo } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
+import { randomUUID } from '@talend/utils';
 import { actions } from './Saga.saga';
 
-function v4() {
-	return crypto.randomUUID();
-}
-
 export function SagaComponent({ startSaga, stopSaga, saga, sagaAttributes, children = null }) {
-	const id = useMemo(v4, []);
+	const id = useMemo(randomUUID, []);
 
 	useEffect(() => {
 		startSaga(id, saga, sagaAttributes);

--- a/packages/cmf/src/components/Saga/Saga.component.test.js
+++ b/packages/cmf/src/components/Saga/Saga.component.test.js
@@ -3,7 +3,6 @@ import { render } from '@testing-library/react';
 import { SagaComponent } from './Saga.component';
 
 const defaultMockUuid = '42';
-jest.mock('uuid', () => ({ v4: () => defaultMockUuid }));
 
 describe('Saga Component', () => {
 	it('should dispatch actions', () => {

--- a/packages/components/src/Actions/ActionFile/ActionFile.component.js
+++ b/packages/components/src/Actions/ActionFile/ActionFile.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
+import { randomUUID } from '@talend/utils';
 
 import TooltipTrigger from '../../TooltipTrigger';
 import CircularProgress from '../../CircularProgress';
@@ -89,7 +90,7 @@ class ActionFile extends React.Component {
 		if (!available) {
 			return null;
 		}
-		const localId = id || crypto.randomUUID();
+		const localId = id || randomUUID();
 		const iconInstance = inProgress ? (
 			<CircularProgress size="small" key="icon" />
 		) : (

--- a/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
+++ b/packages/components/src/Actions/ActionSplitDropdown/ActionSplitDropdown.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { SplitButton, MenuItem } from '@talend/react-bootstrap';
+import { randomUUID } from '@talend/utils';
 import { useTranslation } from 'react-i18next';
 import Icon from '../../Icon';
 import theme from './ActionSplitDropdown.module.scss';
@@ -45,7 +46,7 @@ export default function ActionSplitDropdown(props) {
 		<SplitButton
 			onClick={wrapOnClick(props)}
 			title={Title}
-			id={crypto.randomUUID()}
+			id={randomUUID()}
 			className={classNames(className, theme['tc-split-dropdown'])}
 			aria-label={label}
 			toggleLabel={t('ACTION_MENU_OPEN', { defaultValue: 'Open "{{label}}" menu', label })}

--- a/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
+++ b/packages/components/src/Breadcrumbs/Breadcrumbs.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
+import { randomUUID } from '@talend/utils';
 
 import theme from './Breadcrumbs.module.scss';
 import { Action, ActionDropdown } from '../Actions';
@@ -163,7 +164,7 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 BreadcrumbsComponent.defaultProps = {
-	id: crypto.randomUUID(),
+	id: randomUUID(),
 	items: [],
 	maxItems: DEFAULT_MAX_ITEMS,
 	t: getDefaultT(),

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import classnames from 'classnames';
 import { usePopper } from 'react-popper';
+import { randomUUID } from '@talend/utils';
 
 import FocusManager from '../../FocusManager';
 import { focusOnCalendar } from '../../Gesture/withCalendarGesture';
@@ -33,7 +34,7 @@ function onMouseDown(event) {
 }
 
 export default function InputDatePicker(props) {
-	const popoverId = `date-picker-${props.id || crypto.randomUUID()}`;
+	const popoverId = `date-picker-${props.id || randomUUID()}`;
 
 	const [referenceElement, setReferenceElement] = useState(null);
 	const [popperElement, setPopperElement] = useState(null);

--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.component.js
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import classnames from 'classnames';
 import omit from 'lodash/omit';
 import { usePopper } from 'react-popper';
+import { randomUUID } from '@talend/utils';
 
 import FocusManager from '../../FocusManager';
 import Time from '../Time';
@@ -23,7 +24,7 @@ const PROPS_TO_OMIT_FOR_INPUT = [
 ];
 
 export default function InputTimePicker(props) {
-	const popoverId = `time-picker-${props.id || crypto.randomUUID()}`;
+	const popoverId = `time-picker-${props.id || randomUUID()}`;
 
 	const containerRef = useRef(null);
 

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/InputDateTimePicker/InputDateTimePicker.component.js
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import keycode from 'keycode';
 import { usePopper } from 'react-popper';
+import { randomUUID } from '@talend/utils';
 
 import FocusManager from '../../../FocusManager';
 import { DateTimeContext } from '../DateTime/Context';
@@ -48,7 +49,7 @@ function InputDateTimePicker(props) {
 		placement: getPopperPlacement(),
 	});
 
-	const popoverId = `date-time-picker-${props.id || crypto.randomUUID()}`;
+	const popoverId = `date-time-picker-${props.id || randomUUID()}`;
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define
 	const openPicker = isPicked => setPickerVisibility(true, isPicked);
 	// eslint-disable-next-line @typescript-eslint/no-use-before-define

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.component.js
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/TimePicker/TimePicker.component.js
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import DebounceInput from 'react-debounce-input';
+import { randomUUID } from '@talend/utils';
 import getDefaultT from '../../../../translate';
 import { DateTimeContext } from '../../DateTime/Context';
 import { FIELD_HOURS, FIELD_MINUTES, FIELD_SECONDS } from '../../DateTime/constants';
@@ -29,7 +30,7 @@ class TimePicker extends React.PureComponent {
 
 	constructor(props) {
 		super(props);
-		const id = crypto.randomUUID();
+		const id = randomUUID();
 		this.hourId = `${id}-hour`;
 		this.minuteId = `${id}-minute`;
 		this.secondId = `${id}-second`;

--- a/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
+++ b/packages/components/src/List/ListComposition/DisplayMode/ListDisplayMode.component.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
+import { randomUUID } from '@talend/utils';
 import DisplayModeToggle, {
 	displayModesOptions as options,
 } from '../../Toolbar/DisplayModeToggle/DisplayModeToggle.component';
@@ -35,7 +36,7 @@ function ListDisplayMode({ children, displayModesOptions, id, onChange, selected
 }
 
 ListDisplayMode.defaultProps = {
-	id: crypto.randomUUID(),
+	id: randomUUID(),
 	displayModesOptions: options,
 };
 ListDisplayMode.propTypes = {

--- a/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
+++ b/packages/components/src/List/ListComposition/SortBy/SortBy.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Navbar, MenuItem, NavDropdown, Nav, Button } from '@talend/react-bootstrap';
+import { randomUUID } from '@talend/utils';
 import Icon from '../../../Icon';
 
 import { useListContext } from '../context';
@@ -120,7 +121,7 @@ function SortBy({ id, options, onChange, value }) {
 }
 
 SortBy.defaultProps = {
-	id: crypto.randomUUID(),
+	id: randomUUID(),
 	value: {},
 };
 

--- a/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
+++ b/packages/components/src/List/Toolbar/Pagination/Pagination.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Nav, NavItem, NavDropdown, MenuItem } from '@talend/react-bootstrap';
+import { randomUUID } from '@talend/utils';
 
 import Icon from '../../../Icon';
 
@@ -94,7 +95,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, t, .
 			>
 				<Icon {...prev} />
 			</NavItem>,
-			<li className={theme['page-index']}>
+			<li key="page-index" className={theme['page-index']}>
 				{currentPage}/{pagesLength}
 			</li>,
 			<NavItem
@@ -127,7 +128,7 @@ function Pagination({ id, startIndex, itemsPerPage, totalResults, onChange, t, .
 	return (
 		<Nav className={theme['tc-pagination']} onSelect={selectedKey => changePageTo(selectedKey)}>
 			<NavDropdown
-				id={id ? `${id}-size` : crypto.randomUUID()}
+				id={id ? `${id}-size` : randomUUID()}
 				title={getItemsPerPageTitle(itemsPerPage)}
 				onSelect={onChangeItemsPerPage}
 			>

--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
@@ -1,6 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { Nav, NavDropdown, MenuItem, Button } from '@talend/react-bootstrap';
+import { randomUUID } from '@talend/utils';
 import classNames from 'classnames';
 
 import getDefaultT from '../../../translate';
@@ -56,7 +57,7 @@ function SelectSortBy({ field, id, isDescending, onChange, options, t }) {
 				<li className="navbar-text">{options[0].name}</li>
 			) : (
 				<NavDropdown
-					id={id ? `${id}-by` : crypto.randomUUID()}
+					id={id ? `${id}-by` : randomUUID()}
 					title={currentSortByLabel}
 					onSelect={onChangeField}
 					className={theme['sort-by-items']}

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -953,7 +953,7 @@ exports[`List should render 1`] = `
                           </NavItem>
                           <li
                             className="theme-page-index"
-                            key=".1:2"
+                            key=".1:$page-index"
                             onSelect={[Function]}
                           >
                             2
@@ -1971,7 +1971,7 @@ exports[`List should render id if provided 1`] = `
                           </NavItem>
                           <li
                             className="theme-page-index"
-                            key=".1:2"
+                            key=".1:$page-index"
                             onSelect={[Function]}
                           >
                             2

--- a/packages/components/src/Toggle/LabelToggle/LabelToggle.component.js
+++ b/packages/components/src/Toggle/LabelToggle/LabelToggle.component.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
+import { randomUUID } from '@talend/utils';
 import { getTheme } from '../../theme';
 
 import css from './LabelToggle.module.scss';
@@ -25,7 +26,7 @@ const getAutoFocusValue = (autoFocus, values, value) => {
  * @param {function} onChange - callback that handle the state change
  */
 function LabelToggle({ id, values, name, value, onChange, disabled, autoFocus = false }) {
-	const localId = id || crypto.randomUUID();
+	const localId = id || randomUUID();
 	const handleChange = e => {
 		onChange(e.target.value);
 	};
@@ -52,6 +53,7 @@ function LabelToggle({ id, values, name, value, onChange, disabled, autoFocus = 
 						name={name}
 						disabled={disabled}
 						onChange={e => handleChange(e)}
+						// eslint-disable-next-line jsx-a11y/no-autofocus
 						autoFocus={autoFocusValue === button.value}
 					/>
 					<span>{button.label}</span>

--- a/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
+++ b/packages/components/src/TooltipTrigger/TooltipTrigger.component.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { cloneElement, useState, useRef } from 'react';
 import ReactDOM from 'react-dom';
 import classNames from 'classnames';
+import { randomUUID } from '@talend/utils';
 import theme from './TooltipTrigger.module.scss';
 import useTooltipVisibility from './TooltipTrigger.hook';
 
@@ -111,7 +112,7 @@ function TooltipTrigger({
 
 	const [visible, show, hide] = useTooltipVisibility(tooltipDelay);
 
-	const [id] = useState(crypto.randomUUID());
+	const [id] = useState(randomUUID());
 
 	const { props: childrenProps } = children;
 

--- a/packages/components/src/Typeahead/Typeahead.component.js
+++ b/packages/components/src/Typeahead/Typeahead.component.js
@@ -5,6 +5,7 @@ import Autowhatever from 'react-autowhatever';
 import { useTranslation } from 'react-i18next';
 import keycode from 'keycode';
 import { usePopper } from 'react-popper';
+import { randomUUID } from '@talend/utils';
 
 import theme from './Typeahead.module.scss';
 import {
@@ -280,7 +281,7 @@ Typeahead.displayName = 'Typeahead';
 Typeahead.defaultProps = {
 	autoFocus: false,
 	disabled: false,
-	id: crypto.randomUUID(),
+	id: randomUUID(),
 	items: null,
 	multiSection: true, // TODO this is for compat, see if we can do the reverse :(
 	position: 'left',

--- a/packages/containers/__mocks__/uuid.js
+++ b/packages/containers/__mocks__/uuid.js
@@ -1,6 +1,0 @@
-const uuid = jest.genMockFromModule('uuid');
-const v4 = () => 42;
-uuid.v4 = v4;
-
-export default uuid;
-export { v4 };

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -44,8 +44,7 @@
     "memoize-one": "^6.0.0",
     "react-immutable-proptypes": "^2.2.0",
     "redux-saga": "^1.1.3",
-    "reselect": "^2.5.4",
-    "uuid": "^3.4.0"
+    "reselect": "^2.5.4"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -36,6 +36,7 @@
     "@talend/react-cmf": "^7.1.3",
     "@talend/react-components": "^9.0.0",
     "@talend/react-forms": "^8.1.7",
+    "@talend/utils": "^2.4.0",
     "classnames": "^2.3.1",
     "immutable": "^3.8.2",
     "invariant": "^2.2.4",

--- a/packages/containers/src/Notification/Notification.sagas.js
+++ b/packages/containers/src/Notification/Notification.sagas.js
@@ -1,11 +1,12 @@
 import { put, select, takeEvery } from 'redux-saga/effects';
 import cmf from '@talend/react-cmf';
+import { randomUUID } from '@talend/utils';
 import Notification from './Notification.connect';
 import Constants from './Notification.constants';
 import { pushError } from './Notification.actions';
 
 function objectId() {
-	return crypto.randomUUID();
+	return randomUUID();
 }
 
 const CMF_CONST = cmf.constants;

--- a/packages/containers/src/Notification/Notification.sagas.js
+++ b/packages/containers/src/Notification/Notification.sagas.js
@@ -5,10 +5,6 @@ import Notification from './Notification.connect';
 import Constants from './Notification.constants';
 import { pushError } from './Notification.actions';
 
-function objectId() {
-	return randomUUID();
-}
-
 const CMF_CONST = cmf.constants;
 const onError = cmf.onError;
 
@@ -18,7 +14,7 @@ export function* onPushNotification(action) {
 	const componentState = yield select(state => Notification.getState(state, DEFAULT_COMPONENT_ID));
 	const newComponentState = componentState.updateIn(['notifications'], notifications =>
 		notifications.push({
-			id: objectId(),
+			id: randomUUID(),
 			...action.notification,
 		}),
 	);

--- a/packages/containers/src/Notification/Notification.sagas.js
+++ b/packages/containers/src/Notification/Notification.sagas.js
@@ -1,9 +1,12 @@
 import { put, select, takeEvery } from 'redux-saga/effects';
-import objectId from 'uuid/v4';
 import cmf from '@talend/react-cmf';
 import Notification from './Notification.connect';
 import Constants from './Notification.constants';
 import { pushError } from './Notification.actions';
+
+function objectId() {
+	return crypto.randomUUID();
+}
 
 const CMF_CONST = cmf.constants;
 const onError = cmf.onError;

--- a/packages/containers/src/Notification/pushNotification.js
+++ b/packages/containers/src/Notification/pushNotification.js
@@ -1,6 +1,9 @@
 import get from 'lodash/get';
-import uuid from 'uuid';
 import Immutable from 'immutable';
+
+function v4() {
+	return crypto.randomUUID();
+}
 
 /**
  * transform the APP state to push notification into the Notification component state slot on redux
@@ -16,7 +19,7 @@ export default function pushNotification(state, notification) {
 	const path = ['Container(Notification)', 'Notification', 'notifications'];
 	let notifs = state.cmf.components.getIn(path, new Immutable.List());
 	notifs = notifs.push({
-		id: uuid.v4(),
+		id: v4(),
 		...notification,
 	});
 	const newState = { ...state };

--- a/packages/containers/src/Notification/pushNotification.js
+++ b/packages/containers/src/Notification/pushNotification.js
@@ -1,8 +1,9 @@
 import get from 'lodash/get';
 import Immutable from 'immutable';
+import { randomUUID } from '@talend/utils';
 
 function v4() {
-	return crypto.randomUUID();
+	return randomUUID();
 }
 
 /**

--- a/packages/containers/src/Notification/pushNotification.js
+++ b/packages/containers/src/Notification/pushNotification.js
@@ -2,10 +2,6 @@ import get from 'lodash/get';
 import Immutable from 'immutable';
 import { randomUUID } from '@talend/utils';
 
-function v4() {
-	return randomUUID();
-}
-
 /**
  * transform the APP state to push notification into the Notification component state slot on redux
  * even if this component is not already mounted.
@@ -20,7 +16,7 @@ export default function pushNotification(state, notification) {
 	const path = ['Container(Notification)', 'Notification', 'notifications'];
 	let notifs = state.cmf.components.getIn(path, new Immutable.List());
 	notifs = notifs.push({
-		id: v4(),
+		id: randomUUID(),
 		...notification,
 	});
 	const newState = { ...state };

--- a/packages/datagrid/__mocks__/uuid.js
+++ b/packages/datagrid/__mocks__/uuid.js
@@ -1,6 +1,0 @@
-const uuid = jest.genMockFromModule('uuid');
-const v4 = () => '42';
-uuid.v4 = v4;
-
-export default uuid;
-export { v4 };

--- a/packages/faceted-search/__mocks__/uuid.js
+++ b/packages/faceted-search/__mocks__/uuid.js
@@ -1,6 +1,0 @@
-const uuid = jest.genMockFromModule('uuid');
-const v4 = () => '42';
-uuid.v4 = v4;
-
-export default uuid;
-export { v4 };

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -36,6 +36,7 @@
   },
   "dependencies": {
     "@talend/daikon-tql-client": "^1.3.1",
+    "@talend/utils": "^2.4.0",
     "@talend/react-bootstrap": "^1.35.1",
     "classnames": "^2.3.1",
     "date-fns": "^1.30.1",

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -41,8 +41,7 @@
     "date-fns": "^1.30.1",
     "invariant": "^2.2.4",
     "keycode": "^2.2.1",
-    "lodash": "^4.17.21",
-    "uuid": "^3.4.0"
+    "lodash": "^4.17.21"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/faceted-search/src/components/types/badgeDefinition.type.js
+++ b/packages/faceted-search/src/components/types/badgeDefinition.type.js
@@ -1,8 +1,9 @@
 import get from 'lodash/get';
 import flow from 'lodash/flow';
+import { randomUUID } from '@talend/utils';
 
 const getAttribute = badgeDefinitionRaw => get(badgeDefinitionRaw, 'attribute');
-const createBadgeId = attribute => `${attribute}-${crypto.randomUUID()}`;
+const createBadgeId = attribute => `${attribute}-${randomUUID()}`;
 const getOperators = badgeDefinitionRaw => get(badgeDefinitionRaw, 'operators');
 const getType = badgeDefinitionRaw => get(badgeDefinitionRaw, 'type');
 const getTypeProperties = badgeDefinitionRaw => get(badgeDefinitionRaw, 'typeProperties');

--- a/packages/faceted-search/src/components/types/badgeDefinition.type.js
+++ b/packages/faceted-search/src/components/types/badgeDefinition.type.js
@@ -1,9 +1,8 @@
 import get from 'lodash/get';
-import uuid from 'uuid';
 import flow from 'lodash/flow';
 
 const getAttribute = badgeDefinitionRaw => get(badgeDefinitionRaw, 'attribute');
-const createBadgeId = attribute => `${attribute}-${uuid.v4()}`;
+const createBadgeId = attribute => `${attribute}-${crypto.randomUUID()}`;
 const getOperators = badgeDefinitionRaw => get(badgeDefinitionRaw, 'operators');
 const getType = badgeDefinitionRaw => get(badgeDefinitionRaw, 'type');
 const getTypeProperties = badgeDefinitionRaw => get(badgeDefinitionRaw, 'typeProperties');

--- a/packages/forms/__mocks__/uuid.js
+++ b/packages/forms/__mocks__/uuid.js
@@ -1,3 +1,0 @@
-const uuid = jest.genMockFromModule('uuid');
-uuid.v4 = () => '42';
-export default uuid;

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -54,8 +54,7 @@
     "react-ace": "^6.6.0",
     "react-hook-form": "^6.15.8",
     "react-jsonschema-form": "0.51.0",
-    "tv4": "^1.3.0",
-    "uuid": "^3.4.0"
+    "tv4": "^1.3.0"
   },
   "devDependencies": {
     "@storybook/addon-actions": "^6.5.9",

--- a/packages/forms/src/UIForm/Message/generateId.js
+++ b/packages/forms/src/UIForm/Message/generateId.js
@@ -1,8 +1,10 @@
+import { randomUUID } from '@talend/utils';
+
 export function generateId(id, suffix) {
 	if (id) {
 		return `${id}-${suffix}`;
 	}
-	return crypto.randomUUID();
+	return randomUUID();
 }
 
 export function generateDescriptionId(id) {

--- a/packages/forms/src/UIForm/Message/generateId.js
+++ b/packages/forms/src/UIForm/Message/generateId.js
@@ -1,10 +1,8 @@
-import uuid from 'uuid';
-
 export function generateId(id, suffix) {
 	if (id) {
 		return `${id}-${suffix}`;
 	}
-	return uuid.v4();
+	return crypto.randomUUID();
 }
 
 export function generateDescriptionId(id) {

--- a/packages/forms/src/widgets/templates/utils.js
+++ b/packages/forms/src/widgets/templates/utils.js
@@ -1,8 +1,10 @@
+import { randomUUID } from '@talend/utils';
+
 export function generateId(id, suffix) {
 	if (id) {
 		return `${id}-${suffix}`;
 	}
-	return crypto.randomUUID();
+	return randomUUID();
 }
 
 export function generateDescriptionId(id) {

--- a/packages/forms/src/widgets/templates/utils.js
+++ b/packages/forms/src/widgets/templates/utils.js
@@ -1,10 +1,8 @@
-import uuid from 'uuid';
-
 export function generateId(id, suffix) {
 	if (id) {
 		return `${id}-${suffix}`;
 	}
-	return uuid.v4();
+	return crypto.randomUUID();
 }
 
 export function generateDescriptionId(id) {

--- a/packages/forms/stories/json/FormStoryWithDisplayMode.js
+++ b/packages/forms/stories/json/FormStoryWithDisplayMode.js
@@ -3,7 +3,6 @@
 /* eslint-disable jsx-a11y/label-has-associated-control */
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
-import uuid from 'uuid';
 import { action } from '@storybook/addon-actions';
 
 import Form from '../../src';
@@ -177,7 +176,7 @@ function createCommonProps() {
 							resolve({
 								properties: properties => ({
 									...properties,
-									[key]: `${uuid.v4()}.${stringToB64(name)}`,
+									[key]: `${crypto.randomUUID()}.${stringToB64(name)}`,
 								}),
 							}),
 						3000,

--- a/packages/forms/stories/json/FormStoryWithDisplayMode.js
+++ b/packages/forms/stories/json/FormStoryWithDisplayMode.js
@@ -4,6 +4,7 @@
 /* eslint-disable react/prop-types */
 import React, { useState } from 'react';
 import { action } from '@storybook/addon-actions';
+import { randomUUID } from '@talend/utils';
 
 import Form from '../../src';
 import { PRESIGNED_URL_TRIGGER_ACTION } from '../../src/UIForm/fields/File/File.component';
@@ -176,7 +177,7 @@ function createCommonProps() {
 							resolve({
 								properties: properties => ({
 									...properties,
-									[key]: `${crypto.randomUUID()}.${stringToB64(name)}`,
+									[key]: `${randomUUID()}.${stringToB64(name)}`,
 								}),
 							}),
 						3000,

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -1,4 +1,5 @@
 import date from './date';
 import validation from './validation';
+import { randomUUID } from './uuid';
 
-export { date, validation };
+export { date, validation, randomUUID };

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,0 +1,21 @@
+export function randomUUID() {
+	// works only on https so need  backport if the app is run on unsecure env
+	if (crypto && crypto.randomUUID) {
+		return crypto.randomUUID();
+	}
+	function h(n: number) {
+		return (n | 0).toString(16);
+	}
+	// backport using Math.random and Date
+	function s(n: number) {
+		return h((Math.random() * (1 << (n << 2))) ^ Date.now()).slice(-n);
+	}
+	return [
+		s(4) + s(4),
+		s(4),
+		'4' + s(3), // UUID version 4
+		h(8 | (Math.random() * 4)) + s(3), // {8|9|A|B}xxx
+		// s(4) + s(4) + s(4),
+		Date.now().toString(16).slice(-10) + s(2), // Use timestamp to avoid collisions
+	].join('-');
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -19949,7 +19949,7 @@ uuid-browser@^3.1.0:
   resolved "https://registry.yarnpkg.com/uuid-browser/-/uuid-browser-3.1.0.tgz#0f05a40aef74f9e5951e20efbf44b11871e56410"
   integrity sha512-dsNgbLaTrd6l3MMxTtouOCFw4CBFc/3a+GgYA2YyrJvyQ1u6q4pcu3ktLoUZ/VN/Aw9WsauazbgsgdfVWgAKQg==
 
-uuid@^3.3.2, uuid@^3.4.0:
+uuid@^3.3.2:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

continue the road to remove the old uuid module.
Note global crypto is undefined on FF if the document is not secured (https) which is the case for our playground demo on surge.

**What is the chosen solution to this problem?**

* create `randomUUID` in @talend/utils and use the native crypto.randomUUID if available.
* backport using Math.random with Date if not available

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
