### PR TITLE
fix(jest): add try/catch on some mocks

### DIFF
--- a/.changeset/purple-parents-applaud.md
+++ b/.changeset/purple-parents-applaud.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': patch
+---
+
+fix(jest): try/catch some mocks that are not safely mocked

--- a/tools/scripts-config-jest/test-setup.js
+++ b/tools/scripts-config-jest/test-setup.js
@@ -45,112 +45,124 @@ try {
 } catch (e) {}
 
 // Mock fetch
-const fetch = jest.fn(
-	(url, config) =>
-		new Promise(resolve => {
-			if (config.response) {
-				return resolve(config.response);
+try {
+	const fetch = jest.fn(
+		(url, config) =>
+			new Promise(resolve => {
+				if (config.response) {
+					return resolve(config.response);
+				}
+				return resolve();
+			}),
+	);
+	global.fetch = fetch;
+} catch (e) {}
+
+try {
+	global.crypto = {
+		...global.crypto,
+		randomUUID: () => '42',
+	};
+} catch (e) {}
+
+try {
+	// Mock session storage
+	delete window.sessionStorage;
+	Object.defineProperty(window, 'sessionStorage', {
+		value: (function () {
+			let store = {};
+			return {
+				getItem(key) {
+					return store[key] || null;
+				},
+				setItem(key, value) {
+					store[key] = value.toString();
+				},
+				removeItem(key) {
+					delete store[key];
+				},
+				clear() {
+					store = {};
+				},
+			};
+		})(),
+		writable: true,
+	});
+} catch (e) {}
+
+try {
+	jest.mock('i18next', () => {
+		function tMock(key, options) {
+			if (typeof options === 'string') {
+				return options;
 			}
-			return resolve();
-		}),
-);
-global.fetch = fetch;
-
-global.crypto = {
-	...global.crypto,
-	randomUUID: () => '42',
-};
-
-// Mock session storage
-delete window.sessionStorage;
-Object.defineProperty(window, 'sessionStorage', {
-	value: (function () {
-		let store = {};
-		return {
-			getItem(key) {
-				return store[key] || null;
-			},
-			setItem(key, value) {
-				store[key] = value.toString();
-			},
-			removeItem(key) {
-				delete store[key];
-			},
-			clear() {
-				store = {};
-			},
-		};
-	})(),
-	writable: true,
-});
-
-jest.mock('i18next', () => {
-	function tMock(key, options) {
-		if (typeof options === 'string') {
-			return options;
+			if (options && options.defaultValue) {
+				const getOptionValue = k => (options[k] === undefined ? '' : options[k]);
+				return (options.defaultValue || '').replace(/{{\s*(\w+)\s*}}/g, (_, k) =>
+					getOptionValue(k),
+				);
+			}
+			return key.split(':').reverse()[0];
 		}
-		if (options && options.defaultValue) {
-			const getOptionValue = k => (options[k] === undefined ? '' : options[k]);
-			return (options.defaultValue || '').replace(/{{\s*(\w+)\s*}}/g, (_, k) => getOptionValue(k));
-		}
-		return key.split(':').reverse()[0];
-	}
-	const i18nextMock = jest.genMockFromModule('i18next');
-	i18nextMock.t = tMock;
-	i18nextMock.language = 'en';
-	i18nextMock.getFixedT = () => tMock;
-	i18nextMock.use = () => i18nextMock;
-	i18nextMock.addResources = () => {};
-	return i18nextMock;
-});
+		const i18nextMock = jest.genMockFromModule('i18next');
+		i18nextMock.t = tMock;
+		i18nextMock.language = 'en';
+		i18nextMock.getFixedT = () => tMock;
+		i18nextMock.use = () => i18nextMock;
+		i18nextMock.addResources = () => {};
+		return i18nextMock;
+	});
 
-jest.mock('react-i18next', () => {
-	// from https://github.com/i18next/react-i18next/blob/master/example/test-jest/__mocks__/react-i18next.js
-	const React = require('react');
-	const i18next = require('i18next');
+	jest.mock('react-i18next', () => {
+		// from https://github.com/i18next/react-i18next/blob/master/example/test-jest/__mocks__/react-i18next.js
+		const React = require('react');
+		const i18next = require('i18next');
 
-	const hasChildren = node => node && (node.children || (node.props && node.props.children));
+		const hasChildren = node => node && (node.children || (node.props && node.props.children));
 
-	const getChildren = node =>
-		node && node.children ? node.children : node.props && node.props.children;
+		const getChildren = node =>
+			node && node.children ? node.children : node.props && node.props.children;
 
-	const renderNodes = reactNodes => {
-		if (typeof reactNodes === 'string') {
-			return reactNodes;
-		}
+		const renderNodes = reactNodes => {
+			if (typeof reactNodes === 'string') {
+				return reactNodes;
+			}
 
-		return Object.keys(reactNodes).map((key, i) => {
-			const child = reactNodes[key];
-			const isElement = React.isValidElement(child);
+			return Object.keys(reactNodes).map((key, i) => {
+				const child = reactNodes[key];
+				const isElement = React.isValidElement(child);
 
-			if (typeof child === 'string') {
+				if (typeof child === 'string') {
+					return child;
+				}
+				if (hasChildren(child)) {
+					const inner = renderNodes(getChildren(child));
+					return React.cloneElement(child, { ...child.props, key: i }, inner);
+				}
+				if (typeof child === 'object' && !isElement) {
+					return Object.keys(child).reduce((str, childKey) => `${str}${child[childKey]}`, '');
+				}
+
 				return child;
-			}
-			if (hasChildren(child)) {
-				const inner = renderNodes(getChildren(child));
-				return React.cloneElement(child, { ...child.props, key: i }, inner);
-			}
-			if (typeof child === 'object' && !isElement) {
-				return Object.keys(child).reduce((str, childKey) => `${str}${child[childKey]}`, '');
-			}
-
-			return child;
-		});
-	};
-	// this mock makes sure any components using the translate HoC receive the t function as a prop
-	return {
-		withTranslation: () => Component => {
-			Component.defaultProps = { ...Component.defaultProps, t: i18next.t };
-			Component.displayName = `withI18nextTranslation(${Component.displayName || Component.name})`;
-			return Component;
-		},
-		useTranslation: () => ({ t: i18next.t }),
-		setI18n: () => {},
-		getI18n: () => i18next,
-		Trans: ({ children }) =>
-			Array.isArray(children) ? renderNodes(children) : renderNodes([children]),
-	};
-});
+			});
+		};
+		// this mock makes sure any components using the translate HoC receive the t function as a prop
+		return {
+			withTranslation: () => Component => {
+				Component.defaultProps = { ...Component.defaultProps, t: i18next.t };
+				Component.displayName = `withI18nextTranslation(${
+					Component.displayName || Component.name
+				})`;
+				return Component;
+			},
+			useTranslation: () => ({ t: i18next.t }),
+			setI18n: () => {},
+			getI18n: () => i18next,
+			Trans: ({ children }) =>
+				Array.isArray(children) ? renderNodes(children) : renderNodes([children]),
+		};
+	});
+} catch (e) {}
 
 try {
 	jest.mock('@talend/design-system', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When we use talend script in a node context, we don't have react-i18n libraries loaded
![image](https://user-images.githubusercontent.com/2909671/206420706-9e50aac5-2227-4e9d-af91-775a29d2e8a2.png)

**What is the chosen solution to this problem?**
Add try catch on some libs (like the other ones)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
