### PR TITLE
fix: make checkbox badge with values work again (without fetching the tags all the time)

### DIFF
--- a/.changeset/thin-nails-search.md
+++ b/.changeset/thin-nails-search.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+fix: make checkbox badge with values work again (without fetching the tags all the time)

--- a/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
@@ -55,7 +55,7 @@ export const BadgeCheckboxes = ({
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
-		if (!callbacks || !callbacks.getTags) {
+		if ((values && values.length) || !callbacks || !callbacks.getTags) {
 			setIsLoading(false);
 			return;
 		}

--- a/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
+++ b/packages/faceted-search/src/components/Badges/BadgeCheckboxes/BadgeCheckboxes.component.js
@@ -55,7 +55,7 @@ export const BadgeCheckboxes = ({
 	const [isLoading, setIsLoading] = useState(true);
 
 	useEffect(() => {
-		if ((values && values.length) || !callbacks || !callbacks.getTags) {
+		if (values?.length || !callbacks || !callbacks.getTags) {
 			setIsLoading(false);
 			return;
 		}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
![CleanShot 2024-02-16 at 15 47 32@2x](https://github.com/Talend/ui/assets/2909671/2e4eed5b-ae1e-474b-ad62-14ae78843113)

**What is the chosen solution to this problem?**
![CleanShot 2024-02-16 at 15 47 58@2x](https://github.com/Talend/ui/assets/2909671/771439d2-3fdf-4cc6-9de1-53ce05216337)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
