### PR TITLE
fix(ARCH-662/config-webpack): add meta in head if inject is false

### DIFF
--- a/.changeset/large-planes-pull.md
+++ b/.changeset/large-planes-pull.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix: add meta in head if inject is false

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -147,6 +147,12 @@ const meta = VERSIONS.talendLibraries.reduce(
 	},
 );
 
+function renderMeta() {
+	return Object.keys(meta)
+		.map(key => `<meta name="${key}" content="${meta[key]}" />`)
+		.join('\n');
+}
+
 function getCopyConfig(env, userCopyConfig = [], noDynamicCdn) {
 	const config = [...userCopyConfig];
 	const assetsOverridden = config.some(nextAsset =>
@@ -182,7 +188,8 @@ async function getIndexTemplate(env, mode, indexTemplatePath, useInitiator = tru
 		window.basename = '${BASENAME}';
 	</script>`;
 	if (useInitiator) {
-		headScript = `<script type="text/javascript">
+		// meta are not injected if inject is false
+		headScript = `${renderMeta()}<script type="text/javascript">
 			window.basename = '${BASENAME}';
 			var process = { browser: true, env: { NODE_ENV: '${mode}' } };
 			var TALEND_CDN_VERSIONS = {

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -251,6 +251,9 @@ module.exports = ({ getUserConfig, mode }) => {
 			process.cwd(),
 			userHtmlConfig.template || DEFAULT_INDEX_TEMPLATE_PATH,
 		);
+
+		meta['app-id'] = userHtmlConfig.appId || theme;
+
 		const indexTemplate = await getIndexTemplate(
 			env,
 			mode,
@@ -261,8 +264,6 @@ module.exports = ({ getUserConfig, mode }) => {
 		const isEnvDevelopment = mode === 'development';
 		const isEnvProduction = mode === 'production';
 		const b64favicon = icons.getFavicon(theme);
-
-		meta['app-id'] = userHtmlConfig.appId || theme;
 
 		return {
 			mode,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

meta are not added by html-webpack-plugin if inject is set to false.

**What is the chosen solution to this problem?**

add meta in case inject is false

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
