### PR TITLE
feat(Tabs&Dropdown): add new data-feature & data-testid capabilities

### DIFF
--- a/.changeset/curly-squids-wave.md
+++ b/.changeset/curly-squids-wave.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(Tabs&Dropdown): add new data-feature & data-testid capabilities

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -15,12 +15,12 @@ type DropdownButtonType = Omit<ClickableProps, 'children' | 'as'> & {
 	onClick: () => void;
 	icon?: DeprecatedIconNames;
 	type: 'button';
-};
+} & Partial<DataAttributes>;
 
 type DropdownLinkType = Omit<LinkableType, 'children'> & {
 	label: string;
 	type: 'link';
-};
+} & Partial<DataAttributes>;
 
 type DropdownLabelType = {
 	type: 'title';

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -15,7 +15,7 @@ type DropdownButtonType = Omit<ClickableProps, 'children' | 'as'> & {
 	onClick: () => void;
 	icon?: DeprecatedIconNames;
 	type: 'button';
-} & Partial<DataAttributes>;
+} & DataAttributes;
 
 type DropdownLinkType = Omit<LinkableType, 'children'> & {
 	label: string;

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -20,7 +20,7 @@ type DropdownButtonType = Omit<ClickableProps, 'children' | 'as'> & {
 type DropdownLinkType = Omit<LinkableType, 'children'> & {
 	label: string;
 	type: 'link';
-} & Partial<DataAttributes>;
+} & DataAttributes;
 
 type DropdownLabelType = {
 	type: 'title';

--- a/packages/design-system/src/components/WIP/Tabs/variants/Tabs.tsx
+++ b/packages/design-system/src/components/WIP/Tabs/variants/Tabs.tsx
@@ -24,12 +24,20 @@ const Tabs = forwardRef(
 					{tabs.map((tab, index) => {
 						if (typeof tab.tabTitle === 'string') {
 							return (
-								<Tab {...tabState} size={size} key={index}>
+								<Tab {...tabState} {...tab.tabButtonAttributes} size={size} key={index}>
 									{tab.tabTitle}
 								</Tab>
 							);
 						}
-						return <Tab {...tabState} size={size} key={index} {...tab.tabTitle} />;
+						return (
+							<Tab
+								{...tabState}
+								size={size}
+								key={index}
+								{...tab.tabTitle}
+								{...tab.tabButtonAttributes}
+							/>
+						);
 					})}
 				</TabList>
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

unable to pass data-feature & data-testid to Dropdown items ans Tabs

**What is the chosen solution to this problem?**

add new data-feature & data-testid capabilities

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
