### PR TITLE
chore(components): switch components dates to use design system inputs

### DIFF
--- a/packages/components/src/DateTimePickers/Date/Input/Input.component.js
+++ b/packages/components/src/DateTimePickers/Date/Input/Input.component.js
@@ -1,9 +1,12 @@
 import { useContext } from 'react';
-import PropTypes from 'prop-types';
 import DebounceInput from 'react-debounce-input';
 
-import { DateContext } from '../Context';
+import PropTypes from 'prop-types';
+
+import { Form } from '@talend/design-system';
+
 import InputSizer from '../../shared/InputSizer';
+import { DateContext } from '../Context';
 
 function Input(props) {
 	const { value, inputManagement } = useContext(DateContext);
@@ -14,9 +17,9 @@ function Input(props) {
 			{width => (
 				<DebounceInput
 					autoComplete="off"
-					className="form-control"
 					debounceTimeout={300}
-					type="text"
+					element={Form.Text}
+					hideLabel
 					value={value.textInput}
 					style={{ width }}
 					{...inputManagement}

--- a/packages/components/src/DateTimePickers/Date/Input/Input.component.test.js
+++ b/packages/components/src/DateTimePickers/Date/Input/Input.component.test.js
@@ -38,9 +38,8 @@ describe('Date.Input', () => {
 		const props = JSON.parse(screen.getByTestId('DebounceInput').dataset.props);
 		expect(props).toEqual({
 			autoComplete: 'off',
-			className: 'form-control',
+			hideLabel: true,
 			debounceTimeout: 300,
-			type: 'text',
 			value: '2007-01-02',
 			style: { width: 300 },
 			'aria-labelledby': 'labelId',

--- a/packages/components/src/DateTimePickers/DateRange/Input/Input.component.js
+++ b/packages/components/src/DateTimePickers/DateRange/Input/Input.component.js
@@ -1,10 +1,13 @@
-import { useContext, forwardRef } from 'react';
-import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
+import { forwardRef, useContext } from 'react';
 import DebounceInput from 'react-debounce-input';
 
-import { DateRangeContext } from '../Context';
+import omit from 'lodash/omit';
+import PropTypes from 'prop-types';
+
+import { Form } from '@talend/design-system';
+
 import InputSizer from '../../shared/InputSizer';
+import { DateRangeContext } from '../Context';
 
 const OMIT_INPUT_PROPS = ['date', 'onChange', 'onFocus', 'label', 'minWidth'];
 
@@ -15,16 +18,14 @@ const Input = forwardRef((props, ref) => {
 
 	return (
 		<div className="range-input">
-			<label htmlFor={props.id} className="control-label">
-				{label}
-			</label>
+			{label && <Form.Label htmlFor={props.id}>{label}</Form.Label>}
 			<InputSizer inputText={placeholder} minWidth={minWidth}>
 				{width => (
 					<DebounceInput
 						autoComplete="off"
-						className="form-control"
 						debounceTimeout={300}
-						type="text"
+						element={Form.Text}
+						hideLabel
 						placeholder={placeholder}
 						value={date.textInput}
 						style={{ width }}

--- a/packages/components/src/DateTimePickers/DateRange/Input/Input.component.test.js
+++ b/packages/components/src/DateTimePickers/DateRange/Input/Input.component.test.js
@@ -44,9 +44,7 @@ describe('Date.Input', () => {
 		// then
 		const input = screen.getByTestId('debounce');
 		expect(input).toHaveAttribute('autocomplete', 'off');
-		expect(input).toHaveClass('form-control');
 		expect(input).toHaveAttribute('debouncetimeout', '300');
-		expect(input).toHaveAttribute('type', 'text');
 		expect(input).toHaveAttribute('placeholder', 'YYYY-MM-DD');
 		expect(input).toHaveValue('2019-10-11');
 		expect(input).toHaveStyle('width: 300px;');

--- a/packages/components/src/DateTimePickers/DateRange/Picker/__snapshots__/Picker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateRange/Picker/__snapshots__/Picker.component.test.js.snap
@@ -209,6 +209,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       M
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -218,6 +221,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       T
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -227,6 +233,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       W
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -236,6 +245,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       T
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -245,6 +257,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       F
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -254,6 +269,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       S
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                   <th
                     scope="col"
@@ -263,6 +281,9 @@ exports[`DateRange.Picker should render 1`] = `
                     >
                       S
                     </abbr>
+                    <span
+                      class="CoralDivider"
+                    />
                   </th>
                 </tr>
               </thead>
@@ -834,8 +855,11 @@ exports[`DateRange.Picker should render 1`] = `
       </div>
     </div>
   </div>
+  <span
+    class="CoralDivider"
+  />
   <div
-    class="theme-footer theme-date-padding"
+    class="theme-footer"
   >
     <button
       aria-label="Pick Today"

--- a/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDatePicker/InputDatePicker.module.scss
@@ -1,5 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
 @import '../shared/styles/mixins';
 
 .popper {
@@ -8,5 +6,4 @@
 
 .date-picker {
 	@include date-picker;
-	align-items: center;
 }

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.component.js
@@ -1,18 +1,18 @@
 import { useRef, useState } from 'react';
-import PropTypes from 'prop-types';
-import omit from 'lodash/omit';
-import classnames from 'classnames';
 import { usePopper } from 'react-popper';
 
-import FocusManager from '../../FocusManager';
-import { focus } from '@talend/react-a11y';
-import Icon from '../../Icon';
+import classnames from 'classnames';
+import omit from 'lodash/omit';
+import PropTypes from 'prop-types';
 
+import { SizedIcon } from '@talend/design-system';
+import { focus } from '@talend/react-a11y';
+
+import FocusManager from '../../FocusManager';
+import getDefaultT from '../../translate';
 import DateRange from '../DateRange';
 import { DateRangeContext } from '../DateRange/Context';
 import useInputPickerHandlers from '../hooks/useInputPickerHandlers';
-
-import getDefaultT from '../../translate';
 
 import theme from './InputDateRangePicker.module.scss';
 
@@ -104,7 +104,7 @@ export default function InputDateRangePicker(props) {
 								ref={startDateInputRef}
 							/>
 							<span className={classnames(theme.arrow, 'arrow')}>
-								<Icon name="talend-arrow-right" className={classnames(theme.icon, 'icon')} />
+								<SizedIcon name="arrow-right" size="S" />
 							</span>
 							<DateRange.Input
 								{...inputProps}

--- a/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateRangePicker/InputDateRangePicker.module.scss
@@ -1,5 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
 @import '../shared/styles/mixins';
 
 .popper {
@@ -8,19 +6,12 @@
 
 .date-picker {
 	@include date-picker;
-	align-items: flex-end;
 
 	.arrow {
 		@include arrow;
-		display: flex;
-		align-items: flex-end;
-
-		.icon {
-			@include icon;
-		}
 	}
 }
 
 .date-range-picker-inline {
-	@include range-picker-inline;
+	@include date-picker-inline;
 }

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.component.test.js
@@ -3,6 +3,8 @@ import userEvent from '@testing-library/user-event';
 
 import InputDateTimePicker from './InputDateTimePicker.component';
 
+jest.unmock('@talend/design-system');
+
 describe('InputDateTimePicker', () => {
 	it('should render', () => {
 		// when

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/InputDateTimePicker.module.scss
@@ -1,11 +1,8 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+@use '~@talend/design-tokens/lib/tokens';
+
+@import '../shared/styles/mixins';
 
 .date-time-picker {
-	display: flex;
-	flex-direction: row;
-	align-items: center;
-
-	:global(.date-picker) {
-		margin-right: $padding-small;
-	}
+	@include date-picker;
+	gap: tokens.$coral-spacing-xs;
 }

--- a/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimePicker/__snapshots__/InputDateTimePicker.component.test.js.snap
@@ -8,16 +8,32 @@ exports[`InputDateTimePicker should render 1`] = `
     class="theme-date-picker date-picker"
     tabindex="-1"
   >
-    <input
-      autocomplete="off"
-      class="form-control"
-      data-testid="date-picker"
-      id="my-picker-date-picker-input"
-      placeholder="YYYY-MM-DD"
-      style="width: 47px;"
-      type="text"
-      value="2017-04-04"
-    />
+    <div
+      class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+    >
+      <span
+        class="theme-hidden"
+      >
+        <label
+          class="theme-label"
+          for="my-picker-date-picker-input"
+        />
+      </span>
+      <div
+        class="theme-inputShell"
+      >
+        <input
+          autocomplete="off"
+          class="theme-input"
+          data-testid="date-picker"
+          id="my-picker-date-picker-input"
+          placeholder="YYYY-MM-DD"
+          style="width: 47px;"
+          type="text"
+          value="2017-04-04"
+        />
+      </div>
+    </div>
     <span
       data-testid="InputSizer"
       style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"
@@ -29,17 +45,33 @@ exports[`InputDateTimePicker should render 1`] = `
     class="theme-time-picker time-picker"
     tabindex="-1"
   >
-    <input
-      autocomplete="off"
-      class="form-control theme-time-picker-input"
-      data-testid="time-picker"
-      id="my-picker-time-picker-input"
-      maxlength="8"
-      placeholder="HH:mm:ss"
-      style="width: 47px;"
-      type="text"
-      value="15:27:00"
-    />
+    <div
+      class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+    >
+      <span
+        class="theme-hidden"
+      >
+        <label
+          class="theme-label"
+          for="my-picker-time-picker-input"
+        />
+      </span>
+      <div
+        class="theme-inputShell"
+      >
+        <input
+          autocomplete="off"
+          class="theme-input"
+          data-testid="time-picker"
+          id="my-picker-time-picker-input"
+          maxlength="8"
+          placeholder="HH:mm:ss"
+          style="width: 47px;"
+          type="text"
+          value="15:27:00"
+        />
+      </div>
+    </div>
     <span
       data-testid="InputSizer"
       style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.component.js
@@ -5,7 +5,8 @@ import debounce from 'lodash/debounce';
 import omit from 'lodash/omit';
 import PropTypes from 'prop-types';
 
-import Icon from '../../Icon';
+import { Form, SizedIcon } from '@talend/design-system';
+
 import getDefaultT from '../../translate';
 import DateTimeRange from '../DateTimeRange';
 import { DateTimeRangeContext } from '../DateTimeRange/Context';
@@ -78,9 +79,9 @@ function InputDateTimeRangePicker(props) {
 				{({ startDateTime, endDateTime, onStartChange, onEndChange }) => (
 					<div className={className} ref={containerRef}>
 						<div className="range-input" data-testid="range-start">
-							<label htmlFor={props.id} className="control-label">
+							<Form.Label htmlFor={props.id}>
 								{props.t('TC_DATE_PICKER_RANGE_FROM', { defaultValue: 'From' })}
-							</label>
+							</Form.Label>
 							<InputDateTimePicker
 								{...inputProps}
 								id={`${id}-start`}
@@ -94,12 +95,12 @@ function InputDateTimeRangePicker(props) {
 							/>
 						</div>
 						<span className={classnames(theme.arrow, 'arrow')}>
-							<Icon name="talend-arrow-right" className={classnames(theme.icon, 'icon')} />
+							<SizedIcon name={vertical ? 'arrow-bottom' : 'arrow-right'} size="S" />
 						</span>
 						<div className="range-input" data-testid="range-end">
-							<label htmlFor={props.id} className="control-label">
+							<Form.Label htmlFor={props.id}>
 								{props.t('TC_DATE_PICKER__RANGE_TO', { defaultValue: 'To' })}
-							</label>
+							</Form.Label>
 							<InputDateTimePicker
 								{...inputProps}
 								id={`${id}-end`}

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/InputDateTimeRangePicker.module.scss
@@ -1,39 +1,22 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
 @import '../shared/styles/mixins';
 
 .range-picker {
-	@include range-picker;
+	@include date-picker;
 
 	.arrow {
 		@include arrow;
-		display: flex;
-		align-items: flex-end;
-
-		.icon {
-			@include icon;
-		}
 	}
 }
 
 .range-picker-vertical {
-	@include range-picker;
+	@include date-picker;
 	flex-direction: column;
-	align-items: flex-start;
 
 	:global(.arrow) {
 		@include arrow;
-		display: flex;
-		align-items: center;
-		padding-left: 0;
-
-		:global(.icon) {
-			@include icon;
-			transform: rotate(90deg);
-		}
 	}
 }
 
 .date-time-range-picker-inline {
-	@include range-picker-inline;
+	@include date-picker-inline;
 }

--- a/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/InputDateTimeRangePicker/__snapshots__/InputDateTimeRangePicker.component.test.js.snap
@@ -9,7 +9,7 @@ exports[`InputDateTimeRangePicker should render 1`] = `
     data-testid="range-start"
   >
     <label
-      class="control-label"
+      class="theme-label"
       for="my-picker"
     >
       From
@@ -21,16 +21,32 @@ exports[`InputDateTimeRangePicker should render 1`] = `
         class="theme-date-picker date-picker"
         tabindex="-1"
       >
-        <input
-          autocomplete="off"
-          class="form-control"
-          data-testid="date-picker"
-          id="my-picker-start-date-picker-input"
-          placeholder="YYYY-MM-DD"
-          style="width: 47px;"
-          type="text"
-          value="2019-12-01"
-        />
+        <div
+          class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+        >
+          <span
+            class="theme-hidden"
+          >
+            <label
+              class="theme-label"
+              for="my-picker-start-date-picker-input"
+            />
+          </span>
+          <div
+            class="theme-inputShell"
+          >
+            <input
+              autocomplete="off"
+              class="theme-input"
+              data-testid="date-picker"
+              id="my-picker-start-date-picker-input"
+              placeholder="YYYY-MM-DD"
+              style="width: 47px;"
+              type="text"
+              value="2019-12-01"
+            />
+          </div>
+        </div>
         <span
           data-testid="InputSizer"
           style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"
@@ -42,17 +58,33 @@ exports[`InputDateTimeRangePicker should render 1`] = `
         class="theme-time-picker time-picker"
         tabindex="-1"
       >
-        <input
-          autocomplete="off"
-          class="form-control theme-time-picker-input"
-          data-testid="time-picker"
-          id="my-picker-start-time-picker-input"
-          maxlength="8"
-          placeholder="HH:mm:ss"
-          style="width: 47px;"
-          type="text"
-          value="00:00:00"
-        />
+        <div
+          class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+        >
+          <span
+            class="theme-hidden"
+          >
+            <label
+              class="theme-label"
+              for="my-picker-start-time-picker-input"
+            />
+          </span>
+          <div
+            class="theme-inputShell"
+          >
+            <input
+              autocomplete="off"
+              class="theme-input"
+              data-testid="time-picker"
+              id="my-picker-start-time-picker-input"
+              maxlength="8"
+              placeholder="HH:mm:ss"
+              style="width: 47px;"
+              type="text"
+              value="00:00:00"
+            />
+          </div>
+        </div>
         <span
           data-testid="InputSizer"
           style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"
@@ -67,19 +99,21 @@ exports[`InputDateTimeRangePicker should render 1`] = `
   >
     <svg
       aria-hidden="true"
-      class="tc-svg-icon tc-icon theme-svg theme-icon icon tc-icon-name-talend-arrow-right"
-      focusable="false"
-      name="talend-arrow-right"
       pointer-events="none"
       shape-rendering="geometricPrecision"
-    />
+      style="width: 0.75rem; height: 0.75rem;"
+    >
+      <use
+        xlink:href="#arrow-right:S"
+      />
+    </svg>
   </span>
   <div
     class="range-input"
     data-testid="range-end"
   >
     <label
-      class="control-label"
+      class="theme-label"
       for="my-picker"
     >
       To
@@ -91,16 +125,32 @@ exports[`InputDateTimeRangePicker should render 1`] = `
         class="theme-date-picker date-picker"
         tabindex="-1"
       >
-        <input
-          autocomplete="off"
-          class="form-control"
-          data-testid="date-picker"
-          id="my-picker-end-date-picker-input"
-          placeholder="YYYY-MM-DD"
-          style="width: 47px;"
-          type="text"
-          value="2019-12-11"
-        />
+        <div
+          class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+        >
+          <span
+            class="theme-hidden"
+          >
+            <label
+              class="theme-label"
+              for="my-picker-end-date-picker-input"
+            />
+          </span>
+          <div
+            class="theme-inputShell"
+          >
+            <input
+              autocomplete="off"
+              class="theme-input"
+              data-testid="date-picker"
+              id="my-picker-end-date-picker-input"
+              placeholder="YYYY-MM-DD"
+              style="width: 47px;"
+              type="text"
+              value="2019-12-11"
+            />
+          </div>
+        </div>
         <span
           data-testid="InputSizer"
           style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"
@@ -112,17 +162,33 @@ exports[`InputDateTimeRangePicker should render 1`] = `
         class="theme-time-picker time-picker"
         tabindex="-1"
       >
-        <input
-          autocomplete="off"
-          class="form-control theme-time-picker-input"
-          data-testid="time-picker"
-          id="my-picker-end-time-picker-input"
-          maxlength="8"
-          placeholder="HH:mm:ss"
-          style="width: 47px;"
-          type="text"
-          value="23:59:59"
-        />
+        <div
+          class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+        >
+          <span
+            class="theme-hidden"
+          >
+            <label
+              class="theme-label"
+              for="my-picker-end-time-picker-input"
+            />
+          </span>
+          <div
+            class="theme-inputShell"
+          >
+            <input
+              autocomplete="off"
+              class="theme-input"
+              data-testid="time-picker"
+              id="my-picker-end-time-picker-input"
+              maxlength="8"
+              placeholder="HH:mm:ss"
+              style="width: 47px;"
+              type="text"
+              value="23:59:59"
+            />
+          </div>
+        </div>
         <span
           data-testid="InputSizer"
           style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"

--- a/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/InputTimePicker/InputTimePicker.module.scss
@@ -1,21 +1,17 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
+@import '../shared/styles/mixins';
 
 $tc-timepicker-width: 5rem !default;
 $tc-timepicker-height: 10.625rem !default;
-$tc-timepicker-box-shadow: tokens.$coral-elevation-shadow-neutral-m !default;
-$tc-timepicker-z-index: $zindex-dropdown !default;
 
 .popper {
 	overflow: auto;
 	width: $tc-timepicker-width;
 	height: $tc-timepicker-height;
-	box-shadow: $tc-timepicker-box-shadow;
-	z-index: $tc-timepicker-z-index;
+	box-shadow: tokens.$coral-elevation-shadow-neutral-m;
+	z-index: tokens.$coral-elevation-layer-interactive-front;
 }
 
 .time-picker {
-	width: fit-content;
-	display: flex;
-	align-items: center;
+	@include date-picker;
 }

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
@@ -1,4 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 @import '../../shared/styles/mixins';

--- a/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.module.scss
+++ b/packages/components/src/DateTimePickers/LegacyDateTimePickers/pickers/YearPicker/YearPicker.module.scss
@@ -1,5 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
 @import '../../shared/styles/mixins';
 
 .year-picker {

--- a/packages/components/src/DateTimePickers/Time/Input/Input.component.js
+++ b/packages/components/src/DateTimePickers/Time/Input/Input.component.js
@@ -1,11 +1,12 @@
 import { useContext } from 'react';
-import PropTypes from 'prop-types';
-import classnames from 'classnames';
 import DebounceInput from 'react-debounce-input';
 
-import { TimeContext } from '../Context';
+import PropTypes from 'prop-types';
+
+import { Form } from '@talend/design-system';
+
 import InputSizer from '../../shared/InputSizer';
-import theme from './Input.module.scss';
+import { TimeContext } from '../Context';
 
 export default function Input(props) {
 	const { time, inputManagement } = useContext(TimeContext);
@@ -16,9 +17,9 @@ export default function Input(props) {
 			{width => (
 				<DebounceInput
 					autoComplete="off"
-					className={classnames('form-control', theme['time-picker-input'])}
 					debounceTimeout={300}
-					type="text"
+					element={Form.Text}
+					hideLabel
 					value={time.textInput}
 					style={{ width }}
 					maxLength={inputManagement.placeholder.length}

--- a/packages/components/src/DateTimePickers/Time/Input/Input.module.scss
+++ b/packages/components/src/DateTimePickers/Time/Input/Input.module.scss
@@ -1,6 +1,0 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
-.time-picker-input {
-	display: flex;
-	align-items: center;
-}

--- a/packages/components/src/DateTimePickers/TimeZone/TimeZone.component.js
+++ b/packages/components/src/DateTimePickers/TimeZone/TimeZone.component.js
@@ -7,7 +7,12 @@ import TooltipTrigger from '../../TooltipTrigger';
 function TimeZone(props) {
 	return (
 		<TooltipTrigger label={props.timezone} tooltipPlacement="top">
-			<StackVertical gap="0" display="inline" margin={{ left: 'XS', right: 0, top: 0, bottom: 0 }}>
+			<StackVertical
+				gap="0"
+				justify="center"
+				display="inline"
+				margin={{ left: 'XS', right: 0, top: 0, bottom: 0 }}
+			>
 				<SizedIcon
 					color="var(--coral-color-accent-icon, hsla(204, 88%, 40%, 1))"
 					name="information-filled"

--- a/packages/components/src/DateTimePickers/TimeZone/TimeZone.component.js
+++ b/packages/components/src/DateTimePickers/TimeZone/TimeZone.component.js
@@ -1,16 +1,19 @@
 import PropTypes from 'prop-types';
 
-import Icon from '../../Icon';
-import TooltipTrigger from '../../TooltipTrigger';
+import { SizedIcon, StackVertical } from '@talend/design-system';
 
-import theme from './TimeZone.module.scss';
+import TooltipTrigger from '../../TooltipTrigger';
 
 function TimeZone(props) {
 	return (
 		<TooltipTrigger label={props.timezone} tooltipPlacement="top">
-			<span className={theme['timezone-tooltip']}>
-				<Icon name="talend-info-circle" className={theme.icon} />
-			</span>
+			<StackVertical gap="0" display="inline" margin={{ left: 'XS', right: 0, top: 0, bottom: 0 }}>
+				<SizedIcon
+					color="var(--coral-color-accent-icon, hsla(204, 88%, 40%, 1))"
+					name="information-filled"
+					size="M"
+				/>
+			</StackVertical>
 		</TooltipTrigger>
 	);
 }

--- a/packages/components/src/DateTimePickers/TimeZone/TimeZone.module.scss
+++ b/packages/components/src/DateTimePickers/TimeZone/TimeZone.module.scss
@@ -1,5 +1,0 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
-.timezone-tooltip {
-	margin: 0 $padding-smaller;
-}

--- a/packages/components/src/DateTimePickers/TimeZone/__snapshots__/TimeZone.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/TimeZone/__snapshots__/TimeZone.component.test.js.snap
@@ -5,7 +5,7 @@ exports[`TimeZone should render 1`] = `
   aria-label="Asia/Beijing"
 >
   <div
-    class="theme-stack theme-justify-start theme-align-start theme-nowrap theme-column theme-inline theme-gap-x-0 theme-gap-y-0 theme-margin-top-0 theme-margin-right-0 theme-margin-bottom-0 theme-margin-left-XS"
+    class="theme-stack theme-justify-center theme-align-start theme-nowrap theme-column theme-inline theme-gap-x-0 theme-gap-y-0 theme-margin-top-0 theme-margin-right-0 theme-margin-bottom-0 theme-margin-left-XS"
   >
     <svg
       aria-hidden="true"

--- a/packages/components/src/DateTimePickers/TimeZone/__snapshots__/TimeZone.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/TimeZone/__snapshots__/TimeZone.component.test.js.snap
@@ -4,17 +4,20 @@ exports[`TimeZone should render 1`] = `
 <div
   aria-label="Asia/Beijing"
 >
-  <span
-    class="theme-timezone-tooltip"
+  <div
+    class="theme-stack theme-justify-start theme-align-start theme-nowrap theme-column theme-inline theme-gap-x-0 theme-gap-y-0 theme-margin-top-0 theme-margin-right-0 theme-margin-bottom-0 theme-margin-left-XS"
   >
     <svg
       aria-hidden="true"
-      class="tc-svg-icon tc-icon theme-svg theme-icon tc-icon-name-talend-info-circle"
-      focusable="false"
-      name="talend-info-circle"
+      color="var(--coral-color-accent-icon, hsla(204, 88%, 40%, 1))"
       pointer-events="none"
       shape-rendering="geometricPrecision"
-    />
-  </span>
+      style="width: 1rem; height: 1rem;"
+    >
+      <use
+        xlink:href="#information-filled:M"
+      />
+    </svg>
+  </div>
 </div>
 `;

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.component.js
@@ -1,11 +1,11 @@
 import { Component } from 'react';
 
-import classNames from 'classnames';
 import { getMonth } from 'date-fns/getMonth';
 import { getYear } from 'date-fns/getYear';
 import { startOfDay } from 'date-fns/startOfDay';
 import PropTypes from 'prop-types';
 
+import { Divider } from '@talend/design-system';
 import { focus } from '@talend/react-a11y';
 
 import Action from '../../../Actions/Action/Action.component';
@@ -180,11 +180,8 @@ class CalendarPicker extends Component {
 				aria-label="Date picker"
 			>
 				{viewElement}
-				<div
-					className={classNames(theme.footer, {
-						[theme['date-padding']]: this.state.isDateView,
-					})}
-				>
+				<Divider />
+				<div className={theme.footer}>
 					<Action
 						label={this.props.t('DATEPICKER_TODAY', {
 							defaultValue: 'Today',

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/CalendarPicker.module.scss
@@ -1,25 +1,11 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
-@import '../../shared/styles/mixins';
-@import '../../shared/styles/variables';
 
 .container {
 	color: tokens.$coral-color-neutral-text-weak;
-	min-width: 18.125rem;
-	min-height: 22rem;
-	padding: $padding-normal;
+	min-height: tokens.$coral-sizing-xxxl;
+	padding: tokens.$coral-spacing-m;
 }
 
 .footer {
-	padding-top: $padding-normal;
-
-	&::before {
-		@include picker-underline;
-		display: block;
-		margin-bottom: $padding-normal;
-	}
-
-	&.date-padding {
-		padding-top: $padding-smaller;
-	}
+	padding-top: tokens.$coral-spacing-s;
 }

--- a/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/CalendarPicker/__snapshots__/CalendarPicker.test.js.snap
@@ -20,8 +20,11 @@ exports[`CalendarPicker should render 1`] = `
       onSelectDate
     </button>
   </div>
+  <span
+    class="CoralDivider"
+  />
   <div
-    class="theme-footer theme-date-padding"
+    class="theme-footer"
   >
     <button
       aria-label="Pick Today"

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.component.js
@@ -16,6 +16,7 @@ import { startOfMonth } from 'date-fns/startOfMonth';
 import memoize from 'lodash/memoize';
 import PropTypes from 'prop-types';
 
+import { Divider } from '@talend/design-system';
 import { Gesture } from '@talend/react-a11y';
 
 import getDefaultT from '../../../translate';
@@ -138,6 +139,7 @@ class DatePicker extends PureComponent {
 								<abbr key={i} title={dayName.full}>
 									{dayName.abbr}
 								</abbr>
+								<Divider />
 							</th>
 						))}
 					</tr>

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/DatePicker.module.scss
@@ -1,8 +1,6 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 @import '../../shared/styles/mixins';
-@import '../../shared/styles/variables';
 
 .container {
 	width: 100%;
@@ -10,17 +8,8 @@
 }
 
 .calendar-header {
-	&::after {
-		@include picker-underline;
-		width: 100%;
-		position: absolute;
-		left: 0;
-		top: 1.4375rem;
-	}
-
 	th {
 		text-align: center;
-		padding-bottom: $padding-small;
 	}
 
 	abbr {

--- a/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
+++ b/packages/components/src/DateTimePickers/pickers/DatePicker/__snapshots__/DatePicker.test.js.snap
@@ -22,6 +22,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             M
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -31,6 +34,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             T
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -40,6 +46,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             W
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -49,6 +58,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             T
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -58,6 +70,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             F
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -67,6 +82,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             S
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
         <th
           scope="col"
@@ -76,6 +94,9 @@ exports[`DatePicker should render a DatePicker 1`] = `
           >
             S
           </abbr>
+          <span
+            class="CoralDivider"
+          />
         </th>
       </tr>
     </thead>

--- a/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/MonthPicker/MonthPicker.module.scss
@@ -1,4 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 @import '../../shared/styles/mixins';

--- a/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/TimePicker/TimePicker.module.scss
@@ -1,8 +1,7 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 .container {
-	padding: $padding-smaller 0;
+	padding: tokens.$coral-spacing-xxs 0;
 	background-color: tokens.$coral-color-neutral-background;
 
 	button {

--- a/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.module.scss
+++ b/packages/components/src/DateTimePickers/pickers/YearPicker/YearPicker.module.scss
@@ -1,5 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
 @import '../../shared/styles/mixins';
 
 .year-picker {

--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -41,7 +41,6 @@ $tc-datepicker-width: 19.375rem !default;
 @mixin date-picker {
 	display: flex;
 	width: fit-content;
-	align-items: center;
 
 	:global(.range-input) {
 		display: flex;

--- a/packages/components/src/DateTimePickers/shared/styles/mixins.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/mixins.scss
@@ -1,7 +1,8 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 @import './variables';
+
+$tc-datepicker-width: 19.375rem !default;
 
 @mixin nav-action {
 	padding: 0;
@@ -10,13 +11,13 @@
 }
 
 @mixin picker-action {
-	font-size: 0.75rem;
+	font: tokens.$coral-paragraph-s;
 
 	&.selected {
 		background-color: tokens.$coral-color-accent-background;
 		color: tokens.$coral-color-accent-text;
 		transition: color 0.2s ease-in;
-		font-weight: $font-weight-semi-bold;
+		font: tokens.$coral-paragraph-s-bold;
 	}
 
 	&:disabled {
@@ -34,38 +35,32 @@
 	width: $tc-datepicker-width;
 	background: tokens.$coral-color-neutral-background;
 	box-shadow: tokens.$coral-elevation-shadow-neutral-m;
-	z-index: $tc-datepicker-z-index;
+	z-index: tokens.$coral-elevation-layer-interactive-front;
 }
 
 @mixin date-picker {
 	display: flex;
 	width: fit-content;
-}
+	align-items: center;
 
-@mixin range-picker {
-	@include date-picker;
-	align-items: flex-end;
-}
-
-@mixin range-picker-inline {
 	:global(.range-input) {
 		display: flex;
-		align-items: center;
+		flex-direction: column;
+		gap: tokens.$coral-spacing-xxs;
 	}
+}
 
-	:global(.control-label) {
-		margin: 0 $padding-small;
+@mixin date-picker-inline {
+	:global(.range-input) {
+		display: flex;
+		flex-direction: row;
+		align-items: center;
+		gap: tokens.$coral-spacing-xxs;
 	}
 }
 
 @mixin arrow {
-	height: $tc-range-picker-arrow-height;
-	padding: 0 $padding-smaller;
-	margin-bottom: 0.9375rem;
-	color: tokens.$coral-color-neutral-text;
-}
-
-@mixin icon {
-	width: $svg-sm-size;
-	height: $svg-sm-size;
+	display: flex;
+	align-items: flex-end;
+	margin: tokens.$coral-spacing-s;
 }

--- a/packages/components/src/DateTimePickers/shared/styles/variables.scss
+++ b/packages/components/src/DateTimePickers/shared/styles/variables.scss
@@ -1,10 +1,3 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
 @use '~@talend/design-tokens/lib/tokens';
 
 $border-default: 0.0625rem solid tokens.$coral-color-neutral-border !default;
-
-$tc-datepicker-width: 19.375rem !default;
-$tc-datepicker-box-shadow: $shadow-default !default;
-$tc-datepicker-z-index: $zindex-dropdown !default;
-
-$tc-range-picker-arrow-height: 1.875rem !default;

--- a/packages/components/src/DateTimePickers/views/DateView/DateView.module.scss
+++ b/packages/components/src/DateTimePickers/views/DateView/DateView.module.scss
@@ -1,18 +1,7 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
-
-@import '../../shared/styles/variables';
-
 .body {
 	display: flex;
 
 	.date {
 		flex: 3 0 200px;
-	}
-
-	.time {
-		border-left: $border-default;
-		flex: 1 0 70px;
-		margin-left: $padding-normal;
-		padding-left: $padding-normal;
 	}
 }

--- a/packages/components/src/DateTimePickers/views/ViewLayout/ViewLayout.module.scss
+++ b/packages/components/src/DateTimePickers/views/ViewLayout/ViewLayout.module.scss
@@ -1,4 +1,4 @@
-@use '~@talend/bootstrap-theme/src/theme/guidelines' as *;
+@use '~@talend/design-tokens/lib/tokens';
 
 .container {
 	height: 100%;
@@ -8,14 +8,10 @@
 	.header {
 		display: flex;
 		justify-content: space-between;
-		margin-bottom: $padding-small;
+		margin-bottom: tokens.$coral-spacing-s;
 
 		:global(.btn-icon-only) {
-			padding: 0 $padding-smaller;
-
-			svg {
-				width: $svg-sm-size;
-			}
+			padding: 0 tokens.$coral-spacing-xxs;
 
 			span {
 				display: none;

--- a/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
@@ -296,6 +296,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           M
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -305,6 +309,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           T
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -314,6 +322,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           W
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -323,6 +335,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           T
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -332,6 +348,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           F
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -341,6 +361,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           S
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                       <th
                         scope="col"
@@ -350,6 +374,10 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                         >
                           S
                         </abbr>
+                        <hr
+                          aria-orientation="horizontal"
+                          class="theme-divider"
+                        />
                       </th>
                     </tr>
                   </thead>
@@ -920,8 +948,12 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
           </div>
         </div>
       </div>
+      <hr
+        aria-orientation="horizontal"
+        class="theme-divider"
+      />
       <div
-        class="theme-footer theme-date-padding"
+        class="theme-footer"
       >
         <button
           aria-label="Pick Today"

--- a/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
@@ -11,15 +11,31 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
     >
       Select a date
     </label>
-    <input
-      autocomplete="off"
-      class="form-control"
-      id="customId-date-input"
-      placeholder="Type here"
-      style="width: 5px;"
-      type="text"
-      value="2011-11-18"
-    />
+    <div
+      class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+    >
+      <span
+        class="theme-hidden"
+      >
+        <label
+          class="theme-label"
+          for="customId-date-input"
+        />
+      </span>
+      <div
+        class="theme-inputShell"
+      >
+        <input
+          autocomplete="off"
+          class="theme-input"
+          id="customId-date-input"
+          placeholder="Type here"
+          style="width: 5px;"
+          type="text"
+          value="2011-11-18"
+        />
+      </div>
+    </div>
     <span
       data-testid="InputSizer"
       style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"

--- a/packages/forms/src/UIForm/fields/Date/__snapshots__/Date.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Date/__snapshots__/Date.component.test.js.snap
@@ -14,18 +14,34 @@ exports[`Date widget should render date picker 1`] = `
     class="theme-date-picker date-picker"
     tabindex="-1"
   >
-    <input
-      aria-describedby="myForm-description myForm-error"
-      aria-invalid="true"
-      aria-required="true"
-      autocomplete="off"
-      class="form-control"
-      id="myForm-input"
-      placeholder="Type your date here"
-      style="width: 5px;"
-      type="text"
-      value="15/02/2018 23:55:32"
-    />
+    <div
+      class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+    >
+      <span
+        class="theme-hidden"
+      >
+        <label
+          class="theme-label"
+          for="myForm-input"
+        />
+      </span>
+      <div
+        class="theme-inputShell"
+      >
+        <input
+          aria-describedby="myForm-description myForm-error"
+          aria-invalid="true"
+          aria-required="true"
+          autocomplete="off"
+          class="theme-input"
+          id="myForm-input"
+          placeholder="Type your date here"
+          style="width: 5px;"
+          type="text"
+          value="15/02/2018 23:55:32"
+        />
+      </div>
+    </div>
     <span
       data-testid="InputSizer"
       style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"

--- a/packages/forms/src/UIForm/fields/Date/__snapshots__/Date.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Date/__snapshots__/Date.component.test.js.snap
@@ -304,6 +304,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             M
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -313,6 +317,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             T
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -322,6 +330,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             W
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -331,6 +343,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             T
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -340,6 +356,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             F
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -349,6 +369,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             S
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                         <th
                           scope="col"
@@ -358,6 +382,10 @@ exports[`Date widget should render date picker 1`] = `
                           >
                             S
                           </abbr>
+                          <hr
+                            aria-orientation="horizontal"
+                            class="theme-divider"
+                          />
                         </th>
                       </tr>
                     </thead>
@@ -925,8 +953,12 @@ exports[`Date widget should render date picker 1`] = `
             </div>
           </div>
         </div>
+        <hr
+          aria-orientation="horizontal"
+          class="theme-divider"
+        />
         <div
-          class="theme-footer theme-date-padding"
+          class="theme-footer"
         >
           <button
             aria-label="Pick Today"

--- a/packages/forms/src/UIForm/fields/Date/__snapshots__/DateTime.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Date/__snapshots__/DateTime.component.test.js.snap
@@ -17,16 +17,32 @@ exports[`DateTime widget should render an InputDateTimePicker 1`] = `
       class="theme-date-picker date-picker"
       tabindex="-1"
     >
-      <input
-        autocomplete="off"
-        class="form-control"
-        data-testid="date-picker"
-        id="talend-date-time-date-picker-input"
-        placeholder="YYYY-MM-DD"
-        style="width: 47px;"
-        type="text"
-        value=""
-      />
+      <div
+        class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+      >
+        <span
+          class="theme-hidden"
+        >
+          <label
+            class="theme-label"
+            for="talend-date-time-date-picker-input"
+          />
+        </span>
+        <div
+          class="theme-inputShell"
+        >
+          <input
+            autocomplete="off"
+            class="theme-input"
+            data-testid="date-picker"
+            id="talend-date-time-date-picker-input"
+            placeholder="YYYY-MM-DD"
+            style="width: 47px;"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
       <span
         data-testid="InputSizer"
         style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"
@@ -38,17 +54,33 @@ exports[`DateTime widget should render an InputDateTimePicker 1`] = `
       class="theme-time-picker time-picker"
       tabindex="-1"
     >
-      <input
-        autocomplete="off"
-        class="form-control theme-time-picker-input"
-        data-testid="time-picker"
-        id="talend-date-time-time-picker-input"
-        maxlength="5"
-        placeholder="HH:mm"
-        style="width: 47px;"
-        type="text"
-        value=""
-      />
+      <div
+        class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+      >
+        <span
+          class="theme-hidden"
+        >
+          <label
+            class="theme-label"
+            for="talend-date-time-time-picker-input"
+          />
+        </span>
+        <div
+          class="theme-inputShell"
+        >
+          <input
+            autocomplete="off"
+            class="theme-input"
+            data-testid="time-picker"
+            id="talend-date-time-time-picker-input"
+            maxlength="5"
+            placeholder="HH:mm"
+            style="width: 47px;"
+            type="text"
+            value=""
+          />
+        </div>
+      </div>
       <span
         data-testid="InputSizer"
         style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"

--- a/packages/forms/src/UIForm/fields/Date/__snapshots__/Time.component.test.js.snap
+++ b/packages/forms/src/UIForm/fields/Date/__snapshots__/Time.component.test.js.snap
@@ -14,16 +14,32 @@ exports[`Time component should render an InputTimePicker 1`] = `
     class="theme-time-picker time-picker"
     tabindex="-1"
   >
-    <input
-      autocomplete="off"
-      class="form-control theme-time-picker-input"
-      id="myForm-input"
-      maxlength="5"
-      placeholder="HH:mm"
-      style="width: 5px;"
-      type="text"
-      value="12:34"
-    />
+    <div
+      class="theme-stack theme-justify-start theme-align-stretch theme-nowrap theme-column theme-block theme-height-100 theme-noShrink theme-gap-x-XXS theme-gap-y-XXS"
+    >
+      <span
+        class="theme-hidden"
+      >
+        <label
+          class="theme-label"
+          for="myForm-input"
+        />
+      </span>
+      <div
+        class="theme-inputShell"
+      >
+        <input
+          autocomplete="off"
+          class="theme-input"
+          id="myForm-input"
+          maxlength="5"
+          placeholder="HH:mm"
+          style="width: 5px;"
+          type="text"
+          value="12:34"
+        />
+      </div>
+    </div>
     <span
       data-testid="InputSizer"
       style="padding: 0px 0.625rem; font-size: 0.875rem; visibility: hidden; position: absolute;"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
switch components dates to use design system inputs

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
