### PR TITLE
fix: fix small styling issues on Drawer and UI-Form TextModeArrayTemplate

### DIFF
--- a/.changeset/lucky-spiders-fix.md
+++ b/.changeset/lucky-spiders-fix.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-forms": patch
+---
+
+Fix UI-Form display on TextModeArrayTemplate to have some spacing between templates

--- a/.changeset/wet-badgers-turn.md
+++ b/.changeset/wet-badgers-turn.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+Fix Drawer z-index that could prevent headerbar to display sub-menu

--- a/packages/components/src/Drawer/Drawer.module.scss
+++ b/packages/components/src/Drawer/Drawer.module.scss
@@ -8,7 +8,6 @@ $tc-drawer-header-background: tokens.$coral-color-neutral-background !default;
 $tc-drawer-header-border: tokens.$coral-border-s-solid tokens.$coral-color-neutral-border-weak !default;
 $tc-drawer-tabs-background: tokens.$coral-color-accent-background-weak !default;
 $tc-action-bar-background-color: tokens.$coral-color-neutral-background-medium !default;
-$tc-drawer-z-index: tokens.$coral-elevation-layer-standard-front !default;
 
 .tc-drawer {
 	pointer-events: all;
@@ -19,7 +18,6 @@ $tc-drawer-z-index: tokens.$coral-elevation-layer-standard-front !default;
 	right: 0;
 	bottom: 0;
 	width: tokens.$coral-sizing-maximal;
-	z-index: $tc-drawer-z-index;
 }
 
 @media (min-width: 992px) and (max-width: 1199px) {

--- a/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.module.scss
+++ b/packages/forms/src/UIForm/fieldsets/Array/displayMode/TextModeArrayTemplate.module.scss
@@ -1,5 +1,10 @@
+@use '~@talend/design-tokens/lib/tokens';
+
 .tf-array-text-mode {
 	ol {
 		list-style: none;
+		display: flex;
+		flex-direction: column;
+		gap: tokens.$coral-spacing-xxs;
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix small styling issues 
- components Drawer z-index overlapping with headerbar
- add gap to TextModeArrayTemplate from UI-Form

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
