### PR TITLE
fix: build process to use TypeScript instead of Babel

### DIFF
--- a/.changeset/smart-crews-beam.md
+++ b/.changeset/smart-crews-beam.md
@@ -1,0 +1,5 @@
+---
+'@talend/utils': patch
+---
+
+fix: use typescript to generate @talend/utils instead of babel

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -11,7 +11,7 @@
   "author": "Talend Frontend <frontend@talend.com> (http://www.talend.com)",
   "license": "Apache-2.0",
   "scripts": {
-    "build:lib": "talend-scripts build",
+    "build:lib": "talend-scripts build --tsc",
     "lint": "talend-scripts lint",
     "test": "cross-env TZ=UTC talend-scripts test",
     "test:cov": "cross-env TZ=UTC talend-scripts test --coverage --silent",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Lodash is still loaded all along with the current babel build

**What is the chosen solution to this problem?**
Let's move to typescript as this package is in typescript

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
