### PR TITLE
fix(dataviz): bundle typings

### DIFF
--- a/.changeset/quiet-pens-boil.md
+++ b/.changeset/quiet-pens-boil.md
@@ -2,4 +2,6 @@
 '@talend/react-dataviz': patch
 ---
 
-fix(dataviz): bundle typing in the package
+fix: bundle typing in the package that produce the following error:
+
+    Could not find a declaration file for module '@talend/react-dataviz' since the 3.0

--- a/.changeset/quiet-pens-boil.md
+++ b/.changeset/quiet-pens-boil.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-dataviz': patch
+---
+
+fix(dataviz): bundle typing in the package

--- a/packages/dataviz/tsconfig.build.json
+++ b/packages/dataviz/tsconfig.build.json
@@ -1,4 +1,4 @@
 {
   "extends": "./tsconfig.json",
-  "exclude": ["src/**/*.test.*", "src/**/*.stories.*"]
+  "exclude": ["src/**/*.cy.*", "src/**/*.test.*", "src/**/*.stories.*"]
 }

--- a/packages/dataviz/tsconfig.json
+++ b/packages/dataviz/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "extends": "@talend/scripts-config-typescript/tsconfig.json",
-  "include": ["src/**/*", "./cypress.d.ts", "./cypress/**/*.ts", "./cypress.config.ts"],
+  "include": ["src/**/*"],
   "compilerOptions": {
     "baseUrl": ".",
     "declaration": true,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

`Could not find a declaration file for module '@talend/react-dataviz'` since the 3.0 

**What is the chosen solution to this problem?**

fix tsconfig

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
