### PR TITLE
fix(TDC-7364): FormatValue component - fix content not appearing

### DIFF
--- a/.changeset/tender-jokes-join.md
+++ b/.changeset/tender-jokes-join.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(TDC-7364): FormatValue component - fix content not appearing when there were leading whitespaces

--- a/packages/components/src/FormatValue/FormatValue.component.js
+++ b/packages/components/src/FormatValue/FormatValue.component.js
@@ -12,7 +12,7 @@ export const REG_EXP_LEADING_TRAILING_WHITE_SPACE_CHARACTERS = /(^\s*)?([\s\S]*?
 const REG_EXP_REPLACED_WHITE_SPACE_CHARACTERS = /(\t| |\n)/g;
 const REG_EXP_CAPTUR_LINE_FEEDING = /(\n)/g;
 const REG_EXP_LINE_FEEDING = /\n/;
-const REG_EXP_WHITE_SPACE_CHARACTERS = /^\s/;
+const REG_EXP_WHITE_SPACE_CHARACTERS = /^\s+/;
 
 /**
  * replaceCharacterByIcon - replace a character by the corresponding icon
@@ -54,30 +54,31 @@ function replaceCharacterByIcon(value, index, t) {
 						className={classNames(theme['td-white-space-character'], 'td-white-space-character')}
 						name="talend-carriage-return"
 					/>
-					{'\n'}
 				</span>
 			);
 		default:
-			if (REG_EXP_WHITE_SPACE_CHARACTERS.test(value)) {
-				return (
-					<Icon
-						key={index}
-						aria-label={t('FORMAT_VALUE_WHITE_SPACE_CHARACTER', {
-							defaultValue: 'whitespace character',
-						})}
-						className={classNames(
-							theme['td-white-space-character'],
-							theme['td-other-characters'],
-							'td-white-space-character',
-						)}
-						name="talend-empty-char"
-					/>
-				);
-			}
+			const whitespaces = value.match(REG_EXP_WHITE_SPACE_CHARACTERS)?.[0];
 			return (
-				<span key={index} className={classNames(theme['td-value'], 'td-value')}>
-					{value}
-				</span>
+				<>
+					{whitespaces &&
+						[...whitespaces]?.map(() => (
+							<Icon
+								key={index}
+								aria-label={t('FORMAT_VALUE_WHITE_SPACE_CHARACTER', {
+									defaultValue: 'whitespace character',
+								})}
+								className={classNames(
+									theme['td-white-space-character'],
+									theme['td-other-characters'],
+									'td-white-space-character',
+								)}
+								name="talend-empty-char"
+							/>
+						))}
+					<span key={index} className={classNames(theme['td-value'], 'td-value')}>
+						{value.trimStart()}
+					</span>
+				</>
 			);
 	}
 }
@@ -125,3 +126,5 @@ FormatValueComponent.propTypes = {
 };
 
 export default FormatValueComponent;
+
+// const value = '<?xml version="1.0" encoding="UTF-8"?>\n<ServiceResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://qualysapi.qualys.com/qps/xsd/version.xsd">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.16.0.0-9 OFFICIAL #127 (2023-08-29T14:15:40Z)</PortalApplication-VERSION>\n      <QWEB__VM-VERSION>2.16.0-2</QWEB__VM-VERSION>\n      <CA-VERSION>3.16.0.1</CA-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.23.3.0-2</WEB-VERSION>\n      <SCANNER-VERSION>12.15.57-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.889-3</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>');

--- a/packages/components/src/FormatValue/FormatValue.component.js
+++ b/packages/components/src/FormatValue/FormatValue.component.js
@@ -126,5 +126,3 @@ FormatValueComponent.propTypes = {
 };
 
 export default FormatValueComponent;
-
-// const value = '<?xml version="1.0" encoding="UTF-8"?>\n<ServiceResponse xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://qualysapi.qualys.com/qps/xsd/version.xsd">\n  <responseCode>SUCCESS</responseCode>\n  <count>1</count>\n  <data>\n    <Portal-Version>\n      <PortalApplication-VERSION>3.16.0.0-9 OFFICIAL #127 (2023-08-29T14:15:40Z)</PortalApplication-VERSION>\n      <QWEB__VM-VERSION>2.16.0-2</QWEB__VM-VERSION>\n      <CA-VERSION>3.16.0.1</CA-VERSION>\n    </Portal-Version>\n    <QWeb-Version>\n      <WEB-VERSION>10.23.3.0-2</WEB-VERSION>\n      <SCANNER-VERSION>12.15.57-1</SCANNER-VERSION>\n      <VULNSIGS-VERSION>2.5.889-3</VULNSIGS-VERSION>\n    </QWeb-Version>\n  </data>\n</ServiceResponse>');

--- a/packages/components/src/FormatValue/__snapshots__/FormatValue.test.js.snap
+++ b/packages/components/src/FormatValue/__snapshots__/FormatValue.test.js.snap
@@ -16,6 +16,9 @@ exports[`FormatValue should handle leading empty space in the string 1`] = `
     />
     <span
       class="theme-td-value td-value"
+    />
+    <span
+      class="theme-td-value td-value"
     >
       l
     </span>
@@ -37,8 +40,6 @@ exports[`FormatValue should handle line feeding in the string 1`] = `
         class="CoralIcon theme-td-white-space-character td-white-space-character"
         name="talend-carriage-return"
       />
-      
-
     </span>
     <span
       class="theme-td-value td-value"
@@ -66,8 +67,6 @@ exports[`FormatValue should handle single line feed 1`] = `
         class="CoralIcon theme-td-white-space-character td-white-space-character"
         name="talend-carriage-return"
       />
-      
-
     </span>
   </span>
 </DocumentFragment>
@@ -106,6 +105,9 @@ exports[`FormatValue should handle trailing empty space in the string 1`] = `
       class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
       name="talend-empty-char"
     />
+    <span
+      class="theme-td-value td-value"
+    />
   </span>
 </DocumentFragment>
 `;
@@ -125,6 +127,39 @@ exports[`FormatValue should replace the leading/trailing white space and the lin
       aria-label="whitespace character"
       class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
       name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      class="theme-td-value td-value"
     />
     <span
       aria-label="space character"
@@ -147,14 +182,22 @@ exports[`FormatValue should replace the leading/trailing white space and the lin
         class="CoralIcon theme-td-white-space-character td-white-space-character"
         name="talend-carriage-return"
       />
-      
-
     </span>
     <span
       aria-label="whitespace character"
       class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
       name="talend-empty-char"
     />
+    <span
+      aria-label="whitespace character"
+      class="CoralIcon theme-td-white-space-character theme-td-other-characters td-white-space-character"
+      name="talend-empty-char"
+    />
+    <span
+      class="theme-td-value td-value"
+    >
+      psum
+    </span>
     <span
       aria-label="tab character"
       class="CoralIcon theme-td-white-space-character theme-td-tab-character td-white-space-character"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the cell value had leading spaces, they were being replaced by an icon (as intended) but the content was not being returned.

**What is the chosen solution to this problem?**
Returned the content along with the whitespace icon when there were leading whitespaces

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
