### PR TITLE
fix: Add fix for hoistNonReactStatics available when not using dynamic-cdn-webpack-plugin

### DIFF
--- a/.changeset/dry-donkeys-study.md
+++ b/.changeset/dry-donkeys-study.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+Add patch for hoistNonReactStatics when we are not using initiator

--- a/tools/scripts-config-react-webpack/config/webpack.config.js
+++ b/tools/scripts-config-react-webpack/config/webpack.config.js
@@ -201,6 +201,7 @@ async function getIndexTemplate(env, mode, indexTemplatePath, useInitiator = tru
 		headScript = `${renderMeta()}<base href="${BASENAME}" />
 		<script type="text/javascript">
 			window.basename = '${BASENAME}';
+			var process = { browser: true, env: { NODE_ENV: '${mode}' } };
 		</script>`;
 	}
 	const header = `${customHead}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Currently patch for hoistNonReactStatics is only available when app use initiator
**What is the chosen solution to this problem?**
Add it also when app not use initiator

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
