### PR TITLE
feat(TDC-7254): Stepper progress updating according to current step

### DIFF
--- a/.changeset/pink-llamas-cheer.md
+++ b/.changeset/pink-llamas-cheer.md
@@ -2,4 +2,6 @@
 '@talend/design-system': minor
 ---
 
-feat(TDC-7254): Stepper progress updating according to current step
+feat(TDC-7254/Stepper): Add a new props `currentStepIndex` to control current step. Set to zero by default.
+
+This fix an issue as the previous code is based on react ref which is not updated when dom is changed. As we don't want to observe mutation on the DOM, let's go back on classic react patterns, make it pure and ask for a state

--- a/.changeset/pink-llamas-cheer.md
+++ b/.changeset/pink-llamas-cheer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat(TDC-7254): Stepper progress updating according to current step

--- a/packages/design-system/src/components/Stepper/Progress/variations/Progress.horizontal.module.scss
+++ b/packages/design-system/src/components/Stepper/Progress/variations/Progress.horizontal.module.scss
@@ -12,6 +12,6 @@
 	div {
 		top: 0;
 		height: 0.2rem;
-		transition: width 0.4s ease-in-out;
+		transition: width tokens.$coral-transition-slow;
 	}
 }

--- a/packages/design-system/src/components/Stepper/Progress/variations/Progress.horizontal.module.scss
+++ b/packages/design-system/src/components/Stepper/Progress/variations/Progress.horizontal.module.scss
@@ -1,11 +1,5 @@
 @use '~@talend/design-tokens/lib/tokens';
 
-@keyframes progress {
-	0% {
-		width: 0;
-	}
-}
-
 .horizontal {
 	top: calc(#{tokens.$coral-sizing-xxxs} / 2 - 0.05rem);
 	right: 10rem;
@@ -18,6 +12,6 @@
 	div {
 		top: 0;
 		height: 0.2rem;
-		animation: progress 1s ease-in-out;
+		transition: width 0.4s ease-in-out;
 	}
 }

--- a/packages/design-system/src/components/Stepper/Progress/variations/Progress.vertical.module.scss
+++ b/packages/design-system/src/components/Stepper/Progress/variations/Progress.vertical.module.scss
@@ -1,11 +1,5 @@
 @use '~@talend/design-tokens/lib/tokens';
 
-@keyframes progress {
-	0% {
-		height: 0;
-	}
-}
-
 .vertical {
 	top: tokens.$coral-sizing-xxs;
 	right: calc(#{tokens.$coral-sizing-xxxs} / 2 - 0.05rem);
@@ -15,6 +9,6 @@
 
 	div {
 		width: 0.2rem;
-		animation: progress 1s ease-in-out;
+		transition: height 0.4s ease-in-out;
 	}
 }

--- a/packages/design-system/src/components/Stepper/Progress/variations/Progress.vertical.module.scss
+++ b/packages/design-system/src/components/Stepper/Progress/variations/Progress.vertical.module.scss
@@ -9,6 +9,6 @@
 
 	div {
 		width: 0.2rem;
-		transition: height 0.4s ease-in-out;
+		transition: height tokens.$coral-transition-slow;
 	}
 }

--- a/packages/design-system/src/components/Stepper/Step/Primitive/Step.module.scss
+++ b/packages/design-system/src/components/Stepper/Step/Primitive/Step.module.scss
@@ -71,7 +71,7 @@
 			box-shadow: 0 0 0 0.3rem tokens.$coral-color-accent-background;
 			z-index: 1;
 			transform: scale(1);
-			animation: pulse 2s infinite;
+			animation: pulse 2s 0.2s infinite;
 		}
 	}
 

