### PR TITLE
fix(TDOPS-4938): force windows to use a shell

### DIFF
--- a/.changeset/tiny-paws-build.md
+++ b/.changeset/tiny-paws-build.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-core': patch
+---
+
+Fix the use of spawn on windows

--- a/tools/scripts-core/src/scripts/build-lib.js
+++ b/tools/scripts-core/src/scripts/build-lib.js
@@ -65,6 +65,7 @@ export default async function build(env, presetApi, unsafeOptions) {
 				{
 					stdio: 'inherit',
 					env,
+					shell: process.platform === 'win32',
 				},
 			);
 			babelSpawn.on('exit', status => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Since TMC is a monorepo, it's not possible to build it on windows.
See https://jira.talendforge.org/browse/TDOPS-4938

**What is the chosen solution to this problem?**
Add `shell: true` in the options of the `spawn` command when using windows to force the use of a shell.

See: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
