### PR TITLE
chore: added data attributes to the BadgeDropdown component

### DIFF
--- a/.changeset/fluffy-forks-argue.md
+++ b/.changeset/fluffy-forks-argue.md
@@ -2,4 +2,4 @@
 '@talend/design-system': minor
 ---
 
-chore: added data attributes to the BadgeDropdown component
+feat: add data attributes to the BadgeDropdown component

--- a/.changeset/fluffy-forks-argue.md
+++ b/.changeset/fluffy-forks-argue.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+chore: added data attributes to the BadgeDropdown component

--- a/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
+++ b/packages/design-system/src/components/Badge/variants/BadgeDropdown.tsx
@@ -65,26 +65,33 @@ function mapBadgeItemToDropdownItem(onChange?: (selectedId: string) => void) {
 	});
 }
 
-export type BadgeDropdownProps = Omit<BadgePrimitiveProps, 'children'> & {
-	/**
-	 * Listener for item selection.
-	 */
-	onChange: (selectedId: string) => void;
+export type BadgeDropdownProps = Omit<BadgePrimitiveProps, 'children'> &
+	Partial<DataAttributes> & {
+		/**
+		 * Listener for item selection.
+		 */
+		onChange: (selectedId: string) => void;
 
-	/**
-	 * (Optional) ID of selected item. If not filled, first one is selected.
-	 */
-	selectedId?: string;
+		/**
+		 * (Optional) ID of selected item. If not filled, first one is selected.
+		 */
+		selectedId?: string;
 
-	/**
-	 * List of items available in dropdown menu.
-	 */
-	value: BadgeDropdownItem[];
-};
+		/**
+		 * List of items available in dropdown menu.
+		 */
+		value: BadgeDropdownItem[];
+	};
 
 const BadgeDropdown = forwardRef((props: BadgeDropdownProps, ref: Ref<HTMLSpanElement>) => {
-	const { onChange, selectedId, value } = props;
-
+	const {
+		onChange,
+		selectedId,
+		value,
+		'data-testid': dataTestId,
+		'data-test': dataTest,
+		'data-feature': dataFeature,
+	} = props;
 	const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);
 
 	const selectedValue = value.find(v => v.id === selectedId) || value[0];
@@ -94,10 +101,15 @@ const BadgeDropdown = forwardRef((props: BadgeDropdownProps, ref: Ref<HTMLSpanEl
 			<Dropdown
 				aria-label={t('BADGE_ARIA_lABEL_SELECT_ITEM', 'Select item')}
 				items={value.map(mapBadgeItemToDropdownItem(onChange))}
-				data-testid={props['data-testid']}
-				data-test={props['data-test']}
+				data-testid={dataTestId}
+				data-test={dataTest}
+				data-feature={dataFeature}
 			>
-				<BadgeDropdownButton data-testid={props['data-testid']} data-test={props['data-test']}>
+				<BadgeDropdownButton
+					data-testid={dataTestId}
+					data-test={dataTest}
+					data-feature={dataFeature}
+				>
 					{selectedValue?.label}
 				</BadgeDropdownButton>
 			</Dropdown>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Not having a data attributes on the BadgeDropdown component

**What is the chosen solution to this problem?**
Extending the DataAttributes interface to allow those attributes to be passed forward

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
