### PR TITLE
fix(DFD-491): Fix header bar and layout styles

### DIFF
--- a/.changeset/serious-bees-worry.md
+++ b/.changeset/serious-bees-worry.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(DFD-491): Fix header bar and layout styles

--- a/packages/components/src/HeaderBar/HeaderBar.module.scss
+++ b/packages/components/src/HeaderBar/HeaderBar.module.scss
@@ -27,7 +27,7 @@ $tc-headerbar-logo-full-width: 8.5rem !default;
 	position: fixed;
 	top: 0;
 	width: 100%;
-	z-index: tokens.$coral-elevation-layer-interactive-front;
+	z-index: tokens.$coral-elevation-layer-standard-front;
 
 	svg {
 		margin: 0;
@@ -78,7 +78,6 @@ $tc-headerbar-logo-full-width: 8.5rem !default;
 			display: flex;
 			align-items: center;
 			height: 100%;
-			white-space: nowrap;
 
 			&.separated:not(:last-child)::after {
 				content: ' ';

--- a/packages/components/src/Layout/Layout.module.scss
+++ b/packages/components/src/Layout/Layout.module.scss
@@ -9,10 +9,9 @@
 /// @type Number (Unit)
 
 // Need to be higher to typehead (1035)
-$tc-drawer-z-index: $zindex-navbar-fixed + 6 !default;
+$tc-drawer-z-index: calc($zindex-navbar-fixed + 6) !default;
 $tc-layout-header-height: $navbar-height !default;
-$tc-layout-skip-links-z-index: $tc-drawer-z-index + 20 !default;
-$tc-layout-header-z-index: $tc-drawer-z-index + 10 !default;
+$tc-layout-skip-links-z-index: calc($tc-drawer-z-index + 20) !default;
 
 .layout {
 	display: flex;
@@ -26,7 +25,6 @@ $tc-layout-header-z-index: $tc-drawer-z-index + 10 !default;
 
 	.header {
 		flex: 0 0 $tc-layout-header-height;
-		z-index: $tc-layout-header-z-index;
 	}
 
 	.footer {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Layout and HeaderBar components still use old values for z-indexes.
With the usage of design tokens, some calculations were broken.
Notification center popover has now an empty state, impacted by HeaderBar styles.

**What is the chosen solution to this problem?**
Fix the issues 😬 

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
