### PR TITLE
feat(lint): add --fix option

### DIFF
--- a/.changeset/mighty-taxis-exist.md
+++ b/.changeset/mighty-taxis-exist.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-core': minor
+---
+
+feat: add --fix support

--- a/tools/scripts-core/doc/getting-started.md
+++ b/tools/scripts-core/doc/getting-started.md
@@ -87,3 +87,22 @@ You need to add a tsconfig at the root of your project, extending `@talend/scrip
 ```
 
 6. And you're good to go.
+
+## build options
+
+talend-scripts manage options for build as this is a script not only one sub command.
+
+_--watch_: It will not delete the target folder (which the case by default).
+This is usefull when you have a watcher already on it.
+
+_--umd_: create a UMD bundle from the library using module-to-cdn and cdn-webpack-plugin.
+
+## lint options
+
+talend-scripts manage options for build as this is a script not only one sub command.
+
+_--fix_: fix the corresponding issues that can be automatically fixed.
+
+## tests options
+
+This command is a pass through jest / karma. So you can pass anything you want.

--- a/tools/scripts-core/src/scripts/lint.js
+++ b/tools/scripts-core/src/scripts/lint.js
@@ -37,8 +37,12 @@ async function lintEs(env, presetApi, options) {
 			'.eslintrc',
 		]) || path.join(configRootPath, 'index.js');
 	let args = ['--config', eslintConfigPath, '--ext', '.js,.ts,.tsx'];
-	if (options.length > 0) {
+	if (options.length === 1 && options.includes('--fix')) {
+		args.push('--fix');
+	} else if (options.length > 0) {
 		args = args.concat(options);
+		// eslint-disable-next-line no-console
+		console.log('eslint options:', args.join(' '));
 	} else {
 		args.push('./src');
 	}
@@ -73,8 +77,12 @@ async function lintStyle(env, presetApi, options) {
 			'.stylelintrc',
 		]) || path.join(configRootPath, '.stylelintrc.js');
 	let args = ['--config', stylelintConfigPath];
-	if (options.length > 0) {
+	if (options.length === 1 && options.includes('--fix')) {
+		args.push('--fix');
+	} else if (options.length > 0) {
 		args = args.concat(options);
+		// eslint-disable-next-line no-console
+		console.log('stylelint options:', args.join(' '));
 	} else {
 		args.push('./src/**/*.*css');
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we have a lint command but adding `--fix` do not work.

**What is the chosen solution to this problem?**

Indeed as the script as to reconciliate options between stylelint and eslint we need to manage options.

Add --fix support.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
