### PR TITLE
feat(ARCH-662/cmf/settings): do not write settigns to disk

### DIFF
--- a/.changeset/chilly-emus-sit.md
+++ b/.changeset/chilly-emus-sit.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-cmf-webpack-plugin': minor
+'@talend/scripts-cmf': minor
+---
+
+feat: do not write settings to disk

--- a/tools/cmf-webpack-plugin/src/index.js
+++ b/tools/cmf-webpack-plugin/src/index.js
@@ -86,6 +86,10 @@ ReactCMFWebpackPlugin.prototype.apply = function reactCMFWebpackPluginApply(comp
 			compilationFileDependencies = compilation.fileDependencies;
 		}
 
+		this.mergedSettingsObjects
+			.map(obj => obj.path)
+			.filter(file => !compilationFileDependencies.has(file))
+			.forEach(file => compilation.fileDependencies.add(file));
 		if (!compilationFileDependencies.has(cmfconfigPath)) {
 			compilation.fileDependencies.add(cmfconfigPath);
 		}

--- a/tools/cmf-webpack-plugin/src/index.js
+++ b/tools/cmf-webpack-plugin/src/index.js
@@ -1,6 +1,7 @@
 /* eslint-disable global-require */
 const path = require('path');
 const mergeSettings = require('@talend/scripts-cmf/cmf-settings.merge');
+const RawSource = require('webpack-sources').RawSource;
 
 /**
  * React CMF Webpack Plugin
@@ -60,7 +61,11 @@ ReactCMFWebpackPlugin.prototype.apply = function reactCMFWebpackPluginApply(comp
 		this.lastRun = startTime;
 		this.canRun = false;
 
-		this.modifiedFiles = mergeSettings(this.options, callback);
+		this.mergedSettingsObjects = mergeSettings(this.options, callback, false);
+		console.log('#####', this.mergedSettingsObjects);
+		this.mergedSettingsObjects.forEach(obj => {
+			compilation.assets[path.basename(obj.path)] = new RawSource(JSON.stringify(obj.content));
+		});
 
 		const endTime = Date.now();
 		this.log(`Files merged in ${((endTime - startTime) % 60000) / 1000}s`);

--- a/tools/cmf-webpack-plugin/src/index.js
+++ b/tools/cmf-webpack-plugin/src/index.js
@@ -62,7 +62,7 @@ ReactCMFWebpackPlugin.prototype.apply = function reactCMFWebpackPluginApply(comp
 		this.canRun = false;
 
 		this.mergedSettingsObjects = mergeSettings(this.options, callback, false);
-		console.log('#####', this.mergedSettingsObjects);
+
 		this.mergedSettingsObjects.forEach(obj => {
 			compilation.assets[path.basename(obj.path)] = new RawSource(JSON.stringify(obj.content));
 		});
@@ -86,9 +86,6 @@ ReactCMFWebpackPlugin.prototype.apply = function reactCMFWebpackPluginApply(comp
 			compilationFileDependencies = compilation.fileDependencies;
 		}
 
-		this.modifiedFiles
-			.filter(file => !compilationFileDependencies.has(file))
-			.forEach(file => compilation.fileDependencies.add(file));
 		if (!compilationFileDependencies.has(cmfconfigPath)) {
 			compilation.fileDependencies.add(cmfconfigPath);
 		}

--- a/tools/scripts-cmf/cmf-settings.i18n.js
+++ b/tools/scripts-cmf/cmf-settings.i18n.js
@@ -133,19 +133,22 @@ function parseSettings(i18next, settings, locale) {
   * @param  {string} locale   locale to apply
   * @param  {string} destination destination to write the settings
  */
