### PR TITLE
fix: prettier configuration for subpackages

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "prettier.prettierPath": "./node_modules/prettier/index.cjs",
-  "prettier.configPath": ".prettierrc.js",
   "eslint.workingDirectories": [
     {
       "pattern": "packages/**"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Having the VS code configuration for all TUI packages referring the root .prettierrc.js leads to errors while running prettier in subfolder where there is another .prettierrc.js file.
Only the root one is taken into account and doing it so, the typescript loader is not working in packages like design-system or stepper where typescript is used.

```
["ERROR" - 11:21:53] Error formatting document.
SyntaxError: Unexpected token, expected "," (12:34)
```

**What is the chosen solution to this problem?**
Remove the pointer to the root configuration for prettierrc in the vscode configuration

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
