### PR TITLE
chore: upgrade react-transition-group

### DIFF
--- a/fork/react-bootstrap/package.json
+++ b/fork/react-bootstrap/package.json
@@ -65,7 +65,7 @@
     "prop-types-extra": "^1.1.1",
     "react-overlays": "^0.9.3",
     "react-prop-types": "^0.4.0",
-    "react-transition-group": "^2.9.0",
+    "react-transition-group": "^4.4.5",
     "uncontrollable": "^7.2.1",
     "warning": "^3.0.0"
   },

--- a/fork/react-bootstrap/package.json
+++ b/fork/react-bootstrap/package.json
@@ -63,7 +63,7 @@
     "keycode": "^2.2.1",
     "prop-types": "^15.8.1",
     "prop-types-extra": "^1.1.1",
-    "react-overlays": "^0.9.3",
+    "react-overlays": "^5.2.1",
     "react-prop-types": "^0.4.0",
     "react-transition-group": "^4.4.5",
     "uncontrollable": "^7.2.1",

--- a/fork/react-bootstrap/src/DropdownMenu.js
+++ b/fork/react-bootstrap/src/DropdownMenu.js
@@ -3,13 +3,24 @@ import keycode from 'keycode';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import RootCloseWrapper from 'react-overlays/lib/RootCloseWrapper';
+import useRootClose from 'react-overlays/cjs/useRootClose';
+
+function RootCloseWrapper(props) {
+  /**  ref: React.RefObject<Element> | Element | null | undefined,
+  onRootClose: (e: Event) => void,
+  { disabled, clickTrigger = 'click' }: RootCloseOptions = {}, */
+  useRootClose(props.myRef, props.onRootClose, {
+    disabled: props.disabled,
+    clickTrigger: props.clickTrigger,
+  });
+  return props.children;
+}
 
 import {
   bsClass,
   getClassSet,
   prefix,
-  splitBsPropsAndOmit
+  splitBsPropsAndOmit,
 } from './utils/bootstrapUtils';
 import createChainedFunction from './utils/createChainedFunction';
 import ValidComponentChildren from './utils/ValidComponentChildren';
@@ -20,12 +31,12 @@ const propTypes = {
   onClose: PropTypes.func,
   labelledBy: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
   onSelect: PropTypes.func,
-  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown'])
+  rootCloseEvent: PropTypes.oneOf(['click', 'mousedown']),
 };
 
 const defaultProps = {
   bsRole: 'menu',
-  pullRight: false
+  pullRight: false,
 };
 
 class DropdownMenu extends React.Component {
@@ -34,6 +45,7 @@ class DropdownMenu extends React.Component {
 
     this.handleRootClose = this.handleRootClose.bind(this);
     this.handleKeyDown = this.handleKeyDown.bind(this);
+    this.myRef = React.createRef();
   }
 
   getFocusableMenuItems() {
@@ -110,7 +122,7 @@ class DropdownMenu extends React.Component {
 
     const classes = {
       ...getClassSet(bsProps),
-      [prefix(bsProps, 'right')]: pullRight
+      [prefix(bsProps, 'right')]: pullRight,
     };
 
     return (
@@ -118,20 +130,22 @@ class DropdownMenu extends React.Component {
         disabled={!open}
         onRootClose={this.handleRootClose}
         event={rootCloseEvent}
+        myRef={this.myRef}
       >
         <ul
           {...elementProps}
           role="menu"
+          ref={this.myRef}
           className={classNames(className, classes)}
           aria-labelledby={labelledBy}
         >
-          {ValidComponentChildren.map(children, child =>
+          {ValidComponentChildren.map(children, (child) =>
             React.cloneElement(child, {
               onKeyDown: createChainedFunction(
                 child.props.onKeyDown,
                 this.handleKeyDown
               ),
-              onSelect: createChainedFunction(child.props.onSelect, onSelect)
+              onSelect: createChainedFunction(child.props.onSelect, onSelect),
             })
           )}
         </ul>

--- a/fork/react-bootstrap/src/Modal.js
+++ b/fork/react-bootstrap/src/Modal.js
@@ -6,8 +6,8 @@ import getScrollbarSize from 'dom-helpers/util/scrollbarSize';
 import React from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';
-import BaseModal from 'react-overlays/lib/Modal';
-import isOverflowing from 'react-overlays/lib/utils/isOverflowing';
+import BaseModal from 'react-overlays/cjs/Modal';
+import isOverflowing from 'react-overlays/cjs/isOverflowing';
 import elementType from 'prop-types-extra/lib/elementType';
 
 import Fade from './Fade';
@@ -119,19 +119,19 @@ const propTypes = {
   /**
    * @private
    */
-  container: BaseModal.propTypes.container
+  container: BaseModal.propTypes.container,
 };
 
 const defaultProps = {
   ...BaseModal.defaultProps,
   animation: true,
-  dialogComponentClass: ModalDialog
+  dialogComponentClass: ModalDialog,
 };
 
 const childContextTypes = {
   $bs_modal: PropTypes.shape({
-    onHide: PropTypes.func
-  })
+    onHide: PropTypes.func,
+  }),
 };
 
 /* eslint-disable no-use-before-define, react/no-multi-comp */
@@ -156,15 +156,15 @@ class Modal extends React.Component {
     this.setModalRef = this.setModalRef.bind(this);
 
     this.state = {
-      style: {}
+      style: {},
     };
   }
 
   getChildContext() {
     return {
       $bs_modal: {
-        onHide: this.props.onHide
-      }
+        onHide: this.props.onHide,
+      },
     };
   }
 
@@ -225,8 +225,8 @@ class Modal extends React.Component {
         paddingLeft:
           !bodyIsOverflowing && modalIsOverflowing
             ? getScrollbarSize()
-            : undefined
-      }
+            : undefined,
+      },
     });
   }
 
