### PR TITLE
fix(faceted-search): Move react-bootstrap as dependency instead of devDependency

### DIFF
--- a/.changeset/sharp-goats-obey.md
+++ b/.changeset/sharp-goats-obey.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+Move bootstrap-theme as dependency instead of devDependency

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -33,6 +33,7 @@
     "url": "https://github.com/Talend/ui.git"
   },
   "dependencies": {
+    "@talend/bootstrap-theme": "^8.3.0",
     "@talend/daikon-tql-client": "^1.3.1",
     "@talend/utils": "^2.8.0",
     "@talend/react-bootstrap": "^2.1.1",
@@ -52,7 +53,6 @@
     "@talend/icons": "^7.3.0",
     "@talend/locales-tui-components": "^11.4.5",
     "@talend/locales-tui-faceted-search": "^11.3.0",
-    "@talend/react-components": "^12.2.0",
     "@talend/scripts-core": "^16.3.0",
     "@talend/scripts-config-babel": "^13.2.0",
     "@talend/scripts-config-jest": "^13.1.1",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
faceted-search has bootstrap-theme as devDep instead of dep

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
