### PR TITLE
fix(design-system): Button style while compacted by parent layout

### DIFF
--- a/.changeset/four-eyes-draw.md
+++ b/.changeset/four-eyes-draw.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(design-system): Button style while compacted by layout

--- a/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
+++ b/packages/design-system/src/components/Button/Primitive/ButtonStyles.module.scss
@@ -9,6 +9,7 @@
 	border-radius: tokens.$coral-radius-s;
 	height: tokens.$coral-sizing-m;
 	padding: tokens.$coral-spacing-xxs tokens.$coral-spacing-m;
+	white-space: nowrap;
 
 	&__icon {
 		display: inline-flex;

--- a/packages/storybook/src/design-system/Button/Button.stories.tsx
+++ b/packages/storybook/src/design-system/Button/Button.stories.tsx
@@ -102,51 +102,53 @@ export const Tertiary = TertiaryTemplate.bind({});
 Tertiary.argTypes = commonArgTypes;
 
 export const PrimaryVariations = () => (
-	<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
-		<StackVertical gap="S" justify="start" align="center">
-			<h3>Default</h3>
-			<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
-			<ButtonPrimary onClick={action('Clicked')} size="S">
-				Primary S
-			</ButtonPrimary>
-		</StackVertical>
-		<StackVertical gap="S" justify="start" align="center">
-			<h3>With icon</h3>
-			<ButtonPrimary icon="upload" onClick={action('Clicked')}>
-				Primary M
-			</ButtonPrimary>
-			<ButtonPrimary onClick={action('Clicked')} size="S" icon="upload">
-				Primary S
-			</ButtonPrimary>
-		</StackVertical>
-		<StackVertical gap="S" justify="start" align="center">
-			<h3>With dropdown indicator</h3>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')}>
-				Primary M
-			</ButtonPrimary>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S">
-				Primary S
-			</ButtonPrimary>
-		</StackVertical>
-		<StackVertical gap="S" justify="start" align="center">
-			<h3>Disabled</h3>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} disabled>
-				Primary M
-			</ButtonPrimary>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
-				Primary S
-			</ButtonPrimary>
-		</StackVertical>
-		<StackVertical gap="S" justify="start" align="center">
-			<h3>Loading</h3>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
-				Primary M
-			</ButtonPrimary>
-			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
-				Primary S
-			</ButtonPrimary>
-		</StackVertical>
-	</StackHorizontal>
+	<div style={{ width: '100px' }}>
+		<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
+			<StackVertical gap="S" justify="start" align="center">
+				<h3>Default</h3>
+				<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
+				<ButtonPrimary onClick={action('Clicked')} size="S">
+					Primary Small
+				</ButtonPrimary>
+			</StackVertical>
+			<StackVertical gap="S" justify="start" align="center">
+				<h3>With icon</h3>
+				<ButtonPrimary icon="upload" onClick={action('Clicked')}>
+					Primary M
+				</ButtonPrimary>
+				<ButtonPrimary onClick={action('Clicked')} size="S" icon="upload">
+					Primary Small
+				</ButtonPrimary>
+			</StackVertical>
+			<StackVertical gap="S" justify="start" align="center">
+				<h3>With dropdown indicator</h3>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')}>
+					Primary M
+				</ButtonPrimary>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S">
+					Primary Small
+				</ButtonPrimary>
+			</StackVertical>
+			<StackVertical gap="S" justify="start" align="center">
+				<h3>Disabled</h3>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} disabled>
+					Primary M
+				</ButtonPrimary>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
+					Primary Small
+				</ButtonPrimary>
+			</StackVertical>
+			<StackVertical gap="S" justify="start" align="center">
+				<h3>Loading</h3>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
+					Primary M
+				</ButtonPrimary>
+				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
+					Primary Small
+				</ButtonPrimary>
+			</StackVertical>
+		</StackHorizontal>
+	</div>
 );
 
 export const DestructiveVariations = () => (

--- a/packages/storybook/src/design-system/Button/Button.stories.tsx
+++ b/packages/storybook/src/design-system/Button/Button.stories.tsx
@@ -102,53 +102,51 @@ export const Tertiary = TertiaryTemplate.bind({});
 Tertiary.argTypes = commonArgTypes;
 
 export const PrimaryVariations = () => (
-	<div style={{ width: '100px' }}>
-		<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
-			<StackVertical gap="S" justify="start" align="center">
-				<h3>Default</h3>
-				<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
-				<ButtonPrimary onClick={action('Clicked')} size="S">
-					Primary Small
-				</ButtonPrimary>
-			</StackVertical>
-			<StackVertical gap="S" justify="start" align="center">
-				<h3>With icon</h3>
-				<ButtonPrimary icon="upload" onClick={action('Clicked')}>
-					Primary M
-				</ButtonPrimary>
-				<ButtonPrimary onClick={action('Clicked')} size="S" icon="upload">
-					Primary Small
-				</ButtonPrimary>
-			</StackVertical>
-			<StackVertical gap="S" justify="start" align="center">
-				<h3>With dropdown indicator</h3>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')}>
-					Primary M
-				</ButtonPrimary>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S">
-					Primary Small
-				</ButtonPrimary>
-			</StackVertical>
-			<StackVertical gap="S" justify="start" align="center">
-				<h3>Disabled</h3>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} disabled>
-					Primary M
-				</ButtonPrimary>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
-					Primary Small
-				</ButtonPrimary>
-			</StackVertical>
-			<StackVertical gap="S" justify="start" align="center">
-				<h3>Loading</h3>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
-					Primary M
-				</ButtonPrimary>
-				<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
-					Primary Small
-				</ButtonPrimary>
-			</StackVertical>
-		</StackHorizontal>
-	</div>
+	<StackHorizontal gap="S" justify="spaceBetween" align="stretch">
+		<StackVertical gap="S" justify="start" align="center">
+			<h3>Default</h3>
+			<ButtonPrimary onClick={action('Clicked')}>Primary M</ButtonPrimary>
+			<ButtonPrimary onClick={action('Clicked')} size="S">
+				Primary S
+			</ButtonPrimary>
+		</StackVertical>
+		<StackVertical gap="S" justify="start" align="center">
+			<h3>With icon</h3>
+			<ButtonPrimary icon="upload" onClick={action('Clicked')}>
+				Primary M
+			</ButtonPrimary>
+			<ButtonPrimary onClick={action('Clicked')} size="S" icon="upload">
+				Primary S
+			</ButtonPrimary>
+		</StackVertical>
+		<StackVertical gap="S" justify="start" align="center">
+			<h3>With dropdown indicator</h3>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')}>
+				Primary M
+			</ButtonPrimary>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S">
+				Primary S
+			</ButtonPrimary>
+		</StackVertical>
+		<StackVertical gap="S" justify="start" align="center">
+			<h3>Disabled</h3>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} disabled>
+				Primary M
+			</ButtonPrimary>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" disabled>
+				Primary S
+			</ButtonPrimary>
+		</StackVertical>
+		<StackVertical gap="S" justify="start" align="center">
+			<h3>Loading</h3>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} isLoading>
+				Primary M
+			</ButtonPrimary>
+			<ButtonPrimary icon="upload" isDropdown onClick={action('Clicked')} size="S" isLoading>
+				Primary S
+			</ButtonPrimary>
+		</StackVertical>
+	</StackHorizontal>
 );
 
 export const DestructiveVariations = () => (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
<img width="693" alt="CleanShot 2023-04-13 at 08 13 06@2x" src="https://user-images.githubusercontent.com/2909671/231670358-30c3fb55-34d4-4556-8c2d-45cce66ae5e4.png">

**What is the chosen solution to this problem?**
<img width="744" alt="CleanShot 2023-04-13 at 08 14 28@2x" src="https://user-images.githubusercontent.com/2909671/231670385-6be91438-908e-42c4-b54c-a140a74e0fe9.png">

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
