### PR TITLE
fix(TDOPS-5889/TimezoneList): fix timezone name

### DIFF
--- a/.changeset/perfect-frogs-argue.md
+++ b/.changeset/perfect-frogs-argue.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+fix timezone names

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.js
@@ -1,4 +1,5 @@
 import get from 'lodash/get';
+
 import { date as dateUtils } from '@talend/utils';
 
 /**
@@ -50,7 +51,10 @@ export function getTimezones(lang, cldrTimezones) {
 						} else {
 							// Ex: America/Argentina/Buenos_Aires ...
 							Object.keys(zones[region][city]).forEach(city2 => {
-								const timezone = `${region}/${city}/${city2}`;
+								let timezone = `${region}/${city}`;
+								if (city2 !== 'long') {
+									timezone = `${region}/${city}/${city2}`;
+								}
 								newTimezones.push(getTimezoneInfo(timezone));
 							});
 						}

--- a/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
+++ b/packages/forms/src/UIForm/fields/TimezoneList/TimezoneList.utils.test.js
@@ -14,6 +14,7 @@ describe('getTimezones', () => {
 								},
 								Europe: {
 									Istanbul: { exemplarCity: '[EN] Istanbul' },
+									Berlin: { long: { daylight: 'Irish Standard Time' } },
 								},
 							},
 						},
@@ -86,6 +87,12 @@ describe('getTimezones', () => {
 				timezoneName: '[EN] Freetown',
 				offset: 0,
 				value: 'Africa/Freetown',
+			},
+			{
+				name: '(UTC +01:00) Europe/Berlin',
+				offset: 60,
+				timezoneName: 'Europe/Berlin',
+				value: 'Europe/Berlin',
 			},
 			{
 				name: '(UTC +03:00) [EN] Istanbul',


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
After upgrade dependency `cldr-dates-full`, in timezone data there's an unexpected key "long" in some zones, for example, Dublin:
```
"Dublin": {
  "long": {
    "daylight": "Irish Standard Time"
  }
} 
```
Need to handle this in TimezoneList component of react-forms. "long" should not be added into timezone name.
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
