### PR TITLE
fix(design-system/Modal): sync header x padding with spec

### DIFF
--- a/.changeset/stupid-knives-cross.md
+++ b/.changeset/stupid-knives-cross.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system/Modal): sync header x padding with spec

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -55,7 +55,7 @@
 	&__header {
 		flex-shrink: 0;
 		height: 6rem;
-		padding: tokens.$coral-spacing-xs tokens.$coral-spacing-l;
+		padding: tokens.$coral-spacing-xs tokens.$coral-spacing-xl;
 		border-bottom: tokens.$coral-border-s-solid tokens.$coral-color-neutral-border-weak;
 
 		display: flex;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

sync modal header x padding with spec to have aligned content.

**What is the chosen solution to this problem?**

Use x padding `xl` instead of `l` 

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
