### PR TITLE
fix(TDOPS-5872): Allow subheader subtitle to display long labels

### DIFF
--- a/.changeset/kind-games-kneel.md
+++ b/.changeset/kind-games-kneel.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-5872 - Allow subheader subtitle to display long labels

--- a/packages/components/src/SubHeaderBar/SubHeader.stories.js
+++ b/packages/components/src/SubHeaderBar/SubHeader.stories.js
@@ -1,4 +1,5 @@
 import { action } from '@storybook/addon-actions';
+
 import FilterBar from '../FilterBar';
 import Tag from '../Tag';
 import SubHeaderBar from './SubHeaderBar.component';
@@ -91,6 +92,16 @@ export const WithIcon = () => (
 export const WithSubtitle = () => (
 	<div>
 		<SubHeaderBar {...viewProps} subTitle="mySubTitle" onGoBack={backAction} />
+		<SubHeaderBar
+			{...viewProps}
+			subTitle={
+				<div>
+					<span>Copying from : </span>
+					<b>{'mySubTitle '.repeat(50)}</b>
+				</div>
+			}
+			onGoBack={backAction}
+		/>
 	</div>
 );
 

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/SubTitle.component.js
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/SubTitle.component.js
@@ -1,16 +1,20 @@
 import PropTypes from 'prop-types';
 
 import Skeleton from '../../Skeleton';
-import titleSubHeaderCssModule from './TitleSubHeader.module.scss';
 import { getTheme } from '../../theme';
+import TooltipTrigger from '../../TooltipTrigger';
+
+import titleSubHeaderCssModule from './TitleSubHeader.module.scss';
 
 const theme = getTheme(titleSubHeaderCssModule);
 
 function DefaultSubTitle({ subTitle, subTitleProps }) {
 	return (
-		<small className={theme('tc-subheader-details-text-subtitle')} {...subTitleProps}>
-			{subTitle}
-		</small>
+		<TooltipTrigger label={subTitle} tooltipPlacement="bottom">
+			<small className={theme('tc-subheader-details-text-subtitle')} {...subTitleProps}>
+				{subTitle}
+			</small>
+		</TooltipTrigger>
 	);
 }
 

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/TitleSubHeader.module.scss
@@ -64,8 +64,14 @@ $header-title-max-width: 90rem;
 
 		&-subtitle {
 			@include ellipsis;
+			max-width: 100%;
 			color: tokens.$coral-color-neutral-text;
 			font-size: $tc-input-subheader-size-medium;
+
+			> * {
+				@include ellipsis;
+				max-width: 100%;
+			}
 		}
 	}
 

--- a/packages/components/src/SubHeaderBar/TitleSubHeader/__snapshots__/SubTitle.test.js.snap
+++ b/packages/components/src/SubHeaderBar/TitleSubHeader/__snapshots__/SubTitle.test.js.snap
@@ -2,6 +2,7 @@
 
 exports[`SubTitle should render 1`] = `
 <small
+  aria-describedby="42"
   class="tc-subheader-details-text-subtitle theme-tc-subheader-details-text-subtitle"
 >
   mySubTitle


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow subheader subtitle to display long labels

<img width="1079" alt="image" src="https://github.com/Talend/ui/assets/16574861/72e7abfd-b497-4c46-988c-b24129384ad2">


**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
