### PR TITLE
fix: prevent display log of  sass loader warnings

### DIFF
--- a/.changeset/flat-maps-dream.md
+++ b/.changeset/flat-maps-dream.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+fix: prevent display log of lot of warnings related to sass loader

--- a/tools/scripts-config-react-webpack/config/webpack.config.common.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.common.js
@@ -72,7 +72,13 @@ function getSassLoaders(enableModules, sassData, isEnvDevelopmentServe) {
 		{ loader: require.resolve('resolve-url-loader'), options: { sourceMap } },
 		{
 			loader: require.resolve('sass-loader'),
-			options: { sourceMap, additionalData: sassData },
+			options: {
+				sourceMap,
+				additionalData: sassData,
+				sassOptions: {
+					quietDeps: true,
+				},
+			},
 		},
 	);
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
![CleanShot 2023-11-23 at 14 41 53@2x](https://github.com/Talend/ui/assets/2909671/b5baf553-1301-4400-9d25-6fb58245dfa7)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
