### PR TITLE
fix(TDOPS-872): VList content cell should display a tooltip for 0 value

### DIFF
--- a/.changeset/tall-beds-relax.md
+++ b/.changeset/tall-beds-relax.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-872 - VList cell content should display a tooltip for 0 value as well

--- a/packages/components/src/VirtualizedList/Content.component.js
+++ b/packages/components/src/VirtualizedList/Content.component.js
@@ -5,13 +5,19 @@ import TooltipTrigger from '../TooltipTrigger';
 
 function DefaultRenderer({ cellData, columnData, rowData }) {
 	const { getTooltipLabel } = columnData;
-	let tooltipLabel = columnData.tooltipLabel || cellData;
+	let tooltipLabel = columnData.tooltipLabel != null ? columnData.tooltipLabel : cellData;
 	if (typeof getTooltipLabel === 'function') {
 		tooltipLabel = getTooltipLabel(rowData);
 	}
-	return tooltipLabel ? (
+	return tooltipLabel != null ? (
 		<TooltipTrigger label={tooltipLabel} tooltipPlacement={columnData.tooltipPlacement || 'top'}>
-			<div className="tc-virtualizedlist-default-cell">{cellData}</div>
+			<div
+				className="tc-virtualizedlist-default-cell"
+				data-test="tc-virtualizedlist-default-cell-tooltip"
+				data-testid="tc-virtualizedlist-default-cell-tooltip"
+			>
+				{cellData}
+			</div>
 		</TooltipTrigger>
 	) : (
 		<div className="tc-virtualizedlist-default-cell">{cellData}</div>

--- a/packages/components/src/VirtualizedList/Content.component.test.js
+++ b/packages/components/src/VirtualizedList/Content.component.test.js
@@ -1,0 +1,32 @@
+import { render, screen } from '@testing-library/react';
+import { defaultColumnConfiguration } from './Content.component';
+import userEvent from '@testing-library/user-event';
+jest.unmock('@talend/design-system');
+
+describe('CellLabel', () => {
+	const CellContent = defaultColumnConfiguration.cellRenderer;
+	it('should default render a label', () => {
+		// given
+		const label = 'my label';
+		// when
+		const { container } = render(<CellContent cellData={label} columnData={{}} />);
+		// then
+		expect(container.firstChild).toMatchSnapshot();
+	});
+
+	it('should render a tooltip if available', () => {
+		// given
+		const label = 'my label';
+		// when
+		render(
+			<CellContent
+				cellData={label}
+				columnData={{
+					tooltipLabel: 0,
+				}}
+			/>,
+		);
+		// then
+		expect(screen.getByTestId('tc-virtualizedlist-default-cell-tooltip')).toBeVisible();
+	});
+});

--- a/packages/components/src/VirtualizedList/__snapshots__/Content.component.test.js.snap
+++ b/packages/components/src/VirtualizedList/__snapshots__/Content.component.test.js.snap
@@ -1,0 +1,12 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`CellLabel should default render a label 1`] = `
+<div
+  aria-describedby="42"
+  class="tc-virtualizedlist-default-cell"
+  data-test="tc-virtualizedlist-default-cell-tooltip"
+  data-testid="tc-virtualizedlist-default-cell-tooltip"
+>
+  my label
+</div>
+`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
VList content cell should display a tooltip for 0 value

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
