### PR TITLE
fix(ARCH-669): storybook config without cmf

### DIFF
--- a/.changeset/loud-suns-sip.md
+++ b/.changeset/loud-suns-sip.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: make storybook config when there is no cmf package installed

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -18,9 +18,13 @@ const i18n = initI18n(userI18n);
 let cmfLoader;
 let cmfDecorator;
 if (cmf) {
-	const cmfPreview = require('./cmf').configureCmfModules(cmf.modules, cmf.settings);
-	cmfLoader = cmfPreview.loader;
-	cmfDecorator = cmfPreview.decorator;
+	try {
+		const cmfPreview = require('./cmf').configureCmfModules(cmf.modules, cmf.settings);
+		cmfLoader = cmfPreview.loader;
+		cmfDecorator = cmfPreview.decorator;
+	} catch(e) {
+		console.error(e);
+	}
 }
 
 const defaultPreview = {

--- a/tools/scripts-config-storybook-lib/index.js
+++ b/tools/scripts-config-storybook-lib/index.js
@@ -74,5 +74,11 @@ module.exports = function getStorybookConfiguration() {
 	const files = [...new Set([...defaultFiles, ...userFiles])];
 	files.forEach(copyFile);
 
+	try {
+		require('@talend/react-cmf');
+	} catch (e) {
+		fse.removeSync(path.join(TMP_PATH, 'cmf.js'));
+	}
+
 	return TMP_PATH;
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

on a current project I do not have react-cmf installed and I try to use storybook.

It fails to start asking for storybook.
This came from the require('./cmf') which happens during compile time.

**What is the chosen solution to this problem?**

* remove cmf.js file if no react-cmf installed
* try/catch the require of the file

Note: this is impossible to fix here, so I copy/paste the new file in my project and it now it starts


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
