### PR TITLE
fix(TDOPS-5409/forms): Link render below Password/Text field

### DIFF
--- a/.changeset/twelve-games-provide.md
+++ b/.changeset/twelve-games-provide.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+TDOPS-5409 - fix Link render below Password/Text field

--- a/packages/design-system/src/stories/form/Field/Input/Password.stories.tsx
+++ b/packages/design-system/src/stories/form/Field/Input/Password.stories.tsx
@@ -47,5 +47,14 @@ export const Password = () => (
 			readOnly
 			defaultValue="TalendPassword2012"
 		/>
+		<Form.Password
+			name="password"
+			label="Password with link"
+			defaultValue="TalendPassword2012"
+			link={{
+				href: 'https://talend.com/reset/password',
+				children: 'Need help to log in?',
+			}}
+		/>
 	</StackVertical>
 );

--- a/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
+++ b/packages/forms/src/UIForm/fields/Text/PasswordWidget/index.js
@@ -1,3 +1,0 @@
-import { Form } from '@talend/design-system';
-
-export default Form.Password;

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -1,10 +1,9 @@
 /* eslint-disable jsx-a11y/no-autofocus */
 import PropTypes from 'prop-types';
-import { get, omit } from 'lodash';
-import { Link } from '@talend/design-system';
+import get from 'lodash/get';
+import { Form } from '@talend/design-system';
 import FieldTemplate from '../FieldTemplate';
 import { generateDescriptionId, generateErrorId } from '../../Message/generateId';
-import PasswordWidget from './PasswordWidget';
 
 import { convertValue, extractDataAttributes } from '../../utils/properties';
 
@@ -63,12 +62,12 @@ export default function Text(props) {
 			valueIsUpdating={valueIsUpdating}
 		>
 			{type === 'password' ? (
-				<PasswordWidget
+				<Form.Password
 					{...fieldProps}
 					aria-invalid={!isValid}
 					aria-required={get(schema, 'required')}
 					aria-describedby={`${descriptionId} ${errorId}`}
-					link={link && <Link {...omit(link, ['label'])}> {link.label} </Link>}
+					link={link}
 				/>
 			) : (
 				<input

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -232,7 +232,7 @@ describe('Text field', () => {
 		expect(screen.getByLabelText('My input title')).toHaveAttribute('autoComplete', 'off');
 	});
 
-	it('should pass labelProps to FieldTemplate', () => {
+	it('should pass labelProps to Text field', () => {
 		// given
 		const labelProps = { className: 'hello' };
 		const props = {
@@ -248,5 +248,35 @@ describe('Text field', () => {
 
 		// then
 		expect(screen.getByText('My input title')).toHaveClass('hello');
+	});
+
+	it('should pass link props and password type to Text field', () => {
+		// given
+		const link = {
+			href: 'https://talend.com',
+			title: 'Helps to reset your password',
+			children: 'Need help to log in?',
+			'aria-label': 'Need help to log in?',
+		};
+
+		const props = {
+			...defaultProps,
+			schema: {
+				autoFocus: true,
+				placeholder: 'Enter your password',
+				required: true,
+				title: 'Password',
+				type: 'password',
+				link,
+			},
+		};
+
+		// when
+		render(<Text {...props} />);
+
+		screen.debug();
+		// then
+		expect(screen.getByTitle(link.title)).toHaveTextContent(link.children);
+		expect(screen.getByTestId('link.icon.external')).toBeVisible();
 	});
 });

--- a/packages/forms/src/UIForm/fields/Text/Text.component.test.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.test.js
@@ -274,7 +274,6 @@ describe('Text field', () => {
 		// when
 		render(<Text {...props} />);
 
-		screen.debug();
 		// then
 		expect(screen.getByTitle(link.title)).toHaveTextContent(link.children);
 		expect(screen.getByTestId('link.icon.external')).toBeVisible();

--- a/packages/forms/stories/json/fields/core-text.json
+++ b/packages/forms/stories/json/fields/core-text.json
@@ -52,8 +52,9 @@
       "type": "password",
       "link": {
         "href": "https://talend.com",
-        "label": "Forget?",
-        "aria-label": "Need help to log in?"
+        "title": "Forget?",
+        "aria-label": "Need help to log in?",
+        "children": "Need help to log in?"
       }
     }
   ],


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The link is missing under a Password field

**What is the chosen solution to this problem?**
- link props should be passed instead of React Node 
- an extra import/export of For,.Password removed 

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
