### PR TITLE
feat(TFD-15534): Add status to accordion header

### DIFF
--- a/.changeset/lucky-lemons-jam.md
+++ b/.changeset/lucky-lemons-jam.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+chore(TFD-15534): Add status to accordion header

--- a/packages/design-system/src/components/Status/Primitive/Status.module.scss
+++ b/packages/design-system/src/components/Status/Primitive/Status.module.scss
@@ -1,6 +1,7 @@
 @use '~@talend/design-tokens/lib/tokens';
 
 .status {
+	display: flex;
 	font: tokens.$coral-paragraph-m-bold;
 	color: tokens.$coral-color-neutral-text-weak;
 

--- a/packages/design-system/src/components/Status/Status.tsx
+++ b/packages/design-system/src/components/Status/Status.tsx
@@ -40,4 +40,6 @@ const Status = forwardRef((props: StatusProps, ref: Ref<HTMLSpanElement>) => {
 	}
 });
 
+Status.displayName = 'Status';
+
 export default Status;

--- a/packages/design-system/src/components/WIP/Accordion/Accordion.cy.tsx
+++ b/packages/design-system/src/components/WIP/Accordion/Accordion.cy.tsx
@@ -98,4 +98,41 @@ context('<CollapsiblePanel />', () => {
 			.should('have.attr', 'aria-expanded', 'true');
 		cy.get('#CollapsiblePanel__control--panel-a').should('have.attr', 'aria-expanded', 'false');
 	});
+
+	it('should display proper title without status', () => {
+		cy.mount(
+			<div style={{ maxWidth: '80rem', marginLeft: 'auto', marginRight: 'auto', padding: '3rem' }}>
+				<CollapsiblePanel id="panel-a" title="MyTitle">
+					<SampleParagraph />
+				</CollapsiblePanel>
+			</div>,
+		);
+		cy.get('#CollapsiblePanel__control--panel-a')
+			.find(':nth-child(2)') // Get the second child element
+			.then($element => {
+				const classname = $element.attr('class');
+				expect(classname).to.match(/CollapsiblePanelHeader-module__headerTitle/);
+				expect(classname).to.not.match(/Status-module__status/);
+
+				const title = $element.text(); // Get the text content of the element
+				expect(title).to.equal('MyTitle');
+			});
+	});
+
+	it('should display status without title', () => {
+		cy.mount(
+			<div style={{ maxWidth: '80rem', marginLeft: 'auto', marginRight: 'auto', padding: '3rem' }}>
+				<CollapsiblePanel id="panel-a" status="successful">
+					<SampleParagraph />
+				</CollapsiblePanel>
+			</div>,
+		);
+		cy.get('#CollapsiblePanel__control--panel-a')
+			.find(':nth-child(2)') // Get the second child element
+			.then($element => {
+				const classname = $element.attr('class');
+				expect(classname).to.not.match(/CollapsiblePanelHeader-module__headerTitle/);
+				expect(classname).to.match(/Status-module__status/);
+			});
+	});
 });

--- a/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanel.tsx
+++ b/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanel.tsx
@@ -4,16 +4,17 @@ import { unstable_useId as useId } from 'reakit/Id';
 
 import { DataAttributes } from '../../../../types';
 
+import { variants } from '../../../Status/Primitive/StatusPrimitive';
+
 import CollapsiblePanelHeader from './CollapsiblePanelHeader';
 import { PanelHeaderAction } from './types';
 import styles from './CollapsiblePanel.module.scss';
 
