### PR TITLE
fix(TDOPS-4043/dateUtils): export dateUtil generator functions

### DIFF
--- a/.changeset/happy-snakes-grab.md
+++ b/.changeset/happy-snakes-grab.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': patch
+---
+
+fix(TDOPS-4043/dateUtils): export dateUtil generator functions

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -1,6 +1,6 @@
 import dateFnsFormat from 'date-fns/format';
 import parse from 'date-fns/parse';
-import { buildWeeks } from './generator';
+import * as generator from './generator';
 
 type DateFnsFormatInput = Date | number | string;
 
@@ -222,6 +222,8 @@ export function format(date: DateFnsFormatInput, dateOption: string, lang: strin
 	return new Intl.DateTimeFormat(lang, options[dateOption]).format(parse(date));
 }
 
+export const buildWeeks = generator.buildWeeks;
+
 export default {
 	convertToLocalTime,
 	convertToTimeZone,
@@ -232,5 +234,4 @@ export default {
 	formatToTimeZone,
 	getUTCOffset,
 	timeZoneExists,
-	buildWeeks,
 };

--- a/packages/utils/src/date/index.ts
+++ b/packages/utils/src/date/index.ts
@@ -1,6 +1,6 @@
 import dateFnsFormat from 'date-fns/format';
 import parse from 'date-fns/parse';
-export * from './generator';
+import { buildWeeks } from './generator';
 
 type DateFnsFormatInput = Date | number | string;
 
@@ -232,4 +232,5 @@ export default {
 	formatToTimeZone,
 	getUTCOffset,
 	timeZoneExists,
+	buildWeeks,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Tests are failing without the export of individual date generator util function

**What is the chosen solution to this problem?**
export dateUtil generator functions

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
