### PR TITLE
feat(TDP-12694): add pendo trackers to guided-tour actions

### DIFF
--- a/.changeset/green-drinks-remain.md
+++ b/.changeset/green-drinks-remain.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TDP-12694): add pendo trackers to guided-tour actions

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -21,6 +21,7 @@ function AppGuidedTour({
 	onImportDemoContent,
 	onRequestClose,
 	welcomeStepBody = null,
+	tourId,
 	...rest
 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
@@ -52,6 +53,7 @@ function AppGuidedTour({
 
 	return (
 		<GuidedTour
+			tourId={tourId}
 			isOpen={isOpen}
 			showButtons={!isNavigationDisabled}
 			showCloseButton={!isNavigationDisabled}
@@ -100,6 +102,7 @@ function AppGuidedTour({
 														setImportDemoContent(event.target.checked);
 													}}
 													checked={importDemoContent}
+													data-feature={tourId && `guidedtour.${tourId}.demo`}
 												/>
 											</form>
 										)}
@@ -134,6 +137,7 @@ AppGuidedTour.propTypes = {
 	onRequestOpen: PropTypes.func.isRequired,
 	onImportDemoContent: PropTypes.func,
 	onRequestClose: PropTypes.func.isRequired,
+	tourId: PropTypes.string,
 };
 
 export default AppGuidedTour;

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.stories.js
@@ -22,6 +22,7 @@ function AppGuidedTourContainer({ withDemoContent = false }) {
 
 	return (
 		<AppGuidedTour
+			tourId="preparation"
 			isOpen
 			appName="Data Preparation"
 			steps={[

--- a/packages/components/src/GuidedTour/GuidedTour.component.js
+++ b/packages/components/src/GuidedTour/GuidedTour.component.js
@@ -3,8 +3,8 @@ import Tour from 'reactour';
 import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
+import { ButtonIcon, ButtonPrimary } from '@talend/design-system';
 
-import Action from '../Actions/Action';
 import I18N_DOMAIN_COMPONENTS from '../constants';
 
 import theme from './GuidedTour.module.scss';
@@ -35,12 +35,15 @@ function GuidedTour({
 	disableAllInteractions,
 	steps,
 	lastStepNextButtonDataFeature,
+	tourId,
 	...rest
 }) {
 	const { t } = useTranslation(I18N_DOMAIN_COMPONENTS);
 	if (!steps.length) {
 		return null;
 	}
+
+	const dataFeature = action => tourId && `guidedtour.${tourId}.${action}`;
 
 	return (
 		<Tour
@@ -56,11 +59,29 @@ function GuidedTour({
 			disableInteraction
 			highlightedMaskClassName="tc-guided-tour__highlighted-mask"
 			lastStepNextButton={
-				<Action
-					bsStyle="info"
-					label={t('GUIDEDTOUR_LAST_STEP', { defaultValue: 'Let me try' })}
-					data-feature={lastStepNextButtonDataFeature}
-				/>
+				<ButtonPrimary data-feature={lastStepNextButtonDataFeature ?? dataFeature('last')}>
+					{t('GUIDEDTOUR_LAST_STEP', 'Let me try')}
+				</ButtonPrimary>
+			}
+			nextButton={
+				<ButtonIcon
+					size="S"
+					onClick={() => {}}
+					icon="arrow-right"
+					data-feature={dataFeature('next')}
+				>
+					{t('GUIDEDTOUR_NEXT_STEP', 'Next')}
+				</ButtonIcon>
+			}
+			prevButton={
+				<ButtonIcon
+					size="S"
+					onClick={() => {}}
+					icon="arrow-left"
+					data-feature={dataFeature('prev')}
+				>
+					{t('GUIDEDTOUR_PREV_STEP', 'Previous')}
+				</ButtonIcon>
 			}
 			maskSpace={10}
 			rounded={4}
@@ -98,6 +119,7 @@ GuidedTour.propTypes = {
 	onRequestClose: PropTypes.func,
 	disableAllInteractions: PropTypes.bool,
 	lastStepNextButtonDataFeature: PropTypes.string,
+	tourId: PropTypes.string,
 };
 
 export default GuidedTour;

--- a/packages/components/src/GuidedTour/GuidedTour.module.scss
+++ b/packages/components/src/GuidedTour/GuidedTour.module.scss
@@ -6,7 +6,7 @@ $tc-guidedtour-tooltip-padding: $padding-large !default;
 $tc-guidedtour-mask-opactiy: 0.25 !default;
 $tc-guidedtour-close-button-size: $svg-sm-size !default;
 $tc-guidedtour-nav-button-size: $svg-md-size !default;
-$tc-guidedtour-controls-color: tokens.$coral-color-neutral-text !default;
+$tc-guidedtour-controls-color: tokens.$coral-color-accent-text !default;
 $tc-guidedtour-width: 40rem !default;
 
 /* stylelint-disable-next-line selector-id-pattern*/

--- a/packages/components/src/GuidedTour/GuidedTour.stories.js
+++ b/packages/components/src/GuidedTour/GuidedTour.stories.js
@@ -76,6 +76,7 @@ class GuidedTourContainer extends Component {
 					t: this.props.t,
 				})}
 				lastStepNextButtonDataFeature="HOHOOO"
+				tourId="my-tour"
 				onRequestClose={this.closeTour}
 				isOpen={isOpen}
 				showCloseButton={controls}

--- a/packages/components/src/GuidedTour/README.md
+++ b/packages/components/src/GuidedTour/README.md
@@ -6,23 +6,25 @@ The guided tour is based on [reactour](https://github.com/elrumordelaluz/reactou
 
 ## Props
 
-| Props | Type | Description |
-| ----- | ---- | ----------- |
-| `className` | string | CSS classes for guided tour component |
-| `steps` | array of object or function | Array of steps to construct the guided tour |
-| `isOpen` | boolean | If true, guided tour will start |
-| `onRequestClose` | function | Callback when user close i.e. to toggle `isOpen` |
-| `disableAllInteractions` | boolean | If true, all controls will disappear |
+| Props                           | Type                        | Description                                                               |
+| ------------------------------- | --------------------------- | ------------------------------------------------------------------------- |
+|  `className`                    | string                      | CSS classes for guided tour component                                     |
+|  `steps`                        | array of object or function | Array of steps to construct the guided tour                               |
+|  `isOpen`                       |  boolean                    |  If true, guided tour will start                                          |
+|  `onRequestClose`               | function                    | Callback when user close i.e. to toggle `isOpen`                          |
+| `disableAllInteractions`        |  boolean                    | If true, all controls will disappear                                      |
+| `lastStepNextButtonDataFeature` | string                      | value to data-feature attribute of last step next button                  |
+| `tourId`                        | string                      | tour identifier to be used in data-feature attribute of prev/next buttons |
 
 ## Style
 
 Those classes are accessible from outside.
 
-| CSS class | Type | Description |
-| --------- | ---- | ----------- |
-| `.tc-react-tour` | block | The guided tour |
-| `.tc-react-tour__mask` | element | The dark overlay |
-| `.tc-react-tour__highlighted-mask` | element | The light overlay to highlight element |
-| `.tc-react-tour__header` | element | The header of the tooltip |
-| `.tc-react-tour__body` | element | The body of the tooltip |
-| `.tc-react-tour--no-interaction` | modifier | The guided tour without any controls |
+| CSS class                          | Type     | Description                            |
+| ---------------------------------- | -------- | -------------------------------------- |
+| `.tc-react-tour`                   | block    | The guided tour                        |
+| `.tc-react-tour__mask`             | element  | The dark overlay                       |
+| `.tc-react-tour__highlighted-mask` | element  | The light overlay to highlight element |
+| `.tc-react-tour__header`           | element  | The header of the tooltip              |
+| `.tc-react-tour__body`             | element  | The body of the tooltip                |
+| `.tc-react-tour--no-interaction`   | modifier | The guided tour without any controls   |

--- a/packages/containers/src/GuidedTour/__snapshots__/GuidedTour.test.js.snap
+++ b/packages/containers/src/GuidedTour/__snapshots__/GuidedTour.test.js.snap
@@ -171,22 +171,20 @@ exports[`Guided Tour Container should render 1`] = `
         data-tour-elem="controls"
       >
         <button
-          class="sc-aXZVg cdorhc sc-eqUAAy cTnNMO"
+          class="sc-aXZVg cdorhc sc-eqUAAy jLJOIm"
           data-tour-elem="left-arrow"
           disabled=""
         >
-          <svg
-            viewBox="0 0 18.4 14.4"
+          <span
+            class="sc-gEvEer fZNxWp"
           >
-            <path
-              d="M1.4 7.2h16M7.6 1L1.4 7.2l6.2 6.2"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-miterlimit="10"
-              stroke-width="2"
-            />
-          </svg>
+            <span
+              class="CoralButtonIcon"
+              icon="arrow-left"
+            >
+              Previous
+            </span>
+          </span>
         </button>
         <nav
           class="sc-kAyceB cIhnUi"
@@ -209,21 +207,19 @@ exports[`Guided Tour Container should render 1`] = `
           />
         </nav>
         <button
-          class="sc-aXZVg dbJwZj sc-eqUAAy eqHGdD"
+          class="sc-aXZVg dbJwZj sc-eqUAAy gcKufz"
           data-tour-elem="right-arrow"
         >
-          <svg
-            viewBox="0 0 18.4 14.4"
+          <span
+            class="sc-gEvEer fZNxWp"
           >
-            <path
-              d="M17 7.2H1M10.8 1L17 7.2l-6.2 6.2"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-miterlimit="10"
-              stroke-width="2"
-            />
-          </svg>
+            <span
+              class="CoralButtonIcon"
+              icon="arrow-right"
+            >
+              Next
+            </span>
+          </span>
         </button>
       </div>
       <button


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We had no way to track user clicks on guided-tour modal. 

**What is the chosen solution to this problem?**

This backward-compatible PR provides a new parameter on `GuidedTour` component : `tourId` to be used in pendo `data-feature` attribute. 
If you pass `tourId="my-tour"` then you'll get access to: 
- `guidedtour.my-tour.last`
- `guidedtour.my-tour.next`
- `guidedtour.my-tour.prev`

To do so I had to pass custom next and previous buttons. I chose design-system ones. 
I've also updated the close button color to match with other buttons. 

Before
![image](https://github.com/Talend/ui/assets/6088236/f4a9456c-cc53-44a2-9622-fb19cef3bb19)

After
![SCR-20231110-h2o](https://github.com/Talend/ui/assets/6088236/e4c124d1-d5ea-4dd7-8bfb-ff17f087d29c)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
