### PR TITLE
fix(design-system): add data-testid to InlineEdit

### DIFF
--- a/.changeset/light-numbers-tan.md
+++ b/.changeset/light-numbers-tan.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): add data-testid to InlineEditing

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -125,6 +125,7 @@ const InlineEditingPrimitive = forwardRef(
 
 		const sharedInputProps = {
 			'data-test': testId,
+			'data-testid': testId,
 			hideLabel: true,
 			hasError,
 			description,
@@ -147,7 +148,13 @@ const InlineEditingPrimitive = forwardRef(
 			},
 		};
 		return (
-			<div {...rest} data-test="inlineediting" className={styles.inlineEditor} ref={ref}>
+			<div
+				{...rest}
+				data-test="inlineediting"
+				data-testid="inlineediting"
+				className={styles.inlineEditor}
+				ref={ref}
+			>
 				{isEditing ? (
 					<>
 						<div className={styles.inlineEditor__editor}>
@@ -170,6 +177,7 @@ const InlineEditingPrimitive = forwardRef(
 									<ButtonIcon
 										onClick={handleCancel}
 										icon="cross-filled"
+										data-testid="inlineediting.button.cancel"
 										data-test="inlineediting.button.cancel"
 										size="XS"
 									>
@@ -178,6 +186,7 @@ const InlineEditingPrimitive = forwardRef(
 									<ButtonIcon
 										onClick={handleSubmit}
 										icon="check-filled"
+										data-testid="inlineediting.button.submit"
 										data-test="inlineediting.button.submit"
 										size="XS"
 									>
@@ -201,6 +210,7 @@ const InlineEditingPrimitive = forwardRef(
 						<ValueComponent />
 						<span className={styles.inlineEditor__content__button}>
 							<ButtonIcon
+								data-testid="inlineediting.button.edit"
 								data-test="inlineediting.button.edit"
 								onClick={() => toggleEditionMode(true)}
 								aria-label={ariaLabel || label}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Using this component in Data Prep, i can't use RTL tests to select the buttons and as there is no label on them, i don't find a "good way" to select them. The other way could be to make a find all and take a index of the array but i would like to select it with a clear selector.

**What is the chosen solution to this problem?**
As data-test is not supported out of the box by RTL, i want to provide a data-testid which is compliant.

I wanted also to migrate the associated test from cypress to RTL but i would like to not change the toolchain on this PR. Currently the test suite is launched by cypress component testing (not jest itself) and we would like to have both tests suite (ct and rtl) the time of the migration or going to migrate all at once.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
