### PR TITLE
chore: clean React imports to only used properties

### DIFF
--- a/.changeset/big-crabs-carry.md
+++ b/.changeset/big-crabs-carry.md
@@ -1,0 +1,11 @@
+---
+'@talend/design-system': patch
+'@talend/react-flow-designer': patch
+'@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/ui-storybook': patch
+'@talend/react-dataviz': patch
+'@talend/icons': patch
+---
+
+chore: clean React imports to only used properties

--- a/.changeset/wild-planes-tell.md
+++ b/.changeset/wild-planes-tell.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-babel': major
+---
+
+feat: use React automatic import to transpile jsx (related to useless React import cleaning)

--- a/packages/components/src/DataViewer/ModelViewer/ModelViewer.container.js
+++ b/packages/components/src/DataViewer/ModelViewer/ModelViewer.container.js
@@ -2,7 +2,7 @@ import noop from 'lodash/noop';
 import get from 'lodash/get';
 import head from 'lodash/head';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import { withTranslation } from 'react-i18next';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
@@ -130,7 +130,7 @@ export function getItemType(item) {
 	return null;
 }
 
-export class ModelViewer extends React.Component {
+export class ModelViewer extends RComponent {
 	static displayName = 'ModelViewerContainer';
 
 	static propTypes = {

--- a/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.container.js
+++ b/packages/components/src/DataViewer/RecordsViewer/RecordsViewer.container.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import { withTranslation } from 'react-i18next';
 import I18N_DOMAIN_COMPONENTS from '../../constants';
 import getDefaultT from '../../translate';
@@ -37,7 +37,7 @@ export function getIcon(opened) {
 	};
 }
 
-export class RecordsViewer extends React.Component {
+export class RecordsViewer extends RComponent {
 	static displayName = 'RecordsViewerContainer';
 
 	static propTypes = {

--- a/packages/components/src/List/List.stories.js
+++ b/packages/components/src/List/List.stories.js
@@ -1,7 +1,6 @@
 /* eslint-disable react/prop-types */
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
-import * as React from 'react';
 import PropTypes from 'prop-types';
 import { action } from '@storybook/addon-actions';
 import cloneDeep from 'lodash/cloneDeep';
@@ -579,9 +578,9 @@ const itemsForListWithIcons = [
 ];
 
 const ListTemplate = args => {
-	const [propsMemo, setState] = React.useState(args.listProps);
+	const [propsMemo, setState] = useState(args.listProps);
 	const { patch, listProps } = args;
-	React.useEffect(() => {
+	useEffect(() => {
 		if (patch && listProps) {
 			setState(patch(listProps));
 		}

--- a/packages/components/src/QualityBar/QualityBar.component.tsx
+++ b/packages/components/src/QualityBar/QualityBar.component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { MouseEvent } from 'react';
 
 import { EnrichedQualityType, QualityBarPercentages, QualityCommonProps } from './QualityBar.types';
 import { QualityBarRatioBars } from './QualityBarRatioBars.component';
@@ -9,7 +9,7 @@ export type QualityBarProps = QualityCommonProps & {
 	placeholder?: number;
 	digits?: number;
 	split?: boolean;
-	onClick?: (e: React.MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
+	onClick?: (e: MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
 	getDataFeature?: (type: string) => string;
 };
 

--- a/packages/components/src/QualityBar/QualityBarRatioBars.component.tsx
+++ b/packages/components/src/QualityBar/QualityBarRatioBars.component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { MouseEvent } from 'react';
 
 import {
 	QualityEmptyLine,
@@ -14,7 +14,7 @@ type QualityBarRatioBarsProps = QualityCommonProps & {
 	placeholder?: number;
 	disabled?: boolean;
 	percentages: QualityBarPercentages;
-	onClick?: (e: React.MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
+	onClick?: (e: MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
 	getDataFeature?: (type: string) => string;
 };
 

--- a/packages/components/src/QualityBar/QualityRatioBar.component.tsx
+++ b/packages/components/src/QualityBar/QualityRatioBar.component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import I18N_DOMAIN_COMPONENTS from '../constants';
@@ -31,7 +31,7 @@ type SpecificQualityBarProps = {
 	percentage: number;
 	value: number;
 	getDataFeature?: (type: EnrichedQualityType) => string;
-	onClick?: (e: React.MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
+	onClick?: (e: MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
 };
 
 type QualityRatioBarProps = SpecificQualityBarProps & {
@@ -42,7 +42,7 @@ type QualityRatioBarProps = SpecificQualityBarProps & {
 function QualityRatioBar({ onClick, type, getDataFeature, ...props }: QualityRatioBarProps) {
 	const specificProps = {
 		className: theme('quality-ratio-bar', `quality-ratio-bar--${type}`),
-		onClick: onClick ? (e: React.MouseEvent<HTMLElement>) => onClick(e, { type }) : null,
+		onClick: onClick ? (e: MouseEvent<HTMLElement>) => onClick(e, { type }) : null,
 		dataFeature: getDataFeature ? getDataFeature(type) : null,
 		dataTestId: `quality-bar-${type}`,
 	};

--- a/packages/components/src/QualityBar/SplitQualityBar.component.tsx
+++ b/packages/components/src/QualityBar/SplitQualityBar.component.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { MouseEvent } from 'react';
 
 import { StackHorizontal } from '@talend/design-system';
 
@@ -15,7 +15,7 @@ import theme from './QualityRatioBar.module.scss';
 type SplitQualityBarProps = QualityCommonProps & {
 	percentages: QualityBarPercentages;
 	disabled?: boolean;
-	onClick?: (e: React.MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
+	onClick?: (e: MouseEvent<HTMLElement>, data: { type: EnrichedQualityType }) => void;
 	getDataFeature?: (type: string) => string;
 };
 

--- a/packages/components/src/wrap.tsx
+++ b/packages/components/src/wrap.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import * as React from 'react';
+import type { ReactElement, Component as RComponent, ReactNode } from 'react';
 import omit from 'lodash/omit';
 
 import Inject from './Inject';
@@ -9,7 +9,7 @@ type ToTextProps = {
 };
 
 type Component = Record<string, any> & {
-	(props: any): React.ReactElement<any> | null;
+	(props: any): ReactElement<any> | null;
 	displayName?: string;
 	propTypes?: any;
 };
@@ -47,10 +47,10 @@ function isNotBlackListedAttr(attr: string) {
 }
 
 type WrapperProps = {
-	getComponent: (key: string) => React.Component | Component;
-	components: { [key: string]: React.Component | Component };
+	getComponent: (key: string) => RComponent | Component;
+	components: { [key: string]: RComponent | Component };
 	text?: string | string[];
-	children: React.ReactNode;
+	children: ReactNode;
 };
 
 export default function wrap(Component: Component, key: string) {

--- a/packages/containers/src/AboutDialog/AboutDialog.container.js
+++ b/packages/containers/src/AboutDialog/AboutDialog.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { Map } from 'immutable';
@@ -10,7 +10,7 @@ export const DEFAULT_STATE = new Map({
 	expanded: false,
 });
 
-class AboutDialog extends React.Component {
+class AboutDialog extends RComponent {
 	static displayName = 'Container(AboutDialog)';
 
 	static propTypes = {

--- a/packages/containers/src/EditableText/EditableText.container.js
+++ b/packages/containers/src/EditableText/EditableText.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import Component from '@talend/react-components/lib/EditableText';
 import Immutable from 'immutable';
@@ -10,7 +10,7 @@ export const DEFAULT_STATE = new Immutable.Map({
 	editMode: false,
 });
 
-class EditableText extends React.Component {
+class EditableText extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static propTypes = {

--- a/packages/containers/src/FilterBar/FilterBar.container.js
+++ b/packages/containers/src/FilterBar/FilterBar.container.js
@@ -1,5 +1,5 @@
 import { cmfConnect } from '@talend/react-cmf';
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import Immutable from 'immutable';
@@ -15,7 +15,7 @@ export const DISPLAY_NAME = 'Container(FilterBar)';
 
 const DOCKED_ATTR = 'docked';
 
-class FilterBar extends React.Component {
+class FilterBar extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static contextTypes = {

--- a/packages/containers/src/HeaderBar/HeaderBar.container.js
+++ b/packages/containers/src/HeaderBar/HeaderBar.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { Map } from 'immutable';
@@ -17,7 +17,7 @@ function sortProductsByLabel(a, b) {
 	return a.label > b.label ? 1 : -1;
 }
 
-class HeaderBar extends React.Component {
+class HeaderBar extends RComponent {
 	static displayName = 'Container(HeaderBar)';
 
 	static propTypes = {

--- a/packages/containers/src/ObjectViewer/ObjectViewer.container.js
+++ b/packages/containers/src/ObjectViewer/ObjectViewer.container.js
@@ -1,5 +1,5 @@
 import PropTypes from 'prop-types';
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import { List, Map } from 'immutable';
 import get from 'lodash/get';
 
@@ -71,7 +71,7 @@ export function editWrapper(prevState, data) {
 	return prevState;
 }
 
-class ObjectViewer extends React.Component {
+class ObjectViewer extends RComponent {
 	static displayName = 'CMFContainer(ObjectViewer)';
 
 	static propTypes = {

--- a/packages/containers/src/SelectObject/SelectObject.container.js
+++ b/packages/containers/src/SelectObject/SelectObject.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import omit from 'lodash/omit';
 import { cmfConnect } from '@talend/react-cmf';
@@ -122,7 +122,7 @@ export function filterAll(
 	return result;
 }
 
-class SelectObject extends React.Component {
+class SelectObject extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static FILTER_MODE = {

--- a/packages/containers/src/SidePanel/SidePanel.container.js
+++ b/packages/containers/src/SidePanel/SidePanel.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import Component from '@talend/react-components/lib/SidePanel';
 import { cmfConnect } from '@talend/react-cmf';
 import { Map } from 'immutable';
@@ -13,7 +13,7 @@ export const DEFAULT_STATE = new Map({
  * Checkout the {@link http://talend.surge.sh/containers/?selectedKind=SidePanelExample&selectedStory=Default|examples}
  * @param {object} props react props
  */
-class SidePanel extends React.Component {
+class SidePanel extends RComponent {
 	static displayName = 'Container(SidePanel)';
 
 	static propTypes = {

--- a/packages/containers/src/Slider/Slider.container.js
+++ b/packages/containers/src/Slider/Slider.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import { cmfConnect } from '@talend/react-cmf';
 import Component from '@talend/react-components/lib/Slider';
 import omit from 'lodash/omit';
@@ -12,7 +12,7 @@ export const DEFAULT_STATE = new Immutable.Map({
 
 export const DISPLAY_NAME = 'Container(Slider)';
 
-class Slider extends React.Component {
+class Slider extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static contextTypes = {

--- a/packages/containers/src/SubHeaderBar/SubHeaderBar.container.js
+++ b/packages/containers/src/SubHeaderBar/SubHeaderBar.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import Component from '@talend/react-components/lib/SubHeaderBar';
 import Immutable from 'immutable';
@@ -8,7 +8,7 @@ import { cmfConnect } from '@talend/react-cmf';
 export const DISPLAY_NAME = 'Container(SubHeaderBar)';
 export const DEFAULT_STATE = new Immutable.Map({});
 
-class SubHeaderBar extends React.Component {
+class SubHeaderBar extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static propTypes = {

--- a/packages/containers/src/TreeView/TreeView.container.js
+++ b/packages/containers/src/TreeView/TreeView.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import { cmfConnect } from '@talend/react-cmf';
 import Component from '@talend/react-components/lib/TreeView';
@@ -98,7 +98,7 @@ export function transform(items, props, parent) {
 /**
  * The TreeView React container
  */
-class TreeView extends React.Component {
+class TreeView extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static propTypes = {

--- a/packages/containers/src/Typeahead/Typeahead.container.js
+++ b/packages/containers/src/Typeahead/Typeahead.container.js
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import { Component as RComponent } from 'react';
 import PropTypes from 'prop-types';
 import Immutable from 'immutable';
 import { cmfConnect, componentState } from '@talend/react-cmf';
@@ -18,7 +18,7 @@ export const DEFAULT_STATE = new Immutable.Map({
 /**
  * The Typeahead React container
  */
-export default class Typeahead extends React.Component {
+export default class Typeahead extends RComponent {
 	static displayName = DISPLAY_NAME;
 
 	static propTypes = {

--- a/packages/dataviz/src/components/GeoChart/GeoChart.stories.tsx
+++ b/packages/dataviz/src/components/GeoChart/GeoChart.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import { Story } from '@storybook/react';
 import { action } from '@storybook/addon-actions';
 import GeoChart, { GeoChartProps } from './GeoChart.component';
@@ -8,7 +8,7 @@ export default {
 	title: 'Dataviz/GeoChart',
 	component: GeoChart,
 	decorators: [
-		(fn: () => React.ReactNode) => (
+		(fn: () => ReactNode) => (
 			<div
 				style={{
 					width: 500,

--- a/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
+++ b/packages/design-system/src/components/ButtonIcon/Primitive/ButtonIconPrimitive.tsx
@@ -1,5 +1,6 @@
-import { ButtonHTMLAttributes, forwardRef, ReactElement, Ref } from 'react';
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { MouseEvent, ReactElement, ButtonHTMLAttributes, Ref } from 'react';
+
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
@@ -21,7 +22,7 @@ type CommonTypes<S extends Partial<AvailableSizes>> = Omit<
 > & {
 	children: string;
 	isLoading?: boolean;
-	onClick: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
+	onClick: (event: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
 	tooltipPlacement?: TooltipPlacement;
 	size?: S;
 	icon: ReactElement | IconNameWithSize<S extends 'XS' ? 'S' : 'M'> | DeprecatedIconNames;

--- a/packages/design-system/src/components/Form/Affix/variations/AffixButton.tsx
+++ b/packages/design-system/src/components/Form/Affix/variations/AffixButton.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, Ref } from 'react';
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { MouseEvent, Ref } from 'react';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
@@ -16,7 +16,7 @@ import styles from '../AffixStyles.module.scss';
 type CommonAffixButtonPropsType = {
 	children: string;
 	isDropdown?: boolean;
-	onClick: (event: React.MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
+	onClick: (event: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;
 	isSuffix?: boolean;
 };
 

--- a/packages/design-system/src/components/Form/Buttons/Buttons.tsx
+++ b/packages/design-system/src/components/Form/Buttons/Buttons.tsx
@@ -1,16 +1,17 @@
-import * as React from 'react';
+import { forwardRef, Children, cloneElement } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 import { isElement } from 'react-is';
 import { StackHorizontal } from '../../Stack';
 
 import styles from './Buttons.module.scss';
 
-type ButtonsProps = React.HTMLAttributes<HTMLDivElement> & {
+type ButtonsProps = HTMLAttributes<HTMLDivElement> & {
 	disabled?: boolean;
 	readOnly?: boolean;
 };
 
-const Buttons = React.forwardRef(
-	({ disabled, readOnly, children, ...rest }: ButtonsProps, ref: React.Ref<HTMLDivElement>) => {
+const Buttons = forwardRef(
+	({ disabled, readOnly, children, ...rest }: ButtonsProps, ref: Ref<HTMLDivElement>) => {
 		const childrenProps: { disabled?: boolean; readOnly?: boolean } = {};
 		if (disabled) childrenProps.disabled = true;
 		if (readOnly) childrenProps.readOnly = true;
@@ -24,8 +25,8 @@ const Buttons = React.forwardRef(
 					{...rest}
 					ref={ref}
 				>
-					{React.Children.toArray(children).map(child =>
-						isElement(child) ? React.cloneElement(child, childrenProps) : child,
+					{Children.toArray(children).map(child =>
+						isElement(child) ? cloneElement(child, childrenProps) : child,
 					)}
 				</StackHorizontal>
 			</div>

--- a/packages/design-system/src/components/Form/Field/Input/Input.ToggleSwitch.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.ToggleSwitch.tsx
@@ -1,4 +1,6 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
+
 import { Checkbox as ReakitCheckbox, unstable_useId as useId } from 'reakit';
 import classnames from 'classnames';
 
@@ -7,7 +9,7 @@ import { CheckboxProps } from './Input.Checkbox';
 
 import styles from './Input.ToggleSwitch.module.scss';
 
-const ToggleSwitch = React.forwardRef(
+const ToggleSwitch = forwardRef(
 	(
 		{
 			id,
@@ -21,7 +23,7 @@ const ToggleSwitch = React.forwardRef(
 			isInline,
 			...rest
 		}: Omit<CheckboxProps, 'indeterminate'>,
-		ref: React.Ref<HTMLInputElement>,
+		ref: Ref<HTMLInputElement>,
 	) => {
 		const { id: reakitId } = useId();
 		const switchId = id || `switch--${reakitId}`;

--- a/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/hooks/useRevealPassword.tsx
@@ -1,5 +1,5 @@
-import { MouseEvent, useState } from 'react';
-import * as React from 'react';
+import { useState } from 'react';
+import type { MouseEvent } from 'react';
 import { useTranslation } from 'react-i18next';
 
 import { I18N_DOMAIN_DESIGN_SYSTEM } from '../../../../constants';
@@ -15,7 +15,7 @@ export default function useRevealPassword() {
 	const showMsg = t('FORM_PASSWORD_SHOW', { defaultValue: 'Show password' });
 	const hideMsg = t('FORM_PASSWORD_HIDE', { defaultValue: 'Hide password' });
 
-	function onReveal(event: React.MouseEvent<any>) {
+	function onReveal(event: MouseEvent<any>) {
 		event.preventDefault();
 		setRevealed(prevState => !prevState);
 	}

--- a/packages/design-system/src/components/Form/Field/Select/Select.tsx
+++ b/packages/design-system/src/components/Form/Field/Select/Select.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, Ref } from 'react';
-import * as React from 'react';
+import { forwardRef, Children } from 'react';
+import type { Ref } from 'react';
 import { isElement } from 'react-is';
 import Input from '../Input';
 import {
@@ -12,77 +12,47 @@ import {
 export type SelectProps = FieldPropsPrimitive &
 	Omit<SelectPrimitiveProps, 'className' | 'style' | 'isAffix'> & { readOnly?: boolean };
 
-const Select = forwardRef(
-	(props: SelectProps, ref: React.Ref<HTMLSelectElement | HTMLInputElement>) => {
-		const {
-			label,
-			hasError = false,
-			link,
-			description,
-			id,
-			name,
-			hideLabel,
-			readOnly,
-			required,
-			children,
-			defaultValue,
-			...rest
-		} = props;
+const Select = forwardRef((props: SelectProps, ref: Ref<HTMLSelectElement | HTMLInputElement>) => {
+	const {
+		label,
+		hasError = false,
+		link,
+		description,
+		id,
+		name,
+		hideLabel,
+		readOnly,
+		required,
+		children,
+		defaultValue,
+		...rest
+	} = props;
 
-		if (readOnly) {
-			const values = React.Children.toArray(children).reduce((acc: string[], current) => {
-				if (!isElement(current)) {
-					return acc.concat(current.toString());
-				}
-				const { children: optChildren, selected } = current.props;
-				if (current.type === 'optgroup') {
-					return acc.concat(
-						React.Children.toArray(optChildren)
-							.filter(option => isElement(option) && option.props.selected)
-							.map(option => isElement(option) && option.props.children),
-					);
-				}
-				if (selected) {
-					return acc.concat(optChildren);
-				}
-				return acc;
-			}, []);
-			const displayedValues = values.length > 0 ? values.join('; ') : undefined;
-			return (
-				<Input
-					{...rest}
-					readOnly
-					value={displayedValues}
-					defaultValue={defaultValue}
-					label={label}
-					hasError={hasError || false}
-					link={link}
-					description={description}
-					id={id}
-					name={name}
-					hideLabel={hideLabel}
-					required={required}
-					ref={ref as Ref<HTMLInputElement>}
-				/>
-			);
-		}
-
-		function SelectField(
-			fieldProps: Omit<SelectProps, 'hasError' | 'name' | 'children' | 'label'>,
-		) {
-			return (
-				<SelectPrimitive
-					hasError={hasError || false}
-					{...fieldProps}
-					ref={ref as Ref<HTMLSelectElement>}
-				>
-					{children}
-				</SelectPrimitive>
-			);
-		}
-
+	if (readOnly) {
+		const values = Children.toArray(children).reduce((acc: string[], current) => {
+			if (!isElement(current)) {
+				return acc.concat(current.toString());
+			}
+			const { children: optChildren, selected } = current.props;
+			if (current.type === 'optgroup') {
+				return acc.concat(
+					Children.toArray(optChildren)
+						.filter(option => isElement(option) && option.props.selected)
+						.map(option => isElement(option) && option.props.children),
+				);
+			}
+			if (selected) {
+				return acc.concat(optChildren);
+			}
+			return acc;
+		}, []);
+		const displayedValues = values.length > 0 ? values.join('; ') : undefined;
 		return (
-			<FieldPrimitive
+			<Input
+				{...rest}
+				readOnly
+				value={displayedValues}
+				defaultValue={defaultValue}
 				label={label}
 				hasError={hasError || false}
 				link={link}
@@ -91,12 +61,38 @@ const Select = forwardRef(
 				name={name}
 				hideLabel={hideLabel}
 				required={required}
-			>
-				<SelectField defaultValue={defaultValue} {...rest} />
-			</FieldPrimitive>
+				ref={ref as Ref<HTMLInputElement>}
+			/>
 		);
-	},
-);
+	}
+
+	function SelectField(fieldProps: Omit<SelectProps, 'hasError' | 'name' | 'children' | 'label'>) {
+		return (
+			<SelectPrimitive
+				hasError={hasError || false}
+				{...fieldProps}
+				ref={ref as Ref<HTMLSelectElement>}
+			>
+				{children}
+			</SelectPrimitive>
+		);
+	}
+
+	return (
+		<FieldPrimitive
+			label={label}
+			hasError={hasError || false}
+			link={link}
+			description={description}
+			id={id}
+			name={name}
+			hideLabel={hideLabel}
+			required={required}
+		>
+			<SelectField defaultValue={defaultValue} {...rest} />
+		</FieldPrimitive>
+	);
+});
 
 Select.displayName = 'Select';
 

--- a/packages/design-system/src/components/Form/Fieldset/Fieldset.tsx
+++ b/packages/design-system/src/components/Form/Fieldset/Fieldset.tsx
@@ -1,10 +1,10 @@
-import { Children, cloneElement, forwardRef, Ref } from 'react';
-import * as React from 'react';
+import { Children, cloneElement, forwardRef } from 'react';
+import type { Ref, FieldsetHTMLAttributes } from 'react';
 import { isElement } from 'react-is';
 
 import styles from './Fieldset.module.scss';
 
-export type FieldsetProps = React.FieldsetHTMLAttributes<HTMLFieldSetElement> & {
+export type FieldsetProps = FieldsetHTMLAttributes<HTMLFieldSetElement> & {
 	legend?: string;
 	required?: boolean;
 	disabled?: boolean;

--- a/packages/design-system/src/components/Form/Form.tsx
+++ b/packages/design-system/src/components/Form/Form.tsx
@@ -1,23 +1,25 @@
-import * as React from 'react';
+import { forwardRef, cloneElement, Children } from 'react';
+import type { FormHTMLAttributes, Ref } from 'react';
+
 import { isElement } from 'react-is';
 
 import styles from './Form.module.scss';
 
-type FormProps = React.FormHTMLAttributes<HTMLFormElement> & {
+type FormProps = FormHTMLAttributes<HTMLFormElement> & {
 	disabled?: boolean;
 	readOnly?: boolean;
 };
 
-const Form = React.forwardRef(
-	({ disabled, readOnly, children, ...rest }: FormProps, ref: React.Ref<HTMLFormElement>) => {
+const Form = forwardRef(
+	({ disabled, readOnly, children, ...rest }: FormProps, ref: Ref<HTMLFormElement>) => {
 		const childrenProps: { disabled?: boolean; readOnly?: boolean } = {};
 		if (disabled) childrenProps.disabled = true;
 		if (readOnly) childrenProps.readOnly = true;
 
 		return (
 			<form className={styles.form} {...rest} ref={ref}>
-				{React.Children.toArray(children).map(child =>
-					isElement(child) ? React.cloneElement(child, childrenProps) : child,
+				{Children.toArray(children).map(child =>
+					isElement(child) ? cloneElement(child, childrenProps) : child,
 				)}
 			</form>
 		);

--- a/packages/design-system/src/components/Form/Row/Row.tsx
+++ b/packages/design-system/src/components/Form/Row/Row.tsx
@@ -1,19 +1,20 @@
-import * as React from 'react';
+import { forwardRef, Children, cloneElement } from 'react';
+import type { Ref, HTMLAttributes } from 'react';
 import { isElement } from 'react-is';
 
 import styles from './Row.module.scss';
 import classNames from 'classnames';
 
-type RowProps = React.HTMLAttributes<HTMLDivElement> & {
+type RowProps = HTMLAttributes<HTMLDivElement> & {
 	disabled?: boolean;
 	readOnly?: boolean;
 	isStretched?: boolean;
 };
 
-const Row = React.forwardRef(
+const Row = forwardRef(
 	(
 		{ children, disabled, readOnly, isStretched = false, ...rest }: RowProps,
-		ref: React.Ref<HTMLDivElement>,
+		ref: Ref<HTMLDivElement>,
 	) => {
 		const childrenProps: { disabled?: boolean; readOnly?: boolean } = {};
 		if (disabled) childrenProps.disabled = true;
@@ -25,8 +26,8 @@ const Row = React.forwardRef(
 				{...rest}
 				ref={ref}
 			>
-				{React.Children.toArray(children).map(child =>
-					isElement(child) ? React.cloneElement(child, childrenProps) : child,
+				{Children.toArray(children).map(child =>
+					isElement(child) ? cloneElement(child, childrenProps) : child,
 				)}
 			</div>
 		);

--- a/packages/design-system/src/components/Icon/Icon.tsx
+++ b/packages/design-system/src/components/Icon/Icon.tsx
@@ -1,5 +1,5 @@
-import { PropsWithChildren } from 'react';
-import * as React from 'react';
+import { forwardRef, createRef, useState, useEffect, memo } from 'react';
+import type { PropsWithChildren, Ref } from 'react';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
 import { DeprecatedIconNames } from '../../types';
@@ -33,15 +33,15 @@ const accessibility = {
 };
 
 // eslint-disable-next-line react/display-name
-export const Icon = React.forwardRef(
+export const Icon = forwardRef(
 	(
 		{ className, name = 'talend-empty-space', transform, border, ...rest }: IconProps,
-		ref: React.Ref<SVGSVGElement>,
+		ref: Ref<SVGSVGElement>,
 	) => {
 		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
-		const safeRef = React.createRef<SVGSVGElement>(ref);
-		const [content, setContent] = React.useState<string>();
+		const safeRef = createRef<SVGSVGElement>(ref);
+		const [content, setContent] = useState<string>();
 
 		const isRemote = name.startsWith('remote-');
 		const isImg = name.startsWith('src-');
@@ -49,7 +49,7 @@ export const Icon = React.forwardRef(
 		const isRemoteSVG =
 			isRemote && content && content.includes('svg') && !content.includes('script');
 
-		React.useEffect(() => {
+		useEffect(() => {
 			if (isRemote) {
 				fetch(imgSrc, {
 					headers: {
@@ -75,7 +75,7 @@ export const Icon = React.forwardRef(
 			}
 		}, [imgSrc, isRemote]);
 
-		React.useEffect(() => {
+		useEffect(() => {
 			const current = safeRef?.current;
 			if (current && isRemoteSVG && content) {
 				// eslint-disable-next-line no-param-reassign
@@ -85,7 +85,7 @@ export const Icon = React.forwardRef(
 			}
 		}, [isRemoteSVG, safeRef, content, name, isRemote]);
 
-		React.useEffect(() => {
+		useEffect(() => {
 			if (border) {
 				const svgContainer = safeRef?.current;
 				if (svgContainer) {
@@ -146,6 +146,6 @@ export const Icon = React.forwardRef(
 	},
 );
 
-export const IconMemo = React.memo(Icon);
+export const IconMemo = memo(Icon);
 
 IconMemo.displayName = 'Icon';

--- a/packages/design-system/src/components/Icon/SizedIcon.tsx
+++ b/packages/design-system/src/components/Icon/SizedIcon.tsx
@@ -1,5 +1,5 @@
-import { HTMLAttributes } from 'react';
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { HTMLAttributes, Ref } from 'react';
 // eslint-disable-next-line @talend/import-depth
 import { Icon, icons, IconSize } from '@talend/icons/dist/typeUtils';
 
@@ -12,10 +12,10 @@ const getNumericSize = (size: IconSize) => {
 	}[size];
 };
 
-const SizedIcon = React.forwardRef(
+const SizedIcon = forwardRef(
 	<S extends IconSize>(
 		{ className, style, name, size, ...rest }: HTMLAttributes<SVGSVGElement> & Icon<S>,
-		ref: React.Ref<SVGSVGElement>,
+		ref: Ref<SVGSVGElement>,
 	) => {
 		const numericSize = getNumericSize(size);
 		const fullName = size ? `${name}:${size}` : name;

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -1,15 +1,15 @@
-import {
-	cloneElement,
-	ElementType,
-	forwardRef,
-	HTMLAttributes,
+import { cloneElement, forwardRef, useEffect, useState } from 'react';
+
+import type {
+	MouseEvent,
+	FormEvent,
+	KeyboardEvent as RKeyboardEvent,
 	ReactElement,
 	Ref,
-	useEffect,
-	useState,
+	HTMLAttributes,
+	ElementType,
+	ChangeEvent,
 } from 'react';
-
-import * as React from 'react';
 import classnames from 'classnames';
 import keycode from 'keycode';
 import { useTranslation } from 'react-i18next';
@@ -31,10 +31,10 @@ type ErrorInEditing =
 	  };
 
 export type OnEditEvent =
-	| React.MouseEvent<HTMLButtonElement>
+	| MouseEvent<HTMLButtonElement>
 	| KeyboardEvent
-	| React.FormEvent<HTMLFormElement>
-	| React.KeyboardEvent;
+	| FormEvent<HTMLFormElement>
+	| RKeyboardEvent;
 
 export type InlineEditingPrimitiveProps = {
 	loading?: boolean;
@@ -71,7 +71,7 @@ const InlineEditingPrimitive = forwardRef(
 		} = props;
 		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 		const [isEditing, setEditing] = useState<boolean>(false);
-		const [value, setValue] = React.useState<string | undefined>(defaultValue);
+		const [value, setValue] = useState<string | undefined>(defaultValue);
 		const toggleEditionMode = (isEditionMode: boolean) => {
 			setEditing(isEditionMode);
 			onToggle(isEditionMode);
@@ -135,11 +135,10 @@ const InlineEditingPrimitive = forwardRef(
 			name: label.replace(/\s/g, ''),
 			required,
 			placeholder,
-			onChange: (
-				event: React.ChangeEvent<HTMLInputElement> | React.ChangeEvent<HTMLTextAreaElement>,
-			): void => setValue(event.target.value),
+			onChange: (event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>): void =>
+				setValue(event.target.value),
 			// Keyboard shortcuts
-			onKeyDown: (event: React.KeyboardEvent) => {
+			onKeyDown: (event: RKeyboardEvent) => {
 				if (event.keyCode === keycode.codes.enter && mode !== 'multi') {
 					// Enter
 					handleSubmit(event);

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
@@ -1,7 +1,7 @@
 import styles from './StackPrimitive.module.scss';
 import classnames from 'classnames';
-import { forwardRef, ReactNode } from 'react';
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref, ReactNode } from 'react';
 
 export const justifyOptions = {
 	start: 'justify-start',
@@ -132,7 +132,7 @@ const StackPrimitive = forwardRef(function StackPrimitive(
 		isFullWidth,
 		...props
 	}: StackPrimitiveProps,
-	ref: React.Ref<any>,
+	ref: Ref<any>,
 ) {
 	const TagType = as;
 	const { alignContent, ...spreadableProps } = props;

--- a/packages/design-system/src/components/Stack/StackHorizontal.tsx
+++ b/packages/design-system/src/components/Stack/StackHorizontal.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from 'react';
-import * as React from 'react';
+import type { Ref } from 'react';
 import StackPrimitive, { StackPrimitiveProps } from './Primitive/StackPrimitive';
 
 export type StackHorizontalProps = Omit<StackPrimitiveProps, 'direction' | 'height'>;
 
-export const StackHorizontal = forwardRef((props: StackHorizontalProps, ref: React.Ref<any>) => {
+export const StackHorizontal = forwardRef((props: StackHorizontalProps, ref: Ref<any>) => {
 	return (
 		<StackPrimitive {...props} direction="row" ref={ref}>
 			{props.children}

--- a/packages/design-system/src/components/Stack/StackItem.tsx
+++ b/packages/design-system/src/components/Stack/StackItem.tsx
@@ -1,5 +1,5 @@
 import { forwardRef, ReactNode } from 'react';
-import * as React from 'react';
+import type { Ref } from 'react';
 import classnames from 'classnames';
 import styles from './StackItem.module.scss';
 
@@ -40,7 +40,7 @@ export const StackItem = forwardRef(function StackItem(
 		overflow = 'auto',
 		...props
 	}: ItemProps,
-	ref: React.Ref<any>,
+	ref: Ref<any>,
 ) {
 	const TagType = as;
 	return (

--- a/packages/design-system/src/components/Stack/StackVertical.tsx
+++ b/packages/design-system/src/components/Stack/StackVertical.tsx
@@ -1,10 +1,10 @@
 import { forwardRef } from 'react';
-import * as React from 'react';
+import type { Ref } from 'react';
 import StackPrimitive, { StackPrimitiveProps } from './Primitive/StackPrimitive';
 
 export type StackVerticalProps = Omit<StackPrimitiveProps, 'direction' | 'isFullWidth'>;
 
-export const StackVertical = forwardRef((props: StackVerticalProps, ref: React.Ref<any>) => {
+export const StackVertical = forwardRef((props: StackVerticalProps, ref: Ref<any>) => {
 	return (
 		<StackPrimitive {...props} direction="column" ref={ref}>
 			{props.children}

--- a/packages/design-system/src/components/Status/Primitive/StatusPrimitive.tsx
+++ b/packages/design-system/src/components/Status/Primitive/StatusPrimitive.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import classnames from 'classnames';
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
@@ -26,10 +27,10 @@ export type StatusProps = {
 	variant: keyof typeof variants;
 };
 
-const Status = React.forwardRef(
+const Status = forwardRef(
 	(
 		{ children, icon, inProgress, hideText, variant, ...rest }: StatusProps,
-		ref: React.Ref<HTMLSpanElement>,
+		ref: Ref<HTMLSpanElement>,
 	) => {
 		const text = <span className={styles.status__text}>{children}</span>;
 		const picto = (

--- a/packages/design-system/src/components/Status/Status.tsx
+++ b/packages/design-system/src/components/Status/Status.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import StatusFailed, { StatusFailedProps } from './variations/StatusFailed';
 import StatusWarning, { StatusWarningProps } from './variations/StatusWarning';
 import StatusSuccessful, { StatusSuccessfulProps } from './variations/StatusSuccessful';
@@ -16,7 +17,7 @@ type StatusProps = {
 	| StatusCanceledProps
 );
 
-const Status = React.forwardRef((props: StatusProps, ref: React.Ref<HTMLSpanElement>) => {
+const Status = forwardRef((props: StatusProps, ref: Ref<HTMLSpanElement>) => {
 	const { variant, ...rest } = props;
 	switch (variant) {
 		case variants.failed:

--- a/packages/design-system/src/components/Status/variations/StatusCanceled.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusCanceled.tsx
@@ -1,19 +1,18 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusCanceledProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;
 
-const StatusCanceled = React.forwardRef(
-	(props: StatusCanceledProps, ref: React.Ref<HTMLSpanElement>) => {
-		const { t } = useTranslation('design-system');
-		return (
-			<StatusPrimitive icon="circle-slash" variant="canceled" {...props} ref={ref}>
-				{props.children || t('CANCELED', 'Canceled')}
-			</StatusPrimitive>
-		);
-	},
-);
+const StatusCanceled = forwardRef((props: StatusCanceledProps, ref: Ref<HTMLSpanElement>) => {
+	const { t } = useTranslation('design-system');
+	return (
+		<StatusPrimitive icon="circle-slash" variant="canceled" {...props} ref={ref}>
+			{props.children || t('CANCELED', 'Canceled')}
+		</StatusPrimitive>
+	);
+});
 
 StatusCanceled.displayName = 'StatusCanceled';
 export default StatusCanceled;

--- a/packages/design-system/src/components/Status/variations/StatusFailed.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusFailed.tsx
@@ -1,19 +1,18 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusFailedProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;
 
-const StatusFailed = React.forwardRef(
-	(props: StatusFailedProps, ref: React.Ref<HTMLSpanElement>) => {
-		const { t } = useTranslation('design-system');
-		return (
-			<StatusPrimitive icon="square-cross" variant="failed" {...props} ref={ref}>
-				{props.children || t('FAILED', 'Failed')}
-			</StatusPrimitive>
-		);
-	},
-);
+const StatusFailed = forwardRef((props: StatusFailedProps, ref: Ref<HTMLSpanElement>) => {
+	const { t } = useTranslation('design-system');
+	return (
+		<StatusPrimitive icon="square-cross" variant="failed" {...props} ref={ref}>
+			{props.children || t('FAILED', 'Failed')}
+		</StatusPrimitive>
+	);
+});
 
 StatusFailed.displayName = 'StatusFailed';
 export default StatusFailed;

--- a/packages/design-system/src/components/Status/variations/StatusInProgress.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusInProgress.tsx
@@ -1,19 +1,18 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusInProgressProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;
 
-const StatusInProgress = React.forwardRef(
-	(props: StatusInProgressProps, ref: React.Ref<HTMLSpanElement>) => {
-		const { t } = useTranslation('design-system');
-		return (
-			<StatusPrimitive inProgress variant="inProgress" {...props} ref={ref}>
-				{props.children || t('design-system:IN_PROGRESS', 'In progress')}
-			</StatusPrimitive>
-		);
-	},
-);
+const StatusInProgress = forwardRef((props: StatusInProgressProps, ref: Ref<HTMLSpanElement>) => {
+	const { t } = useTranslation('design-system');
+	return (
+		<StatusPrimitive inProgress variant="inProgress" {...props} ref={ref}>
+			{props.children || t('design-system:IN_PROGRESS', 'In progress')}
+		</StatusPrimitive>
+	);
+});
 
 StatusInProgress.displayName = 'StatusInProgress';
 export default StatusInProgress;

--- a/packages/design-system/src/components/Status/variations/StatusSuccessful.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusSuccessful.tsx
@@ -1,19 +1,18 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusSuccessfulProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;
 
-const StatusSuccessful = React.forwardRef(
-	(props: StatusSuccessfulProps, ref: React.Ref<HTMLSpanElement>) => {
-		const { t } = useTranslation('design-system');
-		return (
-			<StatusPrimitive icon="check-filled" variant="successful" {...props} ref={ref}>
-				{props.children || t('SUCCESSFUL', 'Successful')}
-			</StatusPrimitive>
-		);
-	},
-);
+const StatusSuccessful = forwardRef((props: StatusSuccessfulProps, ref: Ref<HTMLSpanElement>) => {
+	const { t } = useTranslation('design-system');
+	return (
+		<StatusPrimitive icon="check-filled" variant="successful" {...props} ref={ref}>
+			{props.children || t('SUCCESSFUL', 'Successful')}
+		</StatusPrimitive>
+	);
+});
 
 StatusSuccessful.displayName = 'StatusSuccessful';
 export default StatusSuccessful;

--- a/packages/design-system/src/components/Status/variations/StatusWarning.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusWarning.tsx
@@ -1,19 +1,18 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusWarningProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;
 
-const StatusWarning = React.forwardRef(
-	(props: StatusWarningProps, ref: React.Ref<HTMLSpanElement>) => {
-		const { t } = useTranslation('design-system');
-		return (
-			<StatusPrimitive icon="exclamation" variant="warning" {...props} ref={ref}>
-				{props.children || t('WARNING', 'Warning')}
-			</StatusPrimitive>
-		);
-	},
-);
+const StatusWarning = forwardRef((props: StatusWarningProps, ref: Ref<HTMLSpanElement>) => {
+	const { t } = useTranslation('design-system');
+	return (
+		<StatusPrimitive icon="exclamation" variant="warning" {...props} ref={ref}>
+			{props.children || t('WARNING', 'Warning')}
+		</StatusPrimitive>
+	);
+});
 
 StatusWarning.displayName = 'StatusWarning';
 export default StatusWarning;

--- a/packages/design-system/src/components/Switch/Switch.tsx
+++ b/packages/design-system/src/components/Switch/Switch.tsx
@@ -1,10 +1,10 @@
 import { useLayoutEffect, useRef } from 'react';
-import * as React from 'react';
+import type { PropsWithChildren, MouseEvent } from 'react';
 import { Radio, RadioGroup, useRadioState } from 'reakit';
 import classnames from 'classnames';
 import theme from './Switch.module.scss';
 
-export type SwitchProps = React.PropsWithChildren<any> & {
+export type SwitchProps = PropsWithChildren<any> & {
 	label: string;
 	value?: string;
 	defaultValue?: string;
@@ -31,8 +31,8 @@ const Switch = ({
 		unstable_virtual: true,
 	});
 
-	const containerRef = useRef<React.PropsWithChildren<any>>();
-	const switchIndicator = useRef<React.PropsWithChildren<any>>();
+	const containerRef = useRef<PropsWithChildren<any>>();
+	const switchIndicator = useRef<PropsWithChildren<any>>();
 
 	useLayoutEffect(() => {
 		const radioGroup = containerRef?.current;
@@ -69,9 +69,7 @@ const Switch = ({
 					const isChecked = radio.state === v;
 					return (
 						<Radio
-							onChange={(event: React.MouseEvent<HTMLButtonElement>) =>
-								onChange && onChange(event, v)
-							}
+							onChange={(event: MouseEvent<HTMLButtonElement>) => onChange && onChange(event, v)}
 							{...radio}
 							value={v}
 							as="button"

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { cloneElement } from 'react';
+import type { PropsWithChildren, FC } from 'react';
 import {
 	Tooltip as ReakitTooltip,
 	TooltipArrow as ReakitTooltipArrow,
@@ -28,12 +29,12 @@ export type Placement =
 	| 'left'
 	| 'left-start';
 
-export type TooltipProps = React.PropsWithChildren<any> &
+export type TooltipProps = PropsWithChildren<any> &
 	ReakitTooltipProps & {
 		title?: string;
 	};
 
-const Tooltip: React.FC<TooltipProps> = ({ children, title, baseId, ...rest }: TooltipProps) => {
+const Tooltip: FC<TooltipProps> = ({ children, title, baseId, ...rest }: TooltipProps) => {
 	const { id: reakitId } = useId();
 	const tooltipState = useReakitTooltipState({
 		...rest,
@@ -47,7 +48,7 @@ const Tooltip: React.FC<TooltipProps> = ({ children, title, baseId, ...rest }: T
 	return (
 		<>
 			<ReakitTooltipReference {...tooltipState} ref={children.ref} {...children.props}>
-				{referenceProps => React.cloneElement(children, referenceProps)}
+				{referenceProps => cloneElement(children, referenceProps)}
 			</ReakitTooltipReference>
 			{title && (
 				<ReakitTooltip className={styles.tooltip} {...tooltipState} {...rest}>

--- a/packages/design-system/src/components/WIP/Card/Card.tsx
+++ b/packages/design-system/src/components/WIP/Card/Card.tsx
@@ -1,12 +1,12 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 import { StackVertical } from '../../Stack';
 
 import theme from './Card.module.scss';
 
 interface CardPropsType {
-	header?: React.ReactNode;
-	children: React.ReactNode;
+	header?: ReactNode;
+	children: ReactNode;
 }
 
 function Card({ header, children }: CardPropsType) {

--- a/packages/design-system/src/components/WIP/Drawer/Primitive/PrimitiveDrawer.tsx
+++ b/packages/design-system/src/components/WIP/Drawer/Primitive/PrimitiveDrawer.tsx
@@ -1,16 +1,17 @@
-import * as React from 'react';
+import { forwardRef } from 'react';
+import type { Ref, ReactNode } from 'react';
 import { StackVertical } from '../../../Stack';
 
 import theme from './PrimitiveDrawer.module.scss';
 
 export type DrawerProps = {
-	header?: React.ReactNode;
-	footer?: React.ReactNode;
-	children: React.ReactNode;
+	header?: ReactNode;
+	footer?: ReactNode;
+	children: ReactNode;
 };
 
-export const PrimitiveDrawer = React.forwardRef(
-	({ header, children, footer }: DrawerProps, ref: React.Ref<HTMLDivElement>) => (
+export const PrimitiveDrawer = forwardRef(
+	({ header, children, footer }: DrawerProps, ref: Ref<HTMLDivElement>) => (
 		<div className={theme['primitive-drawer']} ref={ref}>
 			<StackVertical gap={0} align="stretch" justify="stretch">
 				{header && <div className={theme['primitive-drawer__header']}>{header}</div>}

--- a/packages/design-system/src/components/WIP/Drawer/variants/FloatingDrawer/FloatingDrawer.tsx
+++ b/packages/design-system/src/components/WIP/Drawer/variants/FloatingDrawer/FloatingDrawer.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useRef } from 'react';
-import * as React from 'react';
+import { useEffect, useRef, cloneElement } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import { Dialog, DialogDisclosure, DialogStateReturn, useDialogState } from 'reakit';
 import PrimitiveDrawer from '../../Primitive/PrimitiveDrawer';
 
 import theme from './FloatingDrawer.module.scss';
 
 type WithDisclosure = {
-	disclosure: React.ReactElement;
+	disclosure: ReactElement;
 	visible?: never;
 };
 type Controlled = {
@@ -15,9 +15,9 @@ type Controlled = {
 };
 
 export type DrawerProps = {
-	header?: ((dialog: DialogStateReturn) => React.ReactNode) | React.ReactNode;
-	children: ((dialog: DialogStateReturn) => React.ReactNode) | React.ReactNode;
-	footer?: ((dialog: DialogStateReturn) => React.ReactNode) | React.ReactNode;
+	header?: ((dialog: DialogStateReturn) => ReactNode) | ReactNode;
+	children: ((dialog: DialogStateReturn) => ReactNode) | ReactNode;
+	footer?: ((dialog: DialogStateReturn) => ReactNode) | ReactNode;
 	onClose?: () => void;
 } & (WithDisclosure | Controlled);
 
@@ -44,7 +44,7 @@ export const FloatingDrawer = ({
 		<>
 			{disclosure && (
 				<DialogDisclosure {...dialog}>
-					{disclosureProps => React.cloneElement(disclosure, disclosureProps)}
+					{disclosureProps => cloneElement(disclosure, disclosureProps)}
 				</DialogDisclosure>
 			)}
 			<Dialog

--- a/packages/flow-designer/src/components/configuration/LinkType.component.ts
+++ b/packages/flow-designer/src/components/configuration/LinkType.component.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import invariant from 'invariant';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function LinkType({ type, component }: { type: string; component: React.ReactNode }) {
+function LinkType({ type, component }: { type: string; component: ReactNode }) {
 	invariant(
 		false,
 		'<LinkType> elements are for DataFlow configuration only and should not be rendered',

--- a/packages/flow-designer/src/components/configuration/NodeType.component.ts
+++ b/packages/flow-designer/src/components/configuration/NodeType.component.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import invariant from 'invariant';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function NodeType({ type, component }: { type: string; component: React.ReactNode }) {
+function NodeType({ type, component }: { type: string; component: ReactNode }) {
 	invariant(
 		false,
 		'<NodeType> elements are for DataFlow configuration only and should not be rendered',

--- a/packages/flow-designer/src/components/configuration/PortType.component.ts
+++ b/packages/flow-designer/src/components/configuration/PortType.component.ts
@@ -1,8 +1,8 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 import invariant from 'invariant';
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-function PortType({ type, component }: { type: string; component: React.ReactNode }) {
+function PortType({ type, component }: { type: string; component: ReactNode }) {
 	invariant(
 		false,
 		'<PortType> elements are for DataFlow configuration only and should not be rendered',

--- a/packages/flow-designer/src/components/link/AbstractLink.component.tsx
+++ b/packages/flow-designer/src/components/link/AbstractLink.component.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { Children, cloneElement, PureComponent } from 'react';
+import type { ReactElement } from 'react';
 
 import { line, curveBasis, interpolateBasis } from 'd3';
 
@@ -33,12 +34,12 @@ type Props = {
 	onTargetDrag?: (event: any) => void;
 	onTargetDragEnd?: (event: any) => void;
 	children?: any;
-	linkSourceHandleComponent?: React.ReactElement;
+	linkSourceHandleComponent?: ReactElement;
 	sourceHandlePosition?: Position;
-	linkTargetHandleComponent?: React.ReactElement;
+	linkTargetHandleComponent?: ReactElement;
 };
 
-class AbstractLink extends React.PureComponent<Props> {
+class AbstractLink extends PureComponent<Props> {
 	static calculatePath = calculatePath;
 
 	renderLinkSourceHandle() {
@@ -75,8 +76,8 @@ class AbstractLink extends React.PureComponent<Props> {
 			this.props.source.getPosition(),
 			this.props.targetHandlePosition || this.props.target.getPosition(),
 		);
-		const newChildren = React.Children.map(this.props.children, child =>
-			React.cloneElement(child, { d: path, xInterpolate, yInterpolate }),
+		const newChildren = Children.map(this.props.children, child =>
+			cloneElement(child, { d: path, xInterpolate, yInterpolate }),
 		);
 		return (
 			<g>

--- a/packages/flow-designer/src/components/link/LinkHandle.component.tsx
+++ b/packages/flow-designer/src/components/link/LinkHandle.component.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { Component } from 'react';
+import type { ReactElement, ElementRef } from 'react';
 import { drag, select } from 'd3';
 import { PositionRecord } from '../../customTypings/index.d';
 
@@ -6,13 +7,13 @@ type Props = {
 	position: PositionRecord;
 	onDrag?: (event: any) => void;
 	onDragEnd?: (event: any) => void;
-	component: React.ReactElement;
+	component: ReactElement;
 };
 
-class LinkHandle extends React.Component<Props> {
+class LinkHandle extends Component<Props> {
 	d3Handle: any;
 
-	handle: React.ElementRef<'g'> | null;
+	handle: ElementRef<'g'> | null;
 
 	constructor(props: Props) {
 		super(props);

--- a/packages/flow-designer/src/components/node/AbstractNode.component.tsx
+++ b/packages/flow-designer/src/components/node/AbstractNode.component.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { Component } from 'react';
+import type { MouseEventHandler, MouseEvent } from 'react';
 import { scaleLinear, drag, select } from 'd3';
 import { Map } from 'immutable';
 
@@ -92,19 +93,19 @@ type Props = {
 	onDragStart?: (event: any) => void;
 	onDrag?: (event: any) => void;
 	onDragEnd?: (event: any) => void;
-	onClick?: React.MouseEventHandler;
-	onDoubleClick?: React.MouseEventHandler;
+	onClick?: MouseEventHandler;
+	onDoubleClick?: MouseEventHandler;
 	children?: any;
 };
 
-class AbstractNode extends React.Component<Props> {
+class AbstractNode extends Component<Props> {
 	static calculatePortPosition = calculatePortPosition;
 
 	d3Node: any;
 
 	nodeElement: any;
 
-	squaredDeltaDrag: number = 0;
+	squaredDeltaDrag = 0;
 
 	constructor(props: Props) {
 		super(props);
@@ -142,13 +143,13 @@ class AbstractNode extends React.Component<Props> {
 		this.d3Node.remove();
 	}
 
-	onClick(clickEvent: React.MouseEvent) {
+	onClick(clickEvent: MouseEvent) {
 		if (this.props.onClick) {
 			this.props.onClick(clickEvent);
 		}
 	}
 
-	onDoubleClick(clickEvent: React.MouseEvent) {
+	onDoubleClick(clickEvent: MouseEvent) {
 		if (this.props.onDoubleClick) {
 			this.props.onDoubleClick(clickEvent);
 		}

--- a/packages/flow-designer/src/components/port/AbstractPort.component.tsx
+++ b/packages/flow-designer/src/components/port/AbstractPort.component.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { Component } from 'react';
+import type { MouseEventHandler, ReactChildren } from 'react';
 import { select } from 'd3';
 
 import { Port, Position } from '../../api';
@@ -6,11 +7,11 @@ import { PortRecord } from '../../customTypings/index.d';
 
 type Props = {
 	port?: PortRecord;
-	onClick?: React.MouseEventHandler;
-	children?: React.ReactChildren;
+	onClick?: MouseEventHandler;
+	children?: ReactChildren;
 };
 
-class AbstractPort extends React.Component<Props> {
+class AbstractPort extends Component<Props> {
 	d3Node: any;
 
 	node: any;

--- a/packages/icons/stories/Icon.tsx
+++ b/packages/icons/stories/Icon.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { createContext, useContext, useState } from 'react';
+import type { ChangeEvent, PropsWithChildren } from 'react';
 import { useCopyToClipboard } from 'react-use';
 
 import tokens from '@talend/design-tokens';
@@ -46,15 +47,15 @@ export const getIconNamesBySize = (size: keyof typeof iconSizes) => {
 		.sort();
 };
 
-const SearchContext = React.createContext({
+const SearchContext = createContext({
 	query: '',
 	setQuery: (value: string) => {},
 });
 
 const IconFilter = () => {
-	const searchContext = React.useContext(SearchContext);
+	const searchContext = useContext(SearchContext);
 
-	const onFilter = (event: React.ChangeEvent<HTMLInputElement>) => {
+	const onFilter = (event: ChangeEvent<HTMLInputElement>) => {
 		const value = event.currentTarget.value;
 		searchContext.setQuery(value);
 	};
@@ -75,7 +76,7 @@ const IconFilter = () => {
 	);
 };
 
-const LegacyIconContext = React.createContext({
+const LegacyIconContext = createContext({
 	size: '',
 	setSize: (value: string) => {},
 	filter: '',
@@ -83,7 +84,7 @@ const LegacyIconContext = React.createContext({
 });
 
 const LegacyIconSizePicker = () => {
-	const legacyIconContext = React.useContext(LegacyIconContext);
+	const legacyIconContext = useContext(LegacyIconContext);
 	return (
 		<div className="form-group">
 			<label htmlFor="select-size">Icon size</label>
@@ -104,7 +105,7 @@ const LegacyIconSizePicker = () => {
 };
 
 const LegacyIconFilterPicker = () => {
-	const legacyIconContext = React.useContext(LegacyIconContext);
+	const legacyIconContext = useContext(LegacyIconContext);
 	return (
 		<div className="form-group">
 			<label htmlFor="select-filter" className="control-label">
@@ -132,13 +133,13 @@ export const LegacyIconToolbar = () => {
 	);
 };
 
-const IconContext = React.createContext({
+const IconContext = createContext({
 	color: '',
 	setColor: (value: string) => {},
 });
 
 const IconColorTokenPicker = () => {
-	const iconContext = React.useContext(IconContext);
+	const iconContext = useContext(IconContext);
 	return (
 		<div className="form-group">
 			<label htmlFor="color" className="control-label">
@@ -171,7 +172,7 @@ const IconToolbar = () => {
 export const Grid = ({
 	columns = 1,
 	children,
-}: React.PropsWithChildren<HTMLElement> & { columns?: number }) => {
+}: PropsWithChildren<HTMLElement> & { columns?: number }) => {
 	return (
 		<div
 			style={{
@@ -184,13 +185,13 @@ export const Grid = ({
 	);
 };
 
-const IconList = (props: React.PropsWithChildren<any>) => (
+const IconList = (props: PropsWithChildren<any>) => (
 	<div {...props} style={{ paddingBlock: tokens.coralSpacingM }} />
 );
 
-export const IconGallery = ({ children }: React.PropsWithChildren<HTMLElement>) => {
-	const [color, setColor] = React.useState('');
-	const [query, setQuery] = React.useState('');
+export const IconGallery = ({ children }: PropsWithChildren<HTMLElement>) => {
+	const [color, setColor] = useState('');
+	const [query, setQuery] = useState('');
 	return (
 		<IconContext.Provider value={{ color, setColor }}>
 			<SearchContext.Provider value={{ query, setQuery }}>
@@ -201,10 +202,10 @@ export const IconGallery = ({ children }: React.PropsWithChildren<HTMLElement>) 
 	);
 };
 
-export const LegacyIconGallery = ({ children }: React.PropsWithChildren<HTMLElement>) => {
-	const [size, setSize] = React.useState('');
-	const [filter, setFilter] = React.useState('');
-	const [query, setQuery] = React.useState('');
+export const LegacyIconGallery = ({ children }: PropsWithChildren<HTMLElement>) => {
+	const [size, setSize] = useState('');
+	const [filter, setFilter] = useState('');
+	const [query, setQuery] = useState('');
 	return (
 		<LegacyIconContext.Provider value={{ size, setSize, filter, setFilter }}>
 			<SearchContext.Provider value={{ query, setQuery }}>
@@ -223,7 +224,7 @@ export const IconItem = ({
 	name: string;
 	size?: 'XS' | 'S' | 'M' | 'L' | undefined;
 }) => {
-	const searchContext = React.useContext(SearchContext);
+	const searchContext = useContext(SearchContext);
 	const [, copyToClipboard] = useCopyToClipboard();
 
 	const onTextClickHandler = () => {
@@ -333,8 +334,8 @@ export const HiddenIconItem = () => {
 };
 
 const Icon = ({ name, size }: { name: string; size?: keyof typeof iconSizes }) => {
-	const iconContext = React.useContext(IconContext);
-	const legacyIconContext = React.useContext(LegacyIconContext);
+	const iconContext = useContext(IconContext);
+	const legacyIconContext = useContext(LegacyIconContext);
 	const style = {
 			display: 'flex',
 			alignItems: 'center',

--- a/packages/storybook/.storybook/docs/AlgoliaAutocomplete.tsx
+++ b/packages/storybook/.storybook/docs/AlgoliaAutocomplete.tsx
@@ -1,5 +1,5 @@
 import { createElement, Fragment, useEffect, useRef } from 'react';
-import * as React from 'react';
+import type { ReactElement } from 'react';
 import { render } from 'react-dom';
 import { autocomplete } from '@algolia/autocomplete-js';
 
@@ -16,7 +16,7 @@ export function Autocomplete(props: any) {
 			container: containerRef.current || '',
 			renderer: { createElement, Fragment },
 			render({ children }, root) {
-				render(children as React.ReactElement, root);
+				render(children as ReactElement, root);
 			},
 			...props,
 		});

--- a/packages/storybook/.storybook/docs/Badge.tsx
+++ b/packages/storybook/.storybook/docs/Badge.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { AnchorHTMLAttributes } from 'react';
 import tokens from '@talend/design-tokens';
 
 import { Status } from './StatusTable';
@@ -71,7 +71,7 @@ const Badge = ({
 	children,
 	status,
 	...props
-}: React.AnchorHTMLAttributes<HTMLAnchorElement> & { icon: string; status?: Status }) => {
+}: AnchorHTMLAttributes<HTMLAnchorElement> & { icon: string; status?: Status }) => {
 	let attrs;
 	if (href) {
 		attrs = {

--- a/packages/storybook/.storybook/docs/BadgeFigma.tsx
+++ b/packages/storybook/.storybook/docs/BadgeFigma.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import { memo } from 'react';
+import type { FunctionComponent } from 'react';
 
 import Badge from './Badge';
 
-const FigmaStatus = (props: React.FunctionComponent) => {
+const FigmaStatus = (props: FunctionComponent) => {
 	return (
 		<Badge {...props} icon="figma">
 			Figma
@@ -10,4 +11,4 @@ const FigmaStatus = (props: React.FunctionComponent) => {
 	);
 };
 
-export default React.memo(FigmaStatus);
+export default memo(FigmaStatus);

--- a/packages/storybook/.storybook/docs/BadgeI18n.tsx
+++ b/packages/storybook/.storybook/docs/BadgeI18n.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import { memo } from 'react';
+import type { FunctionComponent } from 'react';
 
 import Badge from './Badge';
 
-const I18nStatus = (props: React.FunctionComponent) => {
+const I18nStatus = (props: FunctionComponent) => {
 	return (
 		<Badge {...props} icon="i18next">
 			i18n
@@ -10,4 +11,4 @@ const I18nStatus = (props: React.FunctionComponent) => {
 	);
 };
 
-export default React.memo(I18nStatus);
+export default memo(I18nStatus);

--- a/packages/storybook/.storybook/docs/BadgeReact.tsx
+++ b/packages/storybook/.storybook/docs/BadgeReact.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import { memo } from 'react';
+import type { FunctionComponent } from 'react';
 
 import Badge from './Badge';
 
-const ReactStatus = (props: React.FunctionComponent) => {
+const ReactStatus = (props: FunctionComponent) => {
 	return (
 		<Badge {...props} icon="react">
 			React
@@ -10,4 +11,4 @@ const ReactStatus = (props: React.FunctionComponent) => {
 	);
 };
 
-export default React.memo(ReactStatus);
+export default memo(ReactStatus);

--- a/packages/storybook/.storybook/docs/BadgeStorybook.tsx
+++ b/packages/storybook/.storybook/docs/BadgeStorybook.tsx
@@ -1,8 +1,9 @@
-import * as React from 'react';
+import { memo } from 'react';
+import type { FunctionComponent } from 'react';
 
 import Badge from './Badge';
 
-const StorybookStatus = (props: React.FunctionComponent) => {
+const StorybookStatus = (props: FunctionComponent) => {
 	return (
 		<Badge {...props} icon="storybook">
 			Storybook
@@ -10,4 +11,4 @@ const StorybookStatus = (props: React.FunctionComponent) => {
 	);
 };
 
-export default React.memo(StorybookStatus);
+export default memo(StorybookStatus);

--- a/packages/storybook/.storybook/docs/Badges.tsx
+++ b/packages/storybook/.storybook/docs/Badges.tsx
@@ -1,11 +1,10 @@
-import { ReactElement } from 'react';
-import * as React from 'react';
+import type { ReactElement, PropsWithChildren } from 'react';
 
 import Badge from './Badge';
 
 import theme from './Badges.module.scss';
 
-const StatusList = ({ children }: React.PropsWithChildren<any>) => {
+const StatusList = ({ children }: PropsWithChildren<any>) => {
 	return (
 		<ul className={theme.badges} role="list">
 			{children.map((child: ReactElement<typeof Badge>, key: number) => (

--- a/packages/storybook/.storybook/docs/Card.tsx
+++ b/packages/storybook/.storybook/docs/Card.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ReactElement } from 'react';
 import styles from './Card.module.scss';
 
 const Card = ({
@@ -7,10 +7,10 @@ const Card = ({
 	text,
 	link,
 }: {
-	icon: React.ReactElement;
+	icon: ReactElement;
 	title: string;
 	text: string;
-	link: React.ReactElement;
+	link: ReactElement;
 }) => (
 	<article className={styles.card}>
 		{icon}

--- a/packages/storybook/.storybook/docs/Col.tsx
+++ b/packages/storybook/.storybook/docs/Col.tsx
@@ -1,11 +1,11 @@
-import * as React from 'react';
+import type { HTMLAttributes } from 'react';
 
 export default function Col({
 	children,
 	fixed,
 	centered,
 	...props
-}: React.HTMLAttributes<HTMLDivElement> & {
+}: HTMLAttributes<HTMLDivElement> & {
 	fixed: boolean;
 	centered: 'all' | 'vertical' | 'horizontal';
 }) {

--- a/packages/storybook/.storybook/docs/ColorSwatches.tsx
+++ b/packages/storybook/.storybook/docs/ColorSwatches.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { PropsWithChildren } from 'react';
 import { ColorPalette, ColorItem } from '@storybook/components';
 
 function ColorSwatches({
@@ -7,7 +7,7 @@ function ColorSwatches({
 	title,
 	subtitle,
 	...rest
-}: React.PropsWithChildren<any> & {
+}: PropsWithChildren<any> & {
 	colors: { [key: string]: string };
 	color: string;
 	title: string;

--- a/packages/storybook/.storybook/docs/FigmaImage.tsx
+++ b/packages/storybook/.storybook/docs/FigmaImage.tsx
@@ -1,4 +1,5 @@
-import * as React from 'react';
+import { useContext, useState, useEffect, memo } from 'react';
+import type { ImgHTMLAttributes } from 'react';
 import { FileImageResponse } from 'figma-js';
 
 import styles from './FigmaImage.module.scss';
@@ -13,7 +14,7 @@ function getMetadata(url: string) {
 	};
 }
 
-const FigmaImagePlaceholder = React.memo(() => {
+const FigmaImagePlaceholder = memo(() => {
 	return (
 		<div
 			style={{
@@ -39,12 +40,12 @@ const FigmaImage = ({
 	alt = '',
 	full = false,
 	...rest
-}: React.ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string; full?: boolean }) => {
-	const figma = React.useContext(FigmaContext);
+}: ImgHTMLAttributes<HTMLImageElement> & { src: string; alt: string; full?: boolean }) => {
+	const figma = useContext(FigmaContext);
 
-	const [fileImageResponse, setFileImageResponse] = React.useState<FileImageResponse>();
+	const [fileImageResponse, setFileImageResponse] = useState<FileImageResponse>();
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if ('serviceWorker' in navigator) {
 			window.addEventListener('load', () => {
 				navigator.serviceWorker.register('/sw.js').then(
@@ -66,7 +67,7 @@ const FigmaImage = ({
 		}
 	}, []);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (src) {
 			const { projectId, nodeId } = getMetadata(src);
 			figma

--- a/packages/storybook/.storybook/docs/Icons.tsx
+++ b/packages/storybook/.storybook/docs/Icons.tsx
@@ -1,20 +1,20 @@
-import { ChangeEvent } from 'react';
-import * as React from 'react';
+import { useState, useEffect } from 'react';
+import type { ChangeEvent, FormEvent } from 'react';
 import { IconGallery, IconItem } from '@storybook/components';
 
 import { Form, Icon, IconsProvider, ThemeProvider } from '@talend/design-system';
 
 export const Icons = () => {
-	const [icons, setIds] = React.useState<(string | null)[]>([]);
-	const [query, setQuery] = React.useState<string>('');
-	const [size, setSize] = React.useState<number>(2);
-	const [filter, setFilter] = React.useState<boolean>();
-	const [transform, setTransform] = React.useState<string>('');
-	const [useCurrentColor, setUseCurrentColor] = React.useState<boolean>();
-	const [currentColor, setCurrentColor] = React.useState<string>();
-	const [border, setBorder] = React.useState<boolean>();
+	const [icons, setIds] = useState<(string | null)[]>([]);
+	const [query, setQuery] = useState<string>('');
+	const [size, setSize] = useState<number>(2);
+	const [filter, setFilter] = useState<boolean>();
+	const [transform, setTransform] = useState<string>('');
+	const [useCurrentColor, setUseCurrentColor] = useState<boolean>();
+	const [currentColor, setCurrentColor] = useState<string>();
+	const [border, setBorder] = useState<boolean>();
 
-	React.useEffect(() => {
+	useEffect(() => {
 		IconsProvider.getAllIconIds().then((ids: (string | null)[]) => {
 			const cleanIds = ids.filter(id => id && !id.includes(':'));
 			setIds(cleanIds);
@@ -69,7 +69,7 @@ export const Icons = () => {
 							/>
 							<Form.Color
 								label="Color"
-								onChange={(event: React.FormEvent<HTMLInputElement>) =>
+								onChange={(event: FormEvent<HTMLInputElement>) =>
 									setCurrentColor(event.currentTarget.value)
 								}
 								value={currentColor}

--- a/packages/storybook/.storybook/docs/Row.tsx
+++ b/packages/storybook/.storybook/docs/Row.tsx
@@ -1,10 +1,10 @@
-import * as React from 'react';
+import type { HTMLAttributes } from 'react';
 
 export default function Row({
 	children,
 	centered,
 	...props
-}: React.HTMLAttributes<HTMLDivElement> & { centered: 'all' | 'vertical' | 'horizontal' }) {
+}: HTMLAttributes<HTMLDivElement> & { centered: 'all' | 'vertical' | 'horizontal' }) {
 	return (
 		<div
 			{...props}

--- a/packages/storybook/.storybook/docs/Use.tsx
+++ b/packages/storybook/.storybook/docs/Use.tsx
@@ -1,5 +1,4 @@
-import { HTMLAttributes, ReactElement } from 'react';
-import * as React from 'react';
+import type { HTMLAttributes, ReactElement, PropsWithChildren } from 'react';
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 import classnames from 'classnames';
 
@@ -41,7 +40,7 @@ const Dont = ({ children, ...rest }: Omit<BlockTypes, 'icon' | 'title'>) => {
 	);
 };
 
-export const Use = ({ children }: React.PropsWithChildren<HTMLDivElement>) => (
+export const Use = ({ children }: PropsWithChildren<HTMLDivElement>) => (
 	<Grid columns={2}>{children}</Grid>
 );
 

--- a/packages/storybook/.storybook/docs/WithSelector.tsx
+++ b/packages/storybook/.storybook/docs/WithSelector.tsx
@@ -1,17 +1,15 @@
-import * as React from 'react';
+import { useState, useRef, useEffect, cloneElement } from 'react';
+import type { PropsWithChildren } from 'react';
 import { Args, ReactFramework, StoryContext, StoryFn } from '@storybook/react';
 
 type Selector = ':hover' | ':focus' | ':active';
 
-const WithSelector = ({
-	children,
-	selector,
-}: React.PropsWithChildren<any> & { selector: Selector }) => {
-	const [className, setClassName] = React.useState<string>('');
-	const [styles, setStyles] = React.useState<string[]>([]);
-	const ref = React.useRef<HTMLElement>();
+const WithSelector = ({ children, selector }: PropsWithChildren<any> & { selector: Selector }) => {
+	const [className, setClassName] = useState<string>('');
+	const [styles, setStyles] = useState<string[]>([]);
+	const ref = useRef<HTMLElement>();
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!ref.current) return;
 		setStyles([]);
 		const selectors = Array.from(ref.current.classList).map(clazz => {
@@ -44,7 +42,7 @@ const WithSelector = ({
 		}
 	}, [selector]);
 
-	React.useEffect(() => {
+	useEffect(() => {
 		if (!ref.current) return;
 		ref.current.className = `${ref.current.className} ${className}`;
 	}, [className]);
@@ -52,7 +50,7 @@ const WithSelector = ({
 	return (
 		<>
 			{styles && <style>{styles.join(' ')}</style>}
-			{React.cloneElement(children, {
+			{cloneElement(children, {
 				ref,
 			})}
 		</>

--- a/packages/storybook/.storybook/docs/tokensDocHelpers/ColorCompositions/ColorCompositions.tsx
+++ b/packages/storybook/.storybook/docs/tokensDocHelpers/ColorCompositions/ColorCompositions.tsx
@@ -1,5 +1,5 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
-import * as React from 'react';
+import type { HTMLAttributes } from 'react';
 
 import { StackVertical, TabsKit } from '@talend/design-system';
 import { ColorToken, Token, TokenType } from '../../../../src/tokens/types';
@@ -19,7 +19,7 @@ type ColorComposition = {
 
 const SemanticColors = ['Accent', 'Danger', 'Warning', 'Success', 'Beta'];
 
-const ColorTokens = ({ tokens, ...rest }: React.HTMLAttributes<HTMLDivElement> & TokensProps) => {
+const ColorTokens = ({ tokens, ...rest }: HTMLAttributes<HTMLDivElement> & TokensProps) => {
 	const colorTokens = tokens
 		.filter((t: Token) => [TokenType.COLOR, TokenType.GRADIENT].includes(t.type))
 		.reduce((acc: Record<string, ColorToken>, curr: ColorToken) => {

--- a/packages/storybook/.storybook/docs/tokensDocHelpers/TokenName.tsx
+++ b/packages/storybook/.storybook/docs/tokensDocHelpers/TokenName.tsx
@@ -1,9 +1,9 @@
-import * as React from 'react';
+import type { HTMLAttributes } from 'react';
 
 import { getDisplayName } from './TokenFormatter';
 import { PropsWithToken } from './TokensTypes';
 
-const TokenName = ({ token, ...rest }: React.HTMLAttributes<HTMLDivElement> & PropsWithToken) => (
+const TokenName = ({ token, ...rest }: HTMLAttributes<HTMLDivElement> & PropsWithToken) => (
 	<div {...rest}>{getDisplayName(token?.name)}</div>
 );
 

--- a/packages/storybook/.storybook/docs/tokensDocHelpers/TokensTypes.ts
+++ b/packages/storybook/.storybook/docs/tokensDocHelpers/TokensTypes.ts
@@ -1,7 +1,7 @@
-import * as React from 'react';
+import type { PropsWithChildren } from 'react';
 import { Token, Tokens } from '../../../src/tokens/types';
 
-export type TokensProps = React.PropsWithChildren<any> & {
+export type TokensProps = PropsWithChildren<any> & {
 	tokens: Tokens;
 };
 

--- a/packages/storybook/src/design-system/Card/Card.stories.tsx
+++ b/packages/storybook/src/design-system/Card/Card.stories.tsx
@@ -1,4 +1,4 @@
-import * as React from 'react';
+import type { ReactNode } from 'react';
 
 import { Card } from '@talend/design-system';
 
@@ -6,7 +6,7 @@ export default {
 	component: Card,
 };
 
-export const DefaultCard = (): React.ReactNode => (
+export const DefaultCard = (): ReactNode => (
 	<Card header="Hello!">
 		<p>Here lies the card's content</p>
 	</Card>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

- react imports remain with all package import
- @talend/scripts-config-babel has been changed but no bump have been made

**What is the chosen solution to this problem?**

- clean `import * as React` imports by importing only used properties. 
- add changeset for missed @talend/scripts-config-babel change https://github.com/Talend/ui/pull/4662/files#diff-df483b7faccb32d90c98cdedb62b89a0c548c5a4ec488cd47b7c4ba1dbfdc975R9

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
