### PR TITLE
fix(ARCH-658/storybook): add support for import scss file

### DIFF
--- a/.changeset/mean-emus-kneel.md
+++ b/.changeset/mean-emus-kneel.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': patch
+---
+
+fix: support for import of scss file without css module

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -49,6 +49,31 @@ const defaultMain = {
 	},
 	typescript: { reactDocgen: false },
 	webpackFinal: async (config) => {
+		// by default storybook do not support scss without css module
+		// here we remove storybook scss config and replace it by our config
+		const rules = [
+			...config.module.rules.filter(rule => {
+				return !rule.test?.toString().includes('s[ca]ss');
+			}),
+			{
+				test: /\.html$/,
+				use: [
+					{ loader: 'cache-loader' },
+					{ loader: 'ngtemplate-loader' },
+					{ loader: 'html-loader', options: { esModule: false } },
+				],
+				exclude: path.resolve(process.cwd(), 'src', 'app', 'index.html'),
+			},
+			{
+				test: /\.scss$/,
+				exclude: /\.module\.scss$/,
+				use: getSassLoaders(false, '', true),
+			},
+			{
+				test: /\.module\.scss$/,
+				use: getSassLoaders(true, '', true),
+			},
+		];
 		const mergedConfig = {
 			...config,
 			plugins: [
@@ -58,6 +83,7 @@ const defaultMain = {
 					exclude: Object.keys(getAllModules()).filter(name => name.match(/^(@talend\/|angular)/))
 				}),
 			],
+			rules,
 			resolve: {
 				extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.css', '.scss'],
 			},

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -3,6 +3,9 @@ const { merge } = require('lodash');
 const path = require('path');
 const CDNPlugin = require('@talend/dynamic-cdn-webpack-plugin');
 const { getAllModules } = require('@talend/module-to-cdn');
+const {
+	getSassLoaders,
+} = require('@talend/scripts-config-react-webpack/config/webpack.config.common');
 
 const { fixWindowsPaths } = require('./utils');
 
@@ -76,6 +79,10 @@ const defaultMain = {
 		];
 		const mergedConfig = {
 			...config,
+			module: {
+				...config.module,
+				rules,
+			},
 			plugins: [
 				...config.plugins,
 				// use dynamic-cdn-webpack-plugin with default modules
@@ -83,7 +90,6 @@ const defaultMain = {
 					exclude: Object.keys(getAllModules()).filter(name => name.match(/^(@talend\/|angular)/))
 				}),
 			],
-			rules,
 			resolve: {
 				extensions: ['.js', '.jsx', '.ts', '.tsx', '.json', '.css', '.scss'],
 			},

--- a/tools/scripts-config-storybook-lib/.storybook-templates/main.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/main.js
@@ -59,15 +59,6 @@ const defaultMain = {
 				return !rule.test?.toString().includes('s[ca]ss');
 			}),
 			{
-				test: /\.html$/,
-				use: [
-					{ loader: 'cache-loader' },
-					{ loader: 'ngtemplate-loader' },
-					{ loader: 'html-loader', options: { esModule: false } },
-				],
-				exclude: path.resolve(process.cwd(), 'src', 'app', 'index.html'),
-			},
-			{
 				test: /\.scss$/,
 				exclude: /\.module\.scss$/,
 				use: getSassLoaders(false, '', true),

--- a/tools/scripts-config-storybook-lib/package.json
+++ b/tools/scripts-config-storybook-lib/package.json
@@ -29,6 +29,7 @@
     "@storybook/preset-scss": "^1.0.3",
     "@storybook/react": "^6.5.16",
     "@storybook/testing-library": "^0.0.13",
+    "@talend/scripts-config-react-webpack": "^15.2.6",
     "@talend/dynamic-cdn-webpack-plugin": "^13.0.0",
     "assert": "^2.0.0",
     "i18next-http-backend": "^1.4.5",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current storybook default config do not support the following syntax:
```
import './Component.scss';
```

since with preset we have also removed also the merge of scripts-config-react-webpack this behavior is broken in current project as the scss is imported with css module in mind.

**What is the chosen solution to this problem?**

remove scss config from storybook and add our configuration (same as create-react-app)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
