### PR TITLE
fix(webpack): getTalendIconsPath

### DIFF
--- a/.changeset/two-fans-taste.md
+++ b/.changeset/two-fans-taste.md
@@ -1,0 +1,5 @@
+---
+'@talend/scripts-config-react-webpack': patch
+---
+
+Fix getTalendIconsPath

--- a/tools/scripts-config-react-webpack/config/icons.js
+++ b/tools/scripts-config-react-webpack/config/icons.js
@@ -17,10 +17,10 @@ function getTalendIconsPath() {
 
 	if (main.indexOf('.pnpm') > -1) {
 		const startPath = main.substring(0, main.indexOf('icons'));
-		const regex = /@talend\+icons@([^\s/]+)/;
+		const regex = /@talend\+icons@([^\s/\\]+)/;
 		const match = main.match(regex);
 		const version = match[1];
-		return `${startPath}icons@${version}/node_modules/@talend/icons`;
+		return path.join(`${startPath}icons@${version}`, 'node_modules', '@talend', 'icons');
 	}
 	const root = main.split('icons')[0];
 	return `${root}icons`;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
webpack can't access to the icons on windows.

**What is the chosen solution to this problem?**
Fix the issue with `/` and `\`.
Use `path.join`

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
