### PR TITLE
fix(TDOPS-3372/taskParams): validate input value for integer fields

### DIFF
--- a/.changeset/stale-needles-think.md
+++ b/.changeset/stale-needles-think.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-forms': patch
+'@talend/json-schema-form-core': patch
+---
+
+TDOPS-3372 - validate input value for integer fields

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -128,13 +128,19 @@ export class UIFormComponent extends React.Component {
 			this.props.properties,
 			this.props.customValidation,
 			deepValidation,
+			event,
 		);
 		const hasErrors = Object.values(widgetErrors).find(Boolean);
 
+		const { t } = this.props;
 		// update errors map
 		let errors = Object.entries(widgetErrors).reduce((accu, [errorKey, errorValue]) => {
 			const errorSchema = { key: errorKey };
-			return errorValue ? addError(accu, errorSchema, errorValue) : removeError(accu, errorSchema);
+			let errorMsg = errorValue;
+			if (errorValue && errorValue.startsWith('CUSTOM_ERROR')) {
+				errorMsg = t(errorValue, { defaultValue: getLanguage(t)[errorValue] });
+			}
+			return errorMsg ? addError(accu, errorSchema, errorMsg) : removeError(accu, errorSchema);
 		}, this.props.errors);
 
 		// widget error modifier

--- a/packages/forms/src/UIForm/UIForm.component.js
+++ b/packages/forms/src/UIForm/UIForm.component.js
@@ -166,7 +166,7 @@ export class UIFormComponent extends React.Component {
 				propertyName = schema.key[schema.key.length - 1];
 				this.onTrigger(event, { formData, formId: this.props.id, propertyName, value });
 			} else {
-				const trigger = schema.triggers.find(t => t.onEvent === undefined);
+				const trigger = schema.triggers.find(triggerItem => triggerItem.onEvent === undefined);
 				if (trigger) {
 					this.onTrigger(event, {
 						trigger,

--- a/packages/forms/src/UIForm/lang.js
+++ b/packages/forms/src/UIForm/lang.js
@@ -88,5 +88,8 @@ export default function getLanguage(t = defaultTranslate) {
 		UNKNOWN_PROPERTY: t('ERROR_UNKNOWN_PROPERTY', {
 			defaultValue: 'Unknown property (not in schema)',
 		}),
+		CUSTOM_ERROR_INVALID_INPUT: t('CUSTOM_ERROR_INVALID_INPUT', {
+			defaultValue: 'Input is not valid',
+		}),
 	};
 }

--- a/packages/forms/src/UIForm/utils/validation.js
+++ b/packages/forms/src/UIForm/utils/validation.js
@@ -48,9 +48,9 @@ export function adaptAdditionalRules(mergedSchema) {
  * that is applied on schema.customValidation = true
  * @returns {object} The validation result.
  */
-export function validateValue(schema, value, properties, customValidationFn) {
+export function validateValue(schema, value, properties, customValidationFn, event) {
 	const validationSchema = adaptAdditionalRules(schema);
-	const staticResult = validate(validationSchema, value);
+	const staticResult = validate(validationSchema, value, event);
 	if (staticResult.valid && schema.customValidation && customValidationFn) {
 		return customValidationFn(schema, value, properties);
 	}
@@ -111,13 +111,14 @@ export function validateSimple(
 	properties,
 	customValidationFn,
 	deepValidation,
+	event,
 ) {
 	const results = {};
 	const { key, items } = mergedSchema;
 	// do not break in case we do not have the key
 	// we need to keep deepValidation
 	if (key) {
-		results[key] = validateValue(mergedSchema, value, properties, customValidationFn);
+		results[key] = validateValue(mergedSchema, value, properties, customValidationFn, event);
 	}
 
 	if (deepValidation && items) {
@@ -145,11 +146,12 @@ export function validateSingle(
 	properties,
 	customValidationFn,
 	deepValidation,
+	event,
 ) {
 	if (mergedSchema.type === 'array') {
 		return validateArray(mergedSchema, value, properties, customValidationFn, deepValidation);
 	}
-	return validateSimple(mergedSchema, value, properties, customValidationFn, deepValidation);
+	return validateSimple(mergedSchema, value, properties, customValidationFn, deepValidation, event);
 }
 
 /**

--- a/packages/jsfc/src/lib/validate.js
+++ b/packages/jsfc/src/lib/validate.js
@@ -1,6 +1,20 @@
 /*  Common code for validating a value against its form and schema definition */
 import tv4 from 'tv4';
 
+function validateTypeSpecificInput(inputType = '', event = {}) {
+	switch (inputType) {
+		case 'number':
+			// If the user types a non-integer value, the value is emptied by browser but still displayed in UI
+			if (event.target?.validity && !event.target.validity.valid) {
+				return { valid: false, message: 'CUSTOM_ERROR_INVALID_INPUT' };
+			}
+			break;
+		default:
+			break;
+	}
+	return { valid: true };
+}
+
 /**
  * Validate a value against its form definition and schema.
  * The value should either be of proper type or a string, some type
@@ -8,9 +22,10 @@ import tv4 from 'tv4';
  *
  * @param {Object} form A merged form definition, i.e. one with a schema.
  * @param {Any} value the value to validate.
+ * @param {Object} event for input types in which the values are not available in form
  * @return {Object} a tv4js result object.
  */
-export function validate(form, value) {
+export function validate(form, value, event) {
 	if (!form) {
 		return { valid: true };
 	}
@@ -28,9 +43,9 @@ export function validate(form, value) {
 		value = undefined;
 	}
 
-	// Numbers fields will give a null value, which also means empty field
-	if (form.type === 'number' && value === null) {
-		value = undefined;
+	const error = validateTypeSpecificInput(form.type, event);
+	if (!error.valid && error.message) {
+		return { valid: false, error: { message: error.message } };
 	}
 
 	// Version 4 of JSON Schema has the required property not on the

--- a/packages/jsfc/src/lib/validate.spec.js
+++ b/packages/jsfc/src/lib/validate.spec.js
@@ -13,7 +13,7 @@ describe('validate.js', () => {
 		const form = { key: ['hero'], schema: { type: 'string' } };
 		it('should return a result object {"error":null, "missing":[], "valid":true}, with valid set to true when the data is valid for the schema', () => {
 			let value = 'Batman';
-			let result = validate(form, value);
+			let result = validate(form, value, {});
 			should.not.exist(result.error);
 			result.missing.should.be.a('array');
 			result.missing.length.should.equal(0);
@@ -22,8 +22,16 @@ describe('validate.js', () => {
 
 		it('should return an error object with a message "Invalid type: array (expected string)" when the data is not valid', () => {
 			let value = [0];
-			let result = validate(form, value);
+			let result = validate(form, value, {});
 			result.error.message.should.eq('Invalid type: array (expected string)');
+		});
+
+		it('should return an error object with a message "CUSTOM_ERROR_INVALID_INPUT" when the integer value is not valid', () => {
+			let value = 'stringValue';
+			const testForm = { type: 'number', key: ['hero'], schema: { type: 'number' } };
+			const event = { target: { validity: { valid: false } } };
+			let result = validate(testForm, value, event);
+			result.error.message.should.eq('CUSTOM_ERROR_INVALID_INPUT');
 		});
 	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Firefox & edge -> allows non-integers in an input field with type='integer' with no error message on invalid input
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/number

**What is the chosen solution to this problem?**
validate input value for integer fields
https://jira.talendforge.org/browse/TDOPS-3372

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
