### PR TITLE
fix(datagrid): header cell width

### DIFF
--- a/.changeset/ten-feet-tell.md
+++ b/.changeset/ten-feet-tell.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-datagrid': patch
+---
+
+fix(datagrid): header cell width

--- a/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.module.scss
+++ b/packages/datagrid/src/components/HeaderCellRenderer/HeaderCellRenderer.module.scss
@@ -9,6 +9,7 @@
 .header-cell {
 	$self: &;
 	padding: tokens.$coral-spacing-xs;
+	width: 100%;
 
 	&__top-row {
 		overflow: hidden;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
<img width="1282" alt="CleanShot 2022-11-28 at 16 16 19@2x" src="https://user-images.githubusercontent.com/2909671/204313984-2f397d0a-7d91-467e-8c70-47a12da85a44.png">

**What is the chosen solution to this problem?**
<img width="1282" alt="CleanShot 2022-11-28 at 16 16 09@2x" src="https://user-images.githubusercontent.com/2909671/204313950-9b5a6d41-b6c1-4055-abff-511508cc0d5b.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
