### PR TITLE
fix(TDOPS-1878): Notification container max height and overflow

### DIFF
--- a/.changeset/silver-crews-smell.md
+++ b/.changeset/silver-crews-smell.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-1878 - Notification container now has a max height to handle long and multiple notifications not overflowing the screen

--- a/packages/components/src/Notification/Notification.module.scss
+++ b/packages/components/src/Notification/Notification.module.scss
@@ -21,9 +21,12 @@ $tc-notification-icon-size: $svg-md-size !default;
 	&-container {
 		position: absolute;
 		top: 48px;
-		right: $padding-normal;
+		right: 0;
+		padding: tokens.$coral-spacing-s tokens.$coral-spacing-m 0 tokens.$coral-spacing-m;
 		z-index: $zindex-notification;
 		left: auto;
+		max-height: calc(100vh - 48px);
+		overflow-y: auto;
 
 		.tc-notification[pin='true'] {
 			.tc-notification-timer-bar {

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -28,7 +28,122 @@ class NotificationWrapper extends Component {
 		setTimeout(() => {
 			this.notifications = this.notifications.concat([
 				{
-					id: 'story-2',
+					id: 'story-232',
+					type: 'error',
+					title: 'Story 2 example title ',
+					message: [
+						'This is a feedback of your operation2',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+					],
+					action: {
+						label: 'undo',
+						icon: 'talend-undo',
+						onClick: action('click undo'),
+					},
+				},
+			]);
+			this.setState({ counter: this.state.counter + 1 });
+		}, 1000);
+		setTimeout(() => {
+			this.notifications = this.notifications.concat([
+				{
+					id: 'story-234',
+					type: 'error',
+					title: 'Story 2 example title ',
+					message: [
+						'This is a feedback of your operation2',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+					],
+					action: {
+						label: 'undo',
+						icon: 'talend-undo',
+						onClick: action('click undo'),
+					},
+				},
+			]);
+			this.setState({ counter: this.state.counter + 1 });
+		}, 1000);
+		setTimeout(() => {
+			this.notifications = this.notifications.concat([
+				{
+					id: 'story-2444',
+					type: 'error',
+					title: 'Story 2 example title ',
+					message: [
+						'This is a feedback of your operation2',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+					],
+					action: {
+						label: 'undo',
+						icon: 'talend-undo',
+						onClick: action('click undo'),
+					},
+				},
+			]);
+			this.setState({ counter: this.state.counter + 1 });
+		}, 1000);
+		setTimeout(() => {
+			this.notifications = this.notifications.concat([
+				{
+					id: 'story-2333',
+					type: 'error',
+					title: 'Story 2 example title ',
+					message: [
+						'This is a feedback of your operation2',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+					],
+					action: {
+						label: 'undo',
+						icon: 'talend-undo',
+						onClick: action('click undo'),
+					},
+				},
+			]);
+			this.setState({ counter: this.state.counter + 1 });
+		}, 1000);
+		setTimeout(() => {
+			this.notifications = this.notifications.concat([
+				{
+					id: 'story-2222',
+					type: 'error',
+					title: 'Story 2 example title ',
+					message: [
+						'This is a feedback of your operation2',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operation1, This is a feedback of your operation1',
+					],
+					action: {
+						label: 'undo',
+						icon: 'talend-undo',
+						onClick: action('click undo'),
+					},
+				},
+			]);
+			this.setState({ counter: this.state.counter + 1 });
+		}, 1000);
+		setTimeout(() => {
+			this.notifications = this.notifications.concat([
+				{
+					id: 'story-22',
 					type: 'error',
 					title: 'Story 2 example title ',
 					message: [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Notification container now has a max height to handle long and multiple notifications not overflowing the screen
<img width="643" alt="Capture d’écran 2023-09-28 à 14 51 27" src="https://github.com/Talend/ui/assets/16574861/a23289bd-dfac-4aef-9def-8f9f6888d180">


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
