### PR TITLE
fix(ARCH-458/forms): remove jest from TextMode.component.js

### DIFF
--- a/.changeset/fixme-again-foo.md
+++ b/.changeset/fixme-again-foo.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+fix: remove jest from runtime

--- a/packages/forms/src/UIForm/fields/Toggle/displayMode/TextMode.component.js
+++ b/packages/forms/src/UIForm/fields/Toggle/displayMode/TextMode.component.js
@@ -4,8 +4,6 @@ import Toggle from '@talend/react-components/lib/Toggle';
 
 function noop() {}
 
-jest.unmock('@talend/design-system');
-
 export default function TextModeToggle(props) {
 	return (
 		<div className={classNames('form-group', props.className)}>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

during rewrite of tests with have this jest unmock in runtime code :facepalm: 

**What is the chosen solution to this problem?**

remove it

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
