### PR TITLE
chore: make InlineEditForm a form

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "postinstall": "node workspace-run.js build:lib",
     "pre-release": "node workspace-run.js pre-release",
     "start": "yarn workspace @talend/ui-playground run start",
+    "start-storybook": "yarn workspace @talend/ui-storybook run start-storybook",
     "release": "yarn pre-release && yarn changeset publish",
     "lint-staged": "lint-staged",
     "lint:es": "cross-env WORKSPACE_RUN_FAIL=no-bail node workspace-run.js lint:es",

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -30,7 +30,10 @@ type ErrorInEditing =
 
 export type InlineEditingPrimitiveProps = {
 	loading?: boolean;
-	onEdit?: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent, newValue: string) => void;
+	onEdit?: (
+		event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent | React.FormEvent<HTMLFormElement>,
+		newValue: string,
+	) => void;
 	onCancel?: () => void;
 	onToggle?: (isEditionMode: boolean) => void;
 	defaultValue?: string;
@@ -76,7 +79,9 @@ const InlineEditingPrimitive = forwardRef(
 			}
 		}, [hasError]);
 
-		const handleSubmit = (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => {
+		const handleSubmit = (
+			event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent | React.FormEvent<HTMLFormElement>,
+		) => {
 			event.stopPropagation();
 			if (onEdit) {
 				const sentValue = value || '';
@@ -95,16 +100,6 @@ const InlineEditingPrimitive = forwardRef(
 
 		// Keyboard shortcuts
 		useKey('Escape', handleCancel, {}, [isEditing]);
-		useKey(
-			'Enter',
-			(event: KeyboardEvent): void => {
-				if (isEditing && mode !== 'multi') {
-					handleSubmit(event);
-				}
-			},
-			{},
-			[isEditing, value],
-		);
 
 		const testId = `inlineediting.${mode === 'multi' ? 'textarea' : 'input'}`;
 
@@ -147,7 +142,7 @@ const InlineEditingPrimitive = forwardRef(
 		return (
 			<div {...rest} data-test="inlineediting" className={styles.inlineEditor} ref={ref}>
 				{isEditing ? (
-					<>
+					<form onSubmit={e => handleSubmit(e)}>
 						<div className={styles.inlineEditor__editor}>
 							{mode === 'multi' && <Form.Textarea {...sharedInputProps}>{value}</Form.Textarea>}
 							{mode === 'single' && (
@@ -174,6 +169,7 @@ const InlineEditingPrimitive = forwardRef(
 										{t('INLINE_EDITING_CANCEL', 'Cancel')}
 									</ButtonIcon>
 									<ButtonIcon
+										type="submit"
 										onClick={handleSubmit}
 										icon="check-filled"
 										data-test="inlineediting.button.submit"
@@ -184,7 +180,7 @@ const InlineEditingPrimitive = forwardRef(
 								</StackHorizontal>
 							</div>
 						</div>
-					</>
+					</form>
 				) : (
 					<div
 						className={classnames(styles.inlineEditor__content, {

--- a/packages/storybook/src/design-system/InlineEditing/InlineEditing.stories.tsx
+++ b/packages/storybook/src/design-system/InlineEditing/InlineEditing.stories.tsx
@@ -14,13 +14,19 @@ export const Text = {
 			label="Edit the value"
 			placeholder="What is your Lorem Ipsum?"
 			defaultValue="Lorem Ipsum"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
 };
 export const EmptyTextWithPlaceholder = {
 	render: (props: Story) => (
-		<InlineEditing.Text label="Edit the value" placeholder="This is a placeholder" {...props} />
+		<InlineEditing.Text
+			label="Edit the value"
+			placeholder="This is a placeholder"
+			onEdit={action('onEdit')}
+			{...props}
+		/>
 	),
 };
 export const Textarea = {
@@ -29,6 +35,7 @@ export const Textarea = {
 			label="Edit the value"
 			placeholder="What is your Lorem Ipsum?"
 			defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer in massa velit. Duis vestibulum lectus id lacinia aliquam. Aliquam erat volutpat. Donec dignissim augue eu eros blandit faucibus eu quis nulla. In hac habitasse platea dictumst. Ut egestas viverra sem, et dictum elit lacinia interdum. Vivamus accumsan pulvinar faucibus. Donec vestibulum mauris vitae sem lacinia, eget fringilla leo efficitur. In hac habitasse platea dictumst. Nullam consectetur nunc quis tortor congue imperdiet. Ut lobortis suscipit enim, in aliquet sem viverra ut. Sed finibus ex elit, quis ultricies nulla tincidunt sit amet. Maecenas gravida diam ex, vel aliquam tortor elementum et. Duis vitae ligula tristique est iaculis consequat. Nullam in ipsum turpis. Cras aliquam tellus quis turpis convallis, ut faucibus quam tincidunt."
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -39,6 +46,7 @@ export const Default = {
 			label="Edit the value"
 			placeholder="What is your Lorem Ipsum?"
 			defaultValue="Lorem ipsum dolor sit amet"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -49,6 +57,7 @@ export const WithEllipsis = {
 			placeholder="Input a crawler name"
 			label="Crawler name"
 			defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nulla augue, fermentum ac scelerisque quis, aliquet et arcu. Nullam quis sem pulvinar, venenatis nunc vel, lobortis libero"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -59,6 +68,7 @@ export const WithTextarea = {
 			placeholder="Input a crawler name"
 			label="Crawler name"
 			defaultValue="Lorem ipsum dolor sit amet"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -69,6 +79,7 @@ export const LongTextInTextarea = {
 			label="Crawler name"
 			defaultValue="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Morbi nulla augue, fermentum ac scelerisque quis, aliquet et arcu. Nullam quis sem pulvinar, venenatis nunc vel, lobortis libero"
 			placeholder="Enter a description"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -80,6 +91,7 @@ export const AsHeading = {
 			label="AS H3 Crawler name"
 			defaultValue="Lorem ipsum dolor sit amet"
 			renderValueAs="h3"
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),
@@ -91,6 +103,7 @@ export const LoadingMode = {
 			label="Crawler name"
 			defaultValue="Lorem ipsum dolor sit amet"
 			loading
+			onEdit={action('onEdit')}
 			{...props}
 		/>
 	),


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**



**What is the chosen solution to this problem?**

Let's propose a simple fix:
* add form tag as this is InlineForm component
* remove the useKey as the role of the form is to be submited
* use the handleSubmit on the form tag

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
