### PR TITLE
chore: add "section" as an option to the "as" list of possible values 

### DIFF
--- a/.changeset/chilled-bears-speak.md
+++ b/.changeset/chilled-bears-speak.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+chore: add "section" as an option to the "as" list of possible values of the StackPrimitive component

--- a/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
+++ b/packages/design-system/src/components/Stack/Primitive/StackPrimitive.tsx
@@ -1,7 +1,9 @@
-import styles from './StackPrimitive.module.scss';
-import classnames from 'classnames';
 import { forwardRef } from 'react';
-import type { Ref, ReactNode } from 'react';
+import type { ReactNode, Ref } from 'react';
+
+import classnames from 'classnames';
+
+import styles from './StackPrimitive.module.scss';
 
 export const justifyOptions = {
 	start: 'justify-start',
@@ -88,7 +90,7 @@ type SpacingTypeWithAuto =
 			bottom: keyof typeof sizeOptionsWithAuto;
 	  };
 
-export const possibleAsTypes = ['div', 'ul', 'ol', 'article', 'span', 'dl'] as const;
+export const possibleAsTypes = ['div', 'ul', 'ol', 'section', 'article', 'span', 'dl'] as const;
 
 type DirectionType = 'row' | 'column';
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
