### PR TITLE
feat(DFD-632): AffixSelect data-testid

### DIFF
--- a/.changeset/lovely-bulldogs-accept.md
+++ b/.changeset/lovely-bulldogs-accept.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+data-testid on select suffix and input primitive

--- a/packages/design-system/src/components/Form/Affix/variations/AffixButton.tsx
+++ b/packages/design-system/src/components/Form/Affix/variations/AffixButton.tsx
@@ -1,20 +1,23 @@
 import { forwardRef } from 'react';
 import type { MouseEvent, Ref } from 'react';
+
 import classnames from 'classnames';
+
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 
+import { mergeRefs } from '../../../../mergeRef';
 import { DeprecatedIconNames } from '../../../../types';
-import { Tooltip, TooltipChildrenFnProps, TooltipChildrenFnRef } from '../../../Tooltip';
-import { StackHorizontal } from '../../../Stack';
 import { Clickable, ClickableProps } from '../../../Clickable';
-import { getIconWithDeprecatedSupport } from '../../../Icon/DeprecatedIconHelper';
 import { SizedIcon } from '../../../Icon';
+import { getIconWithDeprecatedSupport } from '../../../Icon/DeprecatedIconHelper';
+import { StackHorizontal } from '../../../Stack';
+import { Tooltip, TooltipChildrenFnProps, TooltipChildrenFnRef } from '../../../Tooltip';
 
 import styles from '../AffixStyles.module.scss';
-import { mergeRefs } from '../../../../mergeRef';
 
 type CommonAffixButtonPropsType = {
+	dataTestid?: string;
 	children: string;
 	isDropdown?: boolean;
 	onClick: (event: MouseEvent<HTMLButtonElement> | KeyboardEvent) => void;

--- a/packages/design-system/src/components/Form/Affix/variations/AffixSelect.tsx
+++ b/packages/design-system/src/components/Form/Affix/variations/AffixSelect.tsx
@@ -1,12 +1,15 @@
 import { forwardRef, Ref } from 'react';
+
+import { DataAttributes } from 'src/types';
+
+import { useId } from '../../../../useId';
 import FieldPrimitive, { FieldPropsPrimitive } from '../../Primitives/Field/Field';
 import SelectNoWrapper, { SelectNoWrapperProps } from '../../Primitives/Select/SelectNoWrapper';
-import { useId } from '../../../../useId';
 
 export type AffixSelectPropsType = Omit<FieldPropsPrimitive, 'hasError' | 'description'> &
 	Omit<SelectNoWrapperProps, 'isAffix' | 'className' | 'style'> & {
 		isSuffix: boolean;
-	};
+	} & Partial<DataAttributes>;
 
 const AffixSelect = forwardRef((props: AffixSelectPropsType, ref: Ref<HTMLSelectElement>) => {
 	const { label, children, name, id, isSuffix, ...rest } = props;

--- a/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
@@ -8,6 +8,7 @@ import {
 } from 'react';
 
 import classnames from 'classnames';
+import { DataAttributes } from 'src/types';
 
 import useRevealPassword from '../../../Form/Field/Input/hooks/useRevealPassword';
 import { SizedIcon } from '../../../Icon';
@@ -16,12 +17,10 @@ import InputWrapper, { AffixesProps } from '../InputWrapper/InputWrapper';
 
 import styles from './Input.module.scss';
 
-export type InputPrimitiveProps = Omit<
-	InputHTMLAttributes<any>,
-	'prefix' | 'suffix' | 'dataTestid'
-> &
+export type InputPrimitiveProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> &
 	AffixesProps &
-	Omit<FieldStatusProps, 'errorMessage'>;
+	Omit<FieldStatusProps, 'errorMessage'> &
+	Partial<DataAttributes>;
 
 const Input = forwardRef((props: InputPrimitiveProps, ref: Ref<HTMLInputElement | null>) => {
 	const {

--- a/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Input/Input.tsx
@@ -1,20 +1,25 @@
 import {
+	FocusEvent,
 	forwardRef,
 	InputHTMLAttributes,
 	Ref,
 	useImperativeHandle,
 	useRef,
-	FocusEvent,
 } from 'react';
+
 import classnames from 'classnames';
-import InputWrapper, { AffixesProps } from '../InputWrapper/InputWrapper';
-import { FieldStatusProps } from '../Field/Field';
+
 import useRevealPassword from '../../../Form/Field/Input/hooks/useRevealPassword';
 import { SizedIcon } from '../../../Icon';
+import { FieldStatusProps } from '../Field/Field';
+import InputWrapper, { AffixesProps } from '../InputWrapper/InputWrapper';
 
 import styles from './Input.module.scss';
 
-export type InputPrimitiveProps = Omit<InputHTMLAttributes<any>, 'prefix' | 'suffix'> &
+export type InputPrimitiveProps = Omit<
+	InputHTMLAttributes<any>,
+	'prefix' | 'suffix' | 'dataTestid'
+> &
 	AffixesProps &
 	Omit<FieldStatusProps, 'errorMessage'>;
 

--- a/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
+++ b/packages/design-system/src/components/Form/Primitives/InputWrapper/InputWrapper.tsx
@@ -1,6 +1,8 @@
 import { forwardRef, ReactElement, Ref } from 'react';
 import { isElement } from 'react-is';
+
 import classnames from 'classnames';
+
 import AffixButton, { AffixButtonPropsType } from '../../../Form/Affix/variations/AffixButton';
 import AffixReadOnly, {
 	AffixReadOnlyPropsType,

--- a/packages/design-system/src/components/Form/Primitives/Select/SelectNoWrapper.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Select/SelectNoWrapper.tsx
@@ -12,6 +12,7 @@ export type SelectNoWrapperProps = Omit<SelectHTMLAttributes<any>, 'prefix'> & {
 	hasError?: boolean;
 	isAffix?: boolean;
 	isSuffix?: boolean;
+	dataTestid?: string;
 };
 
 const SelectNoWrapper = forwardRef((props: SelectNoWrapperProps, ref: Ref<HTMLSelectElement>) => {
@@ -25,12 +26,14 @@ const SelectNoWrapper = forwardRef((props: SelectNoWrapperProps, ref: Ref<HTMLSe
 		isAffix = false,
 		isSuffix = false,
 		id,
+		dataTestid,
 		...rest
 	} = props;
 	return (
 		<div className={styles.select__wrapper}>
 			<select
 				{...rest}
+				data-testid={dataTestid}
 				disabled={disabled}
 				ref={ref}
 				id={id}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No datatest-id at all

**What is the chosen solution to this problem?**
Add it from a props

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
