### PR TITLE
feat(TDOPS-4682): Design System to allow maxlength on InlineEdit field

### DIFF
--- a/.changeset/fast-hornets-run.md
+++ b/.changeset/fast-hornets-run.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Design System - InlineEdit and InlineEditMulti can now have a maxLength attribute

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -43,6 +43,7 @@ export type InlineEditingPrimitiveProps = {
 	onToggle?: (isEditionMode: boolean) => void;
 	label: string;
 	required?: boolean;
+	maxLength?: number;
 	placeholder: string;
 	ariaLabel?: string;
 	renderValueAs?: ElementType | ReactElement;
@@ -85,6 +86,7 @@ const InlineEditingPrimitive = forwardRef(
 			onCancel = () => {},
 			onToggle = () => {},
 			required = false,
+			maxLength,
 			label,
 			hasError,
 			description,
@@ -176,6 +178,7 @@ const InlineEditingPrimitive = forwardRef(
 			label,
 			name: label.replace(/\s/g, ''),
 			required,
+			maxLength,
 			placeholder,
 			onChange: (event: ChangeEvent<HTMLInputElement> | ChangeEvent<HTMLTextAreaElement>): void => {
 				if (onChangeValue) {

--- a/packages/design-system/src/components/InlineEditing/variations/InlineEditing.textarea.cy.tsx
+++ b/packages/design-system/src/components/InlineEditing/variations/InlineEditing.textarea.cy.tsx
@@ -1,0 +1,41 @@
+import InlineEditingMulti from './InlineEditing.textarea';
+
+context('<InlineEditing.Textarea />', () => {
+	const defaultProps = {
+		label: 'Textarea inline edit',
+		placeholder: 'Type here',
+	};
+
+	it('should render with filled value', () => {
+		cy.mount(<InlineEditingMulti {...defaultProps} defaultValue="Some text" />);
+
+		cy.get('[data-testid="inlineediting.button.edit"]').should('exist');
+		cy.get('p').should('have.text', 'Some text');
+	});
+
+	it('should allow inline editing', () => {
+		cy.mount(<InlineEditingMulti {...defaultProps} />);
+
+		// Switch to edit mode
+		cy.get('[data-testid="inlineediting.button.edit"]').click();
+		cy.get('[data-testid="inlineediting.textarea"]').should('be.visible');
+		cy.get('[data-testid="inlineediting.button.cancel"]').should('be.visible');
+		cy.get('[data-testid="inlineediting.button.submit"]').should('be.visible');
+
+		// Input some text and submit
+		cy.get('[data-testid="inlineediting.textarea"]').type('Here is a description');
+		cy.get('[data-testid="inlineediting.button.submit"]').click();
+
+		cy.get('p').should('have.text', 'Here is a description');
+	});
+
+	it('should allow to have some constraints', () => {
+		cy.mount(<InlineEditingMulti {...defaultProps} required={true} maxLength={10} />);
+
+		cy.get('[data-testid="inlineediting.button.edit"]').click();
+		cy.get('[data-testid="inlineediting.textarea"]').should('have.attr', 'required');
+		cy.get('[data-testid="inlineediting.textarea"]')
+			.invoke('attr', 'maxLength')
+			.should('equal', '10');
+	});
+});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Design System to allow maxlength on InlineEdit field

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
