### PR TITLE
chore(http): Improve code covering

### DIFF
--- a/.changeset/fluffy-pillows-wink.md
+++ b/.changeset/fluffy-pillows-wink.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': minor
+---
+
+chore(http): Improve code covering

--- a/packages/http/src/config.test.ts
+++ b/packages/http/src/config.test.ts
@@ -24,5 +24,19 @@ describe('Configuration service', () => {
 
 			expect(getDefaultConfig()).toEqual({ headers: { 'Accept-Language': 'ja' } });
 		});
+
+		it('should throw error on second call', () => {
+			setDefaultConfig({
+				headers: {},
+			});
+
+			expect(() => {
+				setDefaultConfig({
+					headers: {},
+				});
+			}).toThrow(
+				'ERROR: setDefaultConfig should not be called twice, if you wish to change the language use setDefaultLanguage api.',
+			);
+		});
 	});
 });

--- a/packages/http/src/csrfHandling.ts
+++ b/packages/http/src/csrfHandling.ts
@@ -56,10 +56,7 @@ function parseCookie(cookie: string): Map<string, string> {
  */
 function findCSRFToken({ CSRFTokenCookieKey = 'csrfToken' }: TalendRequestInitSecurity) {
 	return (cookieValues: Map<string, string>): string | undefined => {
-		if (cookieValues instanceof Map) {
-			return cookieValues.get(CSRFTokenCookieKey);
-		}
-		return undefined;
+		return cookieValues.get(CSRFTokenCookieKey);
 	};
 }
 

--- a/packages/http/src/http.common.test.ts
+++ b/packages/http/src/http.common.test.ts
@@ -4,6 +4,7 @@ import { Response, Headers } from 'node-fetch';
 import { HTTP, getDefaultConfig, setDefaultConfig } from './config';
 import { httpFetch, handleBody, encodePayload, handleHttpResponse } from './http.common';
 import { HTTP_METHODS, HTTP_STATUS } from './http.constants';
+import { TalendHttpError } from './http.types';
 
 const CSRFToken = 'hNjmdpuRgQClwZnb2c59F9gZhCi8jv9x';
 const defaultBody = { is: 'ok' };
@@ -14,6 +15,9 @@ const defaultPayload = {
 beforeEach(() => {
 	jest.clearAllMocks();
 });
+
+const isTalendHttpError = (err: any): err is TalendHttpError<unknown> =>
+	'response' in err && 'data' in err;
 
 describe('handleBody', () => {
 	it('should manage the body of the response like text if no header', async () => {
@@ -95,9 +99,10 @@ describe('handleBody', () => {
 						headers,
 					}) as any,
 				);
-			} catch (e) {
-				// @ts-ignore
-				expect(e.message).toEqual('403');
+			} catch (err) {
+				if (err instanceof Error) {
+					expect(err.message).toEqual('403');
+				}
 			}
 		});
 
@@ -130,11 +135,11 @@ describe('handleBody', () => {
 						status: HTTP_STATUS.INTERNAL_SERVER_ERROR,
 					}) as any,
 				);
-			} catch (e) {
-				// @ts-ignore
-				expect(e.response instanceof Response).toBe(true);
-				// @ts-ignore
-				expect(e.response.status).toEqual(500);
+			} catch (err) {
+				if (isTalendHttpError(err)) {
+					expect(err.response instanceof Response).toBe(true);
+					expect(err.response.status).toEqual(500);
+				}
 			}
 		});
 	});

--- a/packages/http/src/http.common.ts
+++ b/packages/http/src/http.common.ts
@@ -43,7 +43,7 @@ export function encodePayload(headers: HeadersInit, payload: any) {
 export async function handleBody(response: Response) {
 	let methodBody = 'text';
 
-	const headers = response?.headers || new Headers();
+	const { headers } = response;
 	const contentType = headers.get('Content-Type');
 	if (contentType && contentType.includes('application/json')) {
 		methodBody = 'json';

--- a/packages/http/src/http.constants.test.ts
+++ b/packages/http/src/http.constants.test.ts
@@ -1,0 +1,45 @@
+import { HTTP_STATUS, isHTTPStatus, testHTTPCode } from './http.constants';
+
+describe('Http constants', () => {
+	it('isInformational should return true', () => {
+		expect(testHTTPCode.isInformational(HTTP_STATUS.PROCESSING)).toBe(true);
+		expect(testHTTPCode.isInformational(HTTP_STATUS.CONTINUE)).toBe(true);
+	});
+
+	it('isInformational should return false', () => {
+		expect(testHTTPCode.isInformational(HTTP_STATUS.OK)).toBe(false);
+		expect(testHTTPCode.isInformational(HTTP_STATUS.NOT_FOUND)).toBe(false);
+	});
+
+	it('isRedirection should return true', () => {
+		expect(testHTTPCode.isRedirection(HTTP_STATUS.PERMANENT_REDIRECT)).toBe(true);
+		expect(testHTTPCode.isRedirection(HTTP_STATUS.MULTIPLE_CHOICES)).toBe(true);
+	});
+
+	it('isRedirection should return false', () => {
+		expect(testHTTPCode.isRedirection(HTTP_STATUS.IM_USED)).toBe(false);
+		expect(testHTTPCode.isRedirection(HTTP_STATUS.NOT_FOUND)).toBe(false);
+	});
+
+	it('isClientError should return true', () => {
+		expect(testHTTPCode.isClientError(HTTP_STATUS.BAD_REQUEST)).toBe(true);
+		expect(testHTTPCode.isClientError(HTTP_STATUS.UNAVAILABLE_FOR_LEGAL_REASONS)).toBe(true);
+	});
+
+	it('isClientError should return false', () => {
+		expect(testHTTPCode.isClientError(HTTP_STATUS.USE_PROXY)).toBe(false);
+		expect(testHTTPCode.isClientError(HTTP_STATUS.NOT_IMPLEMENTED)).toBe(false);
+	});
+
+	it('isServerError should return true', () => {
+		expect(testHTTPCode.isServerError(HTTP_STATUS.NOT_IMPLEMENTED)).toBe(true);
+	});
+
+	it('isServerError should return false', () => {
+		expect(testHTTPCode.isServerError(HTTP_STATUS.UNAVAILABLE_FOR_LEGAL_REASONS)).toBe(false);
+	});
+
+	it('isHTTPStatus should return 0 for unknown http code', () => {
+		expect(isHTTPStatus(666)).toBe(0);
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Improve @talend/http code covering percentage

**What is the chosen solution to this problem?**
Add unit tests

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
