### PR TITLE
test(ARCH-658): add coverage report

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -2,8 +2,6 @@ name: PR tests
 
 on:
   pull_request:
-  push:
-    branches: [master, maintenance/*]
 
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -32,4 +32,24 @@ jobs:
         run: yarn install --frozen-lockfile
 
       - name: Test
-        run: yarn test
+        run: yarn test --coverage --coverageReporters json-summary
+
+      - name: Jest Coverage Comment
+        uses: MishaKav/jest-coverage-comment@c0e038bed569d269190b056a59b29e0593eccc0a #1.0.22
+        with:
+          multiple-files: |
+            assets-api, ./packages/assets-api/coverage/coverage-summary.json
+            cmf, ./packages/cmf/coverage/coverage-summary.json
+            cmf-cqrs, ./packages/cmf-cqrs/coverage/coverage-summary.json
+            cmf-router, ./packages/cmf-router/coverage/coverage-summary.json
+            components, ./packages/components/coverage/coverage-summary.json
+            containers, ./packages/containers/coverage/coverage-summary.json
+            dataviz, ./packages/dataviz/coverage/coverage-summary.json
+            design-system, ./packages/design-system/coverage/coverage-summary.json
+            faceted-search, ./packages/faceted-search/coverage/coverage-summary.json
+            flow-designer, ./packages/flow-designer/coverage/coverage-summary.json
+            forms, ./packages/forms/coverage/coverage-summary.json
+            http, ./packages/http/coverage/coverage-summary.json
+            sagas, ./packages/sagas/coverage/coverage-summary.json
+            stepper, ./packages/stepper/coverage/coverage-summary.json
+            utils, ./packages/utils/coverage/coverage-summary.json


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we do not have coverage report in pr

**What is the chosen solution to this problem?**

add it

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
