### PR TITLE
fix(TFD-15974): Fix calculate port position with portId action

### DIFF
--- a/.changeset/silver-feet-exercise.md
+++ b/.changeset/silver-feet-exercise.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-flow-designer': minor
+---
+
+fix(TFD-15974): Fix calculate port position with portId action

--- a/packages/flow-designer/src/reducers/flow.reducer.test.ts
+++ b/packages/flow-designer/src/reducers/flow.reducer.test.ts
@@ -185,7 +185,7 @@ describe('calculatePortsPosition behavior', () => {
 		expect(calculatePortPosition.mock.calls.length).toEqual(0);
 	});
 
-	it.only('should trigger using action with port id', () => {
+	it('should trigger using action with port id', () => {
 		const calculatePortPosition = jest.fn();
 		const givenState = state.setIn(['nodeTypes', '42', 'component'], { calculatePortPosition });
 		const action = {

--- a/packages/flow-designer/src/reducers/flow.reducer.test.ts
+++ b/packages/flow-designer/src/reducers/flow.reducer.test.ts
@@ -184,4 +184,18 @@ describe('calculatePortsPosition behavior', () => {
 		});
 		expect(calculatePortPosition.mock.calls.length).toEqual(0);
 	});
+
+	it.only('should trigger using action with port id', () => {
+		const calculatePortPosition = jest.fn();
+		const givenState = state.setIn(['nodeTypes', '42', 'component'], { calculatePortPosition });
+		const action = {
+			type: 'FLOWDESIGNER_PORT_SET_DATA',
+			portId: '42',
+			data: {
+				flowType: '__default__',
+			},
+		};
+		calculatePortsPosition(givenState, action);
+		expect(calculatePortPosition.mock.calls.length).toEqual(1);
+	});
 });

--- a/packages/flow-designer/src/reducers/flow.reducer.ts
+++ b/packages/flow-designer/src/reducers/flow.reducer.ts
@@ -166,7 +166,7 @@ export function calculatePortsPosition(state: State, action: any) {
 		if (action.nodeId) {
 			nodes.push(state.getIn(['nodes', action.nodeId]));
 		} else if (action.portId) {
-			nodes.push(state.getIn(['nodes'], state.getIn(['ports', action.portId]).nodeId));
+			nodes.push(state.getIn(['nodes', state.getIn(['ports', action.portId]).nodeId]));
 		} else {
 			nodes = state.get('nodes');
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fix 'TypeError: node.getNodeType is not a function' error when using flowDesignerReducer with portActions

**What is the chosen solution to this problem?**
Fix the typo

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
