### PR TITLE
fix(TDOPS-3655): change form hint popover to use DS and be aligned

### DIFF
--- a/.changeset/long-hounds-exercise.md
+++ b/.changeset/long-hounds-exercise.md
@@ -1,0 +1,31 @@
+---
+'@talend/react-forms': major
+---
+
+Forms - Change UI Form hint to use design system popover and **fix alignement**
+
+## Breaking changes :
+UI Forms hint definition does not support some properties anymore
+- **id** has been removed, you should rely on **data-test** attributes to target elements
+- **className** has been removed because design system component should not be customized
+
+``` diff
+hint: {
+    overlayComponent: ...,
+-   id: "id",
+-   className: "class",
+}
+```
+
+## New additions :
+UI Forms hint definition can now handle some **data-test** attributes
+- **data-test** has been added to target the hint popover content
+- **icon-data-test** has been added to target the hint icon
+
+``` diff
+hint: {
+    overlayComponent: ...,
++   "data-test": "my-popover-content",
++   "icon-data-test": "my-popover-icon",
+}
+```

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -1,9 +1,7 @@
 import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
 import Message from '../../Message';
-import { I18N_DOMAIN_FORMS } from '../../../constants';
 import theme from './FieldTemplate.module.scss';
 import { ButtonIcon, Popover } from '@talend/design-system';
 
@@ -24,7 +22,6 @@ if (process.env.NODE_ENV !== 'production') {
 }
 
 function FieldTemplate(props) {
-	const { t } = useTranslation(I18N_DOMAIN_FORMS);
 	const groupsClassNames = classNames('form-group', theme.template, props.className, {
 		'has-error': !props.isValid,
 		required: props.required,

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -2,12 +2,10 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Button } from '@talend/react-bootstrap';
-import OverlayTrigger from '@talend/react-components/lib/OverlayTrigger';
-import Icon from '@talend/react-components/lib/Icon';
 import Message from '../../Message';
 import { I18N_DOMAIN_FORMS } from '../../../constants';
 import theme from './FieldTemplate.module.scss';
+import { ButtonIcon, Popover } from '@talend/design-system';
 
 function Label({ id, label, ...rest }) {
 	return (
@@ -21,6 +19,7 @@ if (process.env.NODE_ENV !== 'production') {
 	Label.propTypes = {
 		id: PropTypes.string,
 		label: PropTypes.string,
+		hint: PropTypes.any,
 	};
 }
 
@@ -38,24 +37,19 @@ function FieldTemplate(props) {
 		title = (
 			<div className={theme['field-template-title']}>
 				{title}
-				<OverlayTrigger
-					overlayId={`${props.id}-hint-overlay`}
-					overlayPlacement={props.hint.overlayPlacement || 'right'}
-					overlayComponent={props.hint.overlayComponent}
+				<Popover
+					position={props.hint.overlayPlacement || 'auto'}
+					data-test={props.hint['data-test']}
+					disclosure={
+						<ButtonIcon
+							data-test={props.hint['icon-data-test']}
+							size="S"
+							icon={props.hint.icon || 'talend-info-circle'}
+						></ButtonIcon>
+					}
 				>
-					<Button
-						id={`${props.id}-hint`}
-						bsStyle="link"
-						className={props.hint.className}
-						aria-label={t('FIELD_TEMPLATE_HINT_LABEL', {
-							defaultValue: 'Display the input {{inputLabel}} hint',
-							inputLabel: props.label,
-						})}
-						aria-haspopup
-					>
-						<Icon name={props.hint.icon || 'talend-info-circle'} />
-					</Button>
-				</OverlayTrigger>
+					{props.hint.overlayComponent}
+				</Popover>
 			</div>
 		);
 	}
@@ -82,9 +76,10 @@ if (process.env.NODE_ENV !== 'production') {
 		children: PropTypes.node,
 		hint: PropTypes.shape({
 			icon: PropTypes.string,
-			className: PropTypes.string,
 			overlayComponent: PropTypes.oneOfType([PropTypes.node, PropTypes.string]).isRequired,
 			overlayPlacement: PropTypes.string,
+			'data-test': PropTypes.string,
+			'icon-data-test': PropTypes.string,
 		}),
 		className: PropTypes.string,
 		description: PropTypes.string,

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.test.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.test.js
@@ -57,7 +57,7 @@ describe('FieldTemplate', () => {
 		);
 
 		// then
-		expect(wrapper.find('OverlayTrigger').getElement()).toMatchSnapshot();
+		expect(wrapper.find('Popover').getElement()).toMatchSnapshot();
 	});
 
 	it('should render invalid className', () => {

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
@@ -39,6 +39,7 @@
 			margin-bottom: 0;
 			margin-right: tokens.$coral-spacing-xxs;
 		}
+
 		.tc-svg-icon {
 			fill: tokens.$coral-color-accent-icon;
 		}

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.module.scss
@@ -1,4 +1,5 @@
 @use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+@use '~@talend/design-tokens/lib/tokens';
 
 @import '~@talend/bootstrap-theme/src/theme/animation';
 
@@ -34,13 +35,12 @@
 	align-items: center;
 
 	:global {
-		.btn {
-			padding: 0;
-			margin-left: 5px;
+		.control-label {
+			margin-bottom: 0;
+			margin-right: tokens.$coral-spacing-xxs;
 		}
-
 		.tc-svg-icon {
-			fill: #1476BE;
+			fill: tokens.$coral-color-accent-icon;
 		}
 	}
 }

--- a/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/__snapshots__/FieldTemplate.component.test.js.snap
@@ -66,32 +66,19 @@ exports[`FieldTemplate should render invalid className 1`] = `
 `;
 
 exports[`FieldTemplate should render with hint 1`] = `
-<OverlayTrigger
-  overlayComponent={
-    <span>
-      Tooltip content, which helps to understand what is the purpose of this field
-    </span>
-  }
-  overlayId="myAwesomeField-hint-overlay"
-  overlayPlacement="top"
-  preventScrolling={false}
-  trigger="click"
->
-  <Button
-    active={false}
-    aria-haspopup={true}
-    aria-label="Display the input My awesome label hint"
-    block={false}
-    bsClass="btn"
-    bsStyle="link"
-    disabled={false}
-    id="myAwesomeField-hint"
-  >
-    <Icon
-      name="talend-info-circle"
+<Popover
+  disclosure={
+    <ButtonIcon
+      icon="talend-info-circle"
+      size="S"
     />
-  </Button>
-</OverlayTrigger>
+  }
+  position="top"
+>
+  <span>
+    Tooltip content, which helps to understand what is the purpose of this field
+  </span>
+</Popover>
 `;
 
 exports[`FieldTemplate should render with label after 1`] = `


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
change form hint popover to use DS and be aligned

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
