### PR TITLE
feat(ARCH-720): add storybook toolbar for DS tokens

### DIFF
--- a/.changeset/shaggy-islands-grow.md
+++ b/.changeset/shaggy-islands-grow.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-storybook-lib': minor
+---
+
+feat: add design token update in the toolbar

--- a/packages/storybook/.storybook/preview.js
+++ b/packages/storybook/.storybook/preview.js
@@ -80,20 +80,6 @@ export const i18n = {
 	),
 };
 
-export const globalTypes = {
-	theme: {
-		name: 'Theme',
-		description: 'Choose a theme to apply to the design system',
-		toolbar: {
-			icon: 'paintbrush',
-			items: [
-				{ value: 'light', left: '⚪️', title: 'Default theme' },
-				{ value: 'dark', left: '⚫️', title: 'Dark theme' },
-			],
-		},
-	},
-};
-
 const channel = addons.getChannel();
 
 let statusByPage = {};

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -44,6 +44,17 @@ const defaultPreview = {
 				],
 			},
 		},
+		theme: {
+			name: 'Theme',
+			description: 'Choose a theme to apply to the design system',
+			toolbar: {
+				icon: 'paintbrush',
+				items: [
+					{ value: 'light', left: '⚪️', title: 'Default theme' },
+					{ value: 'dark', left: '⚫️', title: 'Dark theme' },
+				],
+			},
+		},
 	},
 	loaders: [cmfLoader].filter(Boolean),
 	decorators: [
@@ -63,7 +74,8 @@ const defaultPreview = {
 					key: 'icons-provider-decorator'
 				}),
 				React.createElement(ThemeProvider, {
-					key: 'theme-provider-decorator'
+					key: 'theme-provider-decorator',
+					theme: context.globals.theme,
 				}, storyElement)
 			];
 		},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we are using tokens more and more but the storybook config do not let us change it.

**What is the chosen solution to this problem?**

add it as a feature of the configuration

Result:
![image](https://github.com/Talend/ui/assets/19857479/aee174fc-d81a-45dc-9f33-b4f409000f23)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
