### PR TITLE
fix(ARCH-662): fix design system modal accessibility

### DIFF
--- a/.changeset/nasty-birds-cheat.md
+++ b/.changeset/nasty-birds-cheat.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Fix Design System accessibility for Modal

--- a/packages/design-system/src/components/Modal/Modal.module.scss
+++ b/packages/design-system/src/components/Modal/Modal.module.scss
@@ -1,7 +1,7 @@
 @use '~@talend/design-tokens/lib/tokens';
 
 .modal-backdrop::before,
-.modal-container {
+.modal-backdrop {
 	position: fixed;
 	top: 0;
 	left: 0;
@@ -9,23 +9,21 @@
 	bottom: 0;
 }
 
-.modal-backdrop {
-	&::before {
-		z-index: tokens.$coral-elevation-layer-interactive-front;
-		content: '';
-		background-color: tokens.$coral-color-assistive-background;
-		opacity: tokens.$coral-opacity-l;
-	}
+.modal-backdrop::before {
+	content: '';
+	background-color: tokens.$coral-color-assistive-background;
+	opacity: tokens.$coral-opacity-l;
 }
 
-.modal-container {
-	z-index: calc(tokens.$coral-elevation-layer-interactive-front + 1);
+.modal-backdrop {
+	z-index: tokens.$coral-elevation-layer-interactive-front;
 	display: flex;
 	justify-content: center;
 	align-items: center;
 }
 
 .modal {
+	z-index: calc(tokens.$coral-elevation-layer-interactive-front + 1);
 	position: fixed;
 	min-width: 660px;
 	max-width: 95%;

--- a/packages/design-system/src/components/Modal/Modal.test.tsx
+++ b/packages/design-system/src/components/Modal/Modal.test.tsx
@@ -5,7 +5,7 @@ import { render } from '@testing-library/react';
 import { Modal } from './';
 
 describe('Message', () => {
-	xit('should render a11y html', async () => {
+	it('should render a11y html', async () => {
 		const { container } = render(
 			<main>
 				<Modal visible header={{ title: '(Default story title)' }} onClose={() => jest.fn()}>

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -71,6 +71,7 @@ export function Modal(props: ModalPropsType): ReactElement {
 
 	const backdropRef = useRef<HTMLDivElement>(null);
 	const dialogRef = useRef<HTMLDivElement>(null);
+	const titleId = 'modal-header-text-title';
 
 	useEffect(() => {
 		dialogRef.current?.focus();
@@ -108,6 +109,7 @@ export function Modal(props: ModalPropsType): ReactElement {
 					data-testid="modal"
 					className={styles.modal}
 					hide={preventEscaping ? () => undefined : () => onCloseHandler()}
+					aria-labelledby={titleId}
 					ref={dialogRef}
 				>
 					<StackVertical gap={0}>
@@ -120,7 +122,11 @@ export function Modal(props: ModalPropsType): ReactElement {
 								/>
 							)}
 							<div className={styles['modal-header-text']}>
-								<span className={styles['modal-header-text__title']} data-test="modal.header.title">
+								<span
+									id={titleId}
+									className={styles['modal-header-text__title']}
+									data-test="modal.header.title"
+								>
 									{header.title}
 								</span>
 								{header.description && (

--- a/packages/design-system/src/components/Modal/Modal.tsx
+++ b/packages/design-system/src/components/Modal/Modal.tsx
@@ -98,92 +98,84 @@ export function Modal(props: ModalPropsType): ReactElement {
 				className={styles['modal-backdrop']}
 				data-test="modal.backdrop"
 				data-testid="modal.backdrop"
+				onClick={onClickBackdropHandler}
+				ref={backdropRef}
 			>
-				<div
-					aria-hidden
-					className={styles['modal-container']}
-					onClick={onClickBackdropHandler}
-					ref={backdropRef}
+				<Dialog
+					{...rest}
+					visible={dialog.visible}
+					data-test="modal"
+					data-testid="modal"
+					className={styles.modal}
+					hide={preventEscaping ? () => undefined : () => onCloseHandler()}
+					ref={dialogRef}
 				>
-					<Dialog
-						{...rest}
-						visible={dialog.visible}
-						data-test="modal"
-						data-testid="modal"
-						className={styles.modal}
-						hide={preventEscaping ? () => undefined : () => onCloseHandler()}
-						ref={dialogRef}
-					>
-						<StackVertical gap={0}>
-							<div className={styles.modal__header}>
-								{header.icon && (
-									<ModalIcon
-										icon={header.icon}
-										data-test="modal.header.icon"
-										data-testid="modal.header.icon"
+					<StackVertical gap={0}>
+						<div className={styles.modal__header}>
+							{header.icon && (
+								<ModalIcon
+									icon={header.icon}
+									data-test="modal.header.icon"
+									data-testid="modal.header.icon"
+								/>
+							)}
+							<div className={styles['modal-header-text']}>
+								<span className={styles['modal-header-text__title']} data-test="modal.header.title">
+									{header.title}
+								</span>
+								{header.description && (
+									<span
+										className={styles['modal-header-text__description']}
+										data-test="modal.header.description"
+									>
+										{header.description}
+									</span>
+								)}
+							</div>
+						</div>
+
+						<div className={styles.modal__content} data-test="modal.content">
+							{children}
+						</div>
+
+						<div className={styles.modal__buttons} data-test="modal.buttons">
+							<StackHorizontal gap="XS" justify="end">
+								{!preventEscaping && (
+									<span className={styles['close-button']}>
+										<ButtonSecondary
+											onClick={() => onCloseHandler()}
+											data-test="modal.buttons.close"
+											data-testid="modal.buttons.close"
+											data-feature="modal.buttons.close"
+										>
+											{primaryAction || secondaryAction
+												? t('CANCEL', 'Cancel')
+												: t('CLOSE', 'Close')}
+										</ButtonSecondary>
+									</span>
+								)}
+
+								{secondaryAction && (
+									<ButtonSecondary
+										data-test="modal.buttons.secondary"
+										data-testid="modal.buttons.secondary"
+										data-feature="modal.buttons.secondary"
+										{...secondaryAction}
 									/>
 								)}
-								<div className={styles['modal-header-text']}>
-									<span
-										className={styles['modal-header-text__title']}
-										data-test="modal.header.title"
-									>
-										{header.title}
-									</span>
-									{header.description && (
-										<span
-											className={styles['modal-header-text__description']}
-											data-test="modal.header.description"
-										>
-											{header.description}
-										</span>
-									)}
-								</div>
-							</div>
 
-							<div className={styles.modal__content} data-test="modal.content">
-								{children}
-							</div>
-
-							<div className={styles.modal__buttons} data-test="modal.buttons">
-								<StackHorizontal gap="XS" justify="end">
-									{!preventEscaping && (
-										<span className={styles['close-button']}>
-											<ButtonSecondary
-												onClick={() => onCloseHandler()}
-												data-test="modal.buttons.close"
-												data-testid="modal.buttons.close"
-												data-feature="modal.buttons.close"
-											>
-												{primaryAction || secondaryAction
-													? t('CANCEL', 'Cancel')
-													: t('CLOSE', 'Close')}
-											</ButtonSecondary>
-										</span>
-									)}
-
-									{secondaryAction && (
-										<ButtonSecondary
-											data-test="modal.buttons.secondary"
-											data-testid="modal.buttons.secondary"
-											data-feature="modal.buttons.secondary"
-											{...secondaryAction}
-										/>
-									)}
-
-									{primaryAction && (
-										<PrimaryAction
-											data-testid="modal.buttons.primary"
-											data-test="modal.buttons.primary"
-											data-feature="modal.buttons.primary"
-											{...primaryAction}
-										/>
-									)}
-								</StackHorizontal>
-							</div>
-						</StackVertical>
-					</Dialog>
-				</div>
+								{primaryAction && (
+									<PrimaryAction
+										data-testid="modal.buttons.primary"
+										data-test="modal.buttons.primary"
+										data-feature="modal.buttons.primary"
+										{...primaryAction}
+									/>
+								)}
+							</StackHorizontal>
+						</div>
+					</StackVertical>
+				</Dialog>
 			</DialogBackdrop>
 		</>
 	);

--- a/packages/design-system/src/components/Modal/Primitives/DialogBackdrop.tsx
+++ b/packages/design-system/src/components/Modal/Primitives/DialogBackdrop.tsx
@@ -1,16 +1,21 @@
+import { Ref, forwardRef } from 'react';
 import { DialogState } from './DialogState';
 import { Portal } from './Portal';
 
 export type DialogBackdropProps = React.HTMLAttributes<HTMLDivElement> & DialogState;
 
-export function DialogBackdrop(props: DialogBackdropProps) {
+function BaseDialogBackdrop(props: DialogBackdropProps, ref: Ref<HTMLDivElement>) {
 	const { children, visible, ...rest } = props;
 	if (!visible) {
 		return null;
 	}
 	return (
 		<Portal>
-			<div {...rest}>{children}</div>;
+			<div {...rest} ref={ref}>
+				{children}
+			</div>
 		</Portal>
 	);
 }
+
+export const DialogBackdrop = forwardRef(BaseDialogBackdrop);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix design system modal accessibility as aria-hidden is always true
<img width="1145" alt="image" src="https://github.com/Talend/ui/assets/16574861/d8d74fac-5fd3-4ea2-b6f0-2ea4aec2be04">

**What is the chosen solution to this problem?**
reduce dom complexity and use aria-modal
<img width="1125" alt="image" src="https://github.com/Talend/ui/assets/16574861/86af0a61-0647-4cfa-9e96-114f5fd92e97">


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [X] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
