### PR TITLE
fix(Password): use the InputPrimitive for password field

### DIFF
--- a/packages/design-system/src/components/Form/index.ts
+++ b/packages/design-system/src/components/Form/index.ts
@@ -4,6 +4,7 @@ import Form from './Form';
 import Row from './Row';
 import Buttons from './Buttons';
 import Input from './Field/Input';
+import { InputPrimitive } from './Primitives';
 import Label from './Label';
 import Select from './Field/Select';
 import Textarea from './Field/Textarea';
@@ -36,6 +37,7 @@ export const FormComponent = Form as typeof Form & {
 	Week: typeof Input.Week;
 	Buttons: typeof Buttons;
 	Input: typeof Input;
+	InputPrimitive: typeof InputPrimitive;
 };
 
 FormComponent.Row = Row;
@@ -54,6 +56,7 @@ FormComponent.Label = Label;
 FormComponent.Month = Input.Month;
 FormComponent.Number = Input.Number;
 FormComponent.Password = Input.Password;
+FormComponent.InputPrimitive = InputPrimitive;
 FormComponent.Radio = Input.Radio;
 FormComponent.Search = Input.Search;
 FormComponent.Select = Select;

--- a/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
+++ b/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
@@ -1,3 +1,3 @@
 import { Form } from '@talend/design-system';
 
-export default Form.Password;
+export default Form.InputPrimitive;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The password field is directl imported from the design-system.
But it contains the FieldComponent dfrom TUI + the FieldPrimitive from the DS.
So 2 labels.
![image](https://user-images.githubusercontent.com/35027619/207003183-08df5c99-f04e-4b0f-b79b-5d4e2f12f028.png)


**What is the chosen solution to this problem?**
The password field from TUI must just use the FielPrimitive from the DS.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
