### PR TITLE
chore(TUX-1228): update CollapsiblePanel to support multiple actions

### DIFF
--- a/.changeset/blue-frogs-rush.md
+++ b/.changeset/blue-frogs-rush.md
@@ -1,26 +1,5 @@
 ---
-'@talend/design-system': major
+'@talend/design-system': minor
 ---
 
 chore(TUX-1228): update CollapsiblePanel to support multiple actions
-
-## BREAKING CHANGES:
-
-`CollapsiblePanel` now supports multiple actions. The `action` property has been replaced by `actions` which is an array of objects with the same shape used before.
-
-```diff
-  <CollapsiblePanel
-    ...
--   action={{
-+   actions={[
-      {
-        icon: 'plus',
-        tooltip: 'action tooltip',
-        callback: () => window.alert('action callback'),
-      },
-    ]}
--   }}
-  >
-    ...
-  </CollapsiblePanel>
-```

--- a/.changeset/blue-frogs-rush.md
+++ b/.changeset/blue-frogs-rush.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': minor
+---
+
+chore(TUX-1228): update CollapsiblePanel to support two actions

--- a/.changeset/blue-frogs-rush.md
+++ b/.changeset/blue-frogs-rush.md
@@ -1,5 +1,26 @@
 ---
-'@talend/design-system': minor
+'@talend/design-system': major
 ---
 
-chore(TUX-1228): update CollapsiblePanel to support two actions
+chore(TUX-1228): update CollapsiblePanel to support multiple actions
+
+## BREAKING CHANGES:
+
+`CollapsiblePanel` now supports multiple actions. The `action` property has been replaced by `actions` which is an array of objects with the same shape used before.
+
+```diff
+  <CollapsiblePanel
+    ...
+-   action={{
++   actions={[
+      {
+        icon: 'plus',
+        tooltip: 'action tooltip',
+        callback: () => window.alert('action callback'),
+      },
+    ]}
+-   }}
+  >
+    ...
+  </CollapsiblePanel>
+```

--- a/packages/design-system/src/components/Accordion/Accordion.cy.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.cy.tsx
@@ -17,18 +17,16 @@ const SampleParagraph = () => (
 		velit, eget ornare velit. Praesent porttitor sagittis nulla non vehicula. u
 	</p>
 );
