### PR TITLE
fix(DS): Select component should handle required attribute

### DIFF
--- a/.changeset/good-planes-scream.md
+++ b/.changeset/good-planes-scream.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+Design System - Select element should now take `required` attribute into account

--- a/packages/design-system/src/components/Form/Primitives/Select/SelectNoWrapper.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Select/SelectNoWrapper.tsx
@@ -32,6 +32,7 @@ const SelectNoWrapper = forwardRef((props: SelectNoWrapperProps, ref: Ref<HTMLSe
 			<select
 				{...rest}
 				disabled={disabled}
+				required={required}
 				ref={ref}
 				id={id}
 				className={classnames(


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Select component should handle required attribute

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
