### PR TITLE
feat(tools/yarn): add stdout to logs in case code>0

### DIFF
--- a/.changeset/neat-cows-turn.md
+++ b/.changeset/neat-cows-turn.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-yarn-workspace': minor
+---
+
+feat: make it logs stdout so you know what happens in case of error

--- a/tools/scripts-yarn-workspace/src/run.js
+++ b/tools/scripts-yarn-workspace/src/run.js
@@ -27,7 +27,7 @@ export async function run(cmd, opts = {}) {
 			if (code > 0) {
 				run.exitCode += 1;
 				console.error(`#### RUNNER: ${cmd.name} ${cmd.args.join(' ')} exit code ${code}`);
-				reject(stderr);
+				reject(`STDOUT: ${stdout}\n\nSTDERR: ${stderr}`);
 				return;
 			}
 			const end = Date.now();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current yarn workspace script do not log stdout so in case of error, we have only the error not the complete output.

**What is the chosen solution to this problem?**

add the stdout:

![image](https://user-images.githubusercontent.com/19857479/236482678-8e3ed043-c3b5-4abd-8599-c257a83a3a7f.png)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
