### PR TITLE
feat(eslint): warning on bootstrap class

### DIFF
--- a/.changeset/metal-horses-attend.md
+++ b/.changeset/metal-horses-attend.md
@@ -1,0 +1,6 @@
+---
+"@talend/eslint-plugin": minor
+"@talend/eslint-config": minor
+---
+
+feat: add warning on bootstrap class

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -190,7 +190,6 @@ export function ActionBar(props) {
 		css['tc-actionbar-container'],
 		'tc-actionbar-container',
 		'nav',
-		'foo',
 		props.className,
 	);
 

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -1,10 +1,13 @@
-import PropTypes from 'prop-types';
 import { createElement } from 'react';
-import classNames from 'classnames';
 import { useTranslation } from 'react-i18next';
-import { Action, Actions, ActionDropdown, ActionSplitDropdown } from '../Actions';
-import Inject from '../Inject';
+
+import classNames from 'classnames';
+import PropTypes from 'prop-types';
+
+import { Action, ActionDropdown, Actions, ActionSplitDropdown } from '../Actions';
 import I18N_DOMAIN_COMPONENTS from '../constants';
+import Inject from '../Inject';
+
 import css from './ActionBar.module.scss';
 
 const DISPLAY_MODES = {
@@ -187,6 +190,7 @@ export function ActionBar(props) {
 		css['tc-actionbar-container'],
 		'tc-actionbar-container',
 		'nav',
+		'foo',
 		props.className,
 	);
 

--- a/packages/components/src/ActionBar/ActionBar.component.js
+++ b/packages/components/src/ActionBar/ActionBar.component.js
@@ -1,13 +1,10 @@
-import { createElement } from 'react';
-import { useTranslation } from 'react-i18next';
-
-import classNames from 'classnames';
 import PropTypes from 'prop-types';
-
-import { Action, ActionDropdown, Actions, ActionSplitDropdown } from '../Actions';
-import I18N_DOMAIN_COMPONENTS from '../constants';
+import { createElement } from 'react';
+import classNames from 'classnames';
+import { useTranslation } from 'react-i18next';
+import { Action, Actions, ActionDropdown, ActionSplitDropdown } from '../Actions';
 import Inject from '../Inject';
-
+import I18N_DOMAIN_COMPONENTS from '../constants';
 import css from './ActionBar.module.scss';
 
 const DISPLAY_MODES = {

--- a/tools/eslint-plugin/src/rules/use-bootstrap-class.js
+++ b/tools/eslint-plugin/src/rules/use-bootstrap-class.js
@@ -1,0 +1,133 @@
+// https://getbootstrap.com/docs/3.3/css/
+const BOOTSTRAP_CLASS = [
+	// status
+	'disabled',
+	'active',
+	'success',
+	'warning',
+	'danger',
+	'info',
+	'blockquote-reverse',
+	// background
+	'bg-primary',
+	'bg-success',
+	'bg-info',
+	'bg-warning',
+	'bg-danger',
+	// btn
+	'btn',
+	'btn-primary',
+	'btn-default',
+	'btn-success',
+	'btn-info',
+	'btn-warning',
+	'btn-danger',
+	'btn-link',
+	'btn-lg',
+	'btn-sm',
+	'btn-xs',
+	'btn-block',
+
+	'caret',
+	'pull-left',
+	'pull-right',
+	'clearfix',
+	'show',
+	'hide',
+	'sr-only',
+
+	// grid
+	'container',
+	'row',
+
+	// forms
+	'checkbox',
+	'control-label',
+	'form-inline',
+	'form-group',
+	'form-control',
+	'help-block',
+	'input-group',
+	'input-group-addon',
+
+	//navbar
+	'nav',
+	'navbar-left',
+	'navbar-right',
+	'navbar-text',
+	'navbar-btn',
+	'navbar-form',
+	'navbar-link',
+
+	//list
+	'list-unstyled',
+	'list-inline',
+	'dl-horizontal',
+
+	//table
+	'table',
+	'table-condensed',
+	'table-hover',
+	'table-striped',
+	//text
+	'text-muted',
+	'text-primary',
+	'text-sucess',
+	'text-info',
+	'text-warning',
+	'text-danger',
+	'text-hide',
+
+	//responsive
+	'hidden-xs',
+	'hidden-sm',
+	'hidden-md',
+	'hidden-lg',
+];
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Check if any bootstrap class is used inside a className call',
+			category: 'Build',
+			recommended: false,
+		},
+		fixable: null,
+		schema: {},
+		messages: {
+			useBootstrapClass: "'{{className}}' should not be used",
+		},
+	},
+
+	create: function create(context) {
+		let classNameName;
+		return {
+			ImportDeclaration: function (node) {
+				if (node.source.value === 'classnames') {
+					const spec = node.specifiers.find(s => s.type === 'ImportDefaultSpecifier');
+					if (spec) {
+						classNameName = spec.local.name;
+					}
+				}
+			},
+			CallExpression: function (node) {
+				if (!classNameName) {
+					return;
+				}
+				if (node.callee?.name === classNameName) {
+					node.arguments.forEach(value => {
+						if (value.value && typeof value.value === 'string') {
+							const values = value.value.split(' ');
+							if (values.some(v => BOOTSTRAP_CLASS.includes(v))) {
+								context.report({
+									node: value,
+									message: 'bootstrap 3 class are deprecated',
+								});
+							}
+						}
+					});
+				}
+			},
+		};
+	},
+};

