### PR TITLE
fix(TFD-15358): drill props to display only one icon

### DIFF
--- a/.changeset/light-monkeys-invite.md
+++ b/.changeset/light-monkeys-invite.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Prevent default external icon

--- a/.changeset/proud-hairs-relate.md
+++ b/.changeset/proud-hairs-relate.md
@@ -1,0 +1,5 @@
+---
+'@talend/ui-storybook': patch
+---
+
+Add "Prevent external default icon" story

--- a/packages/design-system/src/components/Link/Link.cy.tsx
+++ b/packages/design-system/src/components/Link/Link.cy.tsx
@@ -21,6 +21,11 @@ context('<Link />', () => {
 		cy.findByTestId('link.icon.external').should('be.visible');
 	});
 
+	it('should not render external if prevented', () => {
+		cy.mount(<Link href="https://www.talend.com" icon="talend-logo" hideExternalIcon />);
+		cy.get('[data-testid="link.icon.external"]').should('not.exist');
+	});
+
 	it('should render disabled', () => {
 		cy.mount(<Link href="#" icon="information-filled" disabled data-testid="my.link" />);
 		cy.findByTestId('my.link').should('have.attr', 'aria-disabled');

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -19,7 +19,7 @@ export type LinkProps = Omit<LinkableType, 'className'> & LinkComponentProps;
 
 const Link = forwardRef(
 	(
-		{ children, disabled, href, target, title, hideExternalIcon, ...rest }: LinkProps,
+		{ children, disabled, href, target, title, ...rest }: LinkProps,
 		ref: Ref<HTMLAnchorElement>,
 	) => {
 		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);

--- a/packages/storybook/src/design-system/Link/Link.stories.mdx
+++ b/packages/storybook/src/design-system/Link/Link.stories.mdx
@@ -74,6 +74,14 @@ Even if it's the same domain, when the link opens in a new window or tab, the ti
 
 The attribute `rel="noopener noreferrer"` is added if its target is `_blank`.
 
+### External hiding default external icon
+
+When the link targets a new domain, we add only the custom icon right after.
+
+<Canvas>
+	<Story story={Stories.ExternalWithIcon} />
+</Canvas>
+
 ### Router links
 
 In React SPAs, most links are handled by libraries such as React Router. `Link` takes that into account.

--- a/packages/storybook/src/design-system/Link/Link.stories.tsx
+++ b/packages/storybook/src/design-system/Link/Link.stories.tsx
@@ -83,6 +83,16 @@ export const External = {
 	},
 };
 
+export const ExternalWithIcon = {
+	render(props: Story<LinkProps>) {
+		return (
+			<Link href="https://www.talend.com" {...props} hideExternalIcon icon="information-filled">
+				talend.com
+			</Link>
+		);
+	},
+};
+
 export const TargetBlank = {
 	render(props: Story<LinkProps>) {
 		return (


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Both props icon and 'external-link' icon were displayed by child component

**What is the chosen solution to this problem?**
Do not spread the props so it can it forwarded

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
