### PR TITLE
fix(TDOPS-5081): fix FilterBar in VList having wrong style on hover

### DIFF
--- a/.changeset/serious-shrimps-obey.md
+++ b/.changeset/serious-shrimps-obey.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-5081 - Fixed FilterBar in VList header having wrong style on hover

--- a/packages/components/src/FilterBar/FilterBar.component.js
+++ b/packages/components/src/FilterBar/FilterBar.component.js
@@ -157,12 +157,11 @@ export default function FilterBar(props) {
 		return (
 			<Action
 				id={props.id}
-				className={props.className}
+				className={classNames(props.className, theme['button-docked'])}
 				onClick={props.onToggle}
 				label={t('LIST_FILTER_TOGGLE', { defaultValue: 'Toggle filter' })}
 				hideLabel
 				icon="talend-search"
-				bsStyle="link"
 				data-feature={props['data-feature']}
 				tooltipPlacement={props.tooltipPlacement}
 				role="search"

--- a/packages/components/src/FilterBar/FilterBar.module.scss
+++ b/packages/components/src/FilterBar/FilterBar.module.scss
@@ -86,6 +86,10 @@ $tc-filter-bar-width: 250px !default;
 	}
 }
 
+.button-docked {
+	color: tokens.$coral-color-neutral-icon-weak;
+}
+
 @keyframes reveal {
 	0% {
 		opacity: 0;

--- a/packages/components/src/List/ListComposition/TextFilter/__snapshots__/TextFilter.component.test.js.snap
+++ b/packages/components/src/List/ListComposition/TextFilter/__snapshots__/TextFilter.component.test.js.snap
@@ -4,7 +4,7 @@ exports[`TextFilter should render text filter component 1`] = `
 <button
   aria-describedby="42"
   aria-label="Toggle filter"
-  class="btn-icon-only btn btn-link"
+  class="theme-button-docked btn-icon-only btn btn-default"
   id="myTextFilter"
   role="search"
   type="button"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fix FilterBar in VList having wrong style on hover

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
