### PR TITLE
fix(TDP-11751): VirtualizedList allowing height control

### DIFF
--- a/.changeset/dry-impalas-bow.md
+++ b/.changeset/dry-impalas-bow.md
@@ -2,4 +2,4 @@
 '@talend/react-components': minor
 ---
 
-fix(TDP-11751): Reduce whitespace on run flow
+fix(TDP-11751): adding the possibility to set a specific height to the table and disable autosizer

--- a/.changeset/dry-impalas-bow.md
+++ b/.changeset/dry-impalas-bow.md
@@ -2,4 +2,4 @@
 '@talend/react-components': minor
 ---
 
-fix(TDP-11751): adding the possibility to set a specific height to the table and disable autosizer
+feat(TDP-11751): adding the possibility to set a specific height to the table and disable autosizer

--- a/.changeset/dry-impalas-bow.md
+++ b/.changeset/dry-impalas-bow.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+fix(TDP-11751): Reduce whitespace on run flow

--- a/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
+++ b/packages/components/src/VirtualizedList/ListTable/ListTable.component.js
@@ -51,6 +51,7 @@ function ListTable(props) {
 		onRowDoubleClick,
 		rowCount,
 		headerAction,
+		headerHeight = 40,
 		...restProps
 	} = props;
 
@@ -77,7 +78,7 @@ function ListTable(props) {
 			<VirtualizedTable
 				className={css('tc-list-table', { 'right-action': !!headerAction })}
 				gridClassName={`${theme.grid} ${DROPDOWN_CONTAINER_CN}`}
-				headerHeight={40}
+				headerHeight={headerHeight}
 				id={id}
 				onRowClick={onRowClickCallback}
 				onRowDoubleClick={onRowDoubleClickCallback}
@@ -115,6 +116,7 @@ ListTable.propTypes = {
 	width: PropTypes.number,
 	rowCount: PropTypes.number,
 	headerAction: PropTypes.element,
+	headerHeight: PropTypes.number,
 };
 
 ListTable.defaultProps = {

--- a/packages/components/src/VirtualizedList/RendererSelector.component.js
+++ b/packages/components/src/VirtualizedList/RendererSelector.component.js
@@ -71,6 +71,7 @@ class RendererSelector extends React.Component {
 			scrollToIndex,
 			scrollToAlignment,
 			headerAction,
+			headerHeight,
 		} = this.props;
 
 		const collection = inProgress ? [] : this.props.collection;
@@ -106,6 +107,7 @@ class RendererSelector extends React.Component {
 				sortBy,
 				sortDirection,
 				headerAction,
+				headerHeight,
 			};
 		} else {
 			ListRenderer = ListGrid;

--- a/packages/components/src/VirtualizedList/VirtualizedList.component.js
+++ b/packages/components/src/VirtualizedList/VirtualizedList.component.js
@@ -49,6 +49,8 @@ function VirtualizedList(props) {
 		widthsOfColumns,
 		setWidthsOfColumns,
 		headerAction,
+		headerHeight,
+		disableHeight = false,
 	} = props;
 	const columnDefinitionsWithSelection = insertSelectionConfiguration({
 		children,
@@ -89,7 +91,7 @@ function VirtualizedList(props) {
 
 	return (
 		<virtualizedListContext.Provider value={{ resizeColumn }}>
-			<AutoSizer>
+			<AutoSizer disableHeight={disableHeight}>
 				{({ height, width }) => (
 					<RendererSelector
 						ref={rendererSelectorRef}
@@ -118,6 +120,7 @@ function VirtualizedList(props) {
 						scrollToIndex={scrollToIndex}
 						scrollToAlignment={scrollToAlignment}
 						headerAction={headerAction}
+						headerHeight={headerHeight}
 					>
 						{columnDefinitions}
 					</RendererSelector>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
- ReactVirtualized table list has a fixed height

**What is the chosen solution to this problem?**
- Added parameters to allow the developer to choose between controlling the height of the table list manually or let ReactVirtualized dependency handle it

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
