### PR TITLE
fix(TDP-11600): allow to add new value in datalist

### DIFF
--- a/.changeset/bright-apples-think.md
+++ b/.changeset/bright-apples-think.md
@@ -1,0 +1,9 @@
+---
+'@talend/react-components': minor
+---
+
+fix(TDP-11600): allow the datalist to create new value with a better ux
+
+On the datalist, new props called 
+- `allowAddNewElements` can be passed to let the user create new value with a hint to tell him that the value was not existing in the current titlemap.
+- `allowAddNewElementsSuffix` allow to override the "(new)" suffix by another one.

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -155,9 +155,7 @@ function Datalist(props) {
 		filterValue,
 		multiSection: props.multiSection,
 		allowAddNewElements: props.allowAddNewElements,
-		allowAddNewElementsSuffix: props.allowAddNewElementsSuffix
-			? props.allowAddNewElementsSuffix
-			: t('NEW', { defaultValue: '(new)' }),
+		allowAddNewElementsSuffix: props.allowAddNewElementsSuffix ?? t('NEW', '(new)'),
 	});
 
 	// in uncontrolled mode, props.value acts as an initial value, then Datalist handles state, props.value never changes.

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -155,7 +155,8 @@ function Datalist(props) {
 		filterValue,
 		multiSection: props.multiSection,
 		allowAddNewElements: props.allowAddNewElements,
-		allowAddNewElementsSuffix: props.allowAddNewElementsSuffix ?? t('NEW', '(new)'),
+		allowAddNewElementsSuffix:
+			props.allowAddNewElementsSuffix ?? t('NEW_WITH_PARENTHESIS', '(new)'),
 	});
 
 	// in uncontrolled mode, props.value acts as an initial value, then Datalist handles state, props.value never changes.

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -9,6 +9,8 @@ import Typeahead from '../Typeahead';
 import theme from './Datalist.module.scss';
 import FocusManager from '../FocusManager';
 import Icon from '../Icon';
