### PR TITLE
fix(jest-config): avoid warning spam when mocking missing lib for jest

### DIFF
--- a/.changeset/wet-flowers-beg.md
+++ b/.changeset/wet-flowers-beg.md
@@ -1,0 +1,5 @@
+---
+"@talend/scripts-config-jest": patch
+---
+
+Avoid warning spam in case of mocking missing library for jest

--- a/tools/scripts-config-jest/test-setup.js
+++ b/tools/scripts-config-jest/test-setup.js
@@ -12,35 +12,14 @@ require('core-js/stable');
 require('regenerator-runtime/runtime');
 require('raf/polyfill');
 
-const warnMessageOptionalDep = (mainDepToMock, depList = []) => {
-	if (depList.length === 0) {
-		console.warn(
-			`JEST MOCK WARN: ${mainDepToMock} is not resolved.` +
-				'\nThis is an optional dependency.' +
-				'\nPlease add it in your dependencies if you need it',
-		);
-	} else if (depList.length > 0) {
-		console.warn(
-			`JEST MOCK WARN: one or more of those deps are not resolved: ${depList.join(', ')}` +
-				'These are optional dependencies but work together.' +
-				`\nIt's needed to mock ${mainDepToMock}` +
-				'\nPlease add them in your dependencies if you need them',
-		);
-	}
-};
-
 try {
 	const jestAxe = require('jest-axe');
 	expect.extend(jestAxe.toHaveNoViolations);
-} catch (e) {
-	warnMessageOptionalDep('jest-axe');
-}
+} catch (e) {}
 
 try {
 	jest.mock('ally.js');
-} catch (e) {
-	warnMessageOptionalDep('ally.js');
-}
+} catch (e) {}
 
 // add missing ResizeObserver
 class ResizeObserver {
@@ -147,9 +126,7 @@ try {
 		i18nextMock.addResources = () => {};
 		return i18nextMock;
 	});
-} catch (e) {
-	warnMessageOptionalDep('i18next');
-}
+} catch (e) {}
 
 try {
 	jest.mock('react-i18next', () => {
@@ -201,9 +178,7 @@ try {
 				Array.isArray(children) ? renderNodes(children) : renderNodes([children]),
 		};
 	});
-} catch (e) {
-	warnMessageOptionalDep('react-i18next', ['react-i18next', 'i18next', 'react']);
-}
+} catch (e) {}
 
 try {
 	jest.mock('@talend/design-system', () => {
@@ -260,14 +235,7 @@ try {
 
 		return mocks;
 	});
-} catch {
-	warnMessageOptionalDep('@talend/design-system', [
-		'@talend/design-system',
-		'react',
-		'prop-types',
-		'classnames',
-	]);
-}
+} catch {}
 
 // @floating-ui/react
 // https://github.com/floating-ui/floating-ui/issues/1908


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Avoid warning spam when mocking missing lib for jest

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
