### PR TITLE
doc(icons): allow to download icons on doc

### DIFF
--- a/packages/icons/stories/Icon.tsx
+++ b/packages/icons/stories/Icon.tsx
@@ -3,8 +3,8 @@ import { useCopyToClipboard } from 'react-use';
 
 import tokens from '@talend/design-tokens';
 
-import metadata from '../src/metadata.json';
 import { infoFromFigma as icons } from '../dist/info';
+import metadata from '../src/metadata.json';
 
 const iconColorTokens = {
 	'neutral/icon': tokens.coralColorNeutralIcon,
@@ -225,10 +225,28 @@ export const IconItem = ({
 }) => {
 	const searchContext = React.useContext(SearchContext);
 	const [, copyToClipboard] = useCopyToClipboard();
-	const onClickHandler = () => {
+
+	const onTextClickHandler = () => {
 		const nameToCopy = name.split(':')[0];
 		copyToClipboard(nameToCopy);
 		alert(`"${nameToCopy}" has been copied to clipboard`);
+	};
+
+	const onIconClickHandler = () => {
+		var svgData = document.getElementById(`${name}:${size}`)?.getElementsByTagName('svg')[0];
+		if (svgData) {
+			svgData.removeAttribute('width');
+			svgData.removeAttribute('height');
+
+			var svgBlob = new Blob([svgData?.outerHTML], { type: 'image/svg+xml;charset=utf-8' });
+			var svgUrl = URL.createObjectURL(svgBlob);
+			var downloadLink = document.createElement('a');
+			downloadLink.href = svgUrl;
+			downloadLink.download = `${name}-${size}.svg`;
+			document.body.appendChild(downloadLink);
+			downloadLink.click();
+			document.body.removeChild(downloadLink);
+		}
 	};
 	const iconMetadata = metadata.find(data => data.name.endsWith(size + '/' + name));
 	const isFound = size
@@ -240,64 +258,73 @@ export const IconItem = ({
 	return (
 		<div {...rest}>
 			{isFound ? (
-				<div role="button" onClick={onClickHandler} onKeyPress={onClickHandler} tabIndex={0}>
+				<div
+					style={{
+						display: 'flex',
+						gap: tokens.coralSpacingM,
+						paddingBlock: tokens.coralSpacingXs,
+					}}
+				>
 					<div
 						style={{
 							display: 'flex',
-							gap: tokens.coralSpacingM,
-							paddingBlock: tokens.coralSpacingXs,
+							justifyContent: 'center',
+							alignItems: 'center',
+							width: tokens.coralSizingM,
+							height: tokens.coralSizingM,
+							border: `${tokens.coralBorderSSolid} ${tokens.coralColorNeutralBorderWeak}`,
+							boxShadow: tokens.coralElevationShadowAccent,
+							borderRadius: tokens.coralRadiusS,
 						}}
 					>
 						<div
-							style={{
-								display: 'flex',
-								justifyContent: 'center',
-								alignItems: 'center',
-								width: tokens.coralSizingM,
-								height: tokens.coralSizingM,
-								border: `${tokens.coralBorderSSolid} ${tokens.coralColorNeutralBorderWeak}`,
-								boxShadow: tokens.coralElevationShadowAccent,
-								borderRadius: tokens.coralRadiusS,
-							}}
+							role="button"
+							onClick={onIconClickHandler}
+							onKeyPress={onIconClickHandler}
+							tabIndex={0}
 						>
 							<Icon size={size} name={name} />
 						</div>
-						<div
-							style={{
-								flex: 1,
-								font: tokens.coralParagraphM,
-							}}
-						>
-							{size ? (
-								<dl
-									style={{
-										display: 'grid',
-										gridTemplateColumns: '1fr 3fr',
-									}}
-								>
-									<dt>Name</dt>
-									<dd>{name}</dd>
-									{size && (
+					</div>
+					<div
+						role="button"
+						onClick={onTextClickHandler}
+						onKeyPress={onTextClickHandler}
+						tabIndex={0}
+						style={{
+							flex: 1,
+							font: tokens.coralParagraphM,
+						}}
+					>
+						{size ? (
+							<dl
+								style={{
+									display: 'grid',
+									gridTemplateColumns: '1fr 3fr',
+								}}
+							>
+								<dt>Name</dt>
+								<dd>{name}</dd>
+								{size && (
+									<>
+										<dt>Size</dt>
+										<dd>{size}</dd>
+									</>
+								)}
+								{iconMetadata &&
+									'description' in iconMetadata &&
+									iconMetadata.description.length > 0 && (
 										<>
-											<dt>Size</dt>
-											<dd>{size}</dd>
+											<dt style={{ color: tokens.coralColorNeutralTextWeak }}>Desc</dt>
+											<dd style={{ color: tokens.coralColorNeutralTextWeak }}>
+												{iconMetadata.description}
+											</dd>
 										</>
 									)}
-									{iconMetadata &&
-										'description' in iconMetadata &&
-										iconMetadata.description.length > 0 && (
-											<>
-												<dt style={{ color: tokens.coralColorNeutralTextWeak }}>Desc</dt>
-												<dd style={{ color: tokens.coralColorNeutralTextWeak }}>
-													{iconMetadata.description}
-												</dd>
-											</>
-										)}
-								</dl>
-							) : (
-								<span>{name}</span>
-							)}
-						</div>
+							</dl>
+						) : (
+							<span>{name}</span>
+						)}
 					</div>
 				</div>
 			) : (

--- a/packages/icons/stories/Icon.tsx
+++ b/packages/icons/stories/Icon.tsx
@@ -277,19 +277,13 @@ export const IconItem = ({
 							borderRadius: tokens.coralRadiusS,
 						}}
 					>
-						<div
-							role="button"
-							onClick={onIconClickHandler}
-							onKeyPress={onIconClickHandler}
-							tabIndex={0}
-						>
+						<div role="button" onClick={onIconClickHandler} tabIndex={0}>
 							<Icon size={size} name={name} />
 						</div>
 					</div>
 					<div
 						role="button"
 						onClick={onTextClickHandler}
-						onKeyPress={onTextClickHandler}
 						tabIndex={0}
 						style={{
 							flex: 1,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
To share icons with pre-sales / other teams, we would like to make the icons downloadable (without having to go to github)
(could be also a link to the icon in github, could be fine for me)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
