### PR TITLE
fix(TDOPS-2650): datalist icon size restricted to inline buttons

### DIFF
--- a/.changeset/late-readers-juggle.md
+++ b/.changeset/late-readers-juggle.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-2650 - Datalist icon size should be restricted to inline buttons

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.module.scss
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleActions.module.scss
@@ -29,16 +29,19 @@ $tc-list-title-dropup-menu-triangle: '\25bc';
 	}
 
 	:global {
-		.btn-link {
-			padding: 0 $padding-smaller;
-			.tc-svg-icon[name='talend-caret-down'] {
-				display: none;
-			}
+		.btn-group,
+		.tc-action-button-positionned {
+			> .btn-link {
+				padding: 0 $padding-smaller;
+				.tc-svg-icon[name='talend-caret-down'] {
+					display: none;
+				}
 
-			.tc-svg-icon {
-				margin: 0;
-				height: 2rem;
-				width: 2rem;
+				.tc-svg-icon {
+					margin: 0;
+					height: 2rem;
+					width: 2rem;
+				}
 			}
 		}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Buttons in sub components of datalist line  have incorrect button size like shown in https://jira.talendforge.org/browse/TDOPS-2650

**What is the chosen solution to this problem?**
Restrict icon size to inline buttons in the datalist with more specific css selector

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
