### PR TITLE
fix(TDOPS-421): faceted search should allow list of flat tags or object

### DIFF
--- a/.changeset/kind-schools-shop.md
+++ b/.changeset/kind-schools-shop.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': minor
+---
+
+Faceted search - Tags faceted should allow a list of flat tags or objects

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -1,4 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
+import isObject from 'lodash/isObject';
 import PropTypes from 'prop-types';
 import Badge from '@talend/react-components/lib/Badge';
 import { BadgeTagsForm } from './BadgeTagsForm.component';
@@ -58,7 +59,14 @@ export const BadgeTags = ({
 		callbacks
 			.getTags()
 			.then(data => {
-				setTagsValues(data.map(item => ({ id: item, label: item })));
+				setTagsValues(
+					data.map(item => {
+						if (isObject(item)) {
+							return { id: item.id, label: item.label };
+						}
+						return { id: item, label: item };
+					}),
+				);
 			})
 			.finally(() => {
 				setIsLoading(false);

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.test.js
@@ -1,0 +1,74 @@
+import React from 'react';
+
+import { BadgeTags } from './BadgeTags.component';
+import { BadgeFacetedProvider } from '../../context/badgeFaceted.context';
+import { render, screen, waitFor } from '@testing-library/react';
+import getDefaultT from '../../../translate';
+
+jest.mock('ally.js');
+
+const badgeFacetedContextValue = {
+	onDeleteBadge: jest.fn(),
+	onHideOperator: jest.fn(),
+	onSubmitBadge: jest.fn(),
+};
+
+describe('BadgeText', () => {
+	it('should mount a badge with flat data from callback', async () => {
+		// Given
+		const callbacks = {
+			getTags: () => new Promise(resolve => resolve(['production'])),
+		};
+
+		const props = {
+			id: 'myId',
+			label: 'myLabel',
+			initialOperatorOpened: false,
+			initialValueOpened: true,
+			operators: ['in'],
+			callbacks,
+			t: getDefaultT(),
+		};
+
+		// When
+		render(
+			<BadgeFacetedProvider value={badgeFacetedContextValue}>
+				<BadgeTags {...props} />
+			</BadgeFacetedProvider>,
+		);
+
+		// Then there is a checkbox with data taken from callback
+		await waitFor(() => {
+			expect(screen.getByRole('checkbox', { name: 'production' })).toBeVisible();
+		});
+	});
+
+	it('should mount a badge with object data from callback', async () => {
+		// Given
+		const callbacks = {
+			getTags: () => new Promise(resolve => resolve([{ id: '1234', label: 'production' }])),
+		};
+
+		const props = {
+			id: 'myId',
+			label: 'myLabel',
+			initialOperatorOpened: false,
+			initialValueOpened: true,
+			operators: ['in'],
+			callbacks,
+			t: getDefaultT(),
+		};
+
+		// When
+		render(
+			<BadgeFacetedProvider value={badgeFacetedContextValue}>
+				<BadgeTags {...props} />
+			</BadgeFacetedProvider>,
+		);
+
+		// Then there is a checkbox with data taken from callback
+		await waitFor(() => {
+			expect(screen.getByRole('checkbox', { name: 'production' })).toBeVisible();
+		});
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Faceted search should allow list of flat tags or object

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
