### PR TITLE
feat(DS): Allow StackItem to have a isFullWidth option

### DIFF
--- a/.changeset/three-jobs-repeat.md
+++ b/.changeset/three-jobs-repeat.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+Design System - Allow StackItem to have a `isFullWidth` option to have 100% width style

--- a/packages/design-system/src/components/Stack/StackItem.module.scss
+++ b/packages/design-system/src/components/Stack/StackItem.module.scss
@@ -10,6 +10,10 @@
 		flex-shrink: 1;
 	}
 
+	&.fullWidth {
+		width: 100%;
+	}
+
 	&.align {
 		&-auto {
 			align-self: auto;

--- a/packages/design-system/src/components/Stack/StackItem.tsx
+++ b/packages/design-system/src/components/Stack/StackItem.tsx
@@ -30,6 +30,7 @@ export type ItemProps = {
 	align?: keyof typeof alignOptions;
 	overflow?: keyof typeof overflowOptions;
 	as?: (typeof possibleAsTypes)[number];
+	isFullWidth?: boolean;
 };
 
 export const StackItem = forwardRef(function StackItem(
@@ -40,6 +41,7 @@ export const StackItem = forwardRef(function StackItem(
 		shrink = true,
 		align = 'auto',
 		overflow = 'auto',
+		isFullWidth,
 		...props
 	}: ItemProps,
 	ref: Ref<any>,
@@ -52,6 +54,7 @@ export const StackItem = forwardRef(function StackItem(
 				styles.item,
 				styles[alignOptions[align]],
 				styles[overflowOptions[overflow]],
+				isFullWidth && styles.fullWidth,
 				{
 					[styles.grow]: grow,
 					[styles.shrink]: shrink,

--- a/packages/design-system/src/stories/layout/Stack.stories.tsx
+++ b/packages/design-system/src/stories/layout/Stack.stories.tsx
@@ -159,7 +159,7 @@ export const StackWithStackItem: StoryFn<typeof StackItem> = args => {
 				<Block width="3.75rem" />
 			</li>
 			<StackItem {...args}>
-				<Block width="2.5rem" />
+				<Block width="100%" />
 			</StackItem>
 			<li>
 				<Block width="5rem" />
@@ -173,6 +173,7 @@ StackWithStackItem.args = {
 	align: 'center',
 	overflow: 'auto',
 	as: 'li',
+	isFullWidth: false,
 };
 
 StackWithStackItem.argTypes = {
@@ -190,4 +191,5 @@ StackWithStackItem.argTypes = {
 		options: [...possibleAsTypes],
 		control: { type: 'select' },
 	},
+	isFullWidth: { control: { type: 'boolean' } },
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow StackItem to have a isFullWidth option

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
