### PR TITLE
fix: sort option not interactive with legacy list while in expanded view

### DIFF
--- a/.changeset/loud-humans-wonder.md
+++ b/.changeset/loud-humans-wonder.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: sort option not interactive with legacy list while in expanded view

--- a/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
+++ b/packages/components/src/List/Toolbar/SelectSortBy/SelectSortBy.component.js
@@ -1,13 +1,15 @@
-import PropTypes from 'prop-types';
-import { Nav, NavDropdown, MenuItem, Button } from '@talend/react-bootstrap';
-import { randomUUID } from '@talend/utils';
 import classNames from 'classnames';
+import PropTypes from 'prop-types';
 
-import getDefaultT from '../../../translate';
-import theme from './SelectSortBy.module.scss';
+import { Button, MenuItem, Nav, NavDropdown } from '@talend/react-bootstrap';
+import { randomUUID } from '@talend/utils';
+
 import Icon from '../../../Icon';
+import getDefaultT from '../../../translate';
 
-function SortByItem({ option, id, t }) {
+import theme from './SelectSortBy.module.scss';
+
+function SortByItem({ option, id, t, onSelect }) {
 	const optionLabel = option.name || option.id;
 	return (
 		<MenuItem
@@ -17,12 +19,14 @@ function SortByItem({ option, id, t }) {
 				defaultValue: 'Select {{sortBy}} as current sort criteria.',
 				sortBy: optionLabel,
 			})}
+			onSelect={onSelect}
 		>
 			{optionLabel}
 		</MenuItem>
 	);
 }
 SortByItem.propTypes = {
+	onSelect: PropTypes.func,
 	option: PropTypes.shape({
 		id: PropTypes.string,
 		name: PropTypes.string,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
