### PR TITLE
fix(TDOPS-762): notification can have long words that will not overflow

### DIFF
--- a/.changeset/little-suns-reply.md
+++ b/.changeset/little-suns-reply.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-762 - Allow notification message to have long labels with proper overflow

--- a/packages/components/src/Notification/Notification.module.scss
+++ b/packages/components/src/Notification/Notification.module.scss
@@ -85,6 +85,7 @@ $tc-notification-icon-size: $svg-md-size !default;
 	&-message {
 		margin-right: $padding-larger;
 		font-size: $font-size-small;
+		word-break: break-all;
 
 		&:last-of-type {
 			margin-bottom: 0;

--- a/packages/components/src/Notification/Notification.stories.js
+++ b/packages/components/src/Notification/Notification.stories.js
@@ -15,7 +15,7 @@ class NotificationWrapper extends Component {
 					type: 'info',
 					title: 'Story 1 example title',
 					message:
-						'This is a feedback of your operation1, This is a feedback of your operation1, This is a feedback of your operation1',
+						'This is a feedback of your operationlongnameverylongnamethatwhillbreakwork1, This is a feedback of your operation1, This is a feedback of your operation1',
 					action: {
 						label: 'Haha',
 						icon: 'talend-undo',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Notification can have long words that will not overflow , see https://jira.talendforge.org/browse/TDOPS-762

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