--- a/tools/eslint-plugin/src/rules/use-bootstrap-class.js
+++ b/tools/eslint-plugin/src/rules/use-bootstrap-class.js
@@ -85,6 +85,8 @@ const BOOTSTRAP_CLASS = [
 	'hidden-lg',
 ];
 
+const message = 'bootstrap 3 class are deprecated';
+
 module.exports = {
 	meta: {
 		docs: {
@@ -116,16 +118,36 @@ module.exports = {
 				}
 				if (node.callee?.name === classNameName) {
 					node.arguments.forEach(value => {
-						if (value.value && typeof value.value === 'string') {
+						if (value.type === 'Literal') {
 							const values = value.value.split(' ');
 							if (values.some(v => BOOTSTRAP_CLASS.includes(v))) {
 								context.report({
 									node: value,
-									message: 'bootstrap 3 class are deprecated',
+									message,
 								});
 							}
+						} else if (value.type === 'ObjectExpression') {
+							value.properties.forEach(props => {
+								if (BOOTSTRAP_CLASS.includes(props.key?.value)) {
+									context.report({
+										node: props.key,
+										message,
+									});
+								}
+							});
 						}
 					});
+				}
+			},
+			JSXAttribute: function (node) {
+				if (node.value?.type === 'Literal') {
+					const values = node.value.value.split(' ');
+					if (values.some(v => BOOTSTRAP_CLASS.includes(v))) {
+						context.report({
+							node,
+							message,
+						});
+					}
 				}
 			},
 		};

--- a/tools/eslint-plugin/tests/src/rules/use-bootstrap-class.test.js
+++ b/tools/eslint-plugin/tests/src/rules/use-bootstrap-class.test.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview Check if the import of d3 is not on d3-*
+ * @author Jean-Michel FRANCOIS
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require('../../../src/rules/use-bootstrap-class');
+const RuleTester = require('eslint').RuleTester;
+const parser = require.resolve('@babel/eslint-parser');
+const parserOptions = {
+	babelOptions: {
+		configFile: require.resolve('@talend/scripts-config-babel'),
+	},
+};
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe('test', () => {});
+const ruleTester = new RuleTester();
+ruleTester.run('talend-use-bootstrap-class', rule, {
+	valid: [
+		{
+			code: `import classnames from 'classnames';
+			classnames('foo', { 'bar': true })`,
+			parser,
+			parserOptions,
+		},
+	],
+
+	invalid: [
+		{
+			code: `import classnames from 'classnames';
+			classnames('foo', 'btn')`,
+			parser,
+			parserOptions,
+			errors: [
+				{
+					message: 'bootstrap 3 class are deprecated',
+				},
+			],
+		},
+		{
+			code: `import classnames from 'classnames';
+			classnames('nav', {})`,
+			parser,
+			parserOptions,
+			errors: [
+				{
+					message: 'bootstrap 3 class are deprecated',
+				},
+			],
+		},
+	],
+});

--- a/tools/eslint-plugin/tests/src/rules/use-bootstrap-class.test.js
+++ b/tools/eslint-plugin/tests/src/rules/use-bootstrap-class.test.js
@@ -46,7 +46,17 @@ ruleTester.run('talend-use-bootstrap-class', rule, {
 		},
 		{
 			code: `import classnames from 'classnames';
-			classnames('nav', {})`,
+			classnames('foo', { 'btn-default': true })`,
+			parser,
+			parserOptions,
+			errors: [
+				{
+					message: 'bootstrap 3 class are deprecated',
+				},
+			],
+		},
+		{
+			code: `<button className="btn-default foo">foo</button>`,
 			parser,
 			parserOptions,
 			errors: [

--- a/tools/scripts-config-eslint/.eslintrc.json
+++ b/tools/scripts-config-eslint/.eslintrc.json
@@ -35,6 +35,7 @@
   ],
   "rules": {
     "@talend/import-depth": 2,
+    "@talend/use-bootstrap-class": 1,
     "arrow-parens": [2, "as-needed"],
     "comma-dangle": ["error", "only-multiline"],
     "function-paren-newline": 0,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

We want to remove bootstrap form our codebase.
We identify usage by hand so we may miss usages.

**What is the chosen solution to this problem?**

Start by adding eslint rule to track classnames call with bootstrap in arguments

![Screenshot 2024-04-04 at 11 06 02](https://github.com/Talend/ui/assets/19857479/35b42dff-8468-4fc4-9b39-bae9997aee9f)
![Screenshot 2024-04-04 at 11 14 39](https://github.com/Talend/ui/assets/19857479/9952d81c-19d4-4bd6-940c-cc3bdced48d9)
![Screenshot 2024-04-04 at 11 14 48](https://github.com/Talend/ui/assets/19857479/77d48031-1233-43ce-b683-afe61da6e03e)


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