--- a/packages/design-system/src/components/Stepper/Stepper.cy.tsx
+++ b/packages/design-system/src/components/Stepper/Stepper.cy.tsx
@@ -33,7 +33,7 @@ context('<Stepper />', () => {
 				<Stepper.Step.Enabled title="Next step" />
 			</Stepper>,
 		);
-		cy.get("[role='progressbar'] div").first().should('have.attr', 'style', 'height: 0%;');
+		cy.get("[role='progressbar'] div").should('have.attr', 'style', 'height: 0%;');
 	});
 
 	it('should render progressbar with 100% height', () => {
@@ -44,7 +44,7 @@ context('<Stepper />', () => {
 				<Stepper.Step.InProgress title="Current step" />
 			</Stepper>,
 		);
-		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 100%;');
+		cy.get("[role='progressbar'] div").should('have.attr', 'style', 'height: 100%;');
 	});
 
 	it('should render progressbar with no height if the currentStepIndex is outside of the range of steps', () => {
@@ -55,7 +55,7 @@ context('<Stepper />', () => {
 				<Stepper.Step.InProgress title="Current step" />
 			</Stepper>,
 		);
-		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 0%;');
+		cy.get("[role='progressbar'] div").should('have.attr', 'style', 'height: 0%;');
 	});
 
 	it('should render progressbar with no height if the currentStepIndex is outside of the range of steps', () => {
@@ -66,6 +66,6 @@ context('<Stepper />', () => {
 				<Stepper.Step.InProgress title="Current step" />
 			</Stepper>,
 		);
-		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 0%;');
+		cy.get("[role='progressbar'] div").should('have.attr', 'style', 'height: 0%;');
 	});
 });

--- a/packages/design-system/src/components/Stepper/Stepper.cy.tsx
+++ b/packages/design-system/src/components/Stepper/Stepper.cy.tsx
@@ -1,0 +1,71 @@
+/* eslint-disable testing-library/prefer-screen-queries */
+/* eslint-disable testing-library/await-async-query */
+import Stepper from '.';
+
+context('<Stepper />', () => {
+	it('should render first step as current step', () => {
+		cy.mount(
+			<Stepper currentStepIndex={0}>
+				<Stepper.Step.InProgress title="Current step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+			</Stepper>,
+		);
+		cy.get('ol li').first().should('have.attr', 'aria-current', 'step');
+	});
+
+	it('should have last step as current step', () => {
+		cy.mount(
+			<Stepper currentStepIndex={3}>
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.InProgress title="Current step" />
+			</Stepper>,
+		);
+		cy.get('ol li').last().should('have.attr', 'aria-current', 'step');
+	});
+
+	it('should render progressbar with no height', () => {
+		cy.mount(
+			<Stepper currentStepIndex={0}>
+				<Stepper.Step.InProgress title="Current step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+			</Stepper>,
+		);
+		cy.get("[role='progressbar'] div").first().should('have.attr', 'style', 'height: 0%;');
+	});
+
+	it('should render progressbar with 100% height', () => {
+		cy.mount(
+			<Stepper currentStepIndex={2}>
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.InProgress title="Current step" />
+			</Stepper>,
+		);
+		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 100%;');
+	});
+
+	it('should render progressbar with no height if the currentStepIndex is outside of the range of steps', () => {
+		cy.mount(
+			<Stepper currentStepIndex={5}>
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.InProgress title="Current step" />
+			</Stepper>,
+		);
+		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 0%;');
+	});
+
+	it('should render progressbar with no height if the currentStepIndex is outside of the range of steps', () => {
+		cy.mount(
+			<Stepper currentStepIndex={'3' as any}>
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.Enabled title="Next step" />
+				<Stepper.Step.InProgress title="Current step" />
+			</Stepper>,
+		);
+		cy.get("[role='progressbar'] div").last().should('have.attr', 'style', 'height: 0%;');
+	});
+});

--- a/packages/design-system/src/components/Stepper/Stepper.tsx
+++ b/packages/design-system/src/components/Stepper/Stepper.tsx
@@ -1,5 +1,5 @@
 import classnames from 'classnames';
-import { Children, cloneElement, forwardRef, ReactElement, Ref } from 'react';
+import { Children, cloneElement, forwardRef, ReactElement, Ref, useMemo } from 'react';
 import { isElement } from 'react-is';
 
 import ProgressHorizontal from './Progress/variations/Progress.horizontal';
@@ -21,8 +21,14 @@ const Stepper = forwardRef(
 		{ currentStepIndex = 0, children, orientation = 'vertical', loading, ...rest }: StepperProps,
 		ref: Ref<HTMLDivElement>,
 	) => {
-		const value = currentStepIndex + 1;
 		const max = Children.count(children);
+		const value = useMemo(() => {
+			if (typeof currentStepIndex !== 'number' || currentStepIndex < 0 || currentStepIndex > max) {
+				return 0;
+			}
+
+			return currentStepIndex + 1;
+		}, [currentStepIndex, max]);
 
 		return (
 			<div
@@ -32,6 +38,7 @@ const Stepper = forwardRef(
 			>
 				{orientation === 'vertical' && <ProgressVertical value={value} max={max} />}
 				{orientation === 'horizontal' && <ProgressHorizontal value={value} max={max} />}
+
 				<ol className={styles.stepper__steps}>
 					{children &&
 						Children.map(

--- a/packages/design-system/src/components/Stepper/Stepper.tsx
+++ b/packages/design-system/src/components/Stepper/Stepper.tsx
@@ -1,24 +1,16 @@
-import {
-	Children,
-	cloneElement,
-	forwardRef,
-	ReactElement,
-	Ref,
-	useEffect,
-	useRef,
-	useState,
-} from 'react';
 import classnames from 'classnames';
+import { Children, cloneElement, forwardRef, ReactElement, Ref } from 'react';
 import { isElement } from 'react-is';
 
-import ProgressVertical from './Progress/variations/Progress.vertical';
 import ProgressHorizontal from './Progress/variations/Progress.horizontal';
+import ProgressVertical from './Progress/variations/Progress.vertical';
 
 import styles from './Stepper.module.scss';
 
 export type StepperOrientation = 'horizontal' | 'vertical';
 
 export type StepperProps = {
+	currentStepIndex?: number;
 	orientation?: StepperOrientation;
 	children: ReactElement | ReactElement[];
 	loading?: boolean;
@@ -26,20 +18,10 @@ export type StepperProps = {
 
 const Stepper = forwardRef(
 	(
-		{ children, orientation = 'vertical', loading, ...rest }: StepperProps,
+		{ currentStepIndex = 0, children, orientation = 'vertical', loading, ...rest }: StepperProps,
 		ref: Ref<HTMLDivElement>,
 	) => {
-		const listRef = useRef<null | HTMLOListElement>(null);
-		const [progressIndex, setProgressIndex] = useState(0);
-
-		useEffect(() => {
-			// Find the last active step in the list and store its index
-			const listEntries = listRef.current ? Array.from(listRef.current.children) : [];
-			const indexOfProgress = listEntries.map(entry => entry.ariaCurrent).lastIndexOf('step');
-			setProgressIndex(indexOfProgress);
-		}, []);
-
-		const value = progressIndex + 1;
+		const value = currentStepIndex + 1;
 		const max = Children.count(children);
 
 		return (
@@ -50,7 +32,7 @@ const Stepper = forwardRef(
 			>
 				{orientation === 'vertical' && <ProgressVertical value={value} max={max} />}
 				{orientation === 'horizontal' && <ProgressHorizontal value={value} max={max} />}
-				<ol className={styles.stepper__steps} ref={listRef}>
+				<ol className={styles.stepper__steps}>
 					{children &&
 						Children.map(
 							children,

--- a/packages/storybook/src/design-system/Stepper/Stepper.stories.mdx
+++ b/packages/storybook/src/design-system/Stepper/Stepper.stories.mdx
@@ -146,7 +146,7 @@ In case of an error in the current step, please inform the user by using an inli
 		name="usage"
 		args={{
 			variant: 'Vertical',
-			activeIndex: 1,
+			currentStepIndex: 1,
 		}}
 		argTypes={{
 			variant: {
@@ -156,19 +156,19 @@ In case of an error in the current step, please inform the user by using an inli
 					options: ['Vertical', 'Horizontal'],
 				},
 			},
-			activeIndex: {
-				description: 'Current step',
+			currentStepIndex: {
+				description: 'Current step index',
 				control: {
 					type: 'number',
 				},
 			},
 		}}
 	>
-		{({ activeIndex, variant, index, title }) => {
+		{({ currentStepIndex, variant, index, title }) => {
 			const StepperComponent = Stepper[variant];
 			StepperComponent.displayName = `Stepper.${variant}`;
 			return (
-				<StepperComponent>
+				<StepperComponent currentStepIndex={currentStepIndex}>
 					<Stepper.Step.Validated title="Validated" />
 					<Stepper.Step.InProgress title="In progress" />
 					<Stepper.Step.Enabled title="Enabled" />

--- a/packages/storybook/src/design-system/Stepper/Stepper.stories.mdx
+++ b/packages/storybook/src/design-system/Stepper/Stepper.stories.mdx
@@ -146,6 +146,7 @@ In case of an error in the current step, please inform the user by using an inli
 		name="usage"
 		args={{
 			variant: 'Vertical',
+			activeIndex: 1,
 		}}
 		argTypes={{
 			variant: {
@@ -155,9 +156,15 @@ In case of an error in the current step, please inform the user by using an inli
 					options: ['Vertical', 'Horizontal'],
 				},
 			},
+			activeIndex: {
+				description: 'Current step',
+				control: {
+					type: 'number',
+				},
+			},
 		}}
 	>
-		{({ variant, index, title }) => {
+		{({ activeIndex, variant, index, title }) => {
 			const StepperComponent = Stepper[variant];
 			StepperComponent.displayName = `Stepper.${variant}`;
 			return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Stepper's progress was not being updated as the user moved to the next step

**What is the chosen solution to this problem?**
Added a parameter to control which is the active step allowing the progress to be according to where the user is 

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
