### PR TITLE
fix(TFD-14833) InlineEditing : fix enter key always handled

### DIFF
--- a/.changeset/long-days-vanish.md
+++ b/.changeset/long-days-vanish.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+InlineEditing : don't handle enter key when not in edition

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -98,7 +98,7 @@ const InlineEditingPrimitive = forwardRef(
 		useKey(
 			'Enter',
 			(event: KeyboardEvent): void => {
-				if (mode !== 'multi') {
+				if (isEditing && mode !== 'multi') {
 					handleSubmit(event);
 				}
 			},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Component InlineEditing always handles key enter event even when not editing text

**What is the chosen solution to this problem?**
Check if component is in edition mode

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
