### PR TITLE
fix: change drawer header color

### DIFF
--- a/.changeset/sweet-houses-enjoy.md
+++ b/.changeset/sweet-houses-enjoy.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: change drawer header color

--- a/packages/components/src/Drawer/Drawer.module.scss
+++ b/packages/components/src/Drawer/Drawer.module.scss
@@ -9,7 +9,8 @@ $tc-drawer-transition-easing: cubic-bezier(0.18, 0.89, 0.32, 1.28) !default;
 $tc-drawer-padding: $padding-large !default;
 $tc-drawer-header-height: 5.5rem !default;
 $tc-drawer-header-color: tokens.$coral-color-neutral-text !default;
-$tc-drawer-header-background: tokens.$coral-color-accent-background !default;
+$tc-drawer-header-background: tokens.$coral-color-neutral-background !default;
+$tc-drawer-header-border: tokens.$coral-border-s-solid tokens.$coral-color-neutral-border-weak !default;
 $tc-drawer-tabs-background: tokens.$coral-color-accent-background-weak !default;
 $tc-drawer-content-max-width: 65rem !default;
 $tc-action-bar-background-color: tokens.$coral-color-neutral-background-medium !default;
@@ -80,6 +81,7 @@ $tc-drawer-z-index: $drawer-z-index !default;
 
 .tc-drawer-header {
 	background-color: $tc-drawer-header-background;
+	border: $tc-drawer-header-border;
 
 	:global {
 		.tc-editable-text {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The drawer header color is wrong
<img width="413" alt="Screenshot 2023-09-06 at 13 36 56" src="https://github.com/Talend/ui/assets/124570762/b0f9be27-9eb4-46c7-a672-abd38c3e386f">

**What is the chosen solution to this problem?**
Fixed the drawer header color to white with a border
<img width="409" alt="Screenshot 2023-09-06 at 13 37 59" src="https://github.com/Talend/ui/assets/124570762/98bdeb4a-37d1-42cf-b5ad-a257131e8165">

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
