### PR TITLE
fix(TDOPS-4264/NestedList): expand list based on the schema options

### DIFF
--- a/.changeset/clever-coats-wonder.md
+++ b/.changeset/clever-coats-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+fix(TDOPS-4264/NestedList): expand list based on the schema options

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.test.js
@@ -334,6 +334,12 @@ describe('NestedListView component', () => {
 			const value = { bar: ['bar_2'] };
 			// when
 			render(<NestedListViewWidget {...props} value={value} />);
+			// when expanding the main checkbox
+			userEvent.click(
+				screen.getByRole('button', {
+					name: new RegExp(`\\b${props.schema.items[0].title}\\b`, 'i'),
+				}),
+			);
 			// selecting the children
 			userEvent.click(
 				screen.getByRole('checkbox', {

--- a/packages/forms/src/UIForm/fields/NestedListView/NestedListView.utils.js
+++ b/packages/forms/src/UIForm/fields/NestedListView/NestedListView.utils.js
@@ -64,7 +64,11 @@ export function prepareItemsFromSchema(schema, callbacks, value) {
 
 		return {
 			label: item.title,
-			expanded: (value[key]?.length > 0 && value[key]?.length !== item.titleMap.length) || false,
+			expanded:
+				(schema.options?.expandChecked &&
+					value[key]?.length > 0 &&
+					value[key]?.length !== item.titleMap.length) ||
+				false,
 			key,
 			onExpandToggle,
 			onChange: onParentChange,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Nested list in forms expands by default

**What is the chosen solution to this problem?**
Expand list based on the schema options

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
