### PR TITLE
chore(CI): upgrade to node 20

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -1,0 +1,32 @@
+name: 'Setup nodejs'
+description: 'Setup nodejs'
+author: 'Talend'
+secrets:
+  NPM_TOKEN:
+    description: 'The NPM token to use'
+runs:
+  using: 'composite'
+  steps:
+    - name: Set up Node.js
+      uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d #v3.8.1
+      with:
+        node-version: '20'
+        registry-url: 'https://registry.npmjs.org/'
+        scope: '@talend'
+
+    - name: Install yarn
+      shell: bash
+      run: npm i -g yarn
+
+    - name: Get yarn cache directory path
+      id: yarn-cache-dir-path
+      shell: bash
+      run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
+
+    - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
+      id: yarn-cache # use this to check for `cache-hit` (`steps.yarn-cache.outputs.cache-hit != 'true'`)
+      with:
+        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-yarn-

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -29,14 +29,9 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Setup Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
-
+      - name: Use Node.js
+        uses: ./.github/actions/setup-node
+  
       - name: Install Dependencies
         run: yarn --frozen-lockfile
 

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -22,12 +22,7 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+        uses: ./.github/actions/setup-node
 
       - name: Upgrade dependencies
         run: |

--- a/.github/workflows/design-system-component-testing.yml
+++ b/.github/workflows/design-system-component-testing.yml
@@ -24,12 +24,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
-      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+      - name: Use Node.js
+        uses: ./.github/actions/setup-node
 
       - uses: actions/cache@704facf57e6136b1bc63b828d79edcd491f0ee84 #v3.3.2
         with:

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -25,12 +25,8 @@ jobs:
           persist-credentials: false
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          check-latest: true
-          cache: "yarn"
-
+        uses: ./.github/actions/setup-node
+  
       - name: Download icons
         run: npx @talend/figma-icons-downloader
         env:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -28,14 +28,8 @@ jobs:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          check-latest: true
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
-
+        uses: ./.github/actions/setup-node
+  
       - name: Install
         run: yarn install --frozen-lockfile --ignore-scripts
 

--- a/.github/workflows/pr-playground.yml
+++ b/.github/workflows/pr-playground.yml
@@ -27,12 +27,8 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+        uses: ./.github/actions/setup-node
+
 
       - name: Install and build playground
         id: build

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -24,13 +24,7 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          check-latest: true
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+        uses: ./.github/actions/setup-node
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/surge-cleanup.yml
+++ b/.github/workflows/surge-cleanup.yml
@@ -13,10 +13,8 @@ jobs:
     environment: pull_request_unsafe
 
     steps:
-      - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-
-      - name: Push to surge
-        run: npx surge teardown ${{ github.event.pull_request.number }}.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}
+    - name: Use Node.js
+      uses: ./.github/actions/setup-node
+     
+    - name: Push to surge
+      run: npx surge teardown ${{ github.event.pull_request.number }}.talend.surge.sh --token ${{ secrets.SURGE_TOKEN }}

--- a/.github/workflows/tests-cron.yml
+++ b/.github/workflows/tests-cron.yml
@@ -20,12 +20,7 @@ jobs:
         uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac #v4.0.0
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+        uses: ./.github/actions/setup-node
 
       - name: Install and tests
         run: |

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -32,10 +32,8 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          cache: "yarn"
+      - name: Use Node.js
+        uses: ./.github/actions/setup-node
 
       - name: Install dependencies
         run: yarn --frozen-lock

--- a/.github/workflows/yarn-deduplicate.yml
+++ b/.github/workflows/yarn-deduplicate.yml
@@ -29,12 +29,7 @@ jobs:
           fetch-depth: 0 # otherwise, you will failed to push refs to dest repo
 
       - name: Use Node.js
-        uses: actions/setup-node@5e21ff4d9bc1a8cf6de233a3057d20ec6b3fb69d # v3.8.1
-        with:
-          node-version: 18
-          registry-url: "https://registry.npmjs.org/"
-          scope: "@talend"
-          cache: "yarn"
+        uses: ./.github/actions/setup-node
 
       - name: yarn-deduplicate
         id: deduplicate


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

we are on node 18 with a duplicate setup in every workflow

**What is the chosen solution to this problem?**

upgrade to node 20 and factorize all that
upgrade github actions behind it

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
