### PR TITLE
fix(ARCH-662/scripts-utils): make it public

### DIFF
--- a/.changeset/warm-tools-live.md
+++ b/.changeset/warm-tools-live.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: msw is broken

--- a/.changeset/wicked-pumpkins-visit.md
+++ b/.changeset/wicked-pumpkins-visit.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-utils': patch
+---
+
+fix: make it public

--- a/tools/scripts-config-storybook-lib/.storybook-templates/msw/mockServiceWorker.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/msw/mockServiceWorker.js
@@ -2,7 +2,7 @@
 /* tslint:disable */
 
 /**
- * Mock Service Worker (0.49.0).
+ * Mock Service Worker (0.49.2).
  * @see https://github.com/mswjs/msw
  * - Please do NOT modify this file.
  * - Please do NOT serve this file on production.

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -33,7 +33,7 @@
     "assert": "^2.0.0",
     "i18next-http-backend": "^1.4.5",
     "lodash": "^4.17.21",
-    "msw": "^0.49.2",
+    "msw": "0.49.2",
     "msw-storybook-addon": "^1.6.3",
     "util": "^0.12.5"
   },
@@ -45,5 +45,8 @@
   },
   "publishConfig": {
     "access": "public"
+  },
+  "msw": {
+    "workerDirectory": ".storybook-templates/msw"
   }
 }

--- a/tools/scripts-utils/package.json
+++ b/tools/scripts-utils/package.json
@@ -21,5 +21,8 @@
   "bugs": {
     "url": "https://github.com/Talend/ui/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/Talend/ui#readme"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -14358,7 +14358,7 @@ msw-storybook-addon@^1.6.3:
     "@storybook/addons" "^6.0.0"
     is-node-process "^1.0.1"
 
-msw@^0.49.2:
+msw@0.49.2:
   version "0.49.2"
   resolved "https://registry.yarnpkg.com/msw/-/msw-0.49.2.tgz#c815fa514a1b3532e3d3af01d308bb63329ad1e2"
   integrity sha512-70/E10f+POE2UmMw16v8PnKatpZplpkUwVRLBqiIdimpgaC3le7y2yOq9JmOrL15jpwWM5wAcPTOj0f550LI3g==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`@talend/scripts-utils` is not public

`@talend/scripts-config-storybook-lib` ask for msw ^0.49.2 but provide a configuration which works with 0.49.0

**What is the chosen solution to this problem?**

make scripts-utils it public 
fix msw dep management.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
