### PR TITLE
fix(TDOPS-5103): Fix the notification is covered by detail drawer

### DIFF
--- a/.changeset/olive-eyes-brake.md
+++ b/.changeset/olive-eyes-brake.md
@@ -1,0 +1,5 @@
+---
+'@talend/bootstrap-theme': patch
+---
+
+fix(TDOPS-5103): Fix the notification is covered by detail drawer

--- a/packages/theme/src/theme/_guidelines.scss
+++ b/packages/theme/src/theme/_guidelines.scss
@@ -53,7 +53,7 @@ $navbar-brand-logo-width: 75px !default;
 /// Drawer z-index
 /// should always stay lower than dialog z-index which is set to 1040
 /// @type Number (Unitless)
-$drawer-z-index: 100 !default;
+$drawer-z-index: 15 !default;
 
 /// Navbar form top and bottom width
 /// @type Number (Unit)

--- a/packages/theme/src/theme/_guidelines.scss
+++ b/packages/theme/src/theme/_guidelines.scss
@@ -2,6 +2,7 @@
 /// Talend spec from the guidelines
 /// @group Guidelines
 ////
+@use '~@talend/design-tokens/lib/tokens';
 
 @import './helpers';
 @import './colors';
@@ -53,7 +54,7 @@ $navbar-brand-logo-width: 75px !default;
 /// Drawer z-index
 /// should always stay lower than dialog z-index which is set to 1040
 /// @type Number (Unitless)
-$drawer-z-index: 15 !default;
+$drawer-z-index: tokens.$coral-elevation-layer-standard-front !default; // 4
 
 /// Navbar form top and bottom width
 /// @type Number (Unit)


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The notification is covered by detail drawer.
![image](https://github.com/Talend/ui/assets/7745317/ce74d0bb-28a9-41bc-801e-c210fae49c9e)
https://jira.talendforge.org/browse/TDOPS-5103

**What is the chosen solution to this problem?**
The z-index of notification is `16`, so update the z-index of $drawer-z-index so that its value is slightly smaller than 16

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
