### PR TITLE
fix(storybook): fix stories around RHF and downgrade to v6

### DIFF
--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -84,7 +84,6 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^7.33.1",
     "react-i18next": "^11.18.1",
     "react-is": "^16.13.1",
     "react-router-dom": "~6.3.0",

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -20,7 +20,8 @@
   },
   "dependencies": {
     "@talend/design-tokens": "^2.7.1",
-    "@talend/design-system": "^7.1.0"
+    "@talend/design-system": "^7.1.0",
+    "react-hook-form": "^6.15.8"
   },
   "devDependencies": {
     "@storybook/addon-a11y": "^6.5.9",

--- a/packages/storybook/src/design-system/Form/Field/Input/Input.Copy.stories.tsx
+++ b/packages/storybook/src/design-system/Form/Field/Input/Input.Copy.stories.tsx
@@ -1,5 +1,11 @@
 import React, { useEffect } from 'react';
-import { ButtonPrimary, ButtonTertiary, Form, InlineMessageInformation, StackVertical } from '@talend/design-system';
+import {
+	ButtonPrimary,
+	ButtonTertiary,
+	Form,
+	InlineMessageInformation,
+	StackVertical,
+} from '@talend/design-system';
 import { useForm } from 'react-hook-form';
 
 export default {
@@ -42,7 +48,7 @@ export const CopyWithPrefix = () => (
 );
 
 type CopyFormData = {
-	apiKey: string;
+	apiKey?: string;
 };
 
 export const ReactHookForm = () => {
@@ -77,7 +83,9 @@ export const ReactHookForm = () => {
 					label={'Key'}
 					defaultValue="10ca0868-1010-4b4a-a2cc-ff737527a7b5"
 					description={'This information is displayed only once.'}
-					{...register('apiKey')}
+					name="apiKey"
+					value={inputValue}
+					ref={register()}
 				/>
 				<ButtonTertiary icon="talend-refresh" onClick={() => setValue('apiKey', getUUID())}>
 					Regenerate

--- a/packages/storybook/src/design-system/Form/Field/Input/Input.Radio.stories.tsx
+++ b/packages/storybook/src/design-system/Form/Field/Input/Input.Radio.stories.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { ButtonPrimary, Form, InlineMessageInformation, StackVertical } from '@talend/design-system';
+import {
+	ButtonPrimary,
+	Form,
+	InlineMessageInformation,
+	StackVertical,
+} from '@talend/design-system';
 import { useForm } from 'react-hook-form';
 
 export default {
@@ -28,9 +33,9 @@ export const RadioFillStatesReadonly = () => (
 );
 
 type Inputs = {
-	option: string;
-	'inline-option': string;
-	'readonly-option': string;
+	option?: string;
+	'inline-option'?: string;
+	'readonly-option'?: string;
 	'disabled-inline-option'?: string;
 };
 
@@ -47,36 +52,57 @@ export const ReactHooksForm = () => {
 				/>
 			)}
 			<Form.Fieldset legend="Pick one option" required>
-				<Form.Radio label="Option A" value="option-a" {...register('option')} />
-				<Form.Radio label="Option B" value="option-b" defaultChecked {...register('option')} />
+				<Form.Radio label="Option A" value="option-a" name="option" ref={register()} />
+				<Form.Radio
+					label="Option B"
+					value="option-b"
+					defaultChecked
+					name="option"
+					ref={register()}
+				/>
 			</Form.Fieldset>
 			<Form.Fieldset legend="Pick one inline option" required>
 				<Form.Row>
-					<Form.Radio label="Inline option A" value="option-a" {...register('inline-option')} />
+					<Form.Radio
+						label="Inline option A"
+						value="option-a"
+						name="inline-option"
+						ref={register()}
+					/>
 					<Form.Radio
 						label="Inline option B"
 						value="option-b"
 						defaultChecked
-						{...register('inline-option')}
+						name="inline-option"
+						ref={register()}
 					/>
 				</Form.Row>
 			</Form.Fieldset>
 			<Form.Fieldset legend="Read only are sent" required readOnly>
-				<Form.Radio label="Option C" value="option-c" {...register('readonly-option')} />
-				<Form.Radio label="Option D" value="option-d" checked {...register('readonly-option')} />
+				<Form.Radio label="Option C" value="option-c" name="readonly-option" ref={register()} />
+				<Form.Radio
+					label="Option D"
+					value="option-d"
+					checked
+					name="readonly-option"
+					ref={register()}
+				/>
 			</Form.Fieldset>
 			<Form.Fieldset legend="Disabled are not sent" required disabled>
-				{/* @see https://github.com/react-hook-form/react-hook-form/issues/6690 */}
 				<Form.Radio
 					label="Option E"
 					value="option-e"
-					{...register('disabled-inline-option', { disabled: true })}
+					name="disabled-inline-option"
+					disabled
+					ref={register()}
 				/>
 				<Form.Radio
 					label="Option F"
 					value="option-f"
 					checked
-					{...register('disabled-inline-option', { disabled: true })}
+					name="disabled-inline-option"
+					disabled
+					ref={register()}
 				/>
 			</Form.Fieldset>
 			<Form.Buttons>

--- a/packages/storybook/src/design-system/Form/Field/Input/Input.ToggleSwitch.stories.tsx
+++ b/packages/storybook/src/design-system/Form/Field/Input/Input.ToggleSwitch.stories.tsx
@@ -1,5 +1,10 @@
 import React from 'react';
-import { ButtonPrimary, Form, InlineMessageInformation, StackVertical } from '@talend/design-system';
+import {
+	ButtonPrimary,
+	Form,
+	InlineMessageInformation,
+	StackVertical,
+} from '@talend/design-system';
 import { useForm } from 'react-hook-form';
 
 export default {
@@ -66,8 +71,13 @@ export const Controlled = () => {
 	return (
 		<Form>
 			<Form.Fieldset legend="Control switch state" required>
-				<Form.ToggleSwitch label="Toggle all" {...register('option-a')} />
-				<Form.ToggleSwitch label="Controlled switch" {...register('option-b')} checked={optionA} />
+				<Form.ToggleSwitch label="Toggle all" name="option-a" ref={register()} />
+				<Form.ToggleSwitch
+					label="Controlled switch"
+					name="option-b"
+					ref={register()}
+					checked={optionA}
+				/>
 			</Form.Fieldset>
 			<Form.Buttons>
 				<ButtonPrimary onClick={() => {}} type="submit">
@@ -91,17 +101,16 @@ export const ReactHooksForm = () => {
 				/>
 			)}
 			<Form.Fieldset legend="Enabled">
-				<Form.ToggleSwitch label="Option a" {...register('option-a')} />
-				<Form.ToggleSwitch label="Option b" checked {...register('option-b')} />
+				<Form.ToggleSwitch label="Option a" name="option-a" ref={register()} />
+				<Form.ToggleSwitch label="Option b" checked name="option-b" ref={register()} />
 			</Form.Fieldset>
 			<Form.Fieldset legend="Read only" readOnly>
-				<Form.ToggleSwitch label="Option c" {...register('option-c')} />
-				<Form.ToggleSwitch label="Option d" checked {...register('option-d')} />
+				<Form.ToggleSwitch label="Option c" name="option-c" ref={register()} />
+				<Form.ToggleSwitch label="Option d" checked name="option-d" ref={register()} />
 			</Form.Fieldset>
 			<Form.Fieldset legend="Disabled" disabled>
-				{/* @see https://github.com/react-hook-form/react-hook-form/issues/6690 */}
-				<Form.ToggleSwitch label="Option e" {...register('option-e', { disabled: true })} />
-				<Form.ToggleSwitch label="Option f" checked {...register('option-f', { disabled: true })} />
+				<Form.ToggleSwitch label="Option e" disabled name="option-e" ref={register()} />
+				<Form.ToggleSwitch label="Option f" checked disabled name="option-f" ref={register()} />
 			</Form.Fieldset>
 			<Form.Buttons>
 				<ButtonPrimary onClick={() => {}} type="submit">

--- a/packages/storybook/src/design-system/Form/Fieldset/FormFieldset.stories.tsx
+++ b/packages/storybook/src/design-system/Form/Fieldset/FormFieldset.stories.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from 'react';
 import { useForm } from 'react-hook-form';
-import { ButtonPrimary, ButtonSecondary, Form, InlineMessageDestructive, InlineMessageInformation } from '@talend/design-system';
+import {
+	ButtonPrimary,
+	ButtonSecondary,
+	Form,
+	InlineMessageDestructive,
+	InlineMessageInformation,
+} from '@talend/design-system';
 
 export default {
 	component: Form.Fieldset,
@@ -99,15 +105,12 @@ export const Errors = () => {
 	);
 };
 
-type FormData = {
+type FormDataWithUser = {
 	accountName: string;
 	numberOfSlots: number;
 	withUser: boolean;
-};
-
-type FormDataWithUser = FormData & {
-	name: string;
-	email: string;
+	name?: string;
+	email?: string;
 };
 
 export const ConditionalFieldset = () => {
@@ -119,7 +122,7 @@ export const ConditionalFieldset = () => {
 		handleSubmit,
 		unregister,
 		formState: { errors },
-	} = useForm<FormData | FormDataWithUser>();
+	} = useForm<FormDataWithUser>();
 	const withUserFormSelection = watch('withUser', false);
 	const hasMultipleErrors = Object.keys(errors).length > 1;
 
@@ -131,7 +134,7 @@ export const ConditionalFieldset = () => {
 		}
 	}, [withUserFormSelection]);
 
-	const onSubmit = (data: FormData | FormDataWithUser) => {
+	const onSubmit = (data: FormDataWithUser) => {
 		setFormData(JSON.stringify(data));
 	};
 
@@ -161,16 +164,18 @@ export const ConditionalFieldset = () => {
 						suffix=".info"
 						hasError={!!errors.accountName}
 						description={(!hasMultipleErrors && errors.accountName?.message) || undefined}
-						{...register('accountName', { required: 'This field is required' })}
+						name="accountName"
+						ref={register({ required: 'This field is required' })}
 					/>
 					<Form.Number
 						label="Slots"
 						hasError={!!errors.numberOfSlots}
 						description={(!hasMultipleErrors && errors.numberOfSlots?.message) || undefined}
-						{...register('numberOfSlots', { required: 'This field is required' })}
+						name="numberOfSlots"
+						ref={register({ required: 'This field is required' })}
 					/>
 				</Form.Row>
-				<Form.ToggleSwitch label="Send invite to admin user" {...register('withUser')} />
+				<Form.ToggleSwitch label="Send invite to admin user" name="withUser" ref={register()} />
 			</Form.Fieldset>
 			{withUser && (
 				<Form.Fieldset legend="Invite admin for this account">
@@ -180,7 +185,8 @@ export const ConditionalFieldset = () => {
 						description={
 							(!hasMultipleErrors && 'name' in errors && errors.name?.message) || undefined
 						}
-						{...register('name', { required: 'This field is required' })}
+						name="name"
+						ref={register({ required: 'This field is required' })}
 					/>
 					<Form.Email
 						label="User email"
@@ -188,7 +194,8 @@ export const ConditionalFieldset = () => {
 						description={
 							(!hasMultipleErrors && 'email' in errors && errors.email?.message) || undefined
 						}
-						{...register('email', { required: 'This field is required' })}
+						name="email"
+						ref={register({ required: 'This field is required' })}
 					/>
 				</Form.Fieldset>
 			)}

--- a/yarn.lock
+++ b/yarn.lock
@@ -16328,11 +16328,6 @@ react-hook-form@^6.15.8:
   resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-6.15.8.tgz#725c139d308c431c4611e4b9d85a49f01cfc0e7a"
   integrity sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==
 
-react-hook-form@^7.33.1:
-  version "7.33.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.33.1.tgz#8c4410e3420788d3b804d62cc4c142915c2e46d0"
-  integrity sha512-ydTfTxEJdvgjCZBj5DDXRc58oTEfnFupEwwTAQ9FSKzykEJkX+3CiAkGtAMiZG7IPWHuzgT6AOBfogiKhUvKgg==
-
 react-i18next@^11.18.1:
   version "11.18.1"
   resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-11.18.1.tgz#ba86ed09069e129b8623a28f2b9a03d7f105ea6f"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some stories are using `react-hook-form` v7 from a devDependency on the design-system package. We have another version used in the react-forms packages so it's conflicting and breaks some stories. 
And all Talend apps use `react-hook-form` v6 actually because it is imported from react-forms dependecies.

**What is the chosen solution to this problem?**
- Go back to `react-hook-form` v6 on all packages
- Move dependency from design-system package to the storybook

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
