### PR TITLE
fix(TDOPS-5105): Components badge separator now has the right color

### DIFF
--- a/.changeset/hungry-beers-clap.md
+++ b/.changeset/hungry-beers-clap.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-5105 - Components badge now have the right separator color

--- a/packages/components/src/Badge/Badge.module.scss
+++ b/packages/components/src/Badge/Badge.module.scss
@@ -76,7 +76,7 @@ $tc-badge-disabled-opacity: 0.62;
 			flex-shrink: 0;
 			height: 12px;
 			width: 1px;
-			background-color: tokens.$coral-color-neutral-background-medium;
+			background-color: tokens.$coral-color-neutral-border-weak;
 			margin: $padding-smaller;
 
 			&.tc-badge-separator-icon {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Components badge separator now has the right color

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
