### PR TITLE
feat(ARCH-482): remove react < 18.0.0 from peerdep

### DIFF
--- a/.changeset/honest-icons-laugh.md
+++ b/.changeset/honest-icons-laugh.md
@@ -1,0 +1,18 @@
+---
+'@talend/scripts-config-jest': minor
+'@talend/react-faceted-search': minor
+'@talend/react-flow-designer': minor
+'@talend/react-storybook-cmf': minor
+'@talend/react-cmf-router': minor
+'@talend/react-components': minor
+'@talend/react-containers': minor
+'@talend/react-cmf-cqrs': minor
+'@talend/react-dataviz': minor
+'@talend/react-stepper': minor
+'@talend/react-forms': minor
+'@talend/react-sagas': minor
+'@talend/react-a11y': minor
+'@talend/react-cmf': minor
+---
+
+feat: update peerDependencies to accept react-18

--- a/packages/a11y/package.json
+++ b/packages/a11y/package.json
@@ -35,8 +35,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cmf-cqrs/package.json
+++ b/packages/cmf-cqrs/package.json
@@ -48,8 +48,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/cmf-router/package.json
+++ b/packages/cmf-router/package.json
@@ -29,8 +29,8 @@
     "redux-saga": "^1.2.2"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0"
   },
   "devDependencies": {
     "@redux-saga/testing-utils": "^1.1.5",

--- a/packages/cmf/package.json
+++ b/packages/cmf/package.json
@@ -66,8 +66,8 @@
     "redux-saga-tester": "^1.0.874"
   },
   "peerDependencies": {
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -104,8 +104,8 @@
     "@talend/design-system": "^7.5.0",
     "i18next": "^20.1.0",
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-i18next": "^11.18.6"
   },
   "resolutions": {

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -67,8 +67,8 @@
   "peerDependencies": {
     "i18next": "^20.1.0",
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-i18next": "^11.18.6"
   },
   "publishConfig": {

--- a/packages/dataviz/package.json
+++ b/packages/dataviz/package.json
@@ -71,7 +71,7 @@
   },
   "peerDependencies": {
     "i18next": "^20.1.0",
-    "react": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
     "react-i18next": "^11.18.6"
   },
   "publishConfig": {

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -65,8 +65,8 @@
     "@talend/react-components": "^10.0.0",
     "i18next": "^20.6.1",
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-i18next": "^11.18.6"
   },
   "publishConfig": {

--- a/packages/flow-designer/package.json
+++ b/packages/flow-designer/package.json
@@ -47,8 +47,8 @@
   "peerDependencies": {
     "immutable": "3",
     "lodash": "4",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-redux": "^7.2.9",
     "redux": "^4.2.1",
     "reselect": "^4.1.7"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -82,8 +82,8 @@
   "peerDependencies": {
     "i18next": "^20.1.0",
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-i18next": "^11.18.6"
   },
   "publishConfig": {

--- a/packages/sagas/package.json
+++ b/packages/sagas/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0"
   },
   "devDependencies": {
     "@talend/scripts-core": "^13.1.2",

--- a/packages/stepper/package.json
+++ b/packages/stepper/package.json
@@ -54,8 +54,8 @@
   "peerDependencies": {
     "i18next": "^20.1.0",
     "prop-types": "^15.5.10",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-i18next": "^11.18.6",
     "react-redux": "^7.2.9",
     "react-transition-group": "^2.3.1"

--- a/packages/storybook-cmf/package.json
+++ b/packages/storybook-cmf/package.json
@@ -37,8 +37,8 @@
   },
   "peerDependencies": {
     "@talend/react-cmf": "^7.1.4",
-    "react": ">= 16.14.0 < 18.0.0",
-    "react-dom": ">= 16.14.0 < 18.0.0",
+    "react": ">= 16.14.0",
+    "react-dom": ">= 16.14.0",
     "react-redux": "^7.2.9",
     "redux-saga": "^1.2.2"
   }

--- a/tools/scripts-config-jest/package.json
+++ b/tools/scripts-config-jest/package.json
@@ -19,7 +19,7 @@
   },
   "peerDependencies": {
     "enzyme": "3",
-    "react": ">= 16.14.0 < 18.0.0"
+    "react": ">= 16.14.0"
   },
   "dependencies": {
     "@talend/scripts-config-babel": "^12.0.0",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We are working hard to rewrite all tests using RTL.
We don't want to block project to move forward.

**What is the chosen solution to this problem?**

Unlock react 18, but know the following libraries are not testing against react 18


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
