### PR TITLE
fix(TDOPS-5794): hideExternal on Link

### DIFF
--- a/.changeset/spotty-coats-admire.md
+++ b/.changeset/spotty-coats-admire.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Pass hideExternal to Linkable component

--- a/packages/design-system/src/components/Link/Link.tsx
+++ b/packages/design-system/src/components/Link/Link.tsx
@@ -1,12 +1,13 @@
 import { forwardRef, ReactElement, Ref, useCallback, useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 import classNames from 'classnames';
-import { useTranslation } from 'react-i18next';
+
 import { DeprecatedIconNames } from '../../types';
+import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 import { Linkable, LinkableType, isBlank as targetCheck } from '../Linkable';
 
 import style from './Link.module.scss';
-import { I18N_DOMAIN_DESIGN_SYSTEM } from '../constants';
 
 export type LinkComponentProps = {
 	/** The icon to display before */
@@ -19,7 +20,7 @@ export type LinkProps = Omit<LinkableType, 'className'> & LinkComponentProps;
 
 const Link = forwardRef(
 	(
-		{ children, disabled, href, target, title, hideExternalIcon, ...rest }: LinkProps,
+		{ children, disabled, href, target, title, ...rest }: LinkProps,
 		ref: Ref<HTMLAnchorElement>,
 	) => {
 		const { t } = useTranslation(I18N_DOMAIN_DESIGN_SYSTEM);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The prop `hideExternal` doesn't work on Link as it's not passed to Linkable.

**What is the chosen solution to this problem?**
Do not destructure `hideExternal` and pass it to `Linkable` in the `rest`.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
