### PR TITLE
chore: changed skeleton "sized" variant props type

### DIFF
--- a/.changeset/nice-balloons-flash.md
+++ b/.changeset/nice-balloons-flash.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+chore: changed skeleton "sized" variant width and height props to strings

--- a/packages/design-system/src/components/Skeleton/variations/SkeletonSized.tsx
+++ b/packages/design-system/src/components/Skeleton/variations/SkeletonSized.tsx
@@ -7,26 +7,24 @@ import SkeletonPrimitive, { SkeletonPrimitiveProps } from '../Primitive/Skeleton
 import style from './SkeletonSized.module.scss';
 
 export type SkeletonSizedProps = Omit<SkeletonPrimitiveProps, 'className'> & {
-	height?: number;
-	width?: number;
+	height?: string;
+	width?: string;
 	isCircle?: boolean;
 };
 
 const SkeletonSized = forwardRef(
 	(
-		{ height = 1.4, width = 2, isCircle, ...props }: SkeletonSizedProps,
+		{ height = '1.4rem', width = '2rem', isCircle, ...props }: SkeletonSizedProps,
 		ref: Ref<HTMLSpanElement>,
-	) => {
-		return (
-			<SkeletonPrimitive
-				// @ts-expect-error style is valid
-				style={{ height: `${height}rem`, width: `${width}rem` }}
-				className={classNames({ [style['skeleton-sized-circle']]: isCircle })}
-				{...props}
-				ref={ref}
-			/>
-		);
-	},
+	) => (
+		<SkeletonPrimitive
+			// @ts-expect-error style is valid
+			style={{ height, width }}
+			className={classNames({ [style['skeleton-sized-circle']]: isCircle })}
+			{...props}
+			ref={ref}
+		/>
+	),
 );
 SkeletonSized.displayName = 'SkeletonSized';
 

--- a/packages/design-system/src/stories/feedback/Skeleton.stories.tsx
+++ b/packages/design-system/src/stories/feedback/Skeleton.stories.tsx
@@ -102,16 +102,8 @@ SkeletonParagraphStory.argTypes = {
 export const SkeletonSizedStory = SkeletonSizedTemplate.bind({});
 SkeletonSizedStory.args = {
 	isCircle: true,
-};
-SkeletonSizedStory.argTypes = {
-	height: {
-		control: { type: 'number' },
-		defaultValue: 10,
-	},
-	width: {
-		control: { type: 'number' },
-		defaultValue: 10,
-	},
+	height: '3rem',
+	width: '20%',
 };
 
 export const SkeletonInputStory = SkeletonInputTemplate.bind({});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
The skeleton "sized" variant only allowed for fixed values for the width and height props

**What is the chosen solution to this problem?**
Changed the width and height props from number to string so it can height receive fixed or dynamic values

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
