### PR TITLE
fix(script-core/build-lib): make it compatible with yarn v3.6.0

### DIFF
--- a/.changeset/popular-icons-agree.md
+++ b/.changeset/popular-icons-agree.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-core': minor
+---
+
+Make script-config-cdn compliant with yarn v3.X

--- a/.changeset/popular-icons-agree.md
+++ b/.changeset/popular-icons-agree.md
@@ -2,4 +2,4 @@
 '@talend/scripts-core': minor
 ---
 
-Make script-config-cdn compliant with yarn v3.X
+Make scripts-core compliant with yarn v3.X

--- a/tools/scripts-core/src/scripts/build-lib.js
+++ b/tools/scripts-core/src/scripts/build-lib.js
@@ -48,8 +48,9 @@ export default async function build(env, presetApi, unsafeOptions) {
 			}
 			console.log('Compiling with babel...');
 			const babelSpawn = await utils.process.spawn(
-				babel,
+				'npx',
 				[
+					'babel',
 					'--config-file',
 					babelConfigPath,
 					'-d',
@@ -92,7 +93,9 @@ export default async function build(env, presetApi, unsafeOptions) {
 			} else {
 				console.log('Building with tsc');
 			}
-			const tscSpawn = await utils.process.spawn(tsc, args, { stdio: 'inherit', env });
+			args = 'tsc'.concat(args);
+
+			const tscSpawn = await utils.process.spawn('npx', args, { stdio: 'inherit', env });
 
 			tscSpawn.on('exit', status => {
 				if (parseInt(status, 10) !== 0) {

--- a/tools/scripts-core/src/scripts/build-lib.js
+++ b/tools/scripts-core/src/scripts/build-lib.js
@@ -93,7 +93,7 @@ export default async function build(env, presetApi, unsafeOptions) {
 			} else {
 				console.log('Building with tsc');
 			}
-			args = 'tsc'.concat(args);
+			args = ['tsc'].concat(args);
 
 			const tscSpawn = await utils.process.spawn('npx', args, { stdio: 'inherit', env });
 

--- a/tools/scripts-core/src/scripts/build-lib.js
+++ b/tools/scripts-core/src/scripts/build-lib.js
@@ -21,8 +21,6 @@ export default async function build(env, presetApi, unsafeOptions) {
 		}
 		return true;
 	});
-	const babel = utils.path.resolveBin('@babel/cli', { executable: 'babel' });
-	const tsc = utils.path.resolveBin('typescript', { executable: 'tsc' });
 
 	const babelRootPath = utils.path.getPkgRootPath('@talend/scripts-config-babel');
 	const tsRootPath = utils.path.getPkgRootPath('@talend/scripts-config-typescript');


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently build lib is not compatible with yarn v3.6.0

**What is the chosen solution to this problem?**
Change a bit the code to use npx instead of try to access to the binary of babel or tsc)

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
