### PR TITLE
fix(TDP-12810): fix GeoChart colors

### DIFF
--- a/.changeset/three-books-join.md
+++ b/.changeset/three-books-join.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-dataviz": patch
+---
+
+fix(TPD-12820): fix GeoCharts colors

--- a/packages/dataviz/src/components/GeoChart/GeoChart.component.tsx
+++ b/packages/dataviz/src/components/GeoChart/GeoChart.component.tsx
@@ -1,25 +1,28 @@
-import { useRef, useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import classNames from 'classnames';
 import {
-	rgb,
-	RGBColor,
 	select as d3select,
-	Selection,
-	scaleLinear,
-	ScaleLinear,
+	zoom as d3zoom,
 	geoIdentity,
 	geoPath,
 	GeoPath,
-	zoom as d3zoom,
+	rgb,
+	RGBColor,
+	scaleLinear,
+	ScaleLinear,
+	Selection,
 } from 'd3';
 import { FeatureCollection } from 'geojson';
+import { feature } from 'topojson-client';
 // eslint-disable-next-line import/no-unresolved
 import { Topology } from 'topojson-specification';
-import { feature } from 'topojson-client';
+
 import { Icon } from '@talend/react-components';
 
 import KeyValueTooltip, { TooltipEntry } from '../KeyValueTooltip/KeyValueTooltip.component';
+
 import styles from './GeoChart.module.scss';
 
 // Rename ugly d3 types
@@ -134,11 +137,22 @@ function clearChart(container: HTMLDivElement): void {
 	d3select(container).selectAll('svg').remove();
 }
 
+function parseCssVarColor(cssVarExpression: string): string {
+	try {
+		return cssVarExpression.split(',').slice(1).join(',').trim().slice(0, -1);
+	} catch (e) {
+		return 'hsl(0, 0%, 0%)';
+	}
+}
+
 function getScale(data: Entry[]): ColorScale {
 	const values = data.map(entry => entry.value);
 	return scaleLinear<RGBColor>()
 		.domain([Math.min(...values), Math.max(...values)])
-		.range([rgb(styles.scaleMinColor), rgb(styles.scaleMaxColor)]);
+		.range([
+			rgb(parseCssVarColor(styles.scaleMinColor)),
+			rgb(parseCssVarColor(styles.scaleMaxColor)),
+		]);
 }
 
 function getGeoPath(featureCollection: FeatureCollection): GeoPath {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Colors defined as css var exported from scss are not correctly parsed in javascript - this makes the chart black.

**What is the chosen solution to this problem?**
Convert css variable into css color expression that can be passed to D3 rgb function.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
