### PR TITLE
fix(TMC-27327): Fix input number validation to display correct error msg

### DIFF
--- a/.changeset/wise-owls-sing.md
+++ b/.changeset/wise-owls-sing.md
@@ -1,0 +1,5 @@
+---
+'@talend/json-schema-form-core': patch
+---
+
+TMC-27327 - Fix input number validation to display correct error message

--- a/packages/jsfc/src/validate.js
+++ b/packages/jsfc/src/validate.js
@@ -5,7 +5,7 @@ function validateTypeSpecificInput(inputType = '', event = {}) {
 	switch (inputType) {
 		case 'number':
 			// If the user types a non-integer value, the value is emptied by browser but still displayed in UI
-			if (event.target?.validity && !event.target.validity.valid) {
+			if (event.target?.validity && event.target.validity.badInput) {
 				return { valid: false, message: 'CUSTOM_ERROR_INVALID_INPUT' };
 			}
 			break;

--- a/packages/jsfc/src/validate.test.js
+++ b/packages/jsfc/src/validate.test.js
@@ -24,7 +24,7 @@ describe('validate.js', () => {
 		it('should return an error object with a message "CUSTOM_ERROR_INVALID_INPUT" when the integer value is not valid', () => {
 			let value = 'stringValue';
 			const testForm = { type: 'number', key: ['hero'], schema: { type: 'number' } };
-			const event = { target: { validity: { valid: false } } };
+			const event = { target: { validity: { badInput: true } } };
 			let result = validate(testForm, value, event);
 			expect(result.error.message).toBe('CUSTOM_ERROR_INVALID_INPUT');
 		});


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fix input number validation to display correct error msg

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
