### PR TITLE
fix(TDOPS-5582/designSystem): checkbox state change on click

### DIFF
--- a/.changeset/serious-toes-remember.md
+++ b/.changeset/serious-toes-remember.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(TDOPS-5582/designSystem): checkbox state change on click

--- a/packages/design-system/src/components/Form/Field/Input/Input.ToggleSwitch.tsx
+++ b/packages/design-system/src/components/Form/Field/Input/Input.ToggleSwitch.tsx
@@ -33,6 +33,7 @@ export const ToggleSwitch = forwardRef(
 			onChangeKey: 'onChange',
 			valueKey: 'checked',
 			defaultValueKey: 'defaultChecked',
+			selector: e => e.target.checked,
 			defaultValue: false,
 		});
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
ToggleSwitch not working after RHF upgrade

**What is the chosen solution to this problem?**
Revert the changes made on ToggleSwitch -> checkbox state change on click

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