-const WithActions = () => (
+const WithAction = () => (
 	<div style={{ maxWidth: '50rem', marginLeft: 'auto', marginRight: 'auto', padding: '1.875rem' }}>
 		<CollapsiblePanel
 			id="panel-with-action"
 			title="panel with action"
-			actions={[
-				{
-					icon: 'plus',
-					tooltip: 'action tooltip',
-					callback: () => window.alert('action callback'),
-				},
-			]}
+			action={{
+				icon: 'plus',
+				tooltip: 'action tooltip',
+				callback: () => window.alert('action callback'),
+			}}
 		>
 			<SampleParagraph />
 		</CollapsiblePanel>
@@ -37,13 +35,13 @@ const WithActions = () => (
 
 context('<CollapsiblePanel />', () => {
 	it('should render header', () => {
-		cy.mount(<WithActions />);
+		cy.mount(<WithAction />);
 		cy.findByTestId('panel.header').should('be.visible');
 		cy.findByTestId('panel.section').should('not.exist');
 	});
 
 	it('should expand and collapse', () => {
-		cy.mount(<WithActions />);
+		cy.mount(<WithAction />);
 		cy.get('#CollapsiblePanel__control--panel-with-action').focus().click();
 		cy.findByTestId('panel.section').should('be.visible');
 		cy.get('#CollapsiblePanel__control--panel-with-action').focus().click();
@@ -58,13 +56,11 @@ context('<CollapsiblePanel />', () => {
 				<CollapsiblePanel
 					id="disabled-panel"
 					title="disabled panel"
-					actions={[
-						{
-							icon: 'plus',
-							tooltip: 'action tooltip',
-							callback: () => window.alert('action callback'),
-						},
-					]}
+					action={{
+						icon: 'plus',
+						tooltip: 'action tooltip',
+						callback: () => window.alert('action callback'),
+					}}
 					disabled
 				>
 					<SampleParagraph />
@@ -76,7 +72,7 @@ context('<CollapsiblePanel />', () => {
 	});
 
 	it('should display action toolip', () => {
-		cy.mount(<WithActions />);
+		cy.mount(<WithAction />);
 		cy.findByTestId('action.button.0')
 			.focus()
 			.should('have.attr', 'aria-describedby')

--- a/packages/design-system/src/components/Accordion/Accordion.cy.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.cy.tsx
@@ -72,12 +72,12 @@ context('<CollapsiblePanel />', () => {
 			</div>,
 		);
 		cy.get('#CollapsiblePanel__control--disabled-panel').should('not.exist');
-		cy.findByTestId('action.button').should('not.exist');
+		cy.findByTestId('action.button.0').should('not.exist');
 	});
 
 	it('should display action toolip', () => {
 		cy.mount(<WithActions />);
-		cy.findByTestId('action.button')
+		cy.findByTestId('action.button.0')
 			.focus()
 			.should('have.attr', 'aria-describedby')
 			.then(describedBy => cy.get(`#${describedBy}`).should('have.text', 'action tooltip'));

--- a/packages/design-system/src/components/Accordion/Accordion.cy.tsx
+++ b/packages/design-system/src/components/Accordion/Accordion.cy.tsx
@@ -17,16 +17,18 @@ const SampleParagraph = () => (
 		velit, eget ornare velit. Praesent porttitor sagittis nulla non vehicula. u
 	</p>
 );
-const WithAction = () => (
+const WithActions = () => (
 	<div style={{ maxWidth: '50rem', marginLeft: 'auto', marginRight: 'auto', padding: '1.875rem' }}>
 		<CollapsiblePanel
 			id="panel-with-action"
 			title="panel with action"
-			action={{
-				icon: 'plus',
-				tooltip: 'action tooltip',
-				callback: () => window.alert('action callback'),
-			}}
+			actions={[
+				{
+					icon: 'plus',
+					tooltip: 'action tooltip',
+					callback: () => window.alert('action callback'),
+				},
+			]}
 		>
 			<SampleParagraph />
 		</CollapsiblePanel>
@@ -35,13 +37,13 @@ const WithAction = () => (
 
 context('<CollapsiblePanel />', () => {
 	it('should render header', () => {
-		cy.mount(<WithAction />);
+		cy.mount(<WithActions />);
 		cy.findByTestId('panel.header').should('be.visible');
 		cy.findByTestId('panel.section').should('not.exist');
 	});
 
 	it('should expand and collapse', () => {
-		cy.mount(<WithAction />);
+		cy.mount(<WithActions />);
 		cy.get('#CollapsiblePanel__control--panel-with-action').focus().click();
 		cy.findByTestId('panel.section').should('be.visible');
 		cy.get('#CollapsiblePanel__control--panel-with-action').focus().click();
@@ -56,11 +58,13 @@ context('<CollapsiblePanel />', () => {
 				<CollapsiblePanel
 					id="disabled-panel"
 					title="disabled panel"
-					action={{
-						icon: 'plus',
-						tooltip: 'action tooltip',
-						callback: () => window.alert('action callback'),
-					}}
+					actions={[
+						{
+							icon: 'plus',
+							tooltip: 'action tooltip',
+							callback: () => window.alert('action callback'),
+						},
+					]}
 					disabled
 				>
 					<SampleParagraph />
@@ -72,7 +76,7 @@ context('<CollapsiblePanel />', () => {
 	});
 
 	it('should display action toolip', () => {
-		cy.mount(<WithAction />);
+		cy.mount(<WithActions />);
 		cy.findByTestId('action.button')
 			.focus()
 			.should('have.attr', 'aria-describedby')

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
@@ -15,7 +15,7 @@ type CollapsiblePanelCommonPropsType = {
 	managed?: boolean;
 	expanded?: boolean;
 	index?: number;
-	actions?: PanelHeaderAction[];
+	action?: PanelHeaderAction | PanelHeaderAction[];
 	size?: 'S' | 'M';
 	metadata?: ReactChild[];
 	isFirst?: boolean;
@@ -49,7 +49,7 @@ export const CollapsiblePanel = forwardRef(
 			onToggleExpanded,
 			title,
 			status,
-			actions,
+			action,
 			size,
 			metadata,
 			isFirst = false,
@@ -96,7 +96,7 @@ export const CollapsiblePanel = forwardRef(
 					handleClick={handleToggleExpanded}
 					title={title}
 					status={status}
-					actions={actions}
+					action={action}
 					metadata={metadata}
 					size={size}
 					disabled={disabled}

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
@@ -1,12 +1,13 @@
-import { forwardRef, ReactChild, Ref, useState, useEffect, HTMLAttributes } from 'react';
+import { forwardRef, HTMLAttributes, ReactChild, Ref, useEffect, useState } from 'react';
+
 import classNames from 'classnames';
 
-import { useId } from '../../../useId';
 import { DataAttributes } from '../../../types';
+import { useId } from '../../../useId';
 import { variants } from '../../Status/Primitive/StatusPrimitive';
-
 import CollapsiblePanelHeader from './CollapsiblePanelHeader';
 import { PanelHeaderAction } from './types';
+
 import styles from './CollapsiblePanel.module.scss';
 
 type CollapsiblePanelCommonPropsType = {
@@ -14,7 +15,7 @@ type CollapsiblePanelCommonPropsType = {
 	managed?: boolean;
 	expanded?: boolean;
 	index?: number;
-	action?: PanelHeaderAction;
+	actions?: [PanelHeaderAction, PanelHeaderAction?];
 	size?: 'S' | 'M';
 	metadata?: ReactChild[];
 	isFirst?: boolean;
@@ -48,7 +49,7 @@ export const CollapsiblePanel = forwardRef(
 			onToggleExpanded,
 			title,
 			status,
-			action,
+			actions,
 			size,
 			metadata,
 			isFirst = false,
@@ -95,7 +96,7 @@ export const CollapsiblePanel = forwardRef(
 					handleClick={handleToggleExpanded}
 					title={title}
 					status={status}
-					action={action}
+					actions={actions}
 					metadata={metadata}
 					size={size}
 					disabled={disabled}

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanel.tsx
@@ -15,7 +15,7 @@ type CollapsiblePanelCommonPropsType = {
 	managed?: boolean;
 	expanded?: boolean;
 	index?: number;
-	actions?: [PanelHeaderAction, PanelHeaderAction?];
+	actions?: PanelHeaderAction[];
 	size?: 'S' | 'M';
 	metadata?: ReactChild[];
 	isFirst?: boolean;

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
@@ -22,7 +22,7 @@ export type CollapsiblePanelHeaderPropsType = {
 	title?: ReactChild;
 	status?: keyof typeof variants;
 	metadata?: ReactChild[];
-	action?: PanelHeaderAction;
+	actions?: [PanelHeaderAction, PanelHeaderAction?];
 	handleClick: () => unknown;
 	disabled?: boolean;
 };
@@ -34,7 +34,7 @@ const CollapsiblePanelHeader = forwardRef(
 			sectionId,
 			expanded,
 			handleClick,
-			action,
+			actions,
 			metadata,
 			title,
 			status,
@@ -44,7 +44,7 @@ const CollapsiblePanelHeader = forwardRef(
 		ref: Ref<HTMLButtonElement>,
 	) => {
 		const listMetadata = metadata?.map((item, index) => {
-			if (index === metadata.length - 1 && (!action || disabled)) {
+			if (index === metadata.length - 1 && (!actions || disabled)) {
 				return item;
 			}
 
@@ -60,7 +60,7 @@ const CollapsiblePanelHeader = forwardRef(
 		const buttonIconSize = size === 'S' ? 'XS' : 'S';
 
 		const getChevron = () => {
-			if (action) {
+			if (actions) {
 				return (
 					<ButtonIcon
 						id={controlId}
@@ -109,21 +109,27 @@ const CollapsiblePanelHeader = forwardRef(
 						{listMetadata}
 					</StackHorizontal>
 				)}
-				{action && !disabled && (
-					<ButtonIcon
-						size={buttonIconSize}
-						icon={action.icon}
-						onClick={action.callback}
-						data-test="action.button"
-						data-testid="action.button"
-					>
-						{action.tooltip}
-					</ButtonIcon>
-				)}
+				{actions &&
+					!disabled &&
+					actions.map(
+						(action, index) =>
+							action && (
+								<ButtonIcon
+									key={`action-${index}`}
+									size={buttonIconSize}
+									icon={action.icon}
+									onClick={action.callback}
+									data-test={`action.button.${index}`}
+									data-testid={`action.button.${index}`}
+								>
+									{action.tooltip}
+								</ButtonIcon>
+							),
+					)}
 			</>
 		);
 
-		if (action) {
+		if (actions) {
 			return (
 				<div
 					className={classnames(styles.headerWrapper, {

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
@@ -22,7 +22,7 @@ export type CollapsiblePanelHeaderPropsType = {
 	title?: ReactChild;
 	status?: keyof typeof variants;
 	metadata?: ReactChild[];
-	actions?: [PanelHeaderAction, PanelHeaderAction?];
+	actions?: PanelHeaderAction[];
 	handleClick: () => unknown;
 	disabled?: boolean;
 };

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
@@ -22,7 +22,7 @@ export type CollapsiblePanelHeaderPropsType = {
 	title?: ReactChild;
 	status?: keyof typeof variants;
 	metadata?: ReactChild[];
-	actions?: PanelHeaderAction[];
+	action?: PanelHeaderAction | PanelHeaderAction[];
 	handleClick: () => unknown;
 	disabled?: boolean;
 };
@@ -34,7 +34,7 @@ const CollapsiblePanelHeader = forwardRef(
 			sectionId,
 			expanded,
 			handleClick,
-			actions,
+			action,
 			metadata,
 			title,
 			status,
@@ -44,7 +44,7 @@ const CollapsiblePanelHeader = forwardRef(
 		ref: Ref<HTMLButtonElement>,
 	) => {
 		const listMetadata = metadata?.map((item, index) => {
-			if (index === metadata.length - 1 && (!actions || disabled)) {
+			if (index === metadata.length - 1 && (!action || disabled)) {
 				return item;
 			}
 
@@ -59,8 +59,10 @@ const CollapsiblePanelHeader = forwardRef(
 		const iconSize = size === 'S' ? 'S' : 'M';
 		const buttonIconSize = size === 'S' ? 'XS' : 'S';
 
+		const actions = Array.isArray(action) ? action : [action];
+
 		const getChevron = () => {
-			if (actions) {
+			if (action) {
 				return (
 					<ButtonIcon
 						id={controlId}
@@ -109,27 +111,27 @@ const CollapsiblePanelHeader = forwardRef(
 						{listMetadata}
 					</StackHorizontal>
 				)}
-				{actions &&
+				{action &&
 					!disabled &&
 					actions.map(
-						(action, index) =>
-							action && (
+						(actionItem, index) =>
+							actionItem && (
 								<ButtonIcon
 									key={`action-${index}`}
 									size={buttonIconSize}
-									icon={action.icon}
-									onClick={action.callback}
+									icon={actionItem.icon}
+									onClick={actionItem.callback}
 									data-test={`action.button.${index}`}
 									data-testid={`action.button.${index}`}
 								>
-									{action.tooltip}
+									{actionItem.tooltip}
 								</ButtonIcon>
 							),
 					)}
 			</>
 		);
 
-		if (actions) {
+		if (action) {
 			return (
 				<div
 					className={classnames(styles.headerWrapper, {

--- a/packages/design-system/src/stories/navigation/Accordion.mdx
+++ b/packages/design-system/src/stories/navigation/Accordion.mdx
@@ -36,9 +36,9 @@ Use the prop `size` to change the height, font size and icon size of the panel h
 
 <Canvas of={Stories.SmallPanel} />
 
-**With action**
+**With actions**
 
-The prop `action` takes an object with 3 attributes :
+The prop `action` takes an object or an array of objects with 3 attributes :
 
 - <b>icon</b>: a string containing a talend icon id
 - <b>title</b>: the content of the tooltip displayed on mouseOver

--- a/packages/design-system/src/stories/navigation/Accordion.mdx
+++ b/packages/design-system/src/stories/navigation/Accordion.mdx
@@ -44,7 +44,7 @@ The prop `action` takes an object with 3 attributes :
 - <b>title</b>: the content of the tooltip displayed on mouseOver
 - <b>callback</b>: a function called when the action is triggered
 
-<Canvas of={Stories.WithAction} />
+<Canvas of={Stories.WithActions} />
 
 **With metadata**
 

--- a/packages/design-system/src/stories/navigation/Accordion.stories.tsx
+++ b/packages/design-system/src/stories/navigation/Accordion.stories.tsx
@@ -78,11 +78,13 @@ export const DisabledPanel = {
 				{...props}
 				id="disabled-panel"
 				title="disabled panel"
-				action={{
-					icon: 'plus',
-					tooltip: 'action tooltip',
-					callback: () => window.alert('action callback'),
-				}}
+				actions={[
+					{
+						icon: 'plus',
+						tooltip: 'action tooltip',
+						callback: () => window.alert('action callback'),
+					},
+				]}
 				disabled
 			>
 				<SampleParagraph />
@@ -111,11 +113,13 @@ export const WithMetadata = () => (
 			<CollapsiblePanel
 				title="Simple panel with several metadata and action"
 				metadata={['Duration : 3sec', <TagSuccess key="successTag">Success</TagSuccess>]}
-				action={{
-					icon: 'plus',
-					tooltip: 'action tooltip',
-					callback: () => window.alert('action callback'),
-				}}
+				actions={[
+					{
+						icon: 'plus',
+						tooltip: 'action tooltip',
+						callback: () => window.alert('action callback'),
+					},
+				]}
 			>
 				<SampleParagraph />
 			</CollapsiblePanel>
@@ -126,20 +130,27 @@ export const WithMetadata = () => (
 	</div>
 );
 
-export const WithAction = {
+export const WithActions = {
 	render: (props: Story) => (
 		<div
 			style={{ maxWidth: '50rem', marginLeft: 'auto', marginRight: 'auto', padding: '1.875rem' }}
 		>
 			<CollapsiblePanel
 				{...props}
-				id="panel-with-action"
-				title="panel with action"
-				action={{
-					icon: 'plus',
-					tooltip: 'action tooltip',
-					callback: () => window.alert('action callback'),
-				}}
+				id="panel-with-actions"
+				title="panel with actions"
+				actions={[
+					{
+						icon: 'talend-cog',
+						tooltip: 'action tooltip',
+						callback: () => window.alert('action callback'),
+					},
+					{
+						icon: 'plus',
+						tooltip: 'action tooltip',
+						callback: () => window.alert('action callback'),
+					},
+				]}
 			>
 				<SampleParagraph />
 			</CollapsiblePanel>

--- a/packages/design-system/src/stories/navigation/Accordion.stories.tsx
+++ b/packages/design-system/src/stories/navigation/Accordion.stories.tsx
@@ -78,13 +78,11 @@ export const DisabledPanel = {
 				{...props}
 				id="disabled-panel"
 				title="disabled panel"
-				actions={[
-					{
-						icon: 'plus',
-						tooltip: 'action tooltip',
-						callback: () => window.alert('action callback'),
-					},
-				]}
+				action={{
+					icon: 'plus',
+					tooltip: 'action tooltip',
+					callback: () => window.alert('action callback'),
+				}}
 				disabled
 			>
 				<SampleParagraph />
@@ -113,13 +111,11 @@ export const WithMetadata = () => (
 			<CollapsiblePanel
 				title="Simple panel with several metadata and action"
 				metadata={['Duration : 3sec', <TagSuccess key="successTag">Success</TagSuccess>]}
-				actions={[
-					{
-						icon: 'plus',
-						tooltip: 'action tooltip',
-						callback: () => window.alert('action callback'),
-					},
-				]}
+				action={{
+					icon: 'plus',
+					tooltip: 'action tooltip',
+					callback: () => window.alert('action callback'),
+				}}
 			>
 				<SampleParagraph />
 			</CollapsiblePanel>
@@ -139,7 +135,7 @@ export const WithActions = {
 				{...props}
 				id="panel-with-actions"
 				title="panel with actions"
-				actions={[
+				action={[
 					{
 						icon: 'talend-cog',
 						tooltip: 'action tooltip',

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -117,7 +117,7 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 					index={index}
 					managed={!!managed}
 					expanded={!value.isClosed}
-					actions={[getAction()]}
+					action={getAction()}
 				>
 					{schema.description ? (
 						<InlineMessageInformation

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -117,7 +117,7 @@ export default function createCollapsibleFieldset(title = defaultTitle) {
 					index={index}
 					managed={!!managed}
 					expanded={!value.isClosed}
-					action={getAction()}
+					actions={[getAction()]}
 				>
 					{schema.description ? (
 						<InlineMessageInformation


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
This PR updates `CollapsiblePanel` to support multiple actions passed as prop instead of just one.
For more info: https://jira.talendforge.org/browse/TUX-1228

**What is the chosen solution to this problem?**
Update the component props and their type.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
