### PR TITLE
fix(DFD-914): Fix flashing tooltip on some gesture

### DIFF
--- a/.changeset/wicked-balloons-sell.md
+++ b/.changeset/wicked-balloons-sell.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+fix(DFD-914): Fix flashing tooltip on some gesture

--- a/packages/design-system/src/components/Tooltip/Tooltip.tsx
+++ b/packages/design-system/src/components/Tooltip/Tooltip.tsx
@@ -1,21 +1,22 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useState, useRef } from 'react';
-import type { MutableRefObject, RefCallback, ReactElement, ReactNode } from 'react';
+import { useRef, useState } from 'react';
+import type { MutableRefObject, ReactElement, ReactNode, RefCallback } from 'react';
 
 import {
 	arrow,
-	FloatingArrow,
-	FloatingPortal,
-	useFloating,
-	useHover,
-	useFocus,
-	useDismiss,
-	useRole,
-	useInteractions,
 	autoUpdate,
 	flip,
+	FloatingArrow,
+	FloatingPortal,
 	offset,
+	safePolygon,
 	shift,
+	useDismiss,
+	useFloating,
+	useFocus,
+	useHover,
+	useInteractions,
+	useRole,
 } from '@floating-ui/react';
 
 import { ChildOrGenerator, renderOrClone } from '../../renderOrClone';
@@ -79,7 +80,7 @@ export const Tooltip = ({ id, children, title, placement = 'top', ...rest }: Too
 		],
 		whileElementsMounted: autoUpdate,
 	});
-	const hover = useHover(floating.context, { move: false });
+	const hover = useHover(floating.context, { move: false, handleClose: safePolygon() });
 	const focus = useFocus(floating.context);
 	const dismiss = useDismiss(floating.context);
 	const role = useRole(floating.context, { role: 'tooltip' });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Flashing tooltip on some approach gestures
https://jira.talendforge.org/browse/DFD-914

**What is the chosen solution to this problem?**
See internal floating portal issue: 
https://github.com/floating-ui/floating-ui/issues/2435

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
