### PR TITLE
fix(TDOPS-421/facetedsearch/Badge): check if value has changed before setState

### DIFF
--- a/.changeset/khaki-jars-juggle.md
+++ b/.changeset/khaki-jars-juggle.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+TDOPS-421 - Fix faceted search submit at launch and badge sync on value and operator

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 import PropTypes from 'prop-types';
 import Badge from '@talend/react-components/lib/Badge';
 import { getTheme } from '@talend/react-components/lib/theme';
@@ -14,6 +14,7 @@ import { BADGES_ACTIONS } from '../../../hooks/facetedBadges.hook';
 
 import { operatorPropTypes, operatorsPropTypes } from '../../facetedSearch.propTypes';
 import { USAGE_TRACKING_TAGS } from '../../../constants';
+import { isEqual } from 'lodash';
 
 const theme = getTheme(cssModule);
 
@@ -46,6 +47,15 @@ const BadgeFaceted = ({
 	const { dispatch } = useBadgeFacetedContext();
 	const [badgeOperator, setBadgeOperator] = useState(operator);
 	const [badgeValue, setBadgeValue] = useState(value);
+
+	useEffect(() => {
+		if (!isEqual(value, badgeValue)) {
+			setBadgeValue(value);
+		}
+		if (!isEqual(operator, badgeOperator)) {
+			setBadgeOperator(operator);
+		}
+	}, [value, operator]);
 
 	const onChangeOperator = (_, operatorName) => {
 		const foundOperator = operators.find(findOperatorByName(operatorName));

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useRef, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 import get from 'lodash/get';
 
@@ -28,6 +28,7 @@ import {
 import theme from './BasicSearch.module.scss';
 import { USAGE_TRACKING_TAGS } from '../../constants';
 import { DEFAULT_QUICKSEARCH_OPERATOR } from '../QuickSearchInput/QuickSearchInput.component';
+import { isEqual } from 'lodash';
 
 const css = getTheme(theme);
 
@@ -66,8 +67,11 @@ const BasicSearch = ({
 		[badgesDefinitions],
 	);
 
+	const [badgeState, setBadgeState] = useState(state.badges);
+
 	useEffect(() => {
-		if (!state.badges.some(isInCreation)) {
+		if (!state.badges.some(isInCreation) && !isEqual(badgeState, state.badges)) {
+			setBadgeState(state.badges);
 			onSubmit({}, state.badges);
 		}
 	}, [state.badges, onSubmit]);

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.test.js
@@ -5,6 +5,7 @@ import { mount } from 'enzyme';
 import { BasicSearch } from './BasicSearch.component';
 import { FacetedManager } from '../FacetedManager';
 import { USAGE_TRACKING_TAGS } from '../../constants';
+import { render } from '@testing-library/react';
 
 describe('BasicSearch', () => {
 	const badgeText = {
@@ -169,54 +170,90 @@ describe('BasicSearch', () => {
 		});
 		expect(wrapper.find('[role="option"]')).toHaveLength(0);
 	});
+	it('should not trigger onSubmit when badge definition has not changed', () => {
+		// given
+		const onSubmit = jest.fn();
+		const props = {
+			badgesDefinitions,
+			onSubmit,
+		};
+		// when
+		const { rerender } = render(
+			<FacetedManager id="manager-id">
+				<BasicSearch {...props} />
+			</FacetedManager>,
+		);
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		rerender(
+			<FacetedManager id="manager-id">
+				<BasicSearch {...props} />
+			</FacetedManager>,
+		);
+		// then
+		expect(onSubmit).not.toHaveBeenCalled();
+	});
 	it('should not trigger onSubmit when a badge is in creation', () => {
 		// given
 		const onSubmit = jest.fn();
 		const props = {
 			badgesDefinitions,
-			badgesFaceted,
 			onSubmit,
 		};
 		// when
-		const wrapper = mount(
+		const { rerender } = render(
 			<FacetedManager id="manager-id">
 				<BasicSearch {...props} />
 			</FacetedManager>,
 		);
-		wrapper.update();
-		// then
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		rerender(
+			<FacetedManager id="manager-id">
+				<BasicSearch {...props} badgesFaceted={badgesFaceted} />
+			</FacetedManager>,
+		);
+
 		expect(onSubmit).not.toHaveBeenCalled();
 	});
-	it('should trigger onSubmit when no badge is in creation', () => {
+
+	it('should trigger onSubmit when no badge is in creation and badge definition has changed', () => {
 		// given
 		const onSubmit = jest.fn();
 		const props = {
 			badgesDefinitions,
-			badgesFaceted: {
-				badges: [
-					{
-						...badgeText,
-						metadata: {
-							...badgeText.metadata,
-							isInCreation: false,
-						},
-					},
-				],
-			},
 			onSubmit,
 		};
+		const badgesFacetedNotInCreation = {
+			badges: [
+				{
+					...badgeText,
+					metadata: {
+						...badgeText.metadata,
+						isInCreation: false,
+					},
+				},
+			],
+		};
 		// when
-		const wrapper = mount(
+		const { rerender } = render(
 			<FacetedManager id="manager-id">
 				<BasicSearch {...props} />
 			</FacetedManager>,
 		);
-		wrapper.update();
+		expect(onSubmit).not.toHaveBeenCalled();
+
+		rerender(
+			<FacetedManager id="manager-id">
+				<BasicSearch {...props} badgesFaceted={badgesFacetedNotInCreation} />
+			</FacetedManager>,
+		);
+
 		// then
 		expect(onSubmit).toHaveBeenCalled();
 		expect(onSubmit.mock.calls.length).toBe(1);
 		expect(onSubmit.mock.calls[0][0]).toEqual({});
-		expect(onSubmit.mock.calls[0][1]).toEqual(props.badgesFaceted.badges);
+		expect(onSubmit.mock.calls[0][1]).toEqual(badgesFacetedNotInCreation.badges);
 	});
 
 	it('should not show add filter button when no badge definitions provided', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Faceted search will trigger onSubmit too often especially on component creation 
And badges don't get updated when definition changes for values and operator

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
