### PR TITLE
fix: element overlapping box shadow in large mode for the list

### DIFF
--- a/.changeset/cuddly-files-pump.md
+++ b/.changeset/cuddly-files-pump.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix: element does not goes over the box shadow in large mode for the list

--- a/packages/components/src/List/List.component.js
+++ b/packages/components/src/List/List.component.js
@@ -1,11 +1,12 @@
-import PropTypes from 'prop-types';
 import classNames from 'classnames';
 import omit from 'lodash/omit';
+import PropTypes from 'prop-types';
 
-import Toolbar from './Toolbar';
-import ListToVirtualizedList from './ListToVirtualizedList';
-import theme from './List.module.scss';
 import Inject from '../Inject';
+import ListToVirtualizedList from './ListToVirtualizedList';
+import Toolbar from './Toolbar';
+
+import theme from './List.module.scss';
 
 const SelectAll = Toolbar.SelectAll;
 
@@ -166,7 +167,9 @@ function List({
 			{injected('after-toolbar')}
 			{selectAllCheckbox && <SelectAll {...selectAllCheckbox} />}
 			{injected('before-list-wrapper')}
-			<div className="tc-list-display-virtualized">
+			<div
+				className={classNames('tc-list-display-virtualized', theme[`display-mode-${displayMode}`])}
+			>
 				{injected('before-list')}
 				<ListToVirtualizedList
 					id={id}

--- a/packages/components/src/List/List.module.scss
+++ b/packages/components/src/List/List.module.scss
@@ -10,6 +10,10 @@
 	width: 100%;
 	overflow: hidden;
 
+	.display-mode-large {
+		padding-top: 2px;
+	}
+
 	:global(.tc-list-toolbar) {
 		flex-grow: 0;
 		flex-shrink: 0;

--- a/packages/components/src/List/__snapshots__/List.test.js.snap
+++ b/packages/components/src/List/__snapshots__/List.test.js.snap
@@ -170,7 +170,7 @@ exports[`List should render 1`] = `
     </div>
   </div>
   <div
-    class="tc-list-display-virtualized"
+    class="tc-list-display-virtualized theme-display-mode-table"
   >
     <div
       style="overflow: visible; height: 0px; width: 0px;"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
![CleanShot 2024-02-14 at 08 21 07@2x](https://github.com/Talend/ui/assets/2909671/92ee5f2b-3856-4174-81ec-81e8b306108a)

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
