### PR TITLE
fix(TDOPS-4795): faceted search wrong plural label

### DIFF
--- a/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
@@ -12,8 +12,7 @@ const getSelectBadgeLabel = (value, t) => {
 		if (checkedCheckboxes.length > 3) {
 			return t('FACETED_SEARCH_VALUES_COUNT', {
 				count: checkedCheckboxes.length,
-				defaultValue: '{{count}} value',
-				defaultValue_plural: '{{count}} values',
+				defaultValue: '{{count}} values',
 			});
 		} else if (!checkedCheckboxes.length) {
 			return labelAll;

--- a/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeTags/BadgeTags.component.js
@@ -17,8 +17,7 @@ const getSelectBadgeLabel = (value, t) => {
 		if (checkedCheckboxes.length > 3) {
 			return t('FACETED_SEARCH_VALUES_COUNT', {
 				count: checkedCheckboxes.length,
-				defaultValue: '{{count}} value',
-				defaultValue_plural: '{{count}} values',
+				defaultValue: '{{count}} values',
 			});
 		} else if (!checkedCheckboxes.length) {
 			return labelAll;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
https://jira.talendforge.org/browse/TDOPS-4795
TUI Display issues on Engines and Workspace Permissions lists

**What is the chosen solution to this problem?**
- when more than 3 values are selected, the wrong label is displayed 

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
