### PR TITLE
fix: injecticon support : in id

### DIFF
--- a/.changeset/grumpy-rice-exist.md
+++ b/.changeset/grumpy-rice-exist.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: you can use Icon instead of sizedicon if you want for your custom icons

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.spec.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.spec.tsx
@@ -1,6 +1,7 @@
+/* eslint-disable testing-library/prefer-screen-queries */
 import React from 'react';
 
-import { IconsProvider } from '.';
+import { IconsProvider, Icon } from '.';
 
 context('<IconsProvider />', () => {
 	it('should render', () => {
@@ -63,5 +64,13 @@ context('<IconsProvider />', () => {
 		cy.mount(<IconsProvider bundles={[]} additionalBundles={additionalBundles} />);
 		cy.getByTest('other-icons').should('to.exist');
 		cy.getByTest('more-icons').should('to.exist');
+	});
+	it('should support additionalBundles props', () => {
+		cy.mount(
+			<>
+				<IconsProvider />
+				<Icon name="folder-closed:L" />
+			</>,
+		);
 	});
 });

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
@@ -63,7 +63,7 @@ function getAllFilterIds() {
  * @param {Element} container
  */
 function injectIcon(id: string, container: Element) {
-	const element = document.querySelector(`${ICONS_PROVIDER_CLASS} #${id}`);
+	const element = document.querySelector(`${ICONS_PROVIDER_CLASS} #${id.replace(':', '\\:')}`);
 	if (element) {
 		while (container.hasChildNodes()) {
 			const lastChild = container.lastChild;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current collection of icons contains double dot `:` characters which make it impossible to use with Icon component.

**What is the chosen solution to this problem?**

Fix injectIcons so it will just work

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
