### PR TITLE
fix(TDOPS-4488): VList can handle data attributes for Link column

### DIFF
--- a/.changeset/green-cars-mate.md
+++ b/.changeset/green-cars-mate.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-4488 - Components VList can handle data attributes for Link column

--- a/packages/components/src/VirtualizedList/CellLink/CellLink.component.js
+++ b/packages/components/src/VirtualizedList/CellLink/CellLink.component.js
@@ -13,7 +13,9 @@ function CellLink({ cellData, rowData, columnData, className }) {
 	}
 	const linkRender = (
 		<div className={classNames(className, styles['cell-link-container'])}>
-			<Link as={cellColumnData.linkAs}>{cellData}</Link>
+			<Link {...columnData} as={cellColumnData.linkAs}>
+				{cellData}
+			</Link>
 		</div>
 	);
 

--- a/packages/components/src/VirtualizedList/CellLink/CellLink.test.js
+++ b/packages/components/src/VirtualizedList/CellLink/CellLink.test.js
@@ -10,14 +10,20 @@ describe('CellLink', () => {
 			<BrowserRouter>
 				<CellLink
 					cellData="Link to my website"
-					columnData={{ linkAs: <RouterLink to="/documentation"></RouterLink> }}
+					columnData={{
+						linkAs: <RouterLink to="/documentation"></RouterLink>,
+						'data-testid': 'my-data-test-id',
+					}}
 				/>
 			</BrowserRouter>,
 		);
-		// then
+		// then link is generated
 		expect(screen.getByRole('link', { name: 'Link to my website' })).toHaveAttribute(
 			'href',
 			'/documentation',
 		);
+
+		// then data attributes can be passed
+		expect(screen.getByTestId('my-data-test-id')).toBeInTheDocument();
 	});
 });

--- a/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
+++ b/packages/components/src/VirtualizedList/CellTitle/CellTitleSelector.component.js
@@ -59,7 +59,7 @@ function CellTitleSelector(props) {
 			<CellLink
 				cellData={cellData}
 				rowData={rowData}
-				columnData={{ id, linkAs, tooltip }}
+				columnData={{ ...columnData, id, linkAs, tooltip }}
 				className={className}
 			></CellLink>
 		);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
VList can handle data attributes for Link column

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
