### PR TITLE
fix(TDOPS-3267): fix onBlur on primitive input

### DIFF
--- a/.changeset/real-hornets-suffer.md
+++ b/.changeset/real-hornets-suffer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+TDOPS-3267 - Fixed support for `onBlur` property passed to primitive input

--- a/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
@@ -1,4 +1,11 @@
-import React, { forwardRef, InputHTMLAttributes, Ref, useImperativeHandle, useRef } from 'react';
+import React, {
+	forwardRef,
+	InputHTMLAttributes,
+	Ref,
+	useImperativeHandle,
+	useRef,
+	FocusEvent,
+} from 'react';
 import classnames from 'classnames';
 import InputWrapper, { AffixesProps } from '../InputWrapper/InputWrapper';
 import { FieldStatusProps } from '../Field/Field';
@@ -38,6 +45,15 @@ const Input = forwardRef((props: InputPrimitiveProps, ref: Ref<HTMLInputElement 
 
 	const { currentType, onReset, RevealPasswordButton } = useRevealPassword();
 
+	const handleBlur = (event: FocusEvent<HTMLInputElement, HTMLInputElement>) => {
+		if (!!onBlur) {
+			onBlur(event);
+		}
+		if (type === 'password') {
+			onReset();
+		}
+	};
+
 	return (
 		<InputWrapper
 			prefix={prefix}
@@ -64,7 +80,7 @@ const Input = forwardRef((props: InputPrimitiveProps, ref: Ref<HTMLInputElement 
 					ref={inputRef}
 					disabled={disabled}
 					readOnly={readOnly}
-					onBlur={onReset}
+					onBlur={handleBlur}
 					className={classnames(styles.input, { [styles.input_readOnly]: readOnly }, className)}
 				/>
 				{type === 'password' && <RevealPasswordButton onClick={handleClick} disabled={disabled} />}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
On primitive inputs, passed `onBlur` property is not called

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
