### PR TITLE
chore(): status comp - add date-test attr

### DIFF
--- a/.changeset/two-dolls-obey.md
+++ b/.changeset/two-dolls-obey.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Status : add data-test\* attributes

--- a/packages/design-system/src/components/Status/Primitive/StatusPrimitive.test.tsx
+++ b/packages/design-system/src/components/Status/Primitive/StatusPrimitive.test.tsx
@@ -1,0 +1,18 @@
+/* eslint-disable import/no-extraneous-dependencies */
+import { describe, expect, it } from '@jest/globals';
+import { render, screen } from '@testing-library/react';
+
+import Status from './StatusPrimitive';
+
+describe('Status', () => {
+	it('Should render', async () => {
+		render(
+			<Status data-testid="my-status-component" variant="successful">
+				This is my status
+			</Status>,
+		);
+
+		expect(screen.getByTestId('my-status-component')).toBeInTheDocument();
+		expect(screen.getByText('This is my status')).toBeInTheDocument();
+	});
+});

--- a/packages/design-system/src/components/Status/Primitive/StatusPrimitive.tsx
+++ b/packages/design-system/src/components/Status/Primitive/StatusPrimitive.tsx
@@ -1,16 +1,19 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
+
 import classnames from 'classnames';
+
 // eslint-disable-next-line @talend/import-depth
 import { IconNameWithSize } from '@talend/icons/dist/typeUtils';
 
-import { Tooltip, TooltipChildrenFnProps, TooltipChildrenFnRef } from '../../Tooltip';
-import { Loading } from '../../Loading';
+import { mergeRefs } from '../../../mergeRef';
+import { DataAttributes } from '../../../types';
 import { SizedIcon } from '../../Icon';
+import { Loading } from '../../Loading';
 import { StackHorizontal } from '../../Stack';
+import { Tooltip, TooltipChildrenFnProps, TooltipChildrenFnRef } from '../../Tooltip';
 
 import styles from './Status.module.scss';
-import { mergeRefs } from '../../../mergeRef';
 
 export const variants = {
 	successful: 'successful',
@@ -26,7 +29,7 @@ export type StatusProps = {
 	hideText?: boolean;
 	children?: string;
 	variant: keyof typeof variants;
-};
+} & DataAttributes;
 
 const Status = forwardRef(
 	(

--- a/packages/design-system/src/components/Status/variations/StatusCanceled.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusCanceled.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusCanceledProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;

--- a/packages/design-system/src/components/Status/variations/StatusFailed.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusFailed.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusFailedProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;

--- a/packages/design-system/src/components/Status/variations/StatusInProgress.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusInProgress.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusInProgressProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;

--- a/packages/design-system/src/components/Status/variations/StatusSuccessful.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusSuccessful.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusSuccessfulProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;

--- a/packages/design-system/src/components/Status/variations/StatusWarning.tsx
+++ b/packages/design-system/src/components/Status/variations/StatusWarning.tsx
@@ -1,6 +1,7 @@
 import { forwardRef } from 'react';
 import type { Ref } from 'react';
 import { useTranslation } from 'react-i18next';
+
 import StatusPrimitive, { StatusProps } from '../Primitive/StatusPrimitive';
 
 export type StatusWarningProps = Omit<StatusProps, 'icon' | 'variant' | 'inProgress'>;

--- a/packages/design-system/src/stories/feedback/Status.stories.tsx
+++ b/packages/design-system/src/stories/feedback/Status.stories.tsx
@@ -1,10 +1,10 @@
 import {
-	StatusFailed,
+	Status,
 	StatusCanceled,
+	StatusFailed,
 	StatusInProgress,
 	StatusSuccessful,
 	StatusWarning,
-	Status,
 } from '../../';
 import { variants } from '../../components/Status/Primitive/StatusPrimitive';
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
No data-test* attributes allowed on Status components.

**What is the chosen solution to this problem?**
Add them in available props and pass it to components.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
