### PR TITLE
fix(TDOPS-3536): Design system fix on popover disclosure props

### DIFF
--- a/.changeset/khaki-moose-deny.md
+++ b/.changeset/khaki-moose-deny.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+TDOPS-3536 - Fix passing props to popover disclosure on Design System

--- a/packages/design-system/src/components/WIP/Popover/Popover.spec.tsx
+++ b/packages/design-system/src/components/WIP/Popover/Popover.spec.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import Popover from './Popover';
+import { ButtonPrimary, CollapsiblePanel } from '../../..';
+
+context('<Popover />', () => {
+	describe('default', () => {
+		it('should show a popover', () => {
+			cy.mount(
+				<Popover
+					disclosure={<ButtonPrimary data-test="my.button">Open popover</ButtonPrimary>}
+					data-test="my.popover"
+				>
+					Popover content
+				</Popover>,
+			);
+
+			cy.getByTest('my.button').should('be.visible');
+			cy.getByTest('my.popover').should('not.be.visible');
+			cy.getByTest('my.button').click();
+			cy.getByTest('my.popover').should('be.visible');
+		});
+
+		it('should be able to override disclosure click', () => {
+			cy.mount(
+				<CollapsiblePanel
+					title="panel"
+					metadata={[
+						<Popover
+							disclosure={
+								<ButtonPrimary onClick={event => event.stopPropagation()} data-test="my.button">
+									Open popover
+								</ButtonPrimary>
+							}
+							data-test="my.popover"
+						>
+							<p>Popover content</p>
+						</Popover>,
+					]}
+				>
+					Some text
+				</CollapsiblePanel>,
+			);
+
+			// Disclosure onClick should stop propagation and not open the CollapsiblePanel container
+			cy.getByTest('panel.section').should('not.exist');
+			cy.getByTest('my.button').click();
+			cy.getByTest('panel.section').should('not.exist');
+		});
+	});
+});

--- a/packages/design-system/src/components/WIP/Popover/Popover.spec.tsx
+++ b/packages/design-system/src/components/WIP/Popover/Popover.spec.tsx
@@ -26,6 +26,7 @@ context('<Popover />', () => {
 					title="panel"
 					metadata={[
 						<Popover
+							key="my.popover"
 							disclosure={
 								<ButtonPrimary onClick={event => event.stopPropagation()} data-test="my.button">
 									Open popover

--- a/packages/design-system/src/components/WIP/Popover/Popover.tsx
+++ b/packages/design-system/src/components/WIP/Popover/Popover.tsx
@@ -45,10 +45,10 @@ function Popover({
 		unstable_fixed: isFixed,
 	});
 	const children = Array.isArray(props.children) ? props.children : [props.children];
-
+	const disclosureElementProps = typeof disclosure !== 'function' ? disclosure.props : {};
 	return (
 		<>
-			<ReakitPopoverDisclosure {...popover}>
+			<ReakitPopoverDisclosure {...popover} {...disclosureElementProps}>
 				{disclosureProps => {
 					if (typeof disclosure === 'function') {
 						return disclosure(disclosureProps);

--- a/packages/storybook/src/design-system/Popover/Popover.stories.tsx
+++ b/packages/storybook/src/design-system/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, Ref } from 'react';
+import React from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { PopoverStateReturn } from 'reakit/ts';
@@ -11,20 +11,11 @@ export default {
 
 const EasyPopover = () => <StackVertical gap="S">Hello hello</StackVertical>;
 
-/* eslint-disable-next-line react/display-name */
-const OpenPopover = forwardRef((props: PopoverDisclosureHTMLProps, ref: Ref<HTMLButtonElement>) => {
-	function handleClick(event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) {
-		action('Clicked disclosure');
-		if (props.onClick) {
-			props.onClick(event as React.MouseEvent<any>);
-		}
-	}
-	return (
-		<ButtonPrimary {...props} onClick={handleClick} ref={ref}>
-			Open popover
-		</ButtonPrimary>
-	);
-});
+const OpenPopover = (props: PopoverDisclosureHTMLProps) => (
+	<ButtonPrimary onClick={action('Clicked disclosure')} {...props}>
+		Open popover
+	</ButtonPrimary>
+);
 
 export const DefaultStory = () => (
 	<div style={{ padding: '1.2rem' }}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Props passed to a popover disclosure where not properly handled like `onClick`

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
