### PR TITLE
feat(TDOPS-5212): Components - Add a theme props to Layout component

### DIFF
--- a/.changeset/wicked-points-cough.md
+++ b/.changeset/wicked-points-cough.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+Components - Layout can now be given a theme directly from props by parent app

--- a/packages/components/src/Layout/Layout.component.js
+++ b/packages/components/src/Layout/Layout.component.js
@@ -7,7 +7,7 @@ import OneColumn from './OneColumn';
 import TwoColumns from './TwoColumns';
 import SkipLinks from './SkipLinks';
 
-import theme from './Layout.module.scss';
+import style from './Layout.module.scss';
 
 const DISPLAY_MODES = {
 	ONE_COLUMN: 'OneColumn',
@@ -42,13 +42,14 @@ function Layout({
 	drawers,
 	tabs,
 	hasTheme,
+	theme,
 	children,
 	getComponent,
 	...rest
 }) {
-	const appCSS = classnames('tc-layout', theme.layout, hasTheme && TALEND_T7_THEME_CLASSNAME);
-	const headerCSS = classnames('tc-layout-header', theme.header);
-	const footerCSS = classnames('tc-layout-footer', theme.footer);
+	const appCSS = classnames('tc-layout', style.layout, hasTheme && TALEND_T7_THEME_CLASSNAME);
+	const headerCSS = classnames('tc-layout-header', style.header);
+	const footerCSS = classnames('tc-layout-footer', style.footer);
 	let Component;
 	let skipLinkNavigationId;
 	switch (mode) {
@@ -70,9 +71,9 @@ function Layout({
 	const safeFooter = Inject.getReactElement(getComponent, footer);
 
 	return (
-		<ThemeProvider>
+		<ThemeProvider theme={theme}>
 			<div id={id} className={appCSS}>
-				<div className={theme['skip-links']}>
+				<div className={style['skip-links']}>
 					<SkipLinks navigationId={skipLinkNavigationId} mainId="#tc-layout-main" />
 				</div>
 				{safeHeader && (
@@ -117,6 +118,7 @@ Layout.propTypes = {
 	drawers: PropTypes.arrayOf(PropTypes.element),
 	tabs: PropTypes.shape(TabBar.propTypes),
 	hasTheme: PropTypes.bool,
+	theme: PropTypes.string,
 	children: PropTypes.node,
 	getComponent: PropTypes.func,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add a theme props to Layout component so that the parent app can directly send it to the theme provider

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
