### PR TITLE
fix(components): accent color in subheader actions

### DIFF
--- a/.changeset/large-carpets-film.md
+++ b/.changeset/large-carpets-film.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: setup the interactive stuff in accent color for the subheader bar

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
@@ -120,6 +120,7 @@ function SubHeaderBar({
 								size="M"
 								onClick={onGoBack}
 								id="backArrow"
+								data-testid="tc-subheader-backArrow"
 								data-feature={goBackDataFeature}
 							>
 								{t('BACK_ARROW_TOOLTIP', { defaultValue: 'Go back' })}

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.component.js
@@ -2,6 +2,7 @@ import has from 'lodash/has';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { ButtonIcon } from '@talend/design-system';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 import getDefaultT from '../translate';
 import { Action } from '../Actions';
@@ -111,16 +112,19 @@ function SubHeaderBar({
 				<SubHeaderBarActions left>
 					{injected('before-back')}
 					{onGoBack && (
-						<Renderer.Action
-							id="backArrow"
-							onClick={onGoBack}
-							label={t('BACK_ARROW_TOOLTIP', { defaultValue: 'Go back' })}
-							icon="talend-arrow-left"
-							bsStyle="link"
-							data-feature={goBackDataFeature}
+						<div
 							className={classNames(theme['tc-subheader-back-button'], 'tc-subheader-back-button')}
-							hideLabel
-						/>
+						>
+							<ButtonIcon
+								icon="arrow-left"
+								size="M"
+								onClick={onGoBack}
+								id="backArrow"
+								data-feature={goBackDataFeature}
+							>
+								{t('BACK_ARROW_TOOLTIP', { defaultValue: 'Go back' })}
+							</ButtonIcon>
+						</div>
 					)}
 					{injected('before-title')}
 					<TitleSubHeader t={t} getComponent={getComponent} {...rest} />

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.module.scss
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.module.scss
@@ -18,15 +18,15 @@ $tc-svg-icon-size: $padding-large !default;
 
 	:global(.btn-link),
 	:global(.btn-icon-only) {
-		color: $tc-subheader-color;
+		color: tokens.$coral-color-accent-icon;
 
 		&:focus,
 		&:hover {
-			color: tokens.$coral-color-accent-text-hover;
+			color: tokens.$coral-color-accent-icon-hover;
 		}
 
 		&:active {
-			color: tokens.$coral-color-accent-text-active;
+			color: tokens.$coral-color-accent-icon-active;
 		}
 	}
 
@@ -79,6 +79,9 @@ $tc-svg-icon-size: $padding-large !default;
 		background-color: tokens.$coral-color-neutral-background-strong !important;
 		width: $tc-subheader-bar-height;
 		height: $tc-subheader-bar-height;
+		display: flex;
+		align-items: center;
+		justify-content: center;
 
 		&:focus,
 		&:hover,

--- a/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
+++ b/packages/components/src/SubHeaderBar/SubHeaderBar.test.js
@@ -200,7 +200,7 @@ describe('SubHeaderBar', () => {
 		};
 		render(<SubHeaderBar {...props} />);
 		expect(screen.getByText('myTitle')).toBeVisible();
-		expect(screen.getByLabelText('Go back')).toBeVisible();
+		expect(screen.getByTestId('tc-subheader-backArrow')).toBeVisible();
 	});
 
 	it('Should render SubHeader component if right actions are in loading state', () => {

--- a/packages/components/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
+++ b/packages/components/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
@@ -13,18 +13,18 @@ exports[`SubHeaderBar should render 1`] = `
       <div
         class="theme-navbar-left navbar-left"
       >
-        <button
-          aria-describedby="42"
-          aria-label="Go back"
-          class="theme-tc-subheader-back-button tc-subheader-back-button btn-icon-only btn btn-link"
-          id="backArrow"
-          type="button"
+        <div
+          class="theme-tc-subheader-back-button tc-subheader-back-button"
         >
           <span
-            class="CoralIcon"
-            name="talend-arrow-left"
-          />
-        </button>
+            class="CoralButtonIcon"
+            data-testid="tc-subheader-backArrow"
+            icon="arrow-left"
+            id="backArrow"
+          >
+            Go back
+          </span>
+        </div>
         <div
           class="tc-subheader-details theme-tc-subheader-details"
         >

--- a/packages/containers/src/SubHeaderBar/SubHeaderBar.test.js
+++ b/packages/containers/src/SubHeaderBar/SubHeaderBar.test.js
@@ -23,7 +23,8 @@ describe('SubHeaderBar container', () => {
 		};
 		// When
 		render(<Container {...props} />);
-		fireEvent.click(screen.getByLabelText('Go back'));
+
+		fireEvent.click(screen.getByTestId('tc-subheader-backArrow'));
 		// Then
 		expect(props.onGoBack).toHaveBeenCalled();
 	});
@@ -35,7 +36,7 @@ describe('SubHeaderBar container', () => {
 		};
 		// When
 		render(<Container {...props} />);
-		fireEvent.click(screen.getByLabelText('Go back'));
+		fireEvent.click(screen.getByTestId('tc-subheader-backArrow'));
 		// Then
 		expect(props.dispatchActionCreator).toHaveBeenCalledWith(
 			props.actionCreatorGoBack,

--- a/packages/containers/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
+++ b/packages/containers/src/SubHeaderBar/__snapshots__/SubHeaderBar.test.js.snap
@@ -13,18 +13,18 @@ exports[`SubHeaderBar container should render 1`] = `
       <div
         class="theme-navbar-left navbar-left"
       >
-        <button
-          aria-describedby="42"
-          aria-label="Go back"
-          class="theme-tc-subheader-back-button tc-subheader-back-button btn-icon-only btn btn-link"
-          id="backArrow"
-          type="button"
+        <div
+          class="theme-tc-subheader-back-button tc-subheader-back-button"
         >
           <span
-            class="CoralIcon"
-            name="talend-arrow-left"
-          />
-        </button>
+            class="CoralButtonIcon"
+            data-testid="tc-subheader-backArrow"
+            icon="arrow-left"
+            id="backArrow"
+          >
+            Go back
+          </span>
+        </div>
         <div
           class="tc-subheader-details theme-tc-subheader-details"
         >


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Icons are in a strong black mode
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
