### PR TITLE
feat(ARCH-662/CMF): provide API for RLT

### DIFF
--- a/.changeset/ninety-walls-lay.md
+++ b/.changeset/ninety-walls-lay.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf': minor
+---
+
+feat: provide API for react testing library

--- a/packages/cmf/src/mock/provider.js
+++ b/packages/cmf/src/mock/provider.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { RegistryProvider } from '../RegistryProvider';
-import bootstrap from '../bootstrap';
 import mock from './store';
 
 class ErrorBoundary extends React.Component {

--- a/packages/cmf/src/mock/provider.js
+++ b/packages/cmf/src/mock/provider.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React from 'react';
 import { Provider } from 'react-redux';
 import { RegistryProvider } from '../RegistryProvider';
+import bootstrap from '../bootstrap';
 import mock from './store';
 
 class ErrorBoundary extends React.Component {

--- a/packages/cmf/src/mock/rtl.js
+++ b/packages/cmf/src/mock/rtl.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { render as rtl } from '@testing-library/react';
+import bootstrap from '../bootstrap';
+import registry from '../registry';
+
+export async function prepareCMF(jsx, opts = {}) {
+	// reset global registry
+	const reg = registry.getRegistry();
+	reg._registry = {};
+	reg._isLocked = false;
+
+	function Wrapper() {
+		return jsx;
+	}
+	const config = await bootstrap({
+		RootComponent: Wrapper,
+		render: false,
+		modules: [opts?.cmfModule || { id: 'empty' }],
+	});
+	config.saga.run();
+	return (
+		<config.App
+			store={config.store}
+			loading={opts.AppLoader}
+			withSettings={!!opts.settingsURL}
+			registry={registry.getRegistry()}
+		>
+			{jsx}
+		</config.App>
+	);
+}

--- a/packages/cmf/src/mock/rtl.js
+++ b/packages/cmf/src/mock/rtl.js
@@ -1,5 +1,4 @@
 import React from 'react';
-import { render as rtl } from '@testing-library/react';
 import bootstrap from '../bootstrap';
 import registry from '../registry';
 

--- a/packages/containers/src/HeaderBar/HeaderBar.test.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.test.js
@@ -1,7 +1,10 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Map, List } from 'immutable';
+import { render, screen } from '@testing-library/react';
 
+// eslint-disable-next-line @talend/import-depth
+import { prepareCMF } from '@talend/react-cmf/lib/mock/rtl';
 import Container, { DEFAULT_STATE } from './HeaderBar.container';
 import Connected, { mapStateToProps } from './HeaderBar.connect';
 import Constants from './HeaderBar.constant';
@@ -11,9 +14,9 @@ describe('Container HeaderBar', () => {
 	const dispatch = jest.fn();
 	const containerProps = { state, dispatch };
 
-	it('should render HeaderBar container', () => {
-		const wrapper = shallow(<Container {...containerProps} />);
-		expect(wrapper.getElement()).toMatchSnapshot();
+	it('should render HeaderBar container', async () => {
+		render(await prepareCMF(<Container {...containerProps} />));
+		expect(screen.getByRole('navigation')).toBeVisible();
 	});
 
 	it('should render HeaderBar container with a list of items', () => {

--- a/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
+++ b/packages/containers/src/HeaderBar/__snapshots__/HeaderBar.test.js.snap
@@ -1,3 +1,0 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
-
-exports[`Container HeaderBar should render HeaderBar container 1`] = `<HeaderBar />`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we have no easy to use API to use RTL with CMF.

**What is the chosen solution to this problem?**

Let's add the API

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
