### PR TITLE
feat(TFD-14857): BadgeDropdown is now controlled

### DIFF
--- a/.changeset/rare-monkeys-try.md
+++ b/.changeset/rare-monkeys-try.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(TFD-14857): BadgeDropdown is now controlled

--- a/packages/design-system/src/components/Badge/Badge.spec.tsx
+++ b/packages/design-system/src/components/Badge/Badge.spec.tsx
@@ -32,7 +32,7 @@ context('<Badge />', () => {
 		cy.getByTestId('badge-label').should('have.text', label);
 		cy.getByTestId('badge-divider');
 
-		cy.getByTest('dropdown.button').should('have.text', 'Item');
+		cy.getByTest('dropdown.button.badge-button').should('have.text', 'Item');
 	});
 
 	it('should render BadgePopover', () => {

--- a/packages/design-system/src/components/Badge/Badge.spec.tsx
+++ b/packages/design-system/src/components/Badge/Badge.spec.tsx
@@ -32,7 +32,7 @@ context('<Badge />', () => {
 		cy.getByTestId('badge-label').should('have.text', label);
 		cy.getByTestId('badge-divider');
 
-		cy.getByTestId('badgedropdown-button').should('have.text', 'Item');
+		cy.getByTest('dropdown.button').should('have.text', 'Item');
 	});
 
 	it('should render BadgePopover', () => {
@@ -41,6 +41,6 @@ context('<Badge />', () => {
 		cy.getByTestId('badge-label').should('have.text', label);
 		cy.getByTestId('badge-divider');
 
-		items.forEach(v => cy.getByTestId(`badgepopover-button-${v.id}`).should('have.text', v.label));
+		items.forEach(v => cy.getByTest(`${v.id}.badge-button`).should('have.text', v.label));
 	});
 });

--- a/packages/design-system/src/components/Badge/button/BadgeButton.tsx
+++ b/packages/design-system/src/components/Badge/button/BadgeButton.tsx
@@ -23,16 +23,24 @@ type BadgeButtonProps = {
 } & Partial<DataAttributes>;
 
 const BadgeButton = forwardRef(
-	({ componentId, children, onClick, ...rest }: BadgeButtonProps, ref: Ref<HTMLButtonElement>) => {
+	(
+		{
+			children,
+			componentId,
+			'data-testid': dataTestId,
+			'data-test': dataTest,
+			onClick,
+			...rest
+		}: BadgeButtonProps,
+		ref: Ref<HTMLButtonElement>,
+	) => {
 		const defaultTestId = 'badge-button';
 
 		return (
 			<Clickable
 				className={classnames(styles.badge__button)}
-				data-testid={
-					rest['data-testid'] ? `${rest['data-testid']}.${defaultTestId}` : defaultTestId
-				}
-				data-test={rest['data-testid'] ? `${rest['data-testid']}.${defaultTestId}` : defaultTestId}
+				data-testid={dataTestId ? `${dataTestId}.${defaultTestId}` : defaultTestId}
+				data-test={dataTest ? `${dataTest}.${defaultTestId}` : defaultTestId}
 				key={componentId}
 				onClick={onClick}
 				ref={ref}

--- a/packages/design-system/src/components/Badge/button/BadgeButton.tsx
+++ b/packages/design-system/src/components/Badge/button/BadgeButton.tsx
@@ -3,8 +3,9 @@ import React, { forwardRef, Ref } from 'react';
 import classnames from 'classnames';
 import styles from './BadgeButton.module.scss';
 import Clickable from '../../Clickable';
+import { DataAttributes } from 'src/types';
 
-interface BadgeButtonProps {
+type BadgeButtonProps = {
 	/**
 	 * Component ID used as key and for data-testid.
 	 */
@@ -19,14 +20,19 @@ interface BadgeButtonProps {
 	 * (optional) Button click handler.
 	 */
 	onClick?: () => void;
-}
+} & Partial<DataAttributes>;
 
 const BadgeButton = forwardRef(
 	({ componentId, children, onClick, ...rest }: BadgeButtonProps, ref: Ref<HTMLButtonElement>) => {
+		const defaultTestId = 'badge-button';
+
 		return (
 			<Clickable
 				className={classnames(styles.badge__button)}
-				data-testid={componentId}
+				data-testid={
+					rest['data-testid'] ? `${rest['data-testid']}.${defaultTestId}` : defaultTestId
+				}
+				data-test={rest['data-testid'] ? `${rest['data-testid']}.${defaultTestId}` : defaultTestId}
 				key={componentId}
 				onClick={onClick}
 				ref={ref}

--- a/packages/design-system/src/components/Badge/primitive/BadgePrimitive.tsx
+++ b/packages/design-system/src/components/Badge/primitive/BadgePrimitive.tsx
@@ -64,11 +64,12 @@ export type BadgePrimitiveProps = {
 
 function BadgePrimitive({
 	children,
+	'data-testid': dataTestId,
+	'data-test': dataTest,
 	label,
 	onClose,
 	ref,
 	semanticIcon = 'none',
-	'data-testid': dataTestId,
 }: PropsWithChildren<BadgePrimitiveProps>) {
 	// TODO BADGE - handle onClose to manage close button
 
@@ -89,7 +90,7 @@ function BadgePrimitive({
 				<span
 					className={classnames(styles.badge__label)}
 					data-testid={dataTestId ? `${dataTestId}.${defaultTestId}` : defaultTestId}
-					data-test={dataTestId ? `${dataTestId}.${defaultTestId}` : defaultTestId}
+					data-test={dataTest ? `${dataTest}.${defaultTestId}` : defaultTestId}
 				>
 					{label}
 				</span>

--- a/packages/design-system/src/components/Badge/primitive/BadgePrimitive.tsx
+++ b/packages/design-system/src/components/Badge/primitive/BadgePrimitive.tsx
@@ -5,6 +5,7 @@ import Divider from '../../Divider';
 import classnames from 'classnames';
 import styles from './BadgePrimitive.module.scss';
 import { StackHorizontal } from '../../Stack';
+import { DataAttributes } from 'src/types';
 
 /**
  * Possible semantic values.
@@ -54,12 +55,12 @@ function BadgeDivider() {
 // Badge Primitive
 // --------------------------------------------------
 
-export interface BadgePrimitiveProps {
+export type BadgePrimitiveProps = {
 	label: string;
 	onClose?: () => void;
 	ref: Ref<HTMLSpanElement>;
 	semanticIcon?: SemanticIcon;
-}
+} & Partial<DataAttributes>;
 
 function BadgePrimitive({
 	children,
@@ -67,12 +68,15 @@ function BadgePrimitive({
 	onClose,
 	ref,
 	semanticIcon = 'none',
+	'data-testid': dataTestId,
 }: PropsWithChildren<BadgePrimitiveProps>) {
 	// TODO BADGE - handle onClose to manage close button
 
 	// TODO BADGE - handle semanticIcon to display semantic icon
 
 	// TODO BADGE - implement withOperator props
+
+	const defaultTestId = 'badge-label';
 
 	return (
 		<span className={classnames(styles.badge)} ref={ref}>
@@ -82,7 +86,11 @@ function BadgePrimitive({
 				align="center"
 				display="inline"
 			>
-				<span className={classnames(styles.badge__label)} data-testid="badge-label">
+				<span
+					className={classnames(styles.badge__label)}
+					data-testid={dataTestId ? `${dataTestId}.${defaultTestId}` : defaultTestId}
+					data-test={dataTestId ? `${dataTestId}.${defaultTestId}` : defaultTestId}
+				>
 					{label}
 				</span>
 

--- a/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
@@ -67,12 +67,12 @@ function mapBadgeItemToDropdownItem(onChange?: (selectedId: string) => void) {
 
 export type BadgeDropdownProps = Omit<BadgePrimitiveProps, 'children'> & {
 	/**
-	 * (optional) Listener for item selection.
+	 * Listener for item selection.
 	 */
-	onChange?: (selectedId: string) => void;
+	onChange: (selectedId: string) => void;
 
 	/**
-	 * (optional) ID of item to select by default. If not filled, first one is selected.
+	 * (Optional) ID of selected item. If not filled, first one is selected.
 	 */
 	selectedId?: string;
 
@@ -96,7 +96,7 @@ const BadgeDropdown = forwardRef((props: BadgeDropdownProps, ref: Ref<HTMLSpanEl
 				items={value.map(mapBadgeItemToDropdownItem(onChange))}
 				data-testid={props['data-testid']}
 			>
-				<BadgeDropdownButton data-testid={props['data-testid']}>
+				<BadgeDropdownButton data-testid={props['data-testid']} data-test={props['data-test']}>
 					{selectedValue?.label}
 				</BadgeDropdownButton>
 			</Dropdown>

--- a/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
@@ -95,6 +95,7 @@ const BadgeDropdown = forwardRef((props: BadgeDropdownProps, ref: Ref<HTMLSpanEl
 				aria-label={t('BADGE_ARIA_lABEL_SELECT_ITEM', 'Select item')}
 				items={value.map(mapBadgeItemToDropdownItem(onChange))}
 				data-testid={props['data-testid']}
+				data-test={props['data-test']}
 			>
 				<BadgeDropdownButton data-testid={props['data-testid']} data-test={props['data-test']}>
 					{selectedValue?.label}

--- a/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref, useState } from 'react';
+import React, { forwardRef, Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../constants';
@@ -15,14 +15,15 @@ import BadgePrimitive, {
 import classnames from 'classnames';
 import styles from './BadgeDropdown.module.scss';
 import BadgeButton from '../button/BadgeButton';
+import { DataAttributes } from 'src/types';
 
 // --------------------------------------------------
 // Badge Dropdown button
 // --------------------------------------------------
 
-interface BadgeDropdownButtonProps {
+type BadgeDropdownButtonProps = {
 	children?: string;
-}
+} & Partial<DataAttributes>;
 
 // Note : need to use forwardRef and pass destructuring unknown parameters to be able using with dropdown component
 const BadgeDropdownButton = forwardRef(
@@ -52,16 +53,11 @@ BadgeDropdownButton.displayName = 'BadgeDropdownButton';
  * @param setSelectedValue React.Dispatch action called when click on one Dropdown item
  * @returns Dropdown compatible item
  */
-function mapBadgeItemToDropdownItem(
-	setSelectedValue: React.Dispatch<React.SetStateAction<BadgeDropdownItem | undefined>>,
-	onChange?: (selectedId: string) => void,
-) {
+function mapBadgeItemToDropdownItem(onChange?: (selectedId: string) => void) {
 	return (item: BadgeDropdownItem): DropdownItemType => ({
 		type: 'button',
 		label: item.label,
 		onClick: () => {
-			setSelectedValue(item);
-
 			if (onChange) {
 				onChange(item.id);
 			}
@@ -91,17 +87,18 @@ const BadgeDropdown = forwardRef((props: BadgeDropdownProps, ref: Ref<HTMLSpanEl
 
 	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
-	const [selectedValue, setSelectedValue] = useState(
-		selectedId ? value.find(v => v.id === selectedId) : value[0],
-	);
+	const selectedValue = value.find(v => v.id === selectedId) || value[0];
 
 	return (
 		<BadgePrimitive {...props} ref={ref}>
 			<Dropdown
 				aria-label={t('BADGE_ARIA_lABEL_SELECT_ITEM', 'Select item')}
-				items={value.map(mapBadgeItemToDropdownItem(setSelectedValue, onChange))}
+				items={value.map(mapBadgeItemToDropdownItem(onChange))}
+				data-testid={props['data-testid']}
 			>
-				<BadgeDropdownButton>{selectedValue?.label}</BadgeDropdownButton>
+				<BadgeDropdownButton data-testid={props['data-testid']}>
+					{selectedValue?.label}
+				</BadgeDropdownButton>
 			</Dropdown>
 		</BadgePrimitive>
 	);

--- a/packages/design-system/src/components/Badge/variants/BadgePopover.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgePopover.tsx
@@ -19,26 +19,22 @@ const BadgePopover = forwardRef((props: BadgePopoverProps, ref: Ref<HTMLSpanElem
 		<BadgePrimitive {...props} ref={ref}>
 			{
 				<StackHorizontal gap="XXS" as="span" align="center">
-					{value.map((item: BadgePopoverItem, idx: number) => {
-						const buttonTestId = props['data-testid']
-							? `${props['data-testid']}.${item.id}`
-							: item.id;
-						return (
-							<React.Fragment key={`badgepopover-fragment-${item.id}`}>
-								{idx > 0 && (
-									<Divider key={`badgepopover-divider-${item.id}`} orientation="vertical" />
-								)}
+					{value.map((item: BadgePopoverItem, idx: number) => (
+						<React.Fragment key={`badgepopover-fragment-${item.id}`}>
+							{idx > 0 && (
+								<Divider key={`badgepopover-divider-${item.id}`} orientation="vertical" />
+							)}
 
-								<BadgeButton
-									componentId={`badgepopover-button-${item.id}`}
-									onClick={item.onClick}
-									data-testid={buttonTestId}
-								>
-									{item.label}
-								</BadgeButton>
-							</React.Fragment>
-						);
-					})}
+							<BadgeButton
+								componentId={`badgepopover-button-${item.id}`}
+								onClick={item.onClick}
+								data-testid={props['data-testid'] ? `${props['data-testid']}.${item.id}` : item.id}
+								data-test={props['data-test'] ? `${props['data-test']}.${item.id}` : item.id}
+							>
+								{item.label}
+							</BadgeButton>
+						</React.Fragment>
+					))}
 				</StackHorizontal>
 			}
 		</BadgePrimitive>

--- a/packages/design-system/src/components/Badge/variants/BadgePopover.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgePopover.tsx
@@ -19,17 +19,26 @@ const BadgePopover = forwardRef((props: BadgePopoverProps, ref: Ref<HTMLSpanElem
 		<BadgePrimitive {...props} ref={ref}>
 			{
 				<StackHorizontal gap="XXS" as="span" align="center">
-					{value.map((item: BadgePopoverItem, idx: number) => (
-						<React.Fragment key={`badgepopover-fragment-${item.id}`}>
-							{idx > 0 && (
-								<Divider key={`badgepopover-divider-${item.id}`} orientation="vertical" />
-							)}
+					{value.map((item: BadgePopoverItem, idx: number) => {
+						const buttonTestId = props['data-testid']
+							? `${props['data-testid']}.${item.id}`
+							: item.id;
+						return (
+							<React.Fragment key={`badgepopover-fragment-${item.id}`}>
+								{idx > 0 && (
+									<Divider key={`badgepopover-divider-${item.id}`} orientation="vertical" />
+								)}
 
-							<BadgeButton componentId={`badgepopover-button-${item.id}`} onClick={item.onClick}>
-								{item.label}
-							</BadgeButton>
-						</React.Fragment>
-					))}
+								<BadgeButton
+									componentId={`badgepopover-button-${item.id}`}
+									onClick={item.onClick}
+									data-testid={buttonTestId}
+								>
+									{item.label}
+								</BadgeButton>
+							</React.Fragment>
+						);
+					})}
 				</StackHorizontal>
 			}
 		</BadgePrimitive>

--- a/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.spec.tsx
@@ -78,7 +78,8 @@ context('<Dropdown />', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').click();
 		cy.getByTest('dropdown.menu').should('be.visible');
-		cy.getByTest('dropdown.menuitem').should('have.length', 2);
+		cy.getByTest('dropdown.menuitem.Link with icon-0').should('be.visible');
+		cy.getByTest('dropdown.menuitem.Button with icon-1').should('be.visible');
 		cy.clickOutside();
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
@@ -87,7 +88,7 @@ context('<Dropdown />', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').click();
 		cy.getByTest('dropdown.menu').should('be.visible');
-		cy.get('button[data-test="dropdown.menuitem"]').click();
+		cy.get('button[data-test="dropdown.menuitem.Button with icon-1"]').click();
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
 
@@ -95,8 +96,8 @@ context('<Dropdown />', () => {
 		cy.mount(<WithIcons />);
 		cy.getByTest('dropdown.button').click();
 		cy.getByTest('dropdown.menu').should('be.visible');
-		cy.get('a[data-test="dropdown.menuitem"]').eq(0).invoke('removeAttr', 'href');
-		cy.get('a[data-test="dropdown.menuitem"]').click();
+		cy.get('a[data-test="dropdown.menuitem.Link with icon-0"]').invoke('removeAttr', 'href');
+		cy.get('a[data-test="dropdown.menuitem.Link with icon-0"]').click();
 		cy.getByTest('dropdown.menu').should('not.be.visible');
 	});
 
@@ -115,7 +116,7 @@ context('<Dropdown />', () => {
 		// Let's highlight the second menu item
 		cy.get('body').type('{downArrow}{downArrow}');
 		// And verify that's focused
-		cy.getByTest('dropdown.menuitem').eq(1).should('be.attr', 'tabindex', 0);
+		cy.getByTest('dropdown.menuitem.Button with icon-1').should('be.attr', 'tabindex', 0);
 	});
 
 	it('should have separators', () => {
@@ -132,7 +133,7 @@ context('<Dropdown />', () => {
 	it('should have menu item with external links', () => {
 		cy.mount(<WithDividers />);
 		cy.getByTest('dropdown.button').click();
-		cy.getByTest('dropdown.menuitem')
+		cy.getByTest('dropdown.menuitem.External link-0')
 			.first()
 			.should('be.visible')
 			.within(() => {

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -8,7 +8,7 @@ import DropdownTitle from './Primitive/DropdownTitle';
 import DropdownDivider from './Primitive/DropdownDivider';
 import Clickable, { ClickableProps } from '../Clickable';
 import { LinkableType } from '../Linkable';
-import { DeprecatedIconNames } from '../../types';
+import { DataAttributes, DeprecatedIconNames } from '../../types';
 
 type DropdownButtonType = Omit<ClickableProps, 'children' | 'as'> & {
 	label: string;
@@ -41,25 +41,40 @@ export type DropdownPropsType = {
 	children: ReactElement<typeof Clickable>;
 	items: DropdownItemType[];
 	'aria-label': string;
-};
+} & Partial<DataAttributes>;
 
 const Dropdown = forwardRef(
-	({ children, items, ...rest }: DropdownPropsType, ref: Ref<HTMLDivElement>) => {
+	(
+		{ children, items, 'data-testid': dataTestId, ...rest }: DropdownPropsType,
+		ref: Ref<HTMLDivElement>,
+	) => {
 		const menu = useMenuState({
 			animated: 250,
 			gutter: 4,
 			loop: true,
 		});
 
+		const menuButtonTestId = dataTestId ? `${dataTestId}.dropdown.button` : 'dropdown.button';
+		const menuTestId = dataTestId ? `${dataTestId}.dropdown.menu` : 'dropdown.menu';
+		const menuItemTestId = dataTestId ? `${dataTestId}.dropdown.menuitem` : 'dropdown.menuitem';
+
 		return (
 			<>
-				<MenuButton {...menu} data-test="dropdown.button">
+				<MenuButton {...menu} data-testid={menuButtonTestId} data-test={menuButtonTestId}>
 					{disclosureProps => cloneElement(children, disclosureProps)}
 				</MenuButton>
-				<Menu {...menu} as={DropdownShell} {...rest} ref={ref} data-test="dropdown.menu">
+				<Menu
+					{...menu}
+					as={DropdownShell}
+					{...rest}
+					ref={ref}
+					data-testid={menuTestId}
+					data-test={menuTestId}
+				>
 					{items.map((entry, index) => {
 						if (entry.type === 'button') {
 							const { label, ...entryRest } = entry;
+							const id = `${label}-${index}`;
 							return (
 								<DropdownButton
 									{...entryRest}
@@ -68,9 +83,10 @@ const Dropdown = forwardRef(
 										menu.hide();
 										entry.onClick(event);
 									}}
-									key={`${label}-${index}`}
-									id={`${label}-${index}`}
-									data-test="dropdown.menuitem"
+									key={id}
+									id={id}
+									data-testid={`${menuItemTestId}.${id}`}
+									data-test={menuItemTestId}
 								>
 									{label}
 								</DropdownButton>
@@ -79,34 +95,47 @@ const Dropdown = forwardRef(
 
 						if (entry.type === 'title') {
 							const { label } = entry;
+							const id = `${label}-${index}`;
 							return (
-								<DropdownTitle key={`${label}-${index}`} data-test="dropdown.menuitem">
+								<DropdownTitle
+									key={id}
+									data-testid={`${menuItemTestId}.${id}`}
+									data-test={menuItemTestId}
+								>
 									{label}
 								</DropdownTitle>
 							);
 						}
 
 						if (entry.type === 'divider') {
+							const id = `divider-${index}`;
 							return (
-								<DropdownDivider {...menu} key={`divider-${index}`} data-test="dropdown.menuitem" />
+								<DropdownDivider
+									{...menu}
+									key={id}
+									data-testid={`${menuItemTestId}.${id}`}
+									data-test={menuItemTestId}
+								/>
 							);
 						}
 
 						const { label, as, type, ...entryRest } = entry;
+						const id = `${label}-${index}`;
 						return (
 							<DropdownLink
 								as={as}
 								{...entryRest}
 								{...menu}
-								key={`${label}-${index}`}
-								id={`${label}-${index}`}
+								key={id}
+								id={id}
 								onClick={(event: MouseEvent<HTMLAnchorElement>) => {
 									menu.hide();
 									if (entry.onClick) {
 										entry.onClick(event);
 									}
 								}}
-								data-test="dropdown.menuitem"
+								data-testid={`${menuItemTestId}.${id}`}
+								data-test={menuItemTestId}
 							>
 								{label}
 							</DropdownLink>

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -45,7 +45,13 @@ export type DropdownPropsType = {
 
 const Dropdown = forwardRef(
 	(
-		{ children, items, 'data-testid': dataTestId, ...rest }: DropdownPropsType,
+		{
+			children,
+			'data-test': dataTest,
+			'data-testid': dataTestId,
+			items,
+			...rest
+		}: DropdownPropsType,
 		ref: Ref<HTMLDivElement>,
 	) => {
 		const menu = useMenuState({
@@ -57,10 +63,13 @@ const Dropdown = forwardRef(
 		const menuButtonTestId = dataTestId ? `${dataTestId}.dropdown.button` : 'dropdown.button';
 		const menuTestId = dataTestId ? `${dataTestId}.dropdown.menu` : 'dropdown.menu';
 		const menuItemTestId = dataTestId ? `${dataTestId}.dropdown.menuitem` : 'dropdown.menuitem';
+		const menuButtonTest = dataTest ? `${dataTest}.dropdown.button` : 'dropdown.button';
+		const menuTest = dataTest ? `${dataTest}.dropdown.menu` : 'dropdown.menu';
+		const menuItemTest = dataTest ? `${dataTest}.dropdown.menuitem` : 'dropdown.menuitem';
 
 		return (
 			<>
-				<MenuButton {...menu} data-testid={menuButtonTestId} data-test={menuButtonTestId}>
+				<MenuButton {...menu} data-testid={menuButtonTestId} data-test={menuButtonTest}>
 					{disclosureProps => cloneElement(children, disclosureProps)}
 				</MenuButton>
 				<Menu
@@ -69,7 +78,7 @@ const Dropdown = forwardRef(
 					{...rest}
 					ref={ref}
 					data-testid={menuTestId}
-					data-test={menuTestId}
+					data-test={menuTest}
 				>
 					{items.map((entry, index) => {
 						if (entry.type === 'button') {
@@ -86,7 +95,7 @@ const Dropdown = forwardRef(
 									key={id}
 									id={id}
 									data-testid={`${menuItemTestId}.${id}`}
-									data-test={menuItemTestId}
+									data-test={`${menuItemTest}.${id}`}
 								>
 									{label}
 								</DropdownButton>
@@ -100,7 +109,7 @@ const Dropdown = forwardRef(
 								<DropdownTitle
 									key={id}
 									data-testid={`${menuItemTestId}.${id}`}
-									data-test={menuItemTestId}
+									data-test={`${menuItemTest}.${id}`}
 								>
 									{label}
 								</DropdownTitle>
@@ -114,7 +123,7 @@ const Dropdown = forwardRef(
 									{...menu}
 									key={id}
 									data-testid={`${menuItemTestId}.${id}`}
-									data-test={menuItemTestId}
+									data-test={`${menuItemTest}.${id}`}
 								/>
 							);
 						}
@@ -135,7 +144,7 @@ const Dropdown = forwardRef(
 									}
 								}}
 								data-testid={`${menuItemTestId}.${id}`}
-								data-test={menuItemTestId}
+								data-test={`${menuItemTest}.${id}`}
 							>
 								{label}
 							</DropdownLink>

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownButton.tsx
@@ -31,4 +31,6 @@ const DropdownButton = forwardRef(
 	},
 );
 
+DropdownButton.displayName = 'DropdownButton';
+
 export default DropdownButton;

--- a/packages/storybook/src/design-system/Badge/Badge.stories.mdx
+++ b/packages/storybook/src/design-system/Badge/Badge.stories.mdx
@@ -10,7 +10,7 @@ import * as Stories from './Badge.stories';
 	}}
 />
 
-# Title
+# Badge
 
 A wonderful Badge
 
@@ -25,7 +25,7 @@ A wonderful Badge
 
 <FigmaImage
 	src="https://www.figma.com/file/3YWRmMgPIjAABxJl9X9B3W/Badge?node-id=303%3A144&t=l0MyIsUaO4fb7MjP-0"
-	alt="zoning image"
+	alt="Badge in various state"
 />
 
 ### Variations
@@ -209,12 +209,12 @@ A wonderful Badge
 			<td>(Optional) Provide it to display a close icon on right side.</td>
 		</tr>
 		<tr>
-			<td>Default selected value</td>
+			<td>Selected value</td>
 			<td>selectedId</td>
 			<td>string</td>
 			<td>
-				(Optional) ID of value selected by default. It must match one value's ID in value list. If
-				no one is given, first one in list is selected.
+				(Optional) ID of value selected. It must match one value's ID in value list. If no one is
+				given, first one in list is selected.
 			</td>
 		</tr>
 		<tr>

--- a/packages/storybook/src/design-system/Badge/Badge.stories.mdx
+++ b/packages/storybook/src/design-system/Badge/Badge.stories.mdx
@@ -168,6 +168,8 @@ A wonderful Badge
 
 #### BadgeDropdown
 
+This component is controlled.
+
 <table>
 	<thead>
 		<tr>
@@ -198,7 +200,7 @@ A wonderful Badge
 			<td>
 				<i>function handler</i>
 			</td>
-			<td>(Optional) Provide it to listen at item selection.</td>
+			<td>Provide it to listen at item selection.</td>
 		</tr>
 		<tr>
 			<td>Close</td>
@@ -213,8 +215,8 @@ A wonderful Badge
 			<td>selectedId</td>
 			<td>string</td>
 			<td>
-				(Optional) ID of value selected. It must match one value's ID in value list. If no one is
-				given, first one in list is selected.
+				(Optional) ID of the selected value. It must match one value's ID in value list. If no one
+				is given, first one in list is selected.
 			</td>
 		</tr>
 		<tr>

--- a/packages/storybook/src/design-system/Badge/Badge.stories.tsx
+++ b/packages/storybook/src/design-system/Badge/Badge.stories.tsx
@@ -7,7 +7,7 @@ import {
 	StackHorizontal,
 	StackVertical,
 } from '@talend/design-system';
-import React from 'react';
+import React, { useState } from 'react';
 
 export default {
 	component: Badge,
@@ -46,35 +46,42 @@ export const StoryBadgeTag = () => (
 	</StackVertical>
 );
 
-export const StoryBadgeDropdown = () => (
-	<StackVertical gap="S" justify="spaceBetween">
-		<StackHorizontal align="center" gap="S" justify="spaceBetween">
-			Component Badge w/ variant "dropdown"
-			<Badge
-				label="Awesome"
-				selectedId="3"
-				value={[
-					{ id: '1', label: 'Feature' },
-					{ id: '2', label: 'Item' },
-					{ id: '3', label: 'Component' },
-				]}
-				variant="dropdown"
-			/>
-		</StackHorizontal>
+export const StoryBadgeDropdown = () => {
+	const [selectedValue, setSelectedValue] = useState('3');
 
-		<StackHorizontal align="center" gap="S" justify="spaceBetween">
-			Variant component BadgeDropdown
-			<BadgeDropdown
-				label="Awesome"
-				value={[
-					{ id: '1', label: 'Feature' },
-					{ id: '2', label: 'Item' },
-					{ id: '3', label: 'Component' },
-				]}
-			/>
-		</StackHorizontal>
-	</StackVertical>
-);
+	return (
+		<StackVertical gap="S" justify="spaceBetween">
+			<StackHorizontal align="center" gap="S" justify="spaceBetween">
+				Component Badge w/ variant "dropdown"
+				<Badge
+					label="Awesome"
+					selectedId={selectedValue}
+					value={[
+						{ id: '1', label: 'Feature' },
+						{ id: '2', label: 'Item' },
+						{ id: '3', label: 'Component' },
+					]}
+					onChange={setSelectedValue}
+					variant="dropdown"
+				/>
+			</StackHorizontal>
+
+			<StackHorizontal align="center" gap="S" justify="spaceBetween">
+				Variant component BadgeDropdown
+				<BadgeDropdown
+					label="Awesome"
+					selectedId={selectedValue}
+					value={[
+						{ id: '1', label: 'Feature' },
+						{ id: '2', label: 'Item' },
+						{ id: '3', label: 'Component' },
+					]}
+					onChange={setSelectedValue}
+				/>
+			</StackHorizontal>
+		</StackVertical>
+	);
+};
 
 export const StoryBadgePopover = () => (
 	<StackVertical gap="S" justify="spaceBetween">


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
`BadgeDropdown` is uncontrolled, so it does not allow to change the value externally.

**What is the chosen solution to this problem?**
Remove the internal state and let it be controlled.

As a bonus, some `data-testid` have been added.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
