### PR TITLE
feat(TDP-12106): rework http interceptors to access request object and return promise

### DIFF
--- a/.changeset/brave-birds-report.md
+++ b/.changeset/brave-birds-report.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': major
+---
+
+feat(TDP-12106): improve interceptors to return a promise, have access to request and a business context from caller

--- a/.changeset/brave-birds-report.md
+++ b/.changeset/brave-birds-report.md
@@ -1,5 +1,5 @@
 ---
-'@talend/http': major
+'@talend/http': minor
 ---
 
 feat(TDP-12106): improve interceptors to return a promise, have access to request and a business context from caller

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -47,3 +47,40 @@ async function test() {
 	const response = await http.get('/api/v1/my-resource');
 }
 ```
+
+## Interceptors
+
+You can add global response interceptors to catch or modify responses before resolve.
+
+```es6
+import { addHttpResponseInterceptor, http, HTTP_METHODS } from '@talend/http';
+import type { TalendRequest } from '@talend/http';
+
+addHttpResponseInterceptor('my-interceptor', async (request: TalendRequest, response: Response) => {
+	if (request.method === HTTP_METHODS.GET) {
+		// your custom logic here
+	}
+
+	return response;
+});
+```
+
+You can add multiple interceptors. Each will be called in the order of registration and will receive the same request parameter, but response parameter will be the one returned by previous interceptor.
+
+Once your interceptor is not needed anymore, you can unregister it with `removeHttpResponseInterceptor` function of `@talend/http` package.
+
+You can identify some requests in interceptor by using `context` property in fetch function config:
+
+```es6
+import { addHttpResponseInterceptor, http, HTTP_METHODS } from '@talend/http';
+
+http.get('/api/v1/data', { context: { intercept: true } });
+
+addHttpResponseInterceptor('my-interceptor', async (request: TalendRequest, response: Response) => {
+	const { context } = request;
+	if (request.method === HTTP_METHODS.GET && context.intercept) {
+		// your custom logic here
+	}
+	return response;
+});
+```

--- a/packages/http/README.md
+++ b/packages/http/README.md
@@ -56,7 +56,7 @@ You can add global response interceptors to catch or modify responses before res
 import { addHttpResponseInterceptor, http, HTTP_METHODS } from '@talend/http';
 import type { TalendRequest } from '@talend/http';
 
-addHttpResponseInterceptor('my-interceptor', async (request: TalendRequest, response: Response) => {
+addHttpResponseInterceptor('my-interceptor', async (response: Response, request: TalendRequest) => {
 	if (request.method === HTTP_METHODS.GET) {
 		// your custom logic here
 	}
@@ -65,7 +65,7 @@ addHttpResponseInterceptor('my-interceptor', async (request: TalendRequest, resp
 });
 ```
 
-You can add multiple interceptors. Each will be called in the order of registration and will receive the same request parameter, but response parameter will be the one returned by previous interceptor.
+You can add multiple interceptors. Each will be called in the order of registration and will receive the same request parameter, but response parameter will be the one returned by previous interceptor. If interceptor returns void, then it'll return received response.
 
 Once your interceptor is not needed anymore, you can unregister it with `removeHttpResponseInterceptor` function of `@talend/http` package.
 
@@ -76,7 +76,7 @@ import { addHttpResponseInterceptor, http, HTTP_METHODS } from '@talend/http';
 
 http.get('/api/v1/data', { context: { intercept: true } });
 
