### PR TITLE
Fix(TDS-7331/forms): Select field being re-created instead of updated

### DIFF
--- a/.changeset/fast-eels-sell.md
+++ b/.changeset/fast-eels-sell.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Fix issue with Select component being recreated instead of updated

--- a/packages/design-system/src/components/Form/Field/Select/Select.tsx
+++ b/packages/design-system/src/components/Form/Field/Select/Select.tsx
@@ -1,17 +1,24 @@
-import { forwardRef, Children } from 'react';
+import { Children, forwardRef } from 'react';
 import type { Ref } from 'react';
 import { isElement } from 'react-is';
-import Input from '../Input';
+
+import { useId } from '../../../../useId';
 import {
 	FieldPrimitive,
 	FieldPropsPrimitive,
 	SelectPrimitive,
 	SelectPrimitiveProps,
 } from '../../Primitives';
-import { useId } from '../../../../useId';
+import Input from '../Input';
 
 export type SelectProps = FieldPropsPrimitive &
 	Omit<SelectPrimitiveProps, 'className' | 'style' | 'isAffix'> & { readOnly?: boolean };
+
+const SelectField = forwardRef((fieldProps: SelectProps, ref: Ref<HTMLSelectElement>) => {
+	return <SelectPrimitive {...fieldProps} ref={ref} />;
+});
+
+SelectField.displayName = 'SelectField';
 
 const Select = forwardRef((props: SelectProps, ref: Ref<HTMLSelectElement | HTMLInputElement>) => {
 	const {
@@ -69,18 +76,6 @@ const Select = forwardRef((props: SelectProps, ref: Ref<HTMLSelectElement | HTML
 		);
 	}
 
-	function SelectField(fieldProps: Omit<SelectProps, 'children'>) {
-		return (
-			<SelectPrimitive
-				hasError={hasError || false}
-				{...fieldProps}
-				ref={ref as Ref<HTMLSelectElement>}
-			>
-				{children}
-			</SelectPrimitive>
-		);
-	}
-
 	return (
 		<FieldPrimitive
 			label={label}
@@ -101,7 +96,9 @@ const Select = forwardRef((props: SelectProps, ref: Ref<HTMLSelectElement | HTML
 				label={label}
 				id={fieldID}
 				{...rest}
-			/>
+			>
+				{children}
+			</SelectField>
 		</FieldPrimitive>
 	);
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TDS, semantic form, user has to click on select field twice to open dropdown.
It's caused by select element being recreated rather than updated on every change.
https://www.loom.com/share/1dbb5105d15b46f6a40df068bd5b0107?sid=c91a10f7-43ba-45dc-ae6f-3f27f61c5ef0
**What is the chosen solution to this problem?**
Move `SelectField` component definition out of Select.
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
