### PR TITLE
fix(ARCH-720): use elevation token for headerbar

### DIFF
--- a/.changeset/lucky-jobs-flash.md
+++ b/.changeset/lucky-jobs-flash.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+Use elevation token for headerbar to be in line with other components

--- a/packages/components/src/HeaderBar/HeaderBar.module.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.module.scss
@@ -20,7 +20,7 @@ $tc-headerbar-logo-full-width: 8.5rem !default;
 	position: fixed;
 	top: 0;
 	width: 100%;
-	z-index: 1030;
+	z-index: tokens.$coral-elevation-layer-standard-front;
 
 	svg {
 		margin: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
use elevation token for headerbar

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
