### PR TITLE
feat(http): add global interceptors

### DIFF
--- a/.changeset/good-radios-push.md
+++ b/.changeset/good-radios-push.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': minor
+---
+
+feat(http): add the possibility to add global interceptors for every calls that got through @talend/http calls

--- a/.changeset/good-radios-push.md
+++ b/.changeset/good-radios-push.md
@@ -3,3 +3,15 @@
 ---
 
 feat(http): add the possibility to add global interceptors for every calls that got through @talend/http calls
+
+Usage:
+  
+```typescript
+import { addHttpInterceptor, HTTP_STATUS } from '@talend/http';
+
+addHttpInterceptor('logout', (response: Response): void => {
+	if (response.status === HTTP_STATUS.UNAUTHORIZED) {
+		logout();
+	}
+});
+```

--- a/.changeset/good-radios-push.md
+++ b/.changeset/good-radios-push.md
@@ -7,9 +7,9 @@ feat(http): add the possibility to add global interceptors for every calls that 
 Usage:
   
 ```typescript
-import { addHttpInterceptor, HTTP_STATUS } from '@talend/http';
+import { addHttpResponseInterceptor, HTTP_STATUS } from '@talend/http';
 
-addHttpInterceptor('logout', (response: Response): void => {
+addHttpResponseInterceptor('logout', (response: Response): void => {
 	if (response.status === HTTP_STATUS.UNAUTHORIZED) {
 		logout();
 	}

--- a/packages/http/src/config.test.ts
+++ b/packages/http/src/config.test.ts
@@ -1,4 +1,12 @@
-import { HTTP, getDefaultConfig, setDefaultConfig, setDefaultLanguage } from './config';
+import {
+	HTTP,
+	HTTP_INTERCEPTORS,
+	addHttpInterceptor,
+	getDefaultConfig,
+	removeHttpInterceptor,
+	setDefaultConfig,
+	setDefaultLanguage,
+} from './config';
 
 describe('Configuration service', () => {
 	describe('setDefaultLanguage', () => {
@@ -37,6 +45,53 @@ describe('Configuration service', () => {
 			}).toThrow(
 				'ERROR: setDefaultConfig should not be called twice, if you wish to change the language use setDefaultLanguage api.',
 			);
+		});
+	});
+
+	describe('Http interceptors', () => {
+		beforeEach(() => {
+			for (const key in HTTP_INTERCEPTORS) {
+				if (HTTP_INTERCEPTORS.hasOwnProperty(key)) {
+					delete HTTP_INTERCEPTORS[key];
+				}
+			}
+		});
+
+		it('should add a new interceptor when the name is not already used', () => {
+			const interceptor = jest.fn();
+			addHttpInterceptor('myInterceptor', interceptor);
+			expect(HTTP_INTERCEPTORS).toEqual({
+				myInterceptor: interceptor,
+			});
+		});
+
+		it('should throw an error when the name is already used', () => {
+			const interceptor1 = jest.fn();
+			const interceptor2 = jest.fn();
+			addHttpInterceptor('myInterceptor', interceptor1);
+			expect(() => addHttpInterceptor('myInterceptor', interceptor2)).toThrowError(
+				'Interceptor myInterceptor already exists',
+			);
+			expect(HTTP_INTERCEPTORS).toEqual({
+				myInterceptor: interceptor1,
+			});
+		});
+
+		it('should remove an existing interceptor', () => {
+			const interceptor1 = jest.fn();
+			addHttpInterceptor('myInterceptor', interceptor1);
+
+			removeHttpInterceptor('myInterceptor');
+			expect(HTTP_INTERCEPTORS).toEqual({});
+		});
+
+		it('should throw an error when the interceptor does not exist', () => {
+			const interceptor2 = jest.fn();
+			addHttpInterceptor('myInterceptor2', interceptor2);
+			expect(() => removeHttpInterceptor('myInterceptor')).toThrowError(
+				'Interceptor myInterceptor does not exist',
+			);
+			expect(HTTP_INTERCEPTORS).toEqual({ myInterceptor2: interceptor2 });
 		});
 	});
 });

--- a/packages/http/src/config.test.ts
+++ b/packages/http/src/config.test.ts
@@ -1,9 +1,9 @@
 import {
 	HTTP,
-	HTTP_INTERCEPTORS,
-	addHttpInterceptor,
+	HTTP_RESPONSE_INTERCEPTORS,
+	addHttpResponseInterceptor,
 	getDefaultConfig,
-	removeHttpInterceptor,
+	removeHttpResponseInterceptor,
 	setDefaultConfig,
 	setDefaultLanguage,
 } from './config';
@@ -50,17 +50,17 @@ describe('Configuration service', () => {
 
 	describe('Http interceptors', () => {
 		beforeEach(() => {
-			for (const key in HTTP_INTERCEPTORS) {
-				if (HTTP_INTERCEPTORS.hasOwnProperty(key)) {
-					delete HTTP_INTERCEPTORS[key];
+			for (const key in HTTP_RESPONSE_INTERCEPTORS) {
+				if (HTTP_RESPONSE_INTERCEPTORS.hasOwnProperty(key)) {
+					delete HTTP_RESPONSE_INTERCEPTORS[key];
 				}
 			}
 		});
 
 		it('should add a new interceptor when the name is not already used', () => {
 			const interceptor = jest.fn();
-			addHttpInterceptor('myInterceptor', interceptor);
-			expect(HTTP_INTERCEPTORS).toEqual({
+			addHttpResponseInterceptor('myInterceptor', interceptor);
+			expect(HTTP_RESPONSE_INTERCEPTORS).toEqual({
 				myInterceptor: interceptor,
 			});
 		});
@@ -68,30 +68,30 @@ describe('Configuration service', () => {
 		it('should throw an error when the name is already used', () => {
 			const interceptor1 = jest.fn();
 			const interceptor2 = jest.fn();
-			addHttpInterceptor('myInterceptor', interceptor1);
-			expect(() => addHttpInterceptor('myInterceptor', interceptor2)).toThrowError(
+			addHttpResponseInterceptor('myInterceptor', interceptor1);
+			expect(() => addHttpResponseInterceptor('myInterceptor', interceptor2)).toThrowError(
 				'Interceptor myInterceptor already exists',
 			);
-			expect(HTTP_INTERCEPTORS).toEqual({
+			expect(HTTP_RESPONSE_INTERCEPTORS).toEqual({
 				myInterceptor: interceptor1,
 			});
 		});
 
 		it('should remove an existing interceptor', () => {
 			const interceptor1 = jest.fn();
-			addHttpInterceptor('myInterceptor', interceptor1);
+			addHttpResponseInterceptor('myInterceptor', interceptor1);
 
-			removeHttpInterceptor('myInterceptor');
-			expect(HTTP_INTERCEPTORS).toEqual({});
+			removeHttpResponseInterceptor('myInterceptor');
+			expect(HTTP_RESPONSE_INTERCEPTORS).toEqual({});
 		});
 
 		it('should throw an error when the interceptor does not exist', () => {
 			const interceptor2 = jest.fn();
-			addHttpInterceptor('myInterceptor2', interceptor2);
-			expect(() => removeHttpInterceptor('myInterceptor')).toThrowError(
+			addHttpResponseInterceptor('myInterceptor2', interceptor2);
+			expect(() => removeHttpResponseInterceptor('myInterceptor')).toThrowError(
 				'Interceptor myInterceptor does not exist',
 			);
-			expect(HTTP_INTERCEPTORS).toEqual({ myInterceptor2: interceptor2 });
+			expect(HTTP_RESPONSE_INTERCEPTORS).toEqual({ myInterceptor2: interceptor2 });
 		});
 	});
 });

--- a/packages/http/src/config.ts
+++ b/packages/http/src/config.ts
@@ -7,6 +7,22 @@ export const HTTP: { defaultConfig?: TalendRequestInit | null } = {
 	defaultConfig: null,
 };
 
+export const HTTP_INTERCEPTORS: Record<string, (response: Response) => void> = {};
+
+export function addHttpInterceptor(name: string, interceptor: (response: Response) => void) {
+	if (HTTP_INTERCEPTORS[name]) {
+		throw new Error(`Interceptor ${name} already exists`);
+	}
+	HTTP_INTERCEPTORS[name] = interceptor;
+}
+
+export function removeHttpInterceptor(name: string) {
+	if (!HTTP_INTERCEPTORS[name]) {
+		throw new Error(`Interceptor ${name} does not exist`);
+	}
+	delete HTTP_INTERCEPTORS[name];
+}
+
 /**
  * setDefaultHeader - define a default config to use with the saga http
  * this default config is stored in this module for the whole application

--- a/packages/http/src/config.ts
+++ b/packages/http/src/config.ts
@@ -7,20 +7,23 @@ export const HTTP: { defaultConfig?: TalendRequestInit | null } = {
 	defaultConfig: null,
 };
 
-export const HTTP_INTERCEPTORS: Record<string, (response: Response) => void> = {};
+export const HTTP_RESPONSE_INTERCEPTORS: Record<string, (response: Response) => void> = {};
 
-export function addHttpInterceptor(name: string, interceptor: (response: Response) => void) {
-	if (HTTP_INTERCEPTORS[name]) {
+export function addHttpResponseInterceptor(
+	name: string,
+	interceptor: (response: Response) => void,
+) {
+	if (HTTP_RESPONSE_INTERCEPTORS[name]) {
 		throw new Error(`Interceptor ${name} already exists`);
 	}
-	HTTP_INTERCEPTORS[name] = interceptor;
+	HTTP_RESPONSE_INTERCEPTORS[name] = interceptor;
 }
 
-export function removeHttpInterceptor(name: string) {
-	if (!HTTP_INTERCEPTORS[name]) {
+export function removeHttpResponseInterceptor(name: string) {
+	if (!HTTP_RESPONSE_INTERCEPTORS[name]) {
 		throw new Error(`Interceptor ${name} does not exist`);
 	}
-	delete HTTP_INTERCEPTORS[name];
+	delete HTTP_RESPONSE_INTERCEPTORS[name];
 }
 
 /**

--- a/packages/http/src/http.common.ts
+++ b/packages/http/src/http.common.ts
@@ -1,4 +1,4 @@
-import { HTTP } from './config';
+import { HTTP, HTTP_INTERCEPTORS } from './config';
 import { mergeCSRFToken } from './csrfHandling';
 import { HTTP_STATUS, testHTTPCode } from './http.constants';
 import { TalendHttpResponse, TalendRequestInit } from './http.types';
@@ -125,5 +125,10 @@ export async function httpFetch<T>(
 			body: encodePayload(params.headers || {}, payload),
 		}),
 	);
+
+	Object.values(HTTP_INTERCEPTORS).forEach(interceptor => {
+		interceptor(response);
+	});
+
 	return handleHttpResponse(response);
 }

--- a/packages/http/src/http.common.ts
+++ b/packages/http/src/http.common.ts
@@ -1,4 +1,4 @@
-import { HTTP, HTTP_INTERCEPTORS } from './config';
+import { HTTP, HTTP_RESPONSE_INTERCEPTORS } from './config';
 import { mergeCSRFToken } from './csrfHandling';
 import { HTTP_STATUS, testHTTPCode } from './http.constants';
 import { TalendHttpResponse, TalendRequestInit } from './http.types';
@@ -126,7 +126,7 @@ export async function httpFetch<T>(
 		}),
 	);
 
-	Object.values(HTTP_INTERCEPTORS).forEach(interceptor => {
+	Object.values(HTTP_RESPONSE_INTERCEPTORS).forEach(interceptor => {
 		interceptor(response);
 	});
 

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -5,8 +5,8 @@ export * from './http.types';
 export * from './http.constants';
 
 export {
-	addHttpInterceptor,
-	removeHttpInterceptor,
+	addHttpResponseInterceptor,
+	removeHttpResponseInterceptor,
 	getDefaultConfig,
 	setDefaultConfig,
 	setDefaultLanguage,

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -3,3 +3,11 @@ export { http } from './async';
 
 export * from './http.types';
 export * from './http.constants';
+
+export {
+	addHttpInterceptor,
+	removeHttpInterceptor,
+	getDefaultConfig,
+	setDefaultConfig,
+	setDefaultLanguage,
+} from './config';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We don't have a global interceptor stuff yet
For some use cases, it could be nice to handle some behaviour at only one place, like logout for instance

**What is the chosen solution to this problem?**
Add a local context to http package

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
