### PR TITLE
feat(tdc-7258): added data-checked attribute 

### DIFF
--- a/.changeset/red-readers-leave.md
+++ b/.changeset/red-readers-leave.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+feat(tdc-7258): added data-checked attribute so automated tests can select the checked card

--- a/packages/design-system/src/components/RichRadioButton/RichRadioButton.component.tsx
+++ b/packages/design-system/src/components/RichRadioButton/RichRadioButton.component.tsx
@@ -62,6 +62,7 @@ const RichRadioButton = ({
 				data-feature={dataFeature}
 				checked={isChecked}
 				onChange={() => onChange(id)}
+				data-checked={isChecked}
 			/>
 			<span className={style['rich-radio-button']}>
 				<StackVertical as="span" gap="XS">


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Radio card "checked" attribute only saves the initial "checked" value in the DOM, making it difficult for automated tests to understand which card is selected.

**What is the chosen solution to this problem?**
Added data-checked attribute so automated tests can select the checked card

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