-export type CollapsiblePanelPropsType = {
+type CollapsiblePanelCommonPropsType = {
 	children: ReactChild;
 	managed?: boolean;
 	expanded?: boolean;
 	index?: number;
-	title: string;
 	action?: PanelHeaderAction;
 	size?: 'S' | 'M';
 	metadata?: ReactChild[];
@@ -23,6 +24,19 @@ export type CollapsiblePanelPropsType = {
 	onToggleExpanded?: (index: number) => void;
 } & Omit<HTMLAttributes<HTMLDivElement>, 'className' | 'style'> &
 	DataAttributes;
+
+export type CollapsiblePanelWithTitlePropsType = {
+	title: ReactChild;
+	status?: never;
+};
+
+export type CollapsiblePanelWithStatusPropsType = {
+	title?: never;
+	status: keyof typeof variants;
+};
+
+export type CollapsiblePanelPropsType = CollapsiblePanelCommonPropsType &
+	(CollapsiblePanelWithTitlePropsType | CollapsiblePanelWithStatusPropsType);
 
 const CollapsiblePanel = forwardRef(
 	(
@@ -34,6 +48,7 @@ const CollapsiblePanel = forwardRef(
 			index,
 			onToggleExpanded,
 			title,
+			status,
 			action,
 			size,
 			metadata,
@@ -81,6 +96,7 @@ const CollapsiblePanel = forwardRef(
 					expanded={!disabled && localExpanded}
 					handleClick={handleToggleExpanded}
 					title={title}
+					status={status}
 					action={action}
 					metadata={metadata}
 					size={size}

--- a/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanelHeader.module.scss
+++ b/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanelHeader.module.scss
@@ -3,7 +3,6 @@
 .headerWrapper {
 	display: flex;
 	flex-flow: row nowrap;
-	justify-content: space-between;
 	align-items: center;
 	gap: tokens.$coral-spacing-xxs;
 

--- a/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanelHeader.tsx
+++ b/packages/design-system/src/components/WIP/Accordion/Primitive/CollapsiblePanelHeader.tsx
@@ -1,12 +1,14 @@
 import { forwardRef, ReactChild, Ref } from 'react';
 import classnames from 'classnames';
 
+import tokens from '@talend/design-tokens';
+
 import { ButtonIcon } from '../../../ButtonIcon';
 import { SizedIcon } from '../../../Icon';
 import Divider from '../../../Divider';
 import { StackHorizontal } from '../../../Stack';
-
-import tokens from '@talend/design-tokens';
+import { Status } from '../../../Status';
+import { variants } from '../../../Status/Primitive/StatusPrimitive';
 
 import { PanelHeaderAction } from './types';
 import styles from './CollapsiblePanelHeader.module.scss';
@@ -16,7 +18,8 @@ export type CollapsiblePanelHeaderPropsType = {
 	sectionId: string;
 	size?: 'S' | 'M';
 	expanded: boolean;
-	title: string;
+	title?: ReactChild;
+	status?: keyof typeof variants;
 	metadata?: ReactChild[];
 	action?: PanelHeaderAction;
 	handleClick: () => unknown;
@@ -33,6 +36,7 @@ const CollapsiblePanelHeader = forwardRef(
 			action,
 			metadata,
 			title,
+			status,
 			size,
 			disabled = false,
 		}: CollapsiblePanelHeaderPropsType,
@@ -86,14 +90,18 @@ const CollapsiblePanelHeader = forwardRef(
 			<>
 				{!disabled && getChevron()}
 
-				<span
-					className={classnames(styles.headerTitle, {
-						[styles['headerTitle__size-s']]: size === 'S',
-						[styles.headerTitle__disabled]: disabled,
-					})}
-				>
-					{title}
-				</span>
+				{status ? (
+					<Status variant={status} />
+				) : (
+					<span
+						className={classnames(styles.headerTitle, {
+							[styles['headerTitle__size-s']]: size === 'S',
+							[styles.headerTitle__disabled]: disabled,
+						})}
+					>
+						{title}
+					</span>
+				)}
 				{metadata?.length && (
 					<StackHorizontal gap="S" align="center" justify="end">
 						{listMetadata}

--- a/packages/storybook/src/design-system/Accordion/Accordion.stories.mdx
+++ b/packages/storybook/src/design-system/Accordion/Accordion.stories.mdx
@@ -40,6 +40,12 @@ Accordion is used to display expandable/collapsable cards with a title.
 	<Story story={Stories.SimpleCollapsiblePanel} />
 </Canvas>
 
+## Collapsible panel with status
+
+<Canvas>
+	<Story story={Stories.StatusCollapsiblePanel} />
+</Canvas>
+
 ## Variations
 
 **Disabled**

--- a/packages/storybook/src/design-system/Accordion/Accordion.stories.tsx
+++ b/packages/storybook/src/design-system/Accordion/Accordion.stories.tsx
@@ -25,6 +25,26 @@ export const SimpleCollapsiblePanel = () => (
 	</div>
 );
 
+export const StatusCollapsiblePanel = () => (
+	<div style={{ maxWidth: '80rem', marginLeft: 'auto', marginRight: 'auto', padding: '3rem' }}>
+		<CollapsiblePanel status="successful">
+			<SampleParagraph />
+		</CollapsiblePanel>
+		<CollapsiblePanel status="failed">
+			<SampleParagraph />
+		</CollapsiblePanel>
+		<CollapsiblePanel status="inProgress">
+			<SampleParagraph />
+		</CollapsiblePanel>
+		<CollapsiblePanel status="warning">
+			<SampleParagraph />
+		</CollapsiblePanel>
+		<CollapsiblePanel status="canceled">
+			<SampleParagraph />
+		</CollapsiblePanel>
+	</div>
+);
+
 export const DisabledPanel = {
 	render: (props: Story) => (
 		<div style={{ maxWidth: '80rem', marginLeft: 'auto', marginRight: 'auto', padding: '3rem' }}>
@@ -64,7 +84,7 @@ export const WithMetadata = () => (
 			</CollapsiblePanel>
 			<CollapsiblePanel
 				title="Simple panel with several metadata and action"
-				metadata={['Duration : 3sec', <TagSuccess key="successTag">Succes</TagSuccess>]}
+				metadata={['Duration : 3sec', <TagSuccess key="successTag">Success</TagSuccess>]}
 				action={{
 					icon: 'plus',
 					tooltip: 'action tooltip',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Adding the status variant to an Accordion header instead of simple string title
Figma:
- https://www.figma.com/file/o8mVcWTKrRF99ze5Y59r3C/Control-Flows?type=design&node-id=2236-62870&t=UsV5THoQtIjRLffH-0
- https://www.figma.com/file/CDfr4jLz1m6Ud2RNi4qpQJ/Accordion?type=design&node-id=2006-49458&t=C94f4Sg0w7YXIpOV-0

**What is the chosen solution to this problem?**
Add an optionnal status property that takes variant values ('successful', 'failed', 'inProgress', 'warning', 'canceled')

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
