### PR TITLE
fix(TMC-26227): fix design system loading icon on safari browser

### DIFF
--- a/.changeset/orange-fishes-walk.md
+++ b/.changeset/orange-fishes-walk.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+TMC-26227 - Fix design system loading icon on safari browser

--- a/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
+++ b/packages/design-system/src/components/Accordion/__snapshots__/Accordion.test.tsx.snap
@@ -151,6 +151,7 @@ exports[`Accordion should render a11y html 1`] = `
             class="theme-status__icon"
           >
             <svg
+              style="width: 100%; height: 100%;"
               viewBox="0 0 16 16"
               xmlns="http://www.w3.org/2000/svg"
             >

--- a/packages/design-system/src/components/Button/__snapshots__/Button.test.tsx.snap
+++ b/packages/design-system/src/components/Button/__snapshots__/Button.test.tsx.snap
@@ -75,6 +75,7 @@ exports[`Button should render a11y html 1`] = `
         <svg
           aria-hidden="true"
           data-test="button.loading"
+          style="width: 100%; height: 100%;"
           viewBox="0 0 16 16"
           xmlns="http://www.w3.org/2000/svg"
         >

--- a/packages/design-system/src/components/Loading/Loading.tsx
+++ b/packages/design-system/src/components/Loading/Loading.tsx
@@ -1,9 +1,15 @@
-import { HTMLAttributes, forwardRef } from 'react';
+import { forwardRef, HTMLAttributes } from 'react';
 
 export type LoadingProps = HTMLAttributes<SVGSVGElement>;
 
 export const Loading = forwardRef<SVGSVGElement, LoadingProps>((props, ref) => (
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 16 16" ref={ref} {...props}>
+	<svg
+		xmlns="http://www.w3.org/2000/svg"
+		style={{ width: '100%', height: '100%' }}
+		viewBox="0 0 16 16"
+		ref={ref}
+		{...props}
+	>
 		<g>
 			<path
 				fill="currentColor"

--- a/packages/design-system/src/components/Loading/__snapshots__/Loading.test.tsx.snap
+++ b/packages/design-system/src/components/Loading/__snapshots__/Loading.test.tsx.snap
@@ -3,6 +3,7 @@
 exports[`Loading should render a11y html 1`] = `
 <main>
   <svg
+    style="width: 100%; height: 100%;"
     viewBox="0 0 16 16"
     xmlns="http://www.w3.org/2000/svg"
   >


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix design system loading icon on safari browser

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
