### PR TITLE
fix(DS): Allow DS dropdown to have custom data-test attributes

### DIFF
--- a/.changeset/fifty-fishes-shake.md
+++ b/.changeset/fifty-fishes-shake.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Allow Design System dropdown to have custom data-test attributes

--- a/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.test.tsx
@@ -48,6 +48,8 @@ describe('Dropdown', () => {
 							{
 								label: 'Link as',
 								type: 'link',
+								'data-testid': 'link-as',
+								'data-test': 'link-as',
 								as: <RouterLink to="/route" />,
 							},
 						]}

--- a/packages/design-system/src/components/Dropdown/Dropdown.tsx
+++ b/packages/design-system/src/components/Dropdown/Dropdown.tsx
@@ -114,6 +114,8 @@ export const Dropdown = ({
 						const id = `${label}-${index}`;
 						return (
 							<DropdownButton
+								data-testid={`${menuItemTestId}.${id}`}
+								data-test={`${menuItemTest}.${id}`}
 								{...entryRest}
 								// {...menu}
 								onClick={(event: MouseEvent<HTMLButtonElement> | KeyboardEvent) => {
@@ -123,8 +125,6 @@ export const Dropdown = ({
 								key={uuid}
 								tabIndex={0}
 								id={uuid}
-								data-testid={`${menuItemTestId}.${id}`}
-								data-test={`${menuItemTest}.${id}`}
 							>
 								{label}
 							</DropdownButton>
@@ -161,6 +161,8 @@ export const Dropdown = ({
 					const id = `${label}-${index}`;
 					return (
 						<DropdownLink
+							data-testid={`${menuItemTestId}.${id}`}
+							data-test={`${menuItemTest}.${id}`}
 							as={as}
 							{...entryRest}
 							// {...menu}
@@ -172,8 +174,6 @@ export const Dropdown = ({
 									entry.onClick(event);
 								}
 							}}
-							data-testid={`${menuItemTestId}.${id}`}
-							data-test={`${menuItemTest}.${id}`}
 						>
 							{label}
 						</DropdownLink>

--- a/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/design-system/src/components/Dropdown/__snapshots__/Dropdown.test.tsx.snap
@@ -116,8 +116,8 @@ exports[`Dropdown should render a11y html 1`] = `
         </button>
         <a
           class="theme-linkable theme-dropdownEntry"
-          data-test="dropdown.menuitem.Link as-5"
-          data-testid="dropdown.menuitem.Link as-5"
+          data-test="link-as"
+          data-testid="link-as"
           href="/route"
           id="mocked-uuid-11"
         >

--- a/packages/design-system/src/stories/clickable/Dropdown.stories.tsx
+++ b/packages/design-system/src/stories/clickable/Dropdown.stories.tsx
@@ -1,6 +1,8 @@
-import { Story } from '@storybook/react';
-import { action } from '@storybook/addon-actions';
 import { BrowserRouter, Link as RouterLink } from 'react-router-dom';
+
+import { action } from '@storybook/addon-actions';
+import { Story } from '@storybook/react';
+
 import { ButtonIcon, ButtonPrimary, ButtonSecondary, ButtonTertiary, Dropdown } from '../../';
 
 export default {
@@ -246,6 +248,8 @@ export const Basic = () => (
 						label: 'Router link with too much copy to create an overflow',
 						type: 'link',
 						icon: 'plus-stroke',
+						'data-testid': 'link-as',
+						'data-test': 'link-as',
 						as: <RouterLink to="/documentation" />,
 					},
 					{


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow DS dropdown to have custom data-test attributes

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
