### PR TITLE
fix(utils): randomUUID in node context

### DIFF
--- a/.changeset/wild-worms-behave.md
+++ b/.changeset/wild-worms-behave.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': patch
+---
+
+fix(utils): randomUUID in node context

--- a/packages/utils/src/uuid.ts
+++ b/packages/utils/src/uuid.ts
@@ -1,6 +1,6 @@
 export function randomUUID() {
 	// works only on https so need  backport if the app is run on unsecure env
-	if (crypto && crypto.randomUUID) {
+	if (typeof crypto != 'undefined' && crypto && crypto.randomUUID) {
 		return crypto.randomUUID();
 	}
 	function h(n: number) {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Got this error trying to use random id in a node context
<img width="1038" alt="CleanShot 2022-12-09 at 09 11 01@2x" src="https://user-images.githubusercontent.com/2909671/206655750-e3bfac08-d485-4bc2-aa4a-f41acc1bb04b.png">

**What is the chosen solution to this problem?**
Add another check

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
