### PR TITLE
feat(TUX-1221): add openInNewTab option to LinkAsButton

### DIFF
--- a/.changeset/famous-ravens-hammer.md
+++ b/.changeset/famous-ravens-hammer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(TUX-1221) add openInNewTab option for LinkAsButton

--- a/packages/design-system/src/components/LinkAsButton/LinkAsButton.spec.tsx
+++ b/packages/design-system/src/components/LinkAsButton/LinkAsButton.spec.tsx
@@ -1,0 +1,21 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+import React from 'react';
+
+import { LinkAsButton } from './';
+
+context('<LinkAsButton />', () => {
+	it('should render', () => {
+		cy.mount(<LinkAsButton data-testid="my.link">Link example</LinkAsButton>);
+		cy.getByTestId('my.link').should('have.text', 'Link example');
+	});
+
+	it('should render icon before', () => {
+		cy.mount(<LinkAsButton icon="information-filled">Link example</LinkAsButton>);
+		cy.getByTest('link.icon.before').should('be.visible');
+	});
+
+	it('should render external', () => {
+		cy.mount(<LinkAsButton openInNewTab>Link example</LinkAsButton>);
+		cy.getByTest('link.icon.external').should('be.visible');
+	});
+});

--- a/packages/design-system/src/components/LinkAsButton/LinkAsButton.tsx
+++ b/packages/design-system/src/components/LinkAsButton/LinkAsButton.tsx
@@ -8,13 +8,14 @@ import { LinkComponentProps } from '../Link';
 import sharedLinkableStyles from '../Linkable/LinkableStyles.module.scss';
 import linkStyles from '../Link/Link.module.scss';
 import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
+import { SizedIcon } from '../Icon';
 
 type LinkAsButtonProps = Omit<ClickableProps, 'className'> &
-	Omit<LinkComponentProps, 'hideExternalIcon'>;
+	Omit<LinkComponentProps, 'hideExternalIcon'> & { openInNewTab?: boolean };
 
 const LinkAsButton = forwardRef(
 	(
-		{ disabled, title, icon, children, ...rest }: LinkAsButtonProps,
+		{ disabled, title, icon, children, openInNewTab, ...rest }: LinkAsButtonProps,
 		ref: Ref<HTMLButtonElement>,
 	) => {
 		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
@@ -28,6 +29,17 @@ const LinkAsButton = forwardRef(
 			}
 			if (disabled) {
 				return t('LINK_DISABLED', 'This link is disabled');
+			}
+			if (openInNewTab && title) {
+				return t('LINK_EXTERNAL_TITLE', {
+					title,
+					defaultValue: '{{title}} (open in a new tab)',
+				});
+			}
+			if (openInNewTab) {
+				return t('LINK_EXTERNAL', {
+					defaultValue: 'Open in a new tab',
+				});
 			}
 			return title;
 		};
@@ -44,16 +56,28 @@ const LinkAsButton = forwardRef(
 			>
 				{icon &&
 					(typeof icon === 'string' ? (
-						<Icon className={sharedLinkableStyles.link__icon} name={icon} />
+						<Icon
+							className={sharedLinkableStyles.link__icon}
+							name={icon}
+							data-test="link.icon.before"
+						/>
 					) : (
 						cloneElement(icon, {
+							'data-test': 'link.icon.before',
 							className: classnames(icon.props?.className, sharedLinkableStyles.link__icon),
 						})
 					))}
 				<span className={linkStyles.link__text}>{children}</span>
+				{openInNewTab && (
+					<span className={sharedLinkableStyles.link__iconExternal} data-test="link.icon.external">
+						<SizedIcon size="S" name="external-link" />
+					</span>
+				)}
 			</Clickable>
 		);
 	},
 );
+
+LinkAsButton.displayName = 'LinkAsButton';
 
 export default LinkAsButton;

--- a/packages/storybook/src/design-system/Link/Link.stories.mdx
+++ b/packages/storybook/src/design-system/Link/Link.stories.mdx
@@ -85,6 +85,7 @@ In React SPAs, most links are handled by libraries such as React Router. `Link` 
 ### As a button
 
 In extreme cases we do not condone, you may need the style of a link but the behavior of a button.
+If your action open a new tab, you can use the `openInNewTab` props to trigger the display of the `external-link` icon, and add `open in a new tab` in the link title.
 
 <Canvas>
 	<Story story={StoriesButton.LinkAsButtonStory} name="Link as Button" />


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently, the `LinkAsButton` component doesn't have an option for action that opens a new tab.

**What is the chosen solution to this problem?**
Add an `openInNewTab` props that will display the `external-link` icon on the right, and add `open in a new tab` in the link title.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
