### PR TITLE
chore(ARCH-662): add popover disclosure to rendered unit test

### DIFF
--- a/.changeset/smart-hats-yell.md
+++ b/.changeset/smart-hats-yell.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-jest': patch
+---
+
+Add popover disclosure to rendered unit test

--- a/packages/storybook/src/design-system/Popover/Popover.stories.tsx
+++ b/packages/storybook/src/design-system/Popover/Popover.stories.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { forwardRef, Ref } from 'react';
 
 import { action } from '@storybook/addon-actions';
 import { PopoverStateReturn } from 'reakit/ts';
@@ -11,11 +11,14 @@ export default {
 
 const EasyPopover = () => <StackVertical gap="S">Hello hello</StackVertical>;
 
-const OpenPopover = (props: PopoverDisclosureHTMLProps) => (
-	<ButtonPrimary onClick={action('Clicked disclosure')} {...props}>
-		Open popover
-	</ButtonPrimary>
-);
+/* eslint-disable-next-line react/display-name */
+const OpenPopover = forwardRef((props: PopoverDisclosureHTMLProps, ref: Ref<HTMLButtonElement>) => {
+	return (
+		<ButtonPrimary onClick={action('Clicked disclosure')} {...props} ref={ref}>
+			Open popover
+		</ButtonPrimary>
+	);
+});
 
 export const DefaultStory = () => (
 	<div style={{ padding: '1.2rem' }}>

--- a/tools/scripts-config-jest/test-setup.js
+++ b/tools/scripts-config-jest/test-setup.js
@@ -187,14 +187,21 @@ try {
 
 		function getMock(name) {
 			const mockName = `Coral${name}`;
-			function Component(props) {
-				return React.createElement('span', {
-					...props,
-					className: classnames(mockName, props.className),
-				});
+			function Component({ disclosure, children, ...props }) {
+				return React.createElement(
+					'span',
+					{
+						...props,
+						className: classnames(mockName, props.className),
+					},
+					disclosure,
+					children,
+				);
 			}
 			Component.displayName = name;
 			Component.propTypes = {
+				disclosure: propTypes.element,
+				children: propTypes.element,
 				className: propTypes.string,
 			};
 			return Component;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Popover disclosure in jest test is not rendered

**What is the chosen solution to this problem?**
Add the disclosure next to children in the jest mock

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
