### PR TITLE
feat(faceted-search/BadgeMenu): "Show selected" toggle on BadgeMenu

### DIFF
--- a/.changeset/smooth-dodos-dance.md
+++ b/.changeset/smooth-dodos-dance.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': minor
+---
+
+"Show selected" toggle on BadgeMenu

--- a/packages/faceted-search/src/components/Badges/BadgeMenu/BadgeMenu.module.scss
+++ b/packages/faceted-search/src/components/Badges/BadgeMenu/BadgeMenu.module.scss
@@ -21,6 +21,10 @@ $popover-screen-width: tokens.$coral-sizing-maximal;
 
 		.menu-items-filter {
 			margin: 0;
+
+			:global(.btn) {
+				margin: 0;
+			}
 		}
 	}
 
@@ -42,5 +46,6 @@ $popover-screen-width: tokens.$coral-sizing-maximal;
 	:global(.tc-tooltip-footer) {
 		min-width: auto;
 		width: $popover-screen-width;
+		padding-left: 0;
 	}
 }

--- a/packages/faceted-search/src/components/Badges/BadgeMenu/BadgeMenuForm.component.test.js
+++ b/packages/faceted-search/src/components/Badges/BadgeMenu/BadgeMenuForm.component.test.js
@@ -109,6 +109,38 @@ describe('BadgeMenuForm', () => {
 		expect(screen.queryByTestId('badge-menu-form-item-item-two')).not.toBeInTheDocument();
 		expect(screen.queryByTestId('badge-menu-form-item-item-three')).not.toBeInTheDocument();
 	});
+	it('should show selected item when click on "Selected" button', () => {
+		// Given
+		const props = {
+			id: 'myId',
+			value: {
+				id: 'item-one',
+				label: 'Item One',
+			},
+			values: menuItems,
+			onChange: jest.fn(),
+			onSubmit: jest.fn(),
+			t,
+		};
+		// When
+		render(<BadgeMenuForm {...props} />);
+		// Then all items are visible by default
+		expect(screen.getByTestId('badge-menu-form-item-item-one')).toBeVisible();
+		expect(screen.getByTestId('badge-menu-form-item-item-two')).toBeVisible();
+		expect(screen.getByTestId('badge-menu-form-item-item-three')).toBeVisible();
+		// When click on "Selected" button
+		userEvent.click(screen.getByRole('button', { name: /selected/i }));
+		// Then only item One is visible
+		expect(screen.getByTestId('badge-menu-form-item-item-one')).toBeVisible();
+		expect(screen.queryByTestId('badge-menu-form-item-item-two')).not.toBeInTheDocument();
+		expect(screen.queryByTestId('badge-menu-form-item-item-three')).not.toBeInTheDocument();
+		// When click on "Show all" button
+		userEvent.click(screen.getByRole('button', { name: /show all/i }));
+		// Then all items are visible
+		expect(screen.getByTestId('badge-menu-form-item-item-one')).toBeVisible();
+		expect(screen.getByTestId('badge-menu-form-item-item-two')).toBeVisible();
+		expect(screen.getByTestId('badge-menu-form-item-item-three')).toBeVisible();
+	});
 
 	it('should call the submit callback', () => {
 		const onSubmit = jest.fn();


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add "Selected" toggle on BadgeMenu.

- When no item is selected, "Selected" toggle won't display;
- When one item is selected, "Selected" toggle displays, when click on it, only selected item will be shown, and the button label changes to "Show all";
- When click on "Show all", all items will be shown.

[Figma link](https://www.figma.com/file/W99QEz0JcjAOWjVzJxdq7o/TDOPS-4789%3A-Replace-static-filters-with-faceted-search-filters-in-Management-tab?type=design&node-id=1-179&mode=design&t=lX2iHl15lmD1MhU2-0)

<img width="403" alt="image" src="https://github.com/Talend/ui/assets/3214228/b2559ae6-cc89-400a-aa91-d76ff20ecfd3">

<img width="400" alt="image" src="https://github.com/Talend/ui/assets/3214228/1c9e539a-e125-44ef-a73f-fdad47258f07">

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
