### PR TITLE
fix(script-config-cdn): make it compliant with yarn v3.X

### DIFF
--- a/.changeset/violet-suns-relate.md
+++ b/.changeset/violet-suns-relate.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-cdn': minor
+---
+
+Make scripts-config-cdn compliant with yarn v3.X

--- a/tools/scripts-config-cdn/cdn.js
+++ b/tools/scripts-config-cdn/cdn.js
@@ -9,6 +9,7 @@ const moduleToCdn = require('@talend/module-to-cdn');
 const DynamicCdnWebpackPlugin = require('@talend/dynamic-cdn-webpack-plugin');
 const { findPackage } = require('@talend/dynamic-cdn-webpack-plugin/src/find');
 const lockfile = require('@yarnpkg/lockfile');
+const yaml = require('js-yaml');
 const modules = require('./modules.json');
 const umds = require('./umds.json');
 const { download } = require('./utils');
@@ -117,11 +118,21 @@ function getModulesFromLockFile(dir) {
 		lockType = 'yarn.lock';
 		lockPath = path.join(cwd, lockType);
 		if (fs.existsSync(lockPath)) {
-			const json = lockfile.parse(fs.readFileSync(lockPath, 'utf-8'));
-			infos = Object.keys(json.object)
+			let yarnv1;
+			let yarnv3;
+			try {
+				yarnv1 = lockfile.parse(fs.readFileSync(lockPath, 'utf-8'));
+			} catch (e) {
+				yarnv3 = yaml.load(fs.readFileSync(lockPath, 'utf-8'));
+				// eslint-disable-next-line no-underscore-dangle
+				delete yarnv3.__metadata;
+			}
+
+			const json = yarnv1 ? yarnv1.object : yarnv3;
+			infos = Object.keys(json)
 				.map(moduleAndversion => {
 					const moduleName = getModuleName(moduleAndversion);
-					return moduleToCdn(moduleName, json.object[moduleAndversion].version, {
+					return moduleToCdn(moduleName, json[moduleAndversion].version, {
 						env: 'development',
 					});
 				})

--- a/tools/scripts-config-cdn/package.json
+++ b/tools/scripts-config-cdn/package.json
@@ -13,6 +13,7 @@
     "@talend/dynamic-cdn-webpack-plugin": "^13.0.0",
     "@talend/module-to-cdn": "^9.8.4",
     "@yarnpkg/lockfile": "^1.1.0",
+    "js-yaml": "^3.14.1",
     "read-pkg-up": "^7.0.1"
   },
   "publishConfig": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12078,7 +12078,7 @@ js-string-escape@^1.0.1:
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
-js-yaml@3.14.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.6.1:
+js-yaml@3.14.1, js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.1, js-yaml@^3.6.1:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
   integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
yarn.lock file change between v1 and v3
With v3 we need to use fonction to read yaml

**What is the chosen solution to this problem?**
Make the code compatible with v1 and v3

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
