### PR TITLE
fix(TDOPS-5854): Remove border on MultiSelectTag widget with Typeahead

### DIFF
--- a/.changeset/hot-pumas-tan.md
+++ b/.changeset/hot-pumas-tan.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': patch
+---
+
+TDOPS-5854 - Fix MultiSelectTag widget to remove border from Typeahead component

--- a/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.module.scss
+++ b/packages/forms/src/UIForm/fields/MultiSelectTag/MultiSelectTag.module.scss
@@ -14,8 +14,9 @@ $tc-badge-margin: $padding-smaller !default;
 	height: auto;
 	padding: 0;
 
-	input {
+	[class^='InputWrapper-module'] {
 		border: none;
+		box-shadow: none;
 	}
 
 	.focus-manager {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Remove border on MultiSelectTag widget with Typeahead

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