-addHttpResponseInterceptor('my-interceptor', async (request: TalendRequest, response: Response) => {
+addHttpResponseInterceptor('my-interceptor', async (response: Response, request: TalendRequest) => {
 	const { context } = request;
 	if (request.method === HTTP_METHODS.GET && context.intercept) {
 		// your custom logic here

--- a/packages/http/src/config.test.ts
+++ b/packages/http/src/config.test.ts
@@ -6,7 +6,10 @@ import {
 	removeHttpResponseInterceptor,
 	setDefaultConfig,
 	setDefaultLanguage,
+	applyInterceptors,
 } from './config';
+import { HTTP_METHODS, HTTP_STATUS } from './http.constants';
+import { TalendRequest } from './http.types';
 
 describe('Configuration service', () => {
 	describe('setDefaultLanguage', () => {
@@ -92,6 +95,55 @@ describe('Configuration service', () => {
 				'Interceptor myInterceptor does not exist',
 			);
 			expect(HTTP_RESPONSE_INTERCEPTORS).toEqual({ myInterceptor2: interceptor2 });
+		});
+		it('should apply all interceptors', async () => {
+			const request: TalendRequest = {
+				url: '/api/v1/data',
+				method: HTTP_METHODS.GET,
+			};
+			const response = {
+				ok: true,
+				status: HTTP_STATUS.OK,
+				body: [1, 2, 3],
+			} as unknown as Response;
+
+			const interceptor1 = jest
+				.fn()
+				.mockImplementation((_, resp) => Promise.resolve({ ...resp, body: [...resp.body, 4] }));
+			addHttpResponseInterceptor('interceptor-1', interceptor1);
+
+			const interceptor2 = jest.fn().mockImplementation((req, resp) =>
+				Promise.resolve({
+					...resp,
+					body: { interceptor: `interceptor2-${req.method}`, original: resp.body },
+				}),
+			);
+			addHttpResponseInterceptor('interceptor-2', interceptor2);
+
+			const interceptedResponse = await applyInterceptors(request, response);
+
+			expect(interceptor1).toHaveBeenCalledWith(request, response);
+			expect(interceptor2).toHaveBeenLastCalledWith(
+				request,
+				expect.objectContaining({ body: [1, 2, 3, 4] }),
+			);
+			expect(interceptedResponse).toEqual({
+				...response,
+				body: { interceptor: 'interceptor2-GET', original: [1, 2, 3, 4] },
+			});
+		});
+		it('should return response if no interceptors', () => {
+			const request: TalendRequest = {
+				url: '/api/v1/data',
+				method: HTTP_METHODS.GET,
+			};
+			const response = {
+				ok: true,
+				status: HTTP_STATUS.OK,
+				body: [1, 2, 3],
+			} as unknown as Response;
+
+			expect(applyInterceptors(request, response)).resolves.toEqual(response);
 		});
 	});
 });

--- a/packages/http/src/config.ts
+++ b/packages/http/src/config.ts
@@ -1,4 +1,4 @@
-import { TalendRequestInit } from './http.types';
+import { TalendRequest, TalendRequestInit } from './http.types';
 
 /**
  * Storage point for the doc setup using `setDefaultConfig`
@@ -7,12 +7,11 @@ export const HTTP: { defaultConfig?: TalendRequestInit | null } = {
 	defaultConfig: null,
 };
 
-export const HTTP_RESPONSE_INTERCEPTORS: Record<string, (response: Response) => void> = {};
+export type Interceptor = (request: TalendRequest, response: Response) => Promise<Response>;
 
-export function addHttpResponseInterceptor(
-	name: string,
-	interceptor: (response: Response) => void,
-) {
+export const HTTP_RESPONSE_INTERCEPTORS: Record<string, Interceptor> = {};
+
+export function addHttpResponseInterceptor(name: string, interceptor: Interceptor) {
 	if (HTTP_RESPONSE_INTERCEPTORS[name]) {
 		throw new Error(`Interceptor ${name} already exists`);
 	}
@@ -24,6 +23,13 @@ export function removeHttpResponseInterceptor(name: string) {
 		throw new Error(`Interceptor ${name} does not exist`);
 	}
 	delete HTTP_RESPONSE_INTERCEPTORS[name];
+}
+
+export function applyInterceptors(request: TalendRequest, response: Response): Promise<Response> {
+	return Object.values(HTTP_RESPONSE_INTERCEPTORS).reduce(
+		(promise, interceptor) => promise.then(resp => interceptor(request, resp)),
+		Promise.resolve(response),
+	);
 }
 
 /**

--- a/packages/http/src/config.ts
+++ b/packages/http/src/config.ts
@@ -7,7 +7,7 @@ export const HTTP: { defaultConfig?: TalendRequestInit | null } = {
 	defaultConfig: null,
 };
 
-export type Interceptor = (request: TalendRequest, response: Response) => Promise<Response>;
+export type Interceptor = (response: Response, request: TalendRequest) => Promise<Response> | void;
 
 export const HTTP_RESPONSE_INTERCEPTORS: Record<string, Interceptor> = {};
 
@@ -27,7 +27,8 @@ export function removeHttpResponseInterceptor(name: string) {
 
 export function applyInterceptors(request: TalendRequest, response: Response): Promise<Response> {
 	return Object.values(HTTP_RESPONSE_INTERCEPTORS).reduce(
-		(promise, interceptor) => promise.then(resp => interceptor(request, resp)),
+		(promise, interceptor) =>
+			promise.then(resp => interceptor(resp, request) || Promise.resolve(response)),
 		Promise.resolve(response),
 	);
 }

--- a/packages/http/src/http.common.test.ts
+++ b/packages/http/src/http.common.test.ts
@@ -348,14 +348,30 @@ describe('#httpFetch with interceptors', () => {
 		fetchMock.restore();
 	});
 
-	it('should call interceptors', async () => {
-		const interceptor = jest.fn();
+	it('should call interceptor', async () => {
+		const interceptor = jest.fn().mockImplementation((_, res) => res);
 		addHttpResponseInterceptor('interceptor', interceptor);
 
 		const url = '/foo';
-		fetchMock.mock(url, { status: 200 });
+		fetchMock.mock(url, { body: defaultBody, status: 200 });
 
 		await httpFetch(url, {}, HTTP_METHODS.GET, {});
 		expect(interceptor).toHaveBeenCalled();
+	});
+
+	it('should have access to context in interceptor', async () => {
+		const interceptor = jest.fn().mockImplementation((_, res) => res);
+		addHttpResponseInterceptor('interceptor', interceptor);
+
+		const url = '/foo';
+		const context = { async: true };
+		const response = { body: defaultBody, status: 200 };
+		fetchMock.mock(url, response);
+
+		await httpFetch(url, { context }, HTTP_METHODS.GET, {});
+		expect(interceptor).toHaveBeenCalledWith(
+			expect.objectContaining({ url, context, method: HTTP_METHODS.GET }),
+			expect.anything(),
+		);
 	});
 });

--- a/packages/http/src/http.common.test.ts
+++ b/packages/http/src/http.common.test.ts
@@ -54,7 +54,10 @@ describe('handleBody', () => {
 
 		const blob = jest.fn(() => Promise.resolve());
 
-		await handleBody({ blob, headers } as any);
+		await handleBody({
+			headers,
+			clone: jest.fn().mockReturnValue({ blob }),
+		} as any);
 
 		expect(blob).toHaveBeenCalled();
 	});
@@ -75,6 +78,12 @@ describe('handleBody', () => {
 	it('should manage the body of the response like a text by default', async () => {
 		const result = await handleBody(new Response('') as any);
 		expect(result.data).toBe('');
+	});
+
+	it("should manage response's body and return a clone with unused body", async () => {
+		const result = await handleBody(new Response('ok') as any);
+		expect(result.data).toBe('ok');
+		expect(result.response.bodyUsed).toBe(false);
 	});
 
 	describe('#handleHttpResponse', () => {

--- a/packages/http/src/http.common.test.ts
+++ b/packages/http/src/http.common.test.ts
@@ -349,7 +349,7 @@ describe('#httpFetch with interceptors', () => {
 	});
 
 	it('should call interceptor', async () => {
-		const interceptor = jest.fn().mockImplementation((_, res) => res);
+		const interceptor = jest.fn().mockImplementation((res, _) => res);
 		addHttpResponseInterceptor('interceptor', interceptor);
 
 		const url = '/foo';
@@ -360,7 +360,7 @@ describe('#httpFetch with interceptors', () => {
 	});
 
 	it('should have access to context in interceptor', async () => {
-		const interceptor = jest.fn().mockImplementation((_, res) => res);
+		const interceptor = jest.fn().mockImplementation((res, _) => res);
 		addHttpResponseInterceptor('interceptor', interceptor);
 
 		const url = '/foo';
@@ -370,8 +370,8 @@ describe('#httpFetch with interceptors', () => {
 
 		await httpFetch(url, { context }, HTTP_METHODS.GET, {});
 		expect(interceptor).toHaveBeenCalledWith(
-			expect.objectContaining({ url, context, method: HTTP_METHODS.GET }),
 			expect.anything(),
+			expect.objectContaining({ url, context, method: HTTP_METHODS.GET }),
 		);
 	});
 });

--- a/packages/http/src/http.common.ts
+++ b/packages/http/src/http.common.ts
@@ -118,7 +118,7 @@ export async function httpFetch<T>(
 		},
 	};
 
-	const init = handleCSRFToken({
+	const { context, ...init } = handleCSRFToken({
 		...params,
 		body: encodePayload(params.headers || {}, payload),
 	});
@@ -128,6 +128,7 @@ export async function httpFetch<T>(
 			{
 				url,
 				...init,
+				context,
 			},
 			resp,
 		),

--- a/packages/http/src/http.common.ts
+++ b/packages/http/src/http.common.ts
@@ -40,17 +40,18 @@ export function encodePayload(headers: HeadersInit, payload: any) {
  * @return {Promise}           A promise that resolves with the result of parsing the body
  */
 export async function handleBody(response: Response) {
+	const clonedResponse = response.clone();
 	const { headers } = response;
 	const contentType = headers.get('Content-Type');
 	if (contentType && contentType.includes('application/json')) {
-		return response.json().then(data => ({ data, response }));
+		return clonedResponse.json().then(data => ({ data, response }));
 	}
 
 	if (contentType && contentType.includes('application/zip')) {
-		return response.blob().then(data => ({ data, response }));
+		return clonedResponse.blob().then(data => ({ data, response }));
 	}
 
-	return response.text().then(data => ({ data, response }));
+	return clonedResponse.text().then(data => ({ data, response }));
 }
 
 /**

--- a/packages/http/src/http.types.ts
+++ b/packages/http/src/http.types.ts
@@ -12,6 +12,10 @@ export interface TalendRequestInit extends RequestInit {
 	security?: TalendRequestInitSecurity;
 }
 
+export type TalendRequest = {
+	url: string;
+} & TalendRequestInit;
+
 export interface TalendHttpError<T> extends Error {
 	response: Response;
 	data: T;

--- a/packages/http/src/http.types.ts
+++ b/packages/http/src/http.types.ts
@@ -10,6 +10,7 @@ export type TalendRequestInitSecurity = {
 
 export interface TalendRequestInit extends RequestInit {
 	security?: TalendRequestInitSecurity;
+	context?: Record<string, unknown>;
 }
 
 export type TalendRequest = {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Current interceptors do not have access to request, which is useful in some situation (e.g to intercept only get methods). 
Current interceptors can't identify precisely specific calls (e.g some function send an http request but based on business logic we want to ignore 404 responses on this request to not warn user).
Current interceptors return void so they can't modify the response based on some business logic, or trigger another http call before resolve. 

**What is the chosen solution to this problem?**

You can have more information in the readme.

**Please check if the PR fulfills these requirements**

- [X] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
