### PR TITLE
feat(TDOPS-3583): data tracking attribute in checkbox

### DIFF
--- a/.changeset/tidy-years-wonder.md
+++ b/.changeset/tidy-years-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TDOPS-3583): data tracking attribute in checkbox

--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -3,10 +3,11 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 
-export default function Checkbox({ id, className, label, link, intermediate, ...props }) {
+export default function Checkbox({ id, className, label, intermediate, ...props }) {
 	let dataFeature;
 	let dataChecked = 0;
-	console.log('!!!!!!!!!!!!! ', props);
+	const dataTracking = `${props['data-tracking']}-${props.checked ? 'on' : 'off'}`;
+
 	if (!props.disabled && props['data-feature']) {
 		dataFeature = props['data-feature'];
 		dataFeature += props.checked ? '.disable' : '.enable';
@@ -33,11 +34,10 @@ export default function Checkbox({ id, className, label, link, intermediate, ...
 					type="checkbox"
 					id={id}
 					data-checked={dataChecked}
-					data-tracking={`${props['data-tracking']}-${props.checked ? 'on' : 'off'}`}
-					{...omit(props, 'data-feature')}
+					data-tracking={dataTracking}
+					{...omit(props, ['data-feature', 'data-tracking'])}
 				/>
 				<span>{label}</span>
-				{link}
 			</label>
 		</div>
 	);
@@ -55,7 +55,6 @@ Checkbox.defaultProps = {
 Checkbox.propTypes = {
 	id: PropTypes.string.isRequired,
 	label: PropTypes.node,
-	link: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	onBlur: PropTypes.func,
 	checked: PropTypes.bool,

--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -6,7 +6,11 @@ import omit from 'lodash/omit';
 export default function Checkbox({ id, className, label, intermediate, ...props }) {
 	let dataFeature;
 	let dataChecked = 0;
-	const dataTracking = `${props['data-tracking']}-${props.checked ? 'on' : 'off'}`;
+	let dataTracking;
+
+	if (props['data-tracking']) {
+		dataTracking = `${props['data-tracking']}-${props.checked ? 'on' : 'off'}`;
+	}
 
 	if (!props.disabled && props['data-feature']) {
 		dataFeature = props['data-feature'];

--- a/packages/components/src/Checkbox/Checkbox.js
+++ b/packages/components/src/Checkbox/Checkbox.js
@@ -3,10 +3,10 @@ import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
 
-export default function Checkbox({ id, className, label, intermediate, ...props }) {
+export default function Checkbox({ id, className, label, link, intermediate, ...props }) {
 	let dataFeature;
 	let dataChecked = 0;
-
+	console.log('!!!!!!!!!!!!! ', props);
 	if (!props.disabled && props['data-feature']) {
 		dataFeature = props['data-feature'];
 		dataFeature += props.checked ? '.disable' : '.enable';
@@ -33,9 +33,11 @@ export default function Checkbox({ id, className, label, intermediate, ...props 
 					type="checkbox"
 					id={id}
 					data-checked={dataChecked}
+					data-tracking={`${props['data-tracking']}-${props.checked ? 'on' : 'off'}`}
 					{...omit(props, 'data-feature')}
 				/>
 				<span>{label}</span>
+				{link}
 			</label>
 		</div>
 	);
@@ -53,6 +55,7 @@ Checkbox.defaultProps = {
 Checkbox.propTypes = {
 	id: PropTypes.string.isRequired,
 	label: PropTypes.node,
+	link: PropTypes.node,
 	onChange: PropTypes.func.isRequired,
 	onBlur: PropTypes.func,
 	checked: PropTypes.bool,
@@ -60,5 +63,6 @@ Checkbox.propTypes = {
 	disabled: PropTypes.bool,
 	intermediate: PropTypes.bool,
 	className: PropTypes.string,
+	'data-tracking': PropTypes.string,
 	'data-feature': PropTypes.string,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
In TMC we use separate "data-tracking" attribute to track the element in Pendo, and avoid impact on Pendo when using another attributes (for example "id", "data-test" may be changed, and "data-tracking" is used only for Pendo)
For checkbox we need to track it's checked and unchecked state
Would be nice to have it in TUI component, otherwise we will need to create wrapper component, one more level, just to have access to "checked" property and handle "data-tracking" attribute for different checkbox state

**What is the chosen solution to this problem?**
Having "data-tracking" attribute can be useful for other Teams who may need to do similar tracking with Pendo, so, with this change we will be able to pass "data-tracking" in ui schema, and the component will append "on" or "offf" depending on checkbox state

https://jira.talendforge.org/browse/TDOPS-3583

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
