### PR TITLE
fix(TDOPS-4678/FacetedSearch): Not submit changes when close badge overlay

### DIFF
--- a/.changeset/cool-dolls-think.md
+++ b/.changeset/cool-dolls-think.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+Faceted search: close badge overlay without submitting changes.

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -75,9 +75,9 @@ const BadgeFaceted = ({
 		setBadgeValue(entityValue);
 	};
 
-	const onSubmitBadge = () => {
+	const onSubmitBadge = event => {
 		overlayDispatch(OVERLAY_FLOW_ACTIONS.closeAll);
-		event.preventDefault();
+		event?.preventDefault();
 		dispatch(
 			BADGES_ACTIONS.update(
 				badgeId,

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -101,9 +101,8 @@ const BadgeFaceted = ({
 		dispatch(BADGES_ACTIONS.closeInitialOpened(badgeId));
 	};
 
-	const onHideSubmitBadge = (...args) => {
-		dispatch(BADGES_ACTIONS.closeInitialOpened(badgeId));
-		onSubmitBadge(...args);
+	const onHideOverlay = () => {
+		overlayDispatch(OVERLAY_FLOW_ACTIONS.closeAll);
 	};
 
 	return (
@@ -131,13 +130,13 @@ const BadgeFaceted = ({
 				className={theme('tc-badge-faceted-overlay')}
 				showSpecialChars={!!displayType}
 				label={labelValue}
-				onHide={onHideSubmitBadge}
+				onHide={onHideOverlay}
 				opened={overlayState.valueOpened}
 				onChange={onChangeValueOverlay}
 				readOnly={readOnly}
 				t={t}
 			>
-				{children({ onSubmitBadge, onChangeValue, badgeValue })}
+				{children({ onHideOverlay, onSubmitBadge, onChangeValue, badgeValue })}
 			</BadgeOverlay>
 			{removable && (
 				<Badge.DeleteAction

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.js
@@ -75,9 +75,9 @@ const BadgeFaceted = ({
 		setBadgeValue(entityValue);
 	};
 
-	const onSubmitBadge = event => {
+	const onSubmitBadge = () => {
 		overlayDispatch(OVERLAY_FLOW_ACTIONS.closeAll);
-		event?.preventDefault();
+		event.preventDefault();
 		dispatch(
 			BADGES_ACTIONS.update(
 				badgeId,

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
@@ -11,8 +11,8 @@ const MyWrappedBadge = ({ children, properties, providerValue }) => (
 );
 
 // eslint-disable-next-line react/prop-types
-const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmitBadge }) => (
-	<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmitBadge}>
+const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmit }) => (
+	<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmit}>
 		{badgeValue}
 	</button>
 );
@@ -89,54 +89,6 @@ describe('BadgeFaceted', () => {
 		expect(dispatch).toHaveBeenNthCalledWith(1, {
 			payload: { badgeId: 'my-badge-id' },
 			type: 'DELETE_BADGE',
-		});
-	});
-	it('should trigger onSubmit callback from context when submit button is clicked', () => {
-		// Given
-		const dispatch = jest.fn();
-		const badgeFacetedContextValue = {
-			state: { badges: [] },
-			dispatch,
-			onSubmit: jest.fn(),
-		};
-		const props = {
-			badgeId: 'my-badge-id',
-			category: 'Category',
-			id: 'my-id',
-			labelCategory: 'My Label',
-			labelValue: 'All',
-			operator,
-			operators,
-			t: () => 'Remove filter',
-			value: 'hello world',
-		};
-		// When
-		render(
-			<MyWrappedBadge properties={props} providerValue={badgeFacetedContextValue}>
-				{renderProps => <TestChildren {...renderProps} />}
-			</MyWrappedBadge>,
-		);
-		fireEvent.click(screen.getByRole('button', { name: 'All' }));
-		fireEvent.click(screen.getByRole('button', { name: 'hello world' }));
-		// Then
-		expect(dispatch).toHaveBeenCalledWith({
-			payload: {
-				badgeId: 'my-badge-id',
-				metadata: {
-					isInCreation: false,
-				},
-				properties: {
-					initialOperatorOpened: false,
-					initialValueOpened: false,
-					operator: {
-						iconName: 'talend-my-icon-equal',
-						label: 'My icon operator equal',
-						name: 'operatorIconEqual',
-					},
-					value: 'hello world',
-				},
-			},
-			type: 'UPDATE_BADGE',
 		});
 	});
 	it('should show special chars when a display type is provided', () => {

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
@@ -11,10 +11,15 @@ const MyWrappedBadge = ({ children, properties, providerValue }) => (
 );
 
 // eslint-disable-next-line react/prop-types
-const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmit }) => (
-	<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmit}>
-		{badgeValue}
-	</button>
+const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmitBadge, onHideOverlay }) => (
+	<div data-testid="badge-overlay">
+		<button id="my-cancel-button" onClick={onHideOverlay}>
+			cancel
+		</button>
+		<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmitBadge}>
+			{badgeValue}
+		</button>
+	</div>
 );
 
 describe('BadgeFaceted', () => {
@@ -90,6 +95,37 @@ describe('BadgeFaceted', () => {
 			payload: { badgeId: 'my-badge-id' },
 			type: 'DELETE_BADGE',
 		});
+	});
+	it('should trigger onHideOverlay callback when click cancel button', () => {
+		// Given
+		const dispatch = jest.fn();
+		const badgeFacetedContextValue = {
+			state: { badges: [] },
+			dispatch,
+			onSubmit: jest.fn(),
+		};
+		const props = {
+			badgeId: 'my-badge-id',
+			category: 'Category',
+			id: 'my-id',
+			labelCategory: 'My Label',
+			labelValue: 'All',
+			operator,
+			operators,
+			t: () => 'Remove filter',
+			value: 'hello world',
+		};
+		// When
+		render(
+			<MyWrappedBadge properties={props} providerValue={badgeFacetedContextValue}>
+				{renderProps => <TestChildren {...renderProps} />}
+			</MyWrappedBadge>,
+		);
+
+		fireEvent.click(screen.getByRole('button', { name: 'All' }));
+		fireEvent.click(document.querySelector('button#my-cancel-button'));
+		// Then
+		expect(dispatch).not.toHaveBeenCalled();
 	});
 	it('should show special chars when a display type is provided', () => {
 		// Given

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/BadgeFaceted.component.test.js
@@ -11,8 +11,8 @@ const MyWrappedBadge = ({ children, properties, providerValue }) => (
 );
 
 // eslint-disable-next-line react/prop-types
-const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmit }) => (
-	<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmit}>
+const TestChildren = ({ badgeValue = 'default', onChangeValue, onSubmitBadge }) => (
+	<button data-testid="my-button" id="my-button" onChange={onChangeValue} onClick={onSubmitBadge}>
 		{badgeValue}
 	</button>
 );
@@ -89,6 +89,54 @@ describe('BadgeFaceted', () => {
 		expect(dispatch).toHaveBeenNthCalledWith(1, {
 			payload: { badgeId: 'my-badge-id' },
 			type: 'DELETE_BADGE',
+		});
+	});
+	it('should trigger onSubmit callback from context when submit button is clicked', () => {
+		// Given
+		const dispatch = jest.fn();
+		const badgeFacetedContextValue = {
+			state: { badges: [] },
+			dispatch,
+			onSubmit: jest.fn(),
+		};
+		const props = {
+			badgeId: 'my-badge-id',
+			category: 'Category',
+			id: 'my-id',
+			labelCategory: 'My Label',
+			labelValue: 'All',
+			operator,
+			operators,
+			t: () => 'Remove filter',
+			value: 'hello world',
+		};
+		// When
+		render(
+			<MyWrappedBadge properties={props} providerValue={badgeFacetedContextValue}>
+				{renderProps => <TestChildren {...renderProps} />}
+			</MyWrappedBadge>,
+		);
+		fireEvent.click(screen.getByRole('button', { name: 'All' }));
+		fireEvent.click(screen.getByRole('button', { name: 'hello world' }));
+		// Then
+		expect(dispatch).toHaveBeenCalledWith({
+			payload: {
+				badgeId: 'my-badge-id',
+				metadata: {
+					isInCreation: false,
+				},
+				properties: {
+					initialOperatorOpened: false,
+					initialValueOpened: false,
+					operator: {
+						iconName: 'talend-my-icon-equal',
+						label: 'My icon operator equal',
+						name: 'operatorIconEqual',
+					},
+					value: 'hello world',
+				},
+			},
+			type: 'UPDATE_BADGE',
 		});
 	});
 	it('should show special chars when a display type is provided', () => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Faceted search, badge changes will be submitted even on close overlay.
https://www.loom.com/share/a437eaeb531d448789348c626ff23cd6?sid=e22b50ff-5872-46e1-862b-aec7fbac30bb

**What is the chosen solution to this problem?**
1. Only submit changes when click "Apply" button,  not submit badge changes when close overlay.
2. expose `onHideOverlay` in render props, it can be used for custom badge overlay to close overlay without submitting changes.
https://www.loom.com/share/ecce6694c3d7449a94d571d750dc3e08?sid=396bf2b0-66db-49b1-a807-ab70aecca561
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
