### PR TITLE
fix(TMC-28189): remove wrong config in json-schema-form-core

### DIFF
--- a/.changeset/warm-scissors-judge.md
+++ b/.changeset/warm-scissors-judge.md
@@ -1,0 +1,5 @@
+---
+"@talend/json-schema-form-core": patch
+---
+
+Remove usage of path-browserify as it's not needed

--- a/fork/json-schema-form-core/package.json
+++ b/fork/json-schema-form-core/package.json
@@ -54,7 +54,6 @@
   "dependencies": {
     "json-refs": "3.0.15",
     "objectpath": "^1.2.2",
-    "path-browserify": "^1.0.1",
     "tv4": "^1.3.0"
   },
   "publishConfig": {

--- a/fork/json-schema-form-core/webpack.config.js
+++ b/fork/json-schema-form-core/webpack.config.js
@@ -4,7 +4,7 @@ module.exports = {
 	},
 	resolve: {
 		fallback: {
-			path: require.resolve('path-browserify'),
+			path: false,
 		},
 	},
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
path-browserify has been added by mistake in json-schema-form-core
**What is the chosen solution to this problem?**
like other packages set the config to false

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
