### PR TITLE
chore(DFD-491): Update ArrayItem styles

### DIFF
--- a/.changeset/sharp-crabs-join.md
+++ b/.changeset/sharp-crabs-join.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': minor
+---
+
+chore(DFD-491): Update ArrayItem styles

--- a/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.component.js
+++ b/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.component.js
@@ -82,7 +82,7 @@ function ArrayItem(props) {
 		id: id && `${id}-delete`,
 		onClick: event => onRemove(event, index),
 		disabled: widgetIsDisabled,
-		icon: 'talend-trash',
+		icon: 'trash',
 	};
 	const actions = [];
 	if (!readOnly) {

--- a/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Array/ArrayItem.module.scss
@@ -33,7 +33,6 @@
 	.control {
 		flex-grow: 0;
 		flex-shrink: 0;
-		border-right: tokens.$coral-border-s-solid tokens.$coral-color-neutral-border-weak;
 		display: flex;
 		flex-direction: column;
 		justify-content: space-between;

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/Array.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/Array.component.test.js.snap
@@ -197,12 +197,14 @@ exports[`Array component should render array 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>
@@ -377,12 +379,14 @@ exports[`Array component should render array 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>
@@ -558,12 +562,14 @@ exports[`Array component should render array 1`] = `
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/ArrayItem.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/ArrayItem.component.test.js.snap
@@ -73,12 +73,14 @@ exports[`Array Item component should render control panel with item content 1`] 
       >
         <svg
           aria-hidden="true"
-          class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-          focusable="false"
-          name="talend-trash"
           pointer-events="none"
           shape-rendering="geometricPrecision"
-        />
+          style="width: 1.6rem; height: 1.6rem;"
+        >
+          <use
+            xlink:href="#trash:M"
+          />
+        </svg>
       </span>
     </button>
   </div>

--- a/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/Array/__snapshots__/DefaultArrayTemplate.component.test.js.snap
@@ -137,12 +137,14 @@ exports[`Default Array Template component should render default array template 1
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>
@@ -227,12 +229,14 @@ exports[`Default Array Template component should render default array template 1
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>
@@ -318,12 +322,14 @@ exports[`Default Array Template component should render default array template 1
             >
               <svg
                 aria-hidden="true"
-                class="tc-svg-icon tc-icon theme-svg tc-icon-name-talend-trash"
-                focusable="false"
-                name="talend-trash"
                 pointer-events="none"
                 shape-rendering="geometricPrecision"
-              />
+                style="width: 1.6rem; height: 1.6rem;"
+              >
+                <use
+                  xlink:href="#trash:M"
+                />
+              </svg>
             </span>
           </button>
         </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The ArrayItem use the old trash icon, and has a "border" added on the left side that is not useful.

**What is the chosen solution to this problem?**
Update to the new trash icon and remove the border.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
