### PR TITLE
fix(TDOPS-5968): ListView checkboxes alignement

### DIFF
--- a/.changeset/healthy-cobras-allow.md
+++ b/.changeset/healthy-cobras-allow.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+TDOPS-5968 - Fix ListView checkbox alignement

--- a/packages/components/src/ListView/Items/Item/Item.component.js
+++ b/packages/components/src/ListView/Items/Item/Item.component.js
@@ -1,12 +1,14 @@
 import { Component } from 'react';
-import classNames from 'classnames';
 import { withTranslation } from 'react-i18next';
-import ItemPropTypes from './Item.propTypes';
+
+import classNames from 'classnames';
+
 import Action from '../../../Actions/Action';
-import I18N_DOMAIN_COMPONENTS from '../../../constants';
 import Checkbox from '../../../Checkbox';
+import I18N_DOMAIN_COMPONENTS from '../../../constants';
 import Icon from '../../../Icon';
 import TooltipTrigger from '../../../TooltipTrigger';
+import ItemPropTypes from './Item.propTypes';
 
 class Item extends Component {
 	componentDidUpdate(prevProps) {
@@ -38,7 +40,6 @@ class Item extends Component {
 
 		const itemId = id && `checkbox-${id}`;
 		const itemClassName = classNames(
-			'checkbox',
 			{ 'switch-nested': children },
 			{ switch: isSwitchBox },
 			{ 'with-icon': item.icon },

--- a/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
+++ b/packages/components/src/ListView/Items/Item/__snapshots__/item.snapshot.test.js.snap
@@ -3,7 +3,7 @@
 exports[`Item should display a selected item 1`] = `
 <div
   aria-selected={true}
-  className="checkbox"
+  className=""
   data-test="item"
   data-testid="item"
   id="0-item"

--- a/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
+++ b/packages/components/src/ListView/Items/__snapshots__/items.test.js.snap
@@ -45,7 +45,7 @@ exports[`Items should render 1`] = `
           style="height: 42px; left: 0px; position: absolute; top: 40px; width: 100%;"
         >
           <div
-            class="checkbox"
+            class=""
             data-test="item-0"
             data-testid="item-0"
             role="option"
@@ -74,7 +74,7 @@ exports[`Items should render 1`] = `
         >
           <div
             aria-selected="true"
-            class="checkbox"
+            class=""
             data-test="item-1"
             data-testid="item-1"
             role="option"
@@ -103,7 +103,7 @@ exports[`Items should render 1`] = `
           style="height: 42px; left: 0px; position: absolute; top: 124px; width: 100%;"
         >
           <div
-            class="checkbox"
+            class=""
             data-test="item-2"
             data-testid="item-2"
             role="option"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fix ListView checkboxes alignement that had twice the checkbox classname

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
