### PR TITLE
fix: don't rely on global sr-only classname to hide the icons from the IconsProvider

### DIFF
--- a/.changeset/swift-flies-rescue.md
+++ b/.changeset/swift-flies-rescue.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: don't rely on global sr-only classname to hide the icons from the IconsProvider

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.module.scss
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.module.scss
@@ -1,0 +1,11 @@
+.hidden {
+	border: 0;
+	clip: rect(0, 0, 0, 0);
+	height: 1px;
+	margin: -1px;
+	overflow: hidden;
+	padding: 0;
+	position: absolute;
+	white-space: nowrap;
+	width: 1px;
+}

--- a/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
+++ b/packages/design-system/src/components/IconsProvider/IconsProvider.tsx
@@ -1,6 +1,10 @@
-import { VisuallyHidden } from '../VisuallyHidden';
+import { ReactElement, RefObject, useEffect, useRef, useState } from 'react';
+
+import classNames from 'classnames';
+
 import assetsAPI from '@talend/assets-api';
-import { ReactElement, RefObject, useState, useEffect, useRef } from 'react';
+
+import style from './IconsProvider.module.scss';
 
 const DEFAULT_BUNDLES = [
 	assetsAPI.getURL('/dist/svg-bundle/all.svg', '@talend/icons'),
@@ -85,7 +89,7 @@ function addBundle(response: Response, url: string) {
 		return response.text().then(content => {
 			if (content.startsWith('<svg')) {
 				const container = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
-				container.setAttribute('class', 'tc-iconsprovider sr-only');
+				container.setAttribute('class', classNames('tc-iconsprovider', style.hidden));
 				container.setAttribute('aria-hidden', 'true');
 				container.setAttribute('focusable', 'false');
 				container.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
@@ -159,20 +163,18 @@ export function IconsProvider({
 
 	return (
 		(shouldRender && (
-			<VisuallyHidden>
-				<svg
-					xmlns="http://www.w3.org/2000/svg"
-					focusable="false"
-					className="tc-iconsprovider"
-					ref={ref}
-				>
-					{Object.keys(iconset).map((id, index) => (
-						<symbol key={index} id={id}>
-							{iconset[id]}
-						</symbol>
-					))}
-				</svg>
-			</VisuallyHidden>
+			<svg
+				xmlns="http://www.w3.org/2000/svg"
+				focusable="false"
+				className={classNames('tc-iconsprovider', style.hidden)}
+				ref={ref}
+			>
+				{Object.keys(iconset).map((id, index) => (
+					<symbol key={index} id={id}>
+						{iconset[id]}
+					</symbol>
+				))}
+			</svg>
 		)) ||
 		null
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
If sr-only class is not loaded in global, the injected icon provider are not visually hidden

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
