### PR TITLE
feat(datalist): add new value option display

### DIFF
--- a/.changeset/olive-buses-shop.md
+++ b/.changeset/olive-buses-shop.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(components): add new value available directly in the datalist while been in the add new value mode

--- a/packages/components/src/Datalist/Datalist.component.js
+++ b/packages/components/src/Datalist/Datalist.component.js
@@ -43,6 +43,18 @@ function buildSuggestions({
 		return undefined;
 	}
 
+	if (displayMode === DISPLAY.ALL && filterValue) {
+		const result = [...titleMap];
+		if (allowAddNewElements && !isValuePresentInSuggestions(titleMap, filterValue, multiSection)) {
+			result.unshift({
+				title: `${filterValue} ${allowAddNewElementsSuffix}`,
+				name: filterValue,
+				value: filterValue,
+			});
+		}
+		return result;
+	}
+
 	if (displayMode === DISPLAY.ALL || !filterValue) {
 		return titleMap;
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If we are in the "new values" mode, when we focus back the datalist, the new value entered is not displayed and we have only all the existing values available. That could lead to issue on the UX workflow
**What is the chosen solution to this problem?**
DIsplay the new value by default while been in the "add new value mode" if there is already a value in the filter while enter in the datalist

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
