### PR TITLE
chore: update rich radio button

### DIFF
--- a/.changeset/young-carrots-turn.md
+++ b/.changeset/young-carrots-turn.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+chore: update rich radio button

--- a/packages/design-system/src/components/RichRadioButton/RichRadioButton.component.tsx
+++ b/packages/design-system/src/components/RichRadioButton/RichRadioButton.component.tsx
@@ -7,7 +7,6 @@ import {
 import { StackVertical, StackHorizontal } from '../Stack';
 import { getIconWithDeprecatedSupport } from '../Icon/DeprecatedIconHelper';
 import style from './RichRadioButton.module.scss';
-import classnames from 'classnames';
 import { Tag } from '../Tag';
 import { Icon } from '../Icon';
 import { DataAttributes } from 'src/types';
@@ -15,17 +14,17 @@ import { DataAttributes } from 'src/types';
 function RichRadioButtonIcon({ asset }: { asset?: LogoAsset | IllustrationAsset | IconAsset }) {
 	if (asset?.illustration) {
 		return (
-			<span className={classnames([style['rich-radio-button__illustration']])}>
+			<span className={style['rich-radio-button__illustration']}>
 				<asset.illustration />
 			</span>
 		);
 	}
 	if (asset?.logo) {
-		return <Icon name={asset.logo} className={classnames([style['rich-radio-button__logo']])} />;
+		return <Icon name={asset.logo} className={style['rich-radio-button__logo']} />;
 	}
 	if (asset?.name) {
 		return (
-			<span className={classnames([style['rich-radio-button__icon']])}>
+			<span className={style['rich-radio-button__icon']}>
 				{getIconWithDeprecatedSupport({
 					iconSrc: asset.name || '',
 					size: 'L',
@@ -68,6 +67,12 @@ const RichRadioButton = ({
 				data-test={dataTest}
 				onChange={() => onChange(id)}
 				data-checked={isChecked}
+				onKeyDown={event => {
+					if (event.key === 'Enter') {
+						event.preventDefault();
+						onChange(id);
+					}
+				}}
 			/>
 			<span className={style['rich-radio-button']}>
 				<StackVertical as="span" gap="XS">

--- a/packages/design-system/src/components/RichRadioButton/RichRadioButton.module.scss
+++ b/packages/design-system/src/components/RichRadioButton/RichRadioButton.module.scss
@@ -34,12 +34,17 @@
 	&__wrapper {
 		display: flex;
 		flex: 1;
+		height: 100%;
 		margin: 0;
 		max-width: 400px;
 		min-height: 77px;
 		min-width: 220px;
 		position: relative;
 		width: 100%;
+
+		input {
+			margin: 0;
+		}
 	}
 
 	&__input {
@@ -152,6 +157,11 @@
 
 		&:checked {
 			&:not(:disabled, [readonly]) {
+				+ .rich-radio-button {
+					background-color: tokens.$coral-color-accent-background-selected;
+					border: tokens.$coral-border-m-solid tokens.$coral-color-accent-border;
+				}
+
 				&:hover {
 					+ .rich-radio-button {
 						border-color: tokens.$coral-color-accent-border-hover;
@@ -164,9 +174,10 @@
 					}
 				}
 
-				+ .rich-radio-button {
-					background-color: tokens.$coral-color-accent-background-selected;
-					border: tokens.$coral-border-m-solid tokens.$coral-color-accent-border;
+				&:focus {
+					+ .rich-radio-button {
+						outline-offset: -2px;
+					}
 				}
 			}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This PR updates `design-system/RichRadioButton` focus outline and adds on `Enter` down behaviour to trigger input change, following the work done in https://github.com/Talend/ui/pull/4747.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
