### PR TITLE
fix(TUX-1228): allow more props to be passed to each CollapsiblePanel action

### DIFF
--- a/.changeset/quick-jeans-allow.md
+++ b/.changeset/quick-jeans-allow.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix(TUX-1228): allow more props to be passed to each CollapsiblePanel action

--- a/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
+++ b/packages/design-system/src/components/Accordion/Primitive/CollapsiblePanelHeader.tsx
@@ -119,10 +119,11 @@ const CollapsiblePanelHeader = forwardRef(
 								<ButtonIcon
 									key={`action-${index}`}
 									size={buttonIconSize}
-									icon={actionItem.icon}
 									onClick={actionItem.callback}
 									data-test={`action.button.${index}`}
 									data-testid={`action.button.${index}`}
+									data-feature={actionItem.dataFeature}
+									{...actionItem}
 								>
 									{actionItem.tooltip}
 								</ButtonIcon>

--- a/packages/design-system/src/components/Accordion/Primitive/types.ts
+++ b/packages/design-system/src/components/Accordion/Primitive/types.ts
@@ -1,7 +1,7 @@
-export type PanelHeaderAction = {
+import { ButtonIconType } from 'src/components/ButtonIcon/variations/ButtonIcon';
+
+export type PanelHeaderAction = ButtonIconType<any> & {
 	icon: string;
 	tooltip: string;
 	callback: () => unknown;
-	id?: string;
-	dataFeature?: string;
 };

--- a/packages/design-system/src/components/Accordion/Primitive/types.ts
+++ b/packages/design-system/src/components/Accordion/Primitive/types.ts
@@ -2,4 +2,6 @@ export type PanelHeaderAction = {
 	icon: string;
 	tooltip: string;
 	callback: () => unknown;
+	id?: string;
+	dataFeature?: string;
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Actions passed to `CollapsiblePanel` which are used in the header, have very limitative props (`callback`, `icon`, `tooltip`) making it impossible to pass props like `id`, `data-feature` and so on.

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