@@ -234,7 +234,7 @@ class Modal extends React.Component {
     this._waitingForMouseUp = true;
   };
 
-  handleMouseUp = ev => {
+  handleMouseUp = (ev) => {
     const dialogNode = this._modal.getDialogElement();
     if (this._waitingForMouseUp && ev.target === dialogNode) {
       this._ignoreBackdropClick = true;

--- a/fork/react-bootstrap/src/Modal.test.js
+++ b/fork/react-bootstrap/src/Modal.test.js
@@ -2,7 +2,7 @@ import events from 'dom-helpers/events';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import BaseModal from 'react-overlays/lib/Modal';
+import BaseModal from 'react-overlays/cjs/Modal';
 
 import Modal from '../src/Modal';
 

--- a/fork/react-bootstrap/src/Overlay.js
+++ b/fork/react-bootstrap/src/Overlay.js
@@ -1,7 +1,7 @@
 import classNames from 'classnames';
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
-import BaseOverlay from 'react-overlays/lib/Overlay';
+import BaseOverlay from 'react-overlays/cjs/Overlay';
 import elementType from 'prop-types-extra/lib/elementType';
 
 import Fade from './Fade';
@@ -61,14 +61,14 @@ const propTypes = {
   /**
    * Sets the direction of the Overlay.
    */
-  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left'])
+  placement: PropTypes.oneOf(['top', 'right', 'bottom', 'left']),
 };
 
 const defaultProps = {
   animation: Fade,
   rootClose: false,
   show: false,
-  placement: 'right'
+  placement: 'right',
 };
 
 class Overlay extends React.Component {
@@ -81,7 +81,7 @@ class Overlay extends React.Component {
 
     if (!transition) {
       child = cloneElement(children, {
-        className: classNames(children.props.className, 'in')
+        className: classNames(children.props.className, 'in'),
       });
     } else {
       child = children;

--- a/fork/react-bootstrap/test/ModalSpec.js
+++ b/fork/react-bootstrap/test/ModalSpec.js
@@ -2,7 +2,7 @@ import events from 'dom-helpers/events';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import ReactTestUtils from 'react-dom/test-utils';
-import BaseModal from 'react-overlays/lib/Modal';
+import BaseModal from 'react-overlays/cjs/Modal';
 
 import Modal from '../src/Modal';
 
@@ -33,7 +33,7 @@ describe('<Modal>', () => {
     assert.ok(instance._modal.getDialogElement().querySelector('strong'));
   });
 
-  it('Should close the modal when the modal dialog is clicked', done => {
+  it('Should close the modal when the modal dialog is clicked', (done) => {
     const doneOp = () => {
       done();
     };
@@ -66,7 +66,7 @@ describe('<Modal>', () => {
     expect(onHideSpy).to.not.have.been.called;
   });
 
-  it('Should close the modal when the modal close button is clicked', done => {
+  it('Should close the modal when the modal close button is clicked', (done) => {
     const doneOp = () => {
       done();
     };
@@ -205,7 +205,7 @@ describe('<Modal>', () => {
     assert.equal(instance._modal.getDialogElement().className, 'custom-dialog');
   });
 
-  it('Should pass transition callbacks to Transition', done => {
+  it('Should pass transition callbacks to Transition', (done) => {
     let count = 0;
     const increment = () => {
       ++count;
@@ -252,7 +252,7 @@ describe('<Modal>', () => {
           super(props, context);
 
           this.state = {
-            show: true
+            show: true,
           };
         }
 

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -44,6 +44,7 @@
     "classnames": "^2.3.2",
     "d3": "^7.8.0",
     "date-fns": "^1.30.1",
+    "dom-helpers": "^5.0.1",
     "focus-outline-manager": "^1.0.2",
     "immutable": "^3.8.2",
     "invariant": "^2.2.4",

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -59,7 +59,7 @@
     "react-immutable-proptypes": "^2.2.0",
     "react-is": "^16.13.1",
     "react-popper": "^2.3.0",
-    "react-transition-group": "^2.9.0",
+    "react-transition-group": "^4.4.5",
     "react-use": "^17.4.0",
     "react-virtualized": "^9.22.3",
     "reactour": "^1.19.0",

--- a/packages/components/src/OverlayTrigger/OverlayTrigger.forked.js
+++ b/packages/components/src/OverlayTrigger/OverlayTrigger.forked.js
@@ -1,7 +1,7 @@
 /* eslint-disable import/no-extraneous-dependencies */
 /* eslint-disable react/no-find-dom-node */
 /* eslint-disable no-underscore-dangle */
-import contains from 'dom-helpers/query/contains';
+import contains from 'dom-helpers/cjs/contains';
 import React, { cloneElement } from 'react';
 import PropTypes from 'prop-types';
 import ReactDOM from 'react-dom';

--- a/packages/components/talend-scripts.json
+++ b/packages/components/talend-scripts.json
@@ -1,3 +1,6 @@
 {
-  "preset": "@talend/scripts-preset-react-lib"
+  "preset": "@talend/scripts-preset-react-lib",
+  "dynamic-cdn-webpack-plugin": {
+    "exclude": ["react-transition-group"]
+  }
 }

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -51,7 +51,7 @@
     "react-dom": "^17.0.2",
     "react-i18next": "^11.18.6",
     "react-redux": "^7.2.9",
-    "react-transition-group": "^2.9.0"
+    "react-transition-group": "^4.4.5"
   },
   "peerDependencies": {
     "i18next": "^20.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1293,7 +1293,7 @@
   dependencies:
     regenerator-runtime "^0.13.2"
 
-"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.1", "@babel/runtime@^7.20.6", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.0.0", "@babel/runtime@^7.1.2", "@babel/runtime@^7.10.1", "@babel/runtime@^7.10.2", "@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.13", "@babel/runtime@^7.12.5", "@babel/runtime@^7.13.8", "@babel/runtime@^7.14.5", "@babel/runtime@^7.15.4", "@babel/runtime@^7.16.3", "@babel/runtime@^7.17.8", "@babel/runtime@^7.18.3", "@babel/runtime@^7.18.9", "@babel/runtime@^7.20.1", "@babel/runtime@^7.20.6", "@babel/runtime@^7.5.0", "@babel/runtime@^7.5.5", "@babel/runtime@^7.6.3", "@babel/runtime@^7.7.2", "@babel/runtime@^7.7.6", "@babel/runtime@^7.8.4", "@babel/runtime@^7.8.7", "@babel/runtime@^7.9.2":
   version "7.20.7"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.20.7.tgz#fcb41a5a70550e04a7b708037c7c32f7f356d8fd"
   integrity sha512-UF0tvkUtxwAgZ5W/KrkHf0Rn0fdnLDU9ScxBrEVNUprE/MzirjK4MJUX1/BVDv00Sv8cljtukVK1aky++X1SjQ==
@@ -2475,6 +2475,13 @@
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@redux-saga/types/-/types-1.2.1.tgz#9403f51c17cae37edf870c6bc0c81c1ece5ccef8"
   integrity sha512-1dgmkh+3so0+LlBWRhGA33ua4MYr7tUOj+a9Si28vUi0IUFNbff1T3sgpeDJI/LaC75bBYnQ0A3wXjn0OrRNBA==
+
+"@restart/hooks@^0.4.7":
+  version "0.4.7"
+  resolved "https://registry.yarnpkg.com/@restart/hooks/-/hooks-0.4.7.tgz#d79ca6472c01ce04389fc73d4a79af1b5e33cd39"
+  integrity sha512-ZbjlEHcG+FQtpDPHd7i4FzNNvJf2enAwZfJbpM8CW7BhmOAbsHpZe3tsHwfQUrBuyrxWqPYp2x5UMnilWcY22A==
+  dependencies:
+    dequal "^2.0.2"
 
 "@rooks/use-mutation-observer@4.11.2":
   version "4.11.2"
@@ -4722,6 +4729,11 @@
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
+
+"@types/warning@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/warning/-/warning-3.0.0.tgz#0d2501268ad8f9962b740d387c4654f5f8e23e52"
+  integrity sha512-t/Tvs5qR47OLOr+4E9ckN8AmP2Tf16gWq+/qA4iUGS/OOyHVO8wv2vjJuX8SNOUTJyWb+2t7wJm6cXILFnOROA==
 
 "@types/webpack-env@^1.16.0", "@types/webpack-env@^1.17.0":
   version "1.18.0"
@@ -8606,6 +8618,11 @@ deprecation@^2.0.0, deprecation@^2.3.1:
   resolved "https://registry.yarnpkg.com/deprecation/-/deprecation-2.3.1.tgz#6368cbdb40abf3373b525ac87e4a260c3a700919"
   integrity sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==
 
+dequal@^2.0.2:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 destroy@1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/destroy/-/destroy-1.2.0.tgz#4803735509ad8be552934c67df614f94e66fa015"
@@ -8770,14 +8787,14 @@ dom-converter@^0.2.0:
   dependencies:
     utila "~0.4"
 
-dom-helpers@^3.2.1, dom-helpers@^3.4.0:
+dom-helpers@^3.4.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.4.0.tgz#e9b369700f959f62ecde5a6babde4bccd9169af8"
   integrity sha512-LnuPJ+dwqKDIyotW1VzmOZ5TONUN7CwkCR5hrgawTUbkBGYdeoNLZo6nNfGkCrjtE1nXXaj7iMMpDa8/d9WoIA==
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-helpers@^5.0.1, dom-helpers@^5.1.3:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3, dom-helpers@^5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -16460,7 +16477,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types-extra@^1.0.1, prop-types-extra@^1.1.1:
+prop-types-extra@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/prop-types-extra/-/prop-types-extra-1.1.1.tgz#58c3b74cbfbb95d304625975aa2f0848329a010b"
   integrity sha512-59+AHNnHYCdiC+vMwY52WmvP5dM3QLeoumYuEyceQDi9aEhtwN9zIQ2ZNo25sMyXnbh32h+P1ezDsUpUH3JAew==
@@ -16477,7 +16494,7 @@ prop-types@15.7.2:
     object-assign "^4.1.1"
     react-is "^16.8.1"
 
-prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.10, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@15.x, prop-types@^15.0.0, prop-types@^15.5.8, prop-types@^15.6.1, prop-types@^15.6.2, prop-types@^15.7.0, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -16897,17 +16914,19 @@ react-merge-refs@^1.0.0:
   resolved "https://registry.yarnpkg.com/react-merge-refs/-/react-merge-refs-1.1.0.tgz#73d88b892c6c68cbb7a66e0800faa374f4c38b06"
   integrity sha512-alTKsjEL0dKH/ru1Iyn7vliS2QRcBp9zZPGoWxUOvRGWPUYgjo+V01is7p04It6KhgrzhJGnIj9GgX8W4bZoCQ==
 
-react-overlays@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-0.9.3.tgz#5bac8c1e9e7e057a125181dee2d784864dd62902"
-  integrity sha512-u2T7nOLnK+Hrntho4p0Nxh+BsJl0bl4Xuwj/Y0a56xywLMetgAfyjnDVrudLXsNcKGaspoC+t3C1V80W9QQTdQ==
+react-overlays@^5.2.1:
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/react-overlays/-/react-overlays-5.2.1.tgz#49dc007321adb6784e1f212403f0fb37a74ab86b"
+  integrity sha512-GLLSOLWr21CqtJn8geSwQfoJufdt3mfdsnIiQswouuQ2MMPns+ihZklxvsTDKD3cR2tF8ELbi5xUsvqVhR6WvA==
   dependencies:
-    classnames "^2.2.5"
-    dom-helpers "^3.2.1"
-    prop-types "^15.5.10"
-    prop-types-extra "^1.0.1"
-    react-transition-group "^2.2.1"
-    warning "^3.0.0"
+    "@babel/runtime" "^7.13.8"
+    "@popperjs/core" "^2.11.6"
+    "@restart/hooks" "^0.4.7"
+    "@types/warning" "^3.0.0"
+    dom-helpers "^5.2.0"
+    prop-types "^15.7.2"
+    uncontrollable "^7.2.1"
+    warning "^4.0.3"
 
 react-popper@^2.3.0:
   version "2.3.0"
@@ -17037,7 +17056,7 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-transition-group@2.9.0, react-transition-group@^2.2.1:
+react-transition-group@2.9.0:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -20683,7 +20702,7 @@ warning@^3.0.0:
   dependencies:
     loose-envify "^1.0.0"
 
-warning@^4.0.0, warning@^4.0.2:
+warning@^4.0.0, warning@^4.0.2, warning@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/warning/-/warning-4.0.3.tgz#16e9e077eb8a86d6af7d64aa1e05fd85b4678ca3"
   integrity sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==

--- a/yarn.lock
+++ b/yarn.lock
@@ -8777,7 +8777,7 @@ dom-helpers@^3.2.1, dom-helpers@^3.4.0:
   dependencies:
     "@babel/runtime" "^7.1.2"
 
-dom-helpers@^5.1.3:
+dom-helpers@^5.0.1, dom-helpers@^5.1.3:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-5.2.1.tgz#d9400536b2bf8225ad98fe052e029451ac40e902"
   integrity sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==
@@ -17037,7 +17037,7 @@ react-themeable@^1.1.0:
   dependencies:
     object-assign "^3.0.0"
 
-react-transition-group@2.9.0, react-transition-group@^2.2.1, react-transition-group@^2.9.0:
+react-transition-group@2.9.0, react-transition-group@^2.2.1:
   version "2.9.0"
   resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-2.9.0.tgz#df9cdb025796211151a436c69a8f3b97b5b07c8d"
   integrity sha512-+HzNTCHpeQyl4MJ/bdE0u6XRMe9+XG/+aL4mCxVN4DnPBQ0/5bfHWPDuOZUzYdMj94daZaZdCCc1Dzt9R/xSSg==
@@ -17046,6 +17046,16 @@ react-transition-group@2.9.0, react-transition-group@^2.2.1, react-transition-gr
     loose-envify "^1.4.0"
     prop-types "^15.6.2"
     react-lifecycles-compat "^3.0.4"
+
+react-transition-group@^4.4.5:
+  version "4.4.5"
+  resolved "https://registry.yarnpkg.com/react-transition-group/-/react-transition-group-4.4.5.tgz#e53d4e3f3344da8521489fbef8f2581d42becdd1"
+  integrity sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==
+  dependencies:
+    "@babel/runtime" "^7.5.5"
+    dom-helpers "^5.0.1"
+    loose-envify "^1.4.0"
+    prop-types "^15.6.2"
 
 react-universal-interface@^0.6.2:
   version "0.6.2"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

yarn why:

```
- "_project_#@talend#react-components#react-transition-group"
- "_project_#@talend#react-stepper#react-transition-group"
- "_project_#@talend#react-bootstrap#react-transition-group"
- "_project_#@talend#react-components#recharts#react-smooth" depends on it.
```

**What is the chosen solution to this problem?**

* upgrade direct deps
* upgrade react-overlays
* update code apply breaking changes

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
