### PR TITLE
fix(TDP-11750): WithDrawer content hidden on safari due to hidden overflow

### DIFF
--- a/.changeset/khaki-worms-rest.md
+++ b/.changeset/khaki-worms-rest.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDP-11750): WithDrawer content hidden on safari due to hidden overflow

--- a/packages/components/src/WithDrawer/withDrawer.module.scss
+++ b/packages/components/src/WithDrawer/withDrawer.module.scss
@@ -3,7 +3,6 @@
 .tc-with-drawer {
 	height: 100%;
 	position: initial;
-	overflow: hidden;
 	display: flex;
 	flex-direction: column;
 	// Need to go above the Switcher buttons https://github.com/Talend/ui/blob/master/packages/design-system/src/components/Switch/Switch.style.ts#L12


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

In some case, when multiple WithDrawer components, the highter one hides its content. This issue only occurs on safari. 

**What is the chosen solution to this problem?**

Do not hide WithDrawer overflow

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
