### PR TITLE
chore(components): upgrade autowhatever

### DIFF
--- a/.changeset/forty-jokes-repeat.md
+++ b/.changeset/forty-jokes-repeat.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: upgrade to use renamed componentWillReceiveProps change

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -50,7 +50,7 @@
     "lodash": "^4.17.21",
     "memoize-one": "^6.0.0",
     "rc-slider": "^10.1.0",
-    "react-autowhatever": "10.2.0",
+    "react-autowhatever": "github:moroshko/react-autowhatever#652a90901f1d43b950ddfe7d4e3ac339834b0004",
     "@talend/react-bootstrap": "^1.35.2",
     "react-debounce-input": "^3.3.0",
     "react-draggable": "^4.4.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15314,6 +15314,14 @@ react-autowhatever@10.2.0:
     react-themeable "^1.1.0"
     section-iterator "^2.0.0"
 
+"react-autowhatever@github:moroshko/react-autowhatever#652a90901f1d43b950ddfe7d4e3ac339834b0004":
+  version "10.2.1"
+  resolved "https://codeload.github.com/moroshko/react-autowhatever/tar.gz/652a90901f1d43b950ddfe7d4e3ac339834b0004"
+  dependencies:
+    prop-types "^15.5.8"
+    react-themeable "^1.1.0"
+    section-iterator "^2.0.0"
+
 react-clientside-effect@^1.2.5:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/react-clientside-effect/-/react-clientside-effect-1.2.6.tgz#29f9b14e944a376b03fb650eed2a754dd128ea3a"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

react-autowhatever use deprecated lifecycle not renamed
The change has been commited but not released.

**What is the chosen solution to this problem?**

Let's use the github version

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
