### PR TITLE
fix(TDP-12557): use lighter gray for format value whitespace

### DIFF
--- a/.changeset/shy-baboons-argue.md
+++ b/.changeset/shy-baboons-argue.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+fix(TDP-12557): use lighter gray for format value whitespace

--- a/packages/components/src/FormatValue/FormatValue.module.scss
+++ b/packages/components/src/FormatValue/FormatValue.module.scss
@@ -3,7 +3,7 @@
 
 $svg-tab-width: 2.6rem !default;
 $svg-other-characters: 0.3rem !default;
-$svg-color: tokens.$coral-color-neutral-icon-weak !default;
+$svg-color: tokens.$coral-color-neutral-background-strong !default;
 
 .td-value {
 	white-space: pre;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Format value with whitespace was a bit too dark compared to previous value so we use a lighter token.

before
![image](https://github.com/Talend/ui/assets/6088236/293c5c06-6b48-4f2e-bd50-498eec9e8ec6)

after
![image](https://github.com/Talend/ui/assets/6088236/45ed8d40-3a11-489d-bfd7-8ada551daafd)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
