### PR TITLE
fix(Password): use the InputPrimitive for password field [same but different]

### DIFF
--- a/packages/design-system/src/components/Form/index.ts
+++ b/packages/design-system/src/components/Form/index.ts
@@ -4,7 +4,6 @@ import Form from './Form';
 import Row from './Row';
 import Buttons from './Buttons';
 import Input from './Field/Input';
-import { InputPrimitive } from './Primitives';
 import Label from './Label';
 import Select from './Field/Select';
 import Textarea from './Field/Textarea';
@@ -37,7 +36,6 @@ export const FormComponent = Form as typeof Form & {
 	Week: typeof Input.Week;
 	Buttons: typeof Buttons;
 	Input: typeof Input;
-	InputPrimitive: typeof InputPrimitive;
 };
 
 FormComponent.Row = Row;
@@ -56,7 +54,6 @@ FormComponent.Label = Label;
 FormComponent.Month = Input.Month;
 FormComponent.Number = Input.Number;
 FormComponent.Password = Input.Password;
-FormComponent.InputPrimitive = InputPrimitive;
 FormComponent.Radio = Input.Radio;
 FormComponent.Search = Input.Search;
 FormComponent.Select = Select;

--- a/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
+++ b/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
@@ -1,3 +1,0 @@
-import { Form } from '@talend/design-system';
-
-export default Form.InputPrimitive;

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -2,8 +2,8 @@
 
 import PropTypes from 'prop-types';
 import React from 'react';
-import { get, omit } from 'lodash';
-import { Link, Form } from '@talend/design-system';
+import { get } from 'lodash';
+import { Form } from '@talend/design-system';
 import FieldTemplate from '../FieldTemplate';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
 

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -3,10 +3,9 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import { get, omit } from 'lodash';
-import { Link } from '@talend/design-system';
+import { Link, Form } from '@talend/design-system';
 import FieldTemplate from '../FieldTemplate';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
-import PasswordWidget from './PasswordWidget';
 
 import { convertValue, extractDataAttributes } from '../../utils/properties';
 
@@ -48,7 +47,22 @@ export default function Text(props) {
 		step: get(schema, 'schema.step'),
 		...extractDataAttributes(rest),
 	};
-
+	if (type === 'password') {
+		return (
+			<Form.Password
+				{...fieldProps}
+				id={id}
+				label={title}
+				required={schema.required}
+				hasError={!!errorMessage}
+				description={description}
+				aria-invalid={!isValid}
+				aria-required={get(schema, 'required')}
+				aria-describedby={`${descriptionId} ${errorId}`}
+				link={link && <Link {...omit(link, ['label'])}> {link.label} </Link>}
+			/>
+		);
+	}
 	return (
 		<FieldTemplate
 			hint={schema.hint}
@@ -64,22 +78,12 @@ export default function Text(props) {
 			required={schema.required}
 			valueIsUpdating={valueIsUpdating}
 		>
-			{type === 'password' ? (
-				<PasswordWidget
-					{...fieldProps}
-					aria-invalid={!isValid}
-					aria-required={get(schema, 'required')}
-					aria-describedby={`${descriptionId} ${errorId}`}
-					link={link && <Link {...omit(link, ['label'])}> {link.label} </Link>}
-				/>
-			) : (
-				<input
-					{...fieldProps}
-					aria-invalid={!isValid}
-					aria-required={get(schema, 'required')}
-					aria-describedby={`${descriptionId} ${errorId}`}
-				/>
-			)}
+			<input
+				{...fieldProps}
+				aria-invalid={!isValid}
+				aria-required={get(schema, 'required')}
+				aria-describedby={`${descriptionId} ${errorId}`}
+			/>
 		</FieldTemplate>
 	);
 }

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -59,7 +59,7 @@ export default function Text(props) {
 				aria-invalid={!isValid}
 				aria-required={get(schema, 'required')}
 				aria-describedby={`${descriptionId} ${errorId}`}
-				link={link && omit(link, ['label'])}
+				link={link}
 			/>
 		);
 	}

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -59,7 +59,7 @@ export default function Text(props) {
 				aria-invalid={!isValid}
 				aria-required={get(schema, 'required')}
 				aria-describedby={`${descriptionId} ${errorId}`}
-				link={link && <Link {...omit(link, ['label'])}> {link.label} </Link>}
+				link={link && omit(link, ['label'])}
 			/>
 		);
 	}

--- a/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Text/__snapshots__/Text.component.test.js.snap
@@ -124,32 +124,25 @@ exports[`Text field should render input with min attribute 1`] = `
 `;
 
 exports[`Text field should render password input 1`] = `
-<FieldTemplate
+<FormPassword
+  aria-describedby="myForm-description myForm-error"
+  aria-invalid={false}
+  aria-required={true}
+  autoFocus={true}
+  className="form-control"
   description="my text input hint"
-  descriptionId="myForm-description"
-  errorId="myForm-error"
-  errorMessage="My error message"
+  hasError={true}
   id="myForm"
-  isValid={true}
   label="My input title"
+  link={null}
+  onBlur={[Function]}
+  onChange={[Function]}
+  placeholder="Type something here"
+  readOnly={false}
   required={true}
->
-  <FormInputPrimitive
-    aria-describedby="myForm-description myForm-error"
-    aria-invalid={false}
-    aria-required={true}
-    autoFocus={true}
-    className="form-control"
-    id="myForm"
-    link={null}
-    onBlur={[Function]}
-    onChange={[Function]}
-    placeholder="Type something here"
-    readOnly={false}
-    type="password"
-    value="toto"
-  />
-</FieldTemplate>
+  type="password"
+  value="toto"
+/>
 `;
 
 exports[`Text field should render readonly input 1`] = `


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

#4487 
primitives are meant to be internal.
I continue to think we need to have field without the div but don't know what API for that ?
* a props <Password fieldOnly />
* a dedicated component for that but which name

**What is the chosen solution to this problem?**

I propose here to just do not use the field template from TUI.

If we are ok here is what should be done:
* [x] fix the test
* [ ] ensure all use cases are working well (error, disabled, etc..)

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
