### PR TITLE
fix(webpack): improve performance for dev experience

### DIFF
--- a/.changeset/fair-eagles-look.md
+++ b/.changeset/fair-eagles-look.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: Collapsible state is init by expaneded props

--- a/.changeset/strong-weeks-pretend.md
+++ b/.changeset/strong-weeks-pretend.md
@@ -1,0 +1,16 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix: remove duplicates of meta and simplify head script
+
+* meta was their twice because they are passed to the html-webpack-plugin.
+
+* the INITIATOR part of the script was still here even if we already have set `dynamic-cdn-webpack-plugin` to false.
+
+fix: The copy of assets in a cdn folder should happens if and only if:
+* INTIATOR_URL has not been given at compile time and
+* dynamic-cdn-webpack-plugin is present
+
+
+fix: DuplicatePlugins and BundleAnalyzer take times and slowdown the rebuild a lot. Use them only if option `--env analyze` is passed to the script.

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,7 +5,12 @@ const config = {
 
 if (process.argv.join(' ').includes('.ts')) {
 	// switch to ts config which is the .eslintrc.js
-	config.extends = ['./node_modules/@talend/scripts-config-eslint/.eslintrc.js'];
+	(config.extends = ['./node_modules/@talend/scripts-config-eslint/.eslintrc.js']),
+		(config.parser = '@typescript-eslint/parser');
+	config.parserOptions = {
+		tsconfigRootDir: __dirname,
+		project: 'tsconfig.json',
+	};
 }
 
 module.exports = config;

--- a/package.json
+++ b/package.json
@@ -55,7 +55,10 @@
     "fork/*"
   ],
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": [
+    "*.{js,jsx}": [
+      "eslint --quiet --fix"
+    ],
+    "*.{ts,tsx}": [
       "eslint --quiet --fix"
     ],
     "*.{json,md,mdx,html,js,jsx,ts,tsx}": [

--- a/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanel.tsx
+++ b/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanel.tsx
@@ -44,7 +44,7 @@ const CollapsiblePanel = forwardRef(
 		}: CollapsiblePanelPropsType,
 		ref: Ref<HTMLButtonElement>,
 	) => {
-		const [localExpanded, setLocalExpanded] = useState(false);
+		const [localExpanded, setLocalExpanded] = useState(!!expanded);
 
 		const { id: reakitId } = useId();
 		const componentId = id || reakitId;

--- a/tools/scripts-config-react-webpack/README.md
+++ b/tools/scripts-config-react-webpack/README.md
@@ -289,6 +289,10 @@ const TALEND_APP_INFO = {
 
 This package bundles automatically for dev only [whyDidYouRender](https://github.com/welldone-software/why-did-you-render) library to help you investigate React rendering issues.
 
+## webpack-bundle-analyzer and inspectpack/plugin
+
+You can add these plugin by passing `--env analyze` option to your start / build webpack command.
+
 ### How to use?
 
 ```javascript
@@ -369,7 +373,8 @@ For more information, see [Sentry CLI configuration values](https://docs.sentry.
 ## dynamic-cdn-webpack-plugin
 
 This entry let you pass options to the plugin `@talend/dynamic-cdn-webpack-plugin`.
-If you want you can also pass false to desactivate it.
+
+If you want you can also pass `false` to desactivate the plugin.
 
 ```json
 {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Working on a small project I already suffer from huge lag when change a bit of code.
The page is reloaded after 5 to 10 secondes.

Also looking at the index.html page which is generated I found all meta are present twice.

Latest issue I have a cdn folder copied even if I set the option `dynamic-cdn-webpack-plugin` to false.

Also eslint was broken makes it impossible to commit with husky pre commit hook.

**What is the chosen solution to this problem?**

* fix eslint config on the repo and the husky config

* Playing with the configuration I have discovered the analytics webpack plugins are the root cause.
unplug them but let them available with just the `--env analyze` flag as they are still usefull.

* Do not copy assets in /cdn if no cdn plugin.

* remove meta from the custom header.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
