### PR TITLE
feat(TDOPS-4687): checkbox widget can disable a single value in list

### DIFF
--- a/.changeset/orange-lobsters-poke.md
+++ b/.changeset/orange-lobsters-poke.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': minor
+---
+
+Forms - Allow to disable a single checkbox for checkbox widget list

--- a/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.component.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.component.js
@@ -3,7 +3,7 @@ import SimpleCheckBox from './SimpleCheckBox.component';
 import FieldTemplate from '../FieldTemplate';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
 
-function getValues(value = [], itemValue, checked) {
+function getValues(itemValue, checked, value = []) {
 	if (checked) {
 		return value.concat(itemValue);
 	}
@@ -35,7 +35,7 @@ export default function CheckBoxes(props) {
 			{titleMap.map((item, index) => (
 				<SimpleCheckBox
 					describedby={`${descriptionId} ${errorId}`}
-					disabled={schema.disabled || valueIsUpdating}
+					disabled={item.disabled || schema.disabled || valueIsUpdating}
 					id={id}
 					key={index}
 					isValid={isValid}
@@ -43,13 +43,13 @@ export default function CheckBoxes(props) {
 					onChange={(event, payload) =>
 						onChange(event, {
 							schema: payload.schema,
-							value: getValues(value, item.value, payload.value),
+							value: getValues(item.value, payload.value, value),
 						})
 					}
 					onFinish={(event, payload) =>
 						onFinish(event, {
 							schema: payload.schema,
-							value: getValues(value, item.value, payload.value),
+							value: getValues(item.value, payload.value, value),
 						})
 					}
 					schema={schema}

--- a/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.test.js
+++ b/packages/forms/src/UIForm/fields/CheckBox/CheckBoxes.test.js
@@ -88,6 +88,36 @@ describe('CheckBoxes field', () => {
 		expect(screen.getByRole('checkbox', { name: 'My lol title' })).toBeDisabled();
 	});
 
+	it('should render single disabled checkboxe', () => {
+		// given
+		const singleDisabledSchema = {
+			...schema,
+			titleMap: [
+				{ name: 'My foo title', value: 'foo' },
+				{ name: 'My bar title', value: 'bar', disabled: true },
+				{ name: 'My lol title', value: 'lol' },
+			],
+		};
+
+		// when
+		render(
+			<CheckBoxes
+				id="myForm"
+				isValid
+				errorMessage="My error message"
+				onChange={jest.fn()}
+				onFinish={jest.fn()}
+				schema={singleDisabledSchema}
+			/>,
+		);
+
+		// then
+		expect(screen.getAllByRole('checkbox')).toHaveLength(3);
+		expect(screen.getByRole('checkbox', { name: 'My foo title' })).toBeEnabled();
+		expect(screen.getByRole('checkbox', { name: 'My bar title' })).toBeDisabled();
+		expect(screen.getByRole('checkbox', { name: 'My lol title' })).toBeEnabled();
+	});
+
 	describe('#onChange', () => {
 		it('should trigger callback, adding a value to existing values', async () => {
 			// given


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Forms checkbox widget can disable a single value in list

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
