### PR TITLE
fix(TDOPS-5733): Notification long messages should break on words

### DIFF
--- a/.changeset/hot-suits-argue.md
+++ b/.changeset/hot-suits-argue.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-5733 - Notification long messages should break on words and not characters

--- a/packages/components/src/Notification/Notification.module.scss
+++ b/packages/components/src/Notification/Notification.module.scss
@@ -85,7 +85,7 @@ $tc-notification-icon-size: $svg-md-size !default;
 	&-message {
 		margin-right: $padding-larger;
 		font-size: $font-size-small;
-		word-break: break-all;
+		word-break: break-word;
 
 		&:last-of-type {
 			margin-bottom: 0;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Notification long messages should break on words and not characters

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [X] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
