### PR TITLE
fix(TMC-27845): add missing changeset for script-config-jest

### DIFF
--- a/.changeset/neat-games-juggle.md
+++ b/.changeset/neat-games-juggle.md
@@ -2,4 +2,4 @@
 "@talend/scripts-config-jest": patch
 ---
 
-Manage issue: 'Reference error: _ is not defined'
+fix: 'Reference error: _ is not defined'

--- a/.changeset/neat-games-juggle.md
+++ b/.changeset/neat-games-juggle.md
@@ -1,0 +1,5 @@
+---
+"@talend/scripts-config-jest": patch
+---
+
+Manage issue: 'Reference error: _ is not defined'


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
a change has been done in script-config-jest on this PR without a correct changeset: https://github.com/Talend/ui/pull/5272/files#diff-8410d00747d7736cab28dfc962dc3dc3b982118a5b57ef81da9a91be5dd88633

this PR will add it
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
