### PR TITLE
fix: Dropdown link item to accept "as" property using RouterLink

### DIFF
--- a/.changeset/thin-apes-tie.md
+++ b/.changeset/thin-apes-tie.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Fix Design System dropdown items when using "as" property for links

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -1,8 +1,11 @@
-import { describe, it, expect } from '@jest/globals';
-import { axe } from 'jest-axe';
+import { BrowserRouter, Link as RouterLink } from 'react-router-dom';
+
+import { describe, expect, it } from '@jest/globals';
 import { render } from '@testing-library/react';
-import { Dropdown } from './';
+import { axe } from 'jest-axe';
+
 import { ButtonTertiary } from '../Button';
+import { Dropdown } from './';
 
 jest.mock('@talend/utils', () => {
 	let i = 0;
@@ -15,39 +18,46 @@ jest.mock('@talend/utils', () => {
 describe('Dropdown', () => {
 	it('should render a11y html', async () => {
 		const { container } = render(
-			<main>
-				<Dropdown
-					aria-label="Custom menu"
-					items={[
-						{
-							label: 'External link',
-							href: 'https://community.talend.com/s/?language=en_US',
-							target: '_blank',
-							type: 'link',
-						},
-						{
-							type: 'divider',
-						},
-						{
-							label: 'Link',
-							href: '/download',
-							type: 'link',
-						},
-						{
-							type: 'divider',
-						},
-						{
-							label: 'Button',
-							onClick: jest.fn(),
-							type: 'button',
-						},
-					]}
-				>
-					<ButtonTertiary isDropdown onClick={() => {}}>
-						Dropdown
-					</ButtonTertiary>
-				</Dropdown>
-			</main>,
+			<BrowserRouter>
+				<main>
+					<Dropdown
+						aria-label="Custom menu"
+						items={[
+							{
+								label: 'External link',
+								href: 'https://community.talend.com/s/?language=en_US',
+								target: '_blank',
+								type: 'link',
+							},
+							{
+								type: 'divider',
+							},
+							{
+								label: 'Link',
+								href: '/download',
+								type: 'link',
+							},
+							{
+								type: 'divider',
+							},
+							{
+								label: 'Button',
+								onClick: jest.fn(),
+								type: 'button',
+							},
+							{
+								label: 'Link as',
+								type: 'link',
+								as: <RouterLink to="/route" />,
+							},
+						]}
+					>
+						<ButtonTertiary isDropdown onClick={() => {}}>
+							Dropdown
+						</ButtonTertiary>
+					</Dropdown>
+				</main>
+			</BrowserRouter>,
 		);
 		expect(container.firstChild).toMatchSnapshot();
 		const results = await axe(document.body);

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -31,7 +31,6 @@ type DropdownButtonType = Omit<ClickableProps, 'children'> & {
 type DropdownLinkType = Omit<LinkableType, 'children'> & {
 	label: string;
 	type: 'link';
-	as: ReactElement;
 } & DataAttributes;
 
 type DropdownLabelType = {

--- a/packages/design-system/src/components/Dropdown/Primitive/DropdownLink.tsx
+++ b/packages/design-system/src/components/Dropdown/Primitive/DropdownLink.tsx
@@ -1,4 +1,5 @@
 import { forwardRef, ReactElement, Ref } from 'react';
+
 import { Linkable, LinkableType } from '../../Linkable';
 
 import styles from './DropdownEntry.module.scss';
@@ -9,7 +10,7 @@ export type DropdownLinkType = LinkableType;
 // Since MenuItem and Linkable both have an `as` prop, this enables passing `as` to Linkable.
 const LocalLink = forwardRef(
 	(
-		localProps: DropdownLinkType & { asPassThrough?: ReactElement },
+		localProps: DropdownLinkType & { asPassThrough?: 'a' | ReactElement },
 		ref: Ref<HTMLAnchorElement>,
 	) => {
 		const { asPassThrough, ...rest } = localProps;
@@ -21,7 +22,7 @@ LocalLink.displayName = 'LocalLink';
 const DropdownLink = forwardRef(
 	({ children, as, ...props }: DropdownLinkType, ref: Ref<HTMLAnchorElement>) => {
 		return (
-			<LocalLink {...props} ref={ref}>
+			<LocalLink {...props} asPassThrough={as} ref={ref}>
 				{children}
 			</LocalLink>
 		);

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -52,7 +52,7 @@ exports[`Dropdown should render a11y html 1`] = `
           data-test="dropdown.menuitem.External link-0"
           data-testid="dropdown.menuitem.External link-0"
           href="https://community.talend.com/s/?language=en_US"
-          id="mocked-uuid-5"
+          id="mocked-uuid-6"
           rel="noreferrer noopener"
           target="_blank"
         >
@@ -85,7 +85,7 @@ exports[`Dropdown should render a11y html 1`] = `
           data-test="dropdown.menuitem.Link-2"
           data-testid="dropdown.menuitem.Link-2"
           href="/download"
-          id="mocked-uuid-7"
+          id="mocked-uuid-8"
         >
           Link
         </a>
@@ -99,7 +99,7 @@ exports[`Dropdown should render a11y html 1`] = `
           class="theme-clickable"
           data-test="dropdown.menuitem.Button-4"
           data-testid="dropdown.menuitem.Button-4"
-          id="mocked-uuid-9"
+          id="mocked-uuid-10"
           role="menuitem"
           tabindex="0"
           type="button"
@@ -114,6 +114,15 @@ exports[`Dropdown should render a11y html 1`] = `
             </span>
           </div>
         </button>
+        <a
+          class="theme-linkable theme-dropdownEntry"
+          data-test="dropdown.menuitem.Link as-5"
+          data-testid="dropdown.menuitem.Link as-5"
+          href="/route"
+          id="mocked-uuid-11"
+        >
+          Link as
+        </a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dropdown link item to accept "as" property using RouterLink

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
