### PR TITLE
fix(TFD-16296): Add ellipsis on collapsible panel

### DIFF
--- a/.changeset/spotty-cups-judge.md
+++ b/.changeset/spotty-cups-judge.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TFD-16296): Add ellipsis on collapsible panel header

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.module.scss
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.module.scss
@@ -173,6 +173,13 @@ $tc-collapsible-panel-padding-larger: $padding-larger !default;
 				display: flex;
 				align-items: center;
 				justify-content: space-between;
+				min-width: 0; // trick to avoid conflict between flex and overflow
+
+				> * {
+					white-space: nowrap;
+					overflow: hidden;
+					text-overflow: ellipsis;
+				}
 			}
 		}
 	}

--- a/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
+++ b/packages/components/src/CollapsiblePanel/CollapsiblePanel.stories.js
@@ -173,6 +173,18 @@ export const Header = () => (
 		<h1>Collapsible Panel Headers</h1>
 		<CollapsiblePanel id="panel-header-1" header={[{ label: 'Simple header' }]} />
 		<CollapsiblePanel
+			id="panel-header-1"
+			header={[
+				{
+					label:
+						'Simple header with a very very very very long label that should not completly appear and not push other element outside the headerSimple header with a very very very very long label that should not completly appear and not push other element outside the header',
+				},
+				buttonDownload,
+			]}
+		>
+			Panel content
+		</CollapsiblePanel>
+		<CollapsiblePanel
 			id="panel-header-2"
 			header={[{ label: 'Header with actions' }, { element }]}
 		/>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Collapsible panel does not handle the text overflow for all cases in the header.

For example, when you have a simple header with a label and one action, the whole in a very tiny space, you got a multiline label that exit the panel header.

![CleanShot 2023-10-06 at 16 55 09@2x](https://github.com/Talend/ui/assets/59565911/61c4489d-82b1-4e07-b60d-3b7f548b1198)

https://jira.talendforge.org/browse/TFD-16296

**What is the chosen solution to this problem?**
The goal is to prevent the overflow with a nice ellipsis and the whole text in a tooltip.

![CleanShot 2023-10-06 at 16 57 35@2x](https://github.com/Talend/ui/assets/59565911/dbd2ecd1-3b29-41ce-9b83-6e38b3a9462a)

A story has been added to show the case in storybook.

![CleanShot 2023-10-06 at 16 58 32@2x](https://github.com/Talend/ui/assets/59565911/33b5f98e-2529-4c54-bc92-f7c5d6fdaa5d)


**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
