### PR TITLE
chore: add ChartEntry to dataviz exported types

### DIFF
--- a/.changeset/quiet-goats-cough.md
+++ b/.changeset/quiet-goats-cough.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+chore: add ChartEntry to dataviz exported types

--- a/packages/dataviz/src/index.ts
+++ b/packages/dataviz/src/index.ts
@@ -9,6 +9,7 @@ export * from './components/BarChart/barChart.tooltip';
 export * from './components/GeoChart/GeoChart.utils';
 export * from './components/RangeFilter/handlers';
 
+export type { ChartEntry } from './components/BarChart/barChart.types';
 export type { HorizontalBarChartProps } from './components/BarChart/HorizontalBarChart';
 export type {
 	VerticalBarChartEntry,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This PR adds `ChartEntry` to `dataviz` exported types to avoid deep imports on other packages like:
```
import { ChartEntry } from '@talend/react-dataviz/lib/components/BarChart/barChart.types';
```

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
