### PR TITLE
fix: TimePicker overlay will now close when time is valid using keyboard

### DIFF
--- a/.changeset/three-icons-check.md
+++ b/.changeset/three-icons-check.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+Timer Picker overlay will now close when time is valid using keyboard

--- a/packages/components/src/DateTimePickers/hooks/useInputPickerHandlers.js
+++ b/packages/components/src/DateTimePickers/hooks/useInputPickerHandlers.js
@@ -33,6 +33,15 @@ export default function useInputPickerHandlers({
 			setPicked(true);
 			closePicker();
 		}
+
+		if (['INPUT'].includes(payload.origin)) {
+			if (!payload.errorMessage) {
+				inputRef.focus();
+				closePicker();
+			} else {
+				openPicker();
+			}
+		}
 	}
 
 	function onClick() {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
TimePicker overlay will now close when time is valid using keyboard

**What is the chosen solution to this problem?**
![Apr-24-2024 10-17-36](https://github.com/Talend/ui/assets/16574861/1d30974b-aa38-42c2-b8bb-a0b4d5d6ac96)


**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
