### PR TITLE
fix(DS): fix textarea color when on error

### DIFF
--- a/.changeset/swift-parents-type.md
+++ b/.changeset/swift-parents-type.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Design System - Fix on textarea not having color on error state

--- a/packages/design-system/src/components/Form/Field/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Form/Field/Textarea/Textarea.tsx
@@ -1,11 +1,12 @@
 import { forwardRef, Ref } from 'react';
+
+import { useId } from '../../../../useId';
 import {
 	FieldPrimitive,
 	FieldPropsPrimitive,
 	TextareaPrimitive,
 	TextareaPrimitiveProps,
 } from '../../Primitives';
-import { useId } from '../../../../useId';
 
 export type InputTextareaProps = FieldPropsPrimitive &
 	Omit<TextareaPrimitiveProps, 'className' | 'styles'> & { children?: string };
@@ -46,6 +47,7 @@ const Textarea = forwardRef((props: InputTextareaProps, ref: Ref<HTMLTextAreaEle
 				id={fieldID}
 				name={name}
 				ref={ref}
+				hasError={hasError || false}
 			/>
 		</FieldPrimitive>
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix textarea color when on error

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
