### PR TITLE
chore(TDP-12538): always show tooltip on faceted badge overlay

### DIFF
--- a/.changeset/dirty-geckos-eat.md
+++ b/.changeset/dirty-geckos-eat.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': minor
+---
+
+chore(TDP-12538): always show tooltip on faceted badge overlay

--- a/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDate.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDate.component.test.js.snap
@@ -43,6 +43,7 @@ exports[`BadgeDate should render a default badge 1`] = `
       class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
     >
       <button
+        aria-describedby="42"
         aria-label="2011-10-01"
         class="btn btn-link"
         id="myId-badge-date-action-overlay"

--- a/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeFaceted/__snapshots__/BadgeFaceted.component.test.js.snap
@@ -43,6 +43,7 @@ exports[`BadgeFaceted should render the html output by default 1`] = `
       class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
     >
       <button
+        aria-describedby="42"
         aria-label="All"
         class="btn btn-link"
         id="my-id-action-overlay"

--- a/packages/faceted-search/src/components/Badges/BadgeNumber/__snapshots__/BadgeNumber.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeNumber/__snapshots__/BadgeNumber.component.test.js.snap
@@ -43,6 +43,7 @@ exports[`BadgeNumber should mount a default badge 1`] = `
       class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
     >
       <button
+        aria-describedby="42"
         aria-label="All"
         class="btn btn-link"
         id="myId-badge-number-action-overlay"

--- a/packages/faceted-search/src/components/Badges/BadgeOverlay/BadgeOverlay.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeOverlay/BadgeOverlay.component.js
@@ -88,17 +88,11 @@ const BadgeOverlay = ({
 		</Button>
 	);
 
-	const buttonToRender = iconName ? (
-		<TooltipTrigger label={label} tooltipPlacement="top">
-			{button}
-		</TooltipTrigger>
-	) : (
-		button
-	);
-
 	return (
 		<div className={className}>
-			{buttonToRender}
+			<TooltipTrigger label={label} tooltipPlacement="top">
+				{button}
+			</TooltipTrigger>
 
 			<Overlay
 				id={`${id}-overlay`}

--- a/packages/faceted-search/src/components/Badges/BadgeOverlay/__snapshots__/BadgeOverlay.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeOverlay/__snapshots__/BadgeOverlay.component.test.js.snap
@@ -3,6 +3,7 @@
 exports[`BadgeOverlay should render the html output in the default state 1`] = `
 <div>
   <button
+    aria-describedby="42"
     aria-label="my label"
     class="btn btn-link"
     id="my-id-action-overlay"

--- a/packages/faceted-search/src/components/Badges/BadgeSlider/__snapshots__/BadgeSlider.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeSlider/__snapshots__/BadgeSlider.component.test.js.snap
@@ -43,6 +43,7 @@ exports[`BadgeSlider should mount a default badge 1`] = `
       class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
     >
       <button
+        aria-describedby="42"
         aria-label="0"
         class="btn btn-link"
         id="myId-badge-slider-action-overlay"

--- a/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeText/__snapshots__/BadgeText.component.test.js.snap
@@ -43,6 +43,7 @@ exports[`BadgeText should mount a default badge 1`] = `
       class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
     >
       <button
+        aria-describedby="42"
         aria-label="All"
         class="btn btn-link"
         id="myId-badge-text-action-overlay"

--- a/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
+++ b/packages/faceted-search/src/components/BasicSearch/__snapshots__/BasicSearch.component.test.js.snap
@@ -92,6 +92,7 @@ exports[`BasicSearch should render the default html output with no badges 1`] = 
           class="tc-badge-faceted-overlay theme-tc-badge-faceted-overlay"
         >
           <button
+            aria-describedby="42"
             aria-label="hello"
             class="btn btn-link"
             id="name-7bc9bd07-3b46-4b8c-a406-a08b6263de5b-badge-text-action-overlay"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This PR enforces always showing the tooltip for the faceted badge overlay. As it is implemented at the moment, we only show the tooltip if there's an icon on the overlay. However, [in this ticket](https://jira.talendforge.org/browse/TDP-12538) we are facing the challenge of truncating the overlay text and present the full text to the user using the tooltip. (check image below) 

<img width="469" alt="image" src="https://github.com/Talend/ui/assets/19315900/8cb9651a-7c06-4237-9e6b-414a4ef5f10f">

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