-function saveSettings(i18next, settings, locale, destination) {
+function saveSettings(i18next, settings, locale, destination, writeToFs = true) {
 	const translatedSetting = parseSettings(i18next, settings, locale);
 
-	mkdirp.sync(path.dirname(destination));
 	const basename = `${path.basename(
 		destination,
 		path.extname(destination),
 	)}.${locale}${path.extname(destination)}`;
 	const filePath = path.join(path.dirname(destination), basename);
-	const file = fs.createWriteStream(filePath);
-	file.write(JSON.stringify(translatedSetting) + String.fromCharCode(10));
-	file.end();
-	getLogger()('Settings created:', `${filePath}  settings has been created`);
+	if (writeToFs) {
+		mkdirp.sync(path.dirname(destination));
+		const file = fs.createWriteStream(filePath);
+		file.write(JSON.stringify(translatedSetting) + String.fromCharCode(10));
+		file.end();
+		getLogger()('Settings created:', `${filePath}  settings has been created`);
+	}
+	return { path: filePath, content: translatedSetting };
 }
 
 /**

--- a/tools/scripts-cmf/cmf-settings.merge.js
+++ b/tools/scripts-cmf/cmf-settings.merge.js
@@ -31,7 +31,7 @@ function getCmfconfig(cmfconfigPath, onError) {
  * @param {function} errorCallback
  * @return Array<string> source files used
  */
-function merge(options, errorCallback) {
+function merge(options, errorCallback, writeToFs = true) {
 	const onErrorCallback = errorCallback || Function.prototype;
 	function onError(...args) {
 		console.error(args); // eslint-disable-line no-console
@@ -126,8 +126,8 @@ function merge(options, errorCallback) {
 		const i18next = getI18Next(languages, cmfconfig.settings.i18n['namespace-paths']);
 
 		if (i18next) {
-			languages.forEach(locale => {
-				saveSettings(i18next, settings, locale, destination);
+			return languages.map(locale => {
+				saveSettings(i18next, settings, locale, destination, writeToFs);
 			});
 		}
 	}
@@ -140,15 +140,18 @@ function merge(options, errorCallback) {
 			},
 			settings,
 		);
-		// Write the merged file
-		logger(`Merge to ${destination}`);
-		mkdirp.sync(path.dirname(destination));
-		const file = fs.createWriteStream(destination);
-		file.write(JSON.stringify(settingWithoutI18n) + String.fromCharCode(10));
-		file.end();
-		logger('CMF settings has been merged');
+		if (writeToFs) {
+			// Write the merged file
+			logger(`Merge to ${destination}`);
+			mkdirp.sync(path.dirname(destination));
+			const file = fs.createWriteStream(destination);
+			file.write(JSON.stringify(settingWithoutI18n) + String.fromCharCode(10));
+			file.end();
+			logger('CMF settings has been merged');
+			return jsonFiles;
+		}
+		return [{ path: destination, content: settingWithoutI18n }];
 	}
-	return jsonFiles;
 }
 
 module.exports = merge;

--- a/tools/scripts-cmf/cmf-settings.merge.js
+++ b/tools/scripts-cmf/cmf-settings.merge.js
@@ -127,7 +127,7 @@ function merge(options, errorCallback, writeToFs = true) {
 
 		if (i18next) {
 			return {
-				sources: jsonfiles,
+				sources: jsonFiles,
 				destination: languages.map(locale =>
 					saveSettings(i18next, settings, locale, destination, writeToFs),
 				),

--- a/tools/scripts-cmf/cmf-settings.merge.js
+++ b/tools/scripts-cmf/cmf-settings.merge.js
@@ -126,9 +126,12 @@ function merge(options, errorCallback, writeToFs = true) {
 		const i18next = getI18Next(languages, cmfconfig.settings.i18n['namespace-paths']);
 
 		if (i18next) {
-			return languages.map(locale =>
-				saveSettings(i18next, settings, locale, destination, writeToFs),
-			);
+			return {
+				sources: jsonfiles,
+				destination: languages.map(locale =>
+					saveSettings(i18next, settings, locale, destination, writeToFs),
+				),
+			};
 		}
 	}
 
@@ -150,7 +153,10 @@ function merge(options, errorCallback, writeToFs = true) {
 			logger('CMF settings has been merged');
 			return jsonFiles;
 		}
-		return [{ path: destination, content: settingWithoutI18n }];
+		return {
+			sources: jsonFiles,
+			destination: [{ path: destination, content: settingWithoutI18n }],
+		};
 	}
 }
 

--- a/tools/scripts-cmf/cmf-settings.merge.js
+++ b/tools/scripts-cmf/cmf-settings.merge.js
@@ -126,9 +126,9 @@ function merge(options, errorCallback, writeToFs = true) {
 		const i18next = getI18Next(languages, cmfconfig.settings.i18n['namespace-paths']);
 
 		if (i18next) {
-			return languages.map(locale => {
-				saveSettings(i18next, settings, locale, destination, writeToFs);
-			});
+			return languages.map(locale =>
+				saveSettings(i18next, settings, locale, destination, writeToFs),
+			);
 		}
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

cmf-settings write file to disk
webpack in dev mode build output in memory.

current project rely on both so ask webpack to watch dist folder which doesn't make sens.

**What is the chosen solution to this problem?**

* add option to cmf-settings to not write file to FS.
* make cmf-webpack-plugin emit RawSource


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
