### PR TITLE
feat(design-system): Modal with no close button

### DIFF
--- a/.changeset/young-poets-cheer.md
+++ b/.changeset/young-poets-cheer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(design-system): Modal have no close button if preventEscaping is on

--- a/packages/design-system/src/components/Modal/Modal.spec.tsx
+++ b/packages/design-system/src/components/Modal/Modal.spec.tsx
@@ -69,6 +69,17 @@ context('<Modal />', () => {
 			});
 	});
 
+	it('should not have cancel/close action when preventEscaping is passed', () => {
+		// when
+		cy.mount(
+			<ModalStory header={{ title: 'No disclosure modal' }} preventEscaping>
+				<p>A basic modal with only a title and a text content.</p>
+			</ModalStory>,
+		);
+		cy.getByTest('open-modal').click();
+		cy.getByTestId('modal.buttons.close').should('not.exist');
+	});
+
 	it('should close the modal on ESC key', () => {
 		// when
 		cy.mount(

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -120,17 +120,19 @@ function Modal(props: ModalPropsType): ReactElement {
 
 								<div className={styles.modal__buttons} data-test="modal.buttons">
 									<StackHorizontal gap="XS" justify="end">
-										<span className={styles['close-button']}>
-											<ButtonSecondary
-												onClick={() => onCloseHandler()}
-												data-testid="modal.buttons.close"
-												data-feature="modal.buttons.close"
-											>
-												{primaryAction || secondaryAction
-													? t('CANCEL', 'Cancel')
-													: t('CLOSE', 'Close')}
-											</ButtonSecondary>
-										</span>
+										{!preventEscaping && (
+											<span className={styles['close-button']}>
+												<ButtonSecondary
+													onClick={() => onCloseHandler()}
+													data-testid="modal.buttons.close"
+													data-feature="modal.buttons.close"
+												>
+													{primaryAction || secondaryAction
+														? t('CANCEL', 'Cancel')
+														: t('CLOSE', 'Close')}
+												</ButtonSecondary>
+											</span>
+										)}
 
 										{secondaryAction && (
 											<ButtonSecondary

--- a/packages/storybook/src/design-system/Modal/Modal.stories.tsx
+++ b/packages/storybook/src/design-system/Modal/Modal.stories.tsx
@@ -212,9 +212,10 @@ export const WithDestructivePrimaryAction: ComponentStory<typeof Modal> = props 
 );
 
 export const WithNonClosingBackdrop: ComponentStory<typeof Modal> = props => (
-	<ModalStory {...props} header={{ title: 'With non closing backdrop' }} preventEscaping>
+	<ModalStory {...props} header={{ title: 'A blocking modal' }} preventEscaping>
 		<p>
-			A modal that doesn't trigger <code>onClose</code> when the backdrop is clicked.
+			A modal that doesn't trigger <code>onClose</code> when the backdrop is clicked and without the
+			close button
 		</p>
 	</ModalStory>
 );


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Modal could not have footer for blocking modal
https://www.figma.com/file/0Jolh2prAAdfO5224n3OU3/Modal?node-id=0%3A43&t=jC711zj8e1yDtQDu-1

**What is the chosen solution to this problem?**
Use the current prop to display or not the cancel button

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
