### PR TITLE
feat(TDOPS-4488): Add VList Link column to dictionary

### DIFF
--- a/.changeset/friendly-oranges-pull.md
+++ b/.changeset/friendly-oranges-pull.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-4488: Add VList Link column to disctionary

--- a/packages/components/src/VirtualizedList/utils/dictionary.js
+++ b/packages/components/src/VirtualizedList/utils/dictionary.js
@@ -4,6 +4,7 @@ import RowCollapsiblePanel, { rowType as rowCollapsiblePanelType } from '../RowC
 import CellActionsRenderer, { cellType as cellActionsType } from '../CellActions';
 import CellCheckboxRenderer, { cellType as cellCheckboxType } from '../CellCheckbox';
 import CellTitleRenderer, { cellType as cellTitleType } from '../CellTitle';
+import CellLinkRenderer, { cellType as cellLinkType } from '../CellLink';
 import CellBadgeRenderer, { cellType as cellBadgeType } from '../CellBadge';
 import CellLabelRenderer, { cellType as cellLabelType } from '../CellLabel';
 import CellDatetimeRenderer, { cellType as cellDatetimeType } from '../CellDatetime';
@@ -17,6 +18,7 @@ export const cellDictionary = {
 	[cellActionsType]: CellActionsRenderer,
 	[cellCheckboxType]: CellCheckboxRenderer,
 	[cellTitleType]: CellTitleRenderer,
+	[cellLinkType]: CellLinkRenderer,
 	[cellBadgeType]: CellBadgeRenderer,
 	[cellLabelType]: CellLabelRenderer,
 	[cellTextType]: CellTextIconRenderer,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add VList Link column to dictionary

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
