### PR TITLE
feat: allow token override with theme provider

### DIFF
--- a/.changeset/nine-coats-lie.md
+++ b/.changeset/nine-coats-lie.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+feat: allow token override with theme provider

--- a/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemeProvider.tsx
@@ -1,18 +1,26 @@
-import ThemeContext from './ThemeContext';
-import './ThemeProvider.scss';
+import { PropsWithChildren, useContext, useEffect, useState } from 'react';
+
+import 'modern-css-reset/dist/reset.min.css';
+import 'typeface-inconsolata/index.css';
+import 'typeface-source-sans-pro/index.css';
+
 // eslint-disable-next-line @talend/import-depth
 import '@talend/design-tokens/dist/TalendDesignTokens.css';
-import { useEffect, PropsWithChildren, useContext, useState } from 'react';
 
-import 'typeface-source-sans-pro/index.css';
-import 'typeface-inconsolata/index.css';
-import 'modern-css-reset/dist/reset.min.css';
+import ThemeContext from './ThemeContext';
+
+import './ThemeProvider.scss';
 
 export type ThemeProviderProps = PropsWithChildren<{
 	theme?: string;
+	tokensOverride?: React.CSSProperties;
 }>;
 
-export const ThemeProvider = ({ theme = 'light', children }: ThemeProviderProps) => {
+export const ThemeProvider = ({
+	theme = 'light',
+	children,
+	tokensOverride,
+}: ThemeProviderProps) => {
 	const [selectedTheme, setSelectedTheme] = useState(theme);
 	// Handle nested Providers: parent Provider doesn't have context, child does
 	const context = useContext(ThemeContext);
@@ -28,7 +36,7 @@ export const ThemeProvider = ({ theme = 'light', children }: ThemeProviderProps)
 	const switchTheme = (newTheme: string) => setSelectedTheme(newTheme);
 	return (
 		<ThemeContext.Provider value={context.theme ? context : { switchTheme, theme: selectedTheme }}>
-			{children}
+			{tokensOverride ? <div style={tokensOverride}>{children}</div> : children}
 		</ThemeContext.Provider>
 	);
 };

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -110,9 +110,6 @@ const defaultPreview = {
 				React.createElement(ThemeProvider, {
 					key: 'theme-provider-decorator',
 					theme: context.globals.theme,
-					// tokensOverride: {
-					// 	"--coral-color-accent-background-strong": "red"
-					// }
 				}, storyElement)
 			];
 		},

--- a/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
+++ b/tools/scripts-config-storybook-lib/.storybook-templates/preview.js
@@ -110,6 +110,9 @@ const defaultPreview = {
 				React.createElement(ThemeProvider, {
 					key: 'theme-provider-decorator',
 					theme: context.globals.theme,
+					// tokensOverride: {
+					// 	"--coral-color-accent-background-strong": "red"
+					// }
 				}, storyElement)
 			];
 		},


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
We can't override some specific token using the theme provider

**What is the chosen solution to this problem?**
Allow to pass some css variables, for instance :
```
tokensOverride: {
   "--coral-color-accent-background-strong": "red"
}
```

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