+import { useTranslation } from 'react-i18next';
+import I18N_DOMAIN_COMPONENTS from '../constants';
 
 export function escapeRegexCharacters(str) {
 	return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -21,7 +23,22 @@ const DISPLAY = {
 	NONE: 'none',
 };
 
-function buildSuggestions({ displayMode, titleMap, filterValue, multiSection }) {
+function isValuePresentInSuggestions(titleMap, filterValue, multiSection) {
+	return !!multiSection
+		? titleMap.find(group =>
+				group.suggestions.find(item => filterValue.toLowerCase() === item.name.toLowerCase()),
+		  )
+		: titleMap.find(itemValue => filterValue.toLowerCase() === itemValue.name.toLowerCase());
+}
+
+function buildSuggestions({
+	displayMode,
+	titleMap,
+	filterValue,
+	multiSection,
+	allowAddNewElements,
+	allowAddNewElementsSuffix,
+}) {
 	if (displayMode === DISPLAY.NONE) {
 		return undefined;
 	}
@@ -33,19 +50,26 @@ function buildSuggestions({ displayMode, titleMap, filterValue, multiSection }) 
 	// building multiSection items or single section items
 	const escapedValue = escapeRegexCharacters(filterValue.trim());
 	const regex = new RegExp(escapedValue, 'i');
-	if (multiSection) {
-		return titleMap
-			.map(group => ({
-				...group,
-				suggestions: filterValue
-					? group.suggestions.filter(item => regex.test(item.name))
-					: group.suggestions,
-			}))
-			.filter(group => group.suggestions.length > 0);
+	const result = multiSection
+		? titleMap
+				.map(group => ({
+					...group,
+					suggestions: filterValue
+						? group.suggestions.filter(item => regex.test(item.name))
+						: group.suggestions,
+				}))
+				.filter(group => group.suggestions.length > 0)
+		: titleMap.filter(itemValue => regex.test(itemValue.name));
+
+	if (allowAddNewElements && !isValuePresentInSuggestions(titleMap, filterValue, multiSection)) {
+		result.unshift({
+			title: `${filterValue} ${allowAddNewElementsSuffix}`,
+			name: filterValue,
+			value: filterValue,
+		});
 	}
 
-	// only one group so items are inline
-	return titleMap.filter(itemValue => regex.test(itemValue.name));
+	return result;
 }
 
 function findEntry(titleMap, attributeName, attributeValue = '') {
@@ -113,6 +137,7 @@ function Datalist(props) {
 	// Current persisted value
 	// It's the object value key { name: "display value", value: "technical value" }
 	const [{ name, value }, setEntry] = useState({});
+	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 
 	// suggestions: filter value, display flag, current hover selection
 	const [filterValue, setFilterValue] = useState('');
@@ -129,6 +154,10 @@ function Datalist(props) {
 		titleMap: props.titleMap,
 		filterValue,
 		multiSection: props.multiSection,
+		allowAddNewElements: props.allowAddNewElements,
+		allowAddNewElementsSuffix: props.allowAddNewElementsSuffix
+			? props.allowAddNewElementsSuffix
+			: t('NEW', { defaultValue: '(new)' }),
 	});
 
 	// in uncontrolled mode, props.value acts as an initial value, then Datalist handles state, props.value never changes.
@@ -429,6 +458,8 @@ Datalist.defaultProps = {
 
 Datalist.propTypes = {
 	autoFocus: PropTypes.bool,
+	allowAddNewElements: PropTypes.bool,
+	allowAddNewElementsSuffix: PropTypes.string,
 	isLoading: PropTypes.bool,
 	className: PropTypes.string,
 	onBlur: PropTypes.func,

--- a/packages/components/src/Datalist/Datalist.component.test.js
+++ b/packages/components/src/Datalist/Datalist.component.test.js
@@ -416,6 +416,26 @@ describe('Datalist component', () => {
 		});
 	});
 
+	describe('allowAddNewElements mode', () => {
+		it('should persist new value on blur', () => {
+			// given
+			jest.useFakeTimers();
+			const onChange = jest.fn();
+			render(<Datalist id="my-datalist" allowAddNewElements onChange={onChange} {...props} />);
+			expect(onChange).not.toBeCalled();
+			const input = screen.getByRole('textbox');
+
+			// when
+			userEvent.type(input, 'not there');
+			expect(screen.getByTitle('not there (new)')).toBeInTheDocument();
+			fireEvent.blur(input);
+			jest.runAllTimers(); // focus manager
+
+			// // then
+			expect(onChange).toBeCalledWith(expect.anything(), { value: 'not there' });
+		});
+	});
+
 	describe('restricted mode', () => {
 		it('should persist known value on blur', () => {
 			// given

--- a/packages/components/src/Datalist/Datalist.stories.js
+++ b/packages/components/src/Datalist/Datalist.stories.js
@@ -102,6 +102,14 @@ export const DefaultSingleSection = () => {
 		<form className="form">
 			<h3>By default</h3>
 			<Datalist {...singleSectionProps} />
+
+			<h3>Allow adding new elements</h3>
+			<Datalist
+				{...singleSectionProps}
+				allowAddNewElements
+				allowAddNewElementsSuffix="(Not in the dictionary)"
+			/>
+
 			<h3>default value</h3>
 			<Datalist {...defaultValue} />
 			<h3>Restricted values</h3>
@@ -115,11 +123,15 @@ export const DefaultSingleSection = () => {
 			<h3>With icons</h3>
 			<Datalist {...withIcons} />
 			<h3>With suggestions API</h3>
-			<Datalist {...defaultValue} titleMap={titleMap} onLiveChange={() => {
-				setTimeout(() => {
-					setTitleMap(prev => [...prev])
-				}, 200);
-			}}/>
+			<Datalist
+				{...defaultValue}
+				titleMap={titleMap}
+				onLiveChange={() => {
+					setTimeout(() => {
+						setTitleMap(prev => [...prev]);
+					}, 200);
+				}}
+			/>
 			<h3>Insert custom elements via render props</h3>
 			<Datalist {...singleSectionProps}>
 				{(content, { isShown }, _, inputRef) => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If the value is not existing, we have only "no result found" and no way to understand that we can add a value in the datalist

**What is the chosen solution to this problem?**
On the datalist, new props called 
- `allowAddNewElements` can be passed to let the user create new value with a hint to tell him that the value was not existing in the current titlemap.
- `allowAddNewElementsSuffix` allow to override the "(new)" suffix by another one.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
