### PR TITLE
feat(cmf-cqrs): useWebsocket & filter the events

### DIFF
--- a/.changeset/stupid-bears-march.md
+++ b/.changeset/stupid-bears-march.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-cmf-cqrs': major
+---
+
+feat(cmf-cqrs): allow to pass a filter function to useWebsocket

--- a/packages/cmf-cqrs/src/index.ts
+++ b/packages/cmf-cqrs/src/index.ts
@@ -1,12 +1,12 @@
 import actions from './actions';
 import ACKDispatcher from './components/ACKDispatcher';
+import * as constants from './constants';
 import middlewares from './middleware';
 import reducers from './reducers';
 import { ackProcessed } from './reducers/ack';
-import * as constants from './constants';
 import sagas from './sagas';
 
-export { useWebSocket } from './hooks';
+export { useWebSocket } from './useWebSocket.hook';
 export { actions, ACKDispatcher, constants, middlewares, reducers, sagas, ackProcessed };
 
 export default {

--- a/packages/cmf-cqrs/src/useWebSocket.hook.test.ts
+++ b/packages/cmf-cqrs/src/useWebSocket.hook.test.ts
@@ -1,7 +1,7 @@
 import { renderHook, act } from '@testing-library/react-hooks';
 
-import { useWebSocket } from './hooks';
 import { addWebsocketToRegistry, removeWebSocketFromRegistry } from './registry';
+import { useWebSocket } from './useWebSocket.hook';
 
 const messageEvent1 = {
 	data: '{"messageType": "unit test", "value": "test"}',
@@ -84,7 +84,9 @@ describe('hooks', () => {
 
 	it('should filter the messages based on their types', () => {
 		// given
-		const { result } = renderHook(() => useWebSocket(['unit test']));
+		const { result } = renderHook(() =>
+			useWebSocket((data: any) => data.messageType !== 'unit test'),
+		);
 		expect(result.current.lastMessage).toBeUndefined();
 		expect(result.current.lastJsonMessage).toBeUndefined();
 

--- a/packages/cmf-cqrs/src/useWebSocket.hook.ts
+++ b/packages/cmf-cqrs/src/useWebSocket.hook.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
+
 import { WEBSOCKET_READY_STATE } from './constants';
 import { getWebSocketFromRegistry } from './registry';
 
@@ -8,8 +9,8 @@ export interface WebsocketMessageData {
 }
 
 export const useWebSocket = <T extends WebsocketMessageData>(
-	messageTypeDenyList: string[] = [],
-	id: string = 'default',
+	messageFilterFunction: (data: T) => boolean = () => true,
+	id = 'default',
 ) => {
 	const websocketRef = useRef<WebSocket>();
 	const [lastMessage, setLastMessage] = useState<{
@@ -32,7 +33,7 @@ export const useWebSocket = <T extends WebsocketMessageData>(
 
 	const onMessage = (messageEvent: MessageEvent<string>) => {
 		const data: T = JSON.parse(messageEvent.data);
-		if (!messageTypeDenyList.includes(data.messageType)) {
+		if (messageFilterFunction(data)) {
 			setLastMessage({ message: messageEvent, jsonData: data });
 		}
 	};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can only pass a denylist to useWebsocket while passing a function to filter the even we want to have would be a better API for this hook.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
