### PR TITLE
fix(TDS-7339/Date): Language switch does not update Date Field error messages

### DIFF
--- a/.changeset/slimy-tigers-bow.md
+++ b/.changeset/slimy-tigers-bow.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+Fix translation for date range

--- a/packages/components/src/DateTimePickers/shared/error-messages.js
+++ b/packages/components/src/DateTimePickers/shared/error-messages.js
@@ -1,8 +1,7 @@
 import getDefaultT from '../../translate';
 
-const t = getDefaultT();
-
 export default function getErrorMessage(key) {
+	const t = getDefaultT();
 	switch (key) {
 		case 'INVALID_HOUR_EMPTY':
 			return t('INVALID_HOUR_EMPTY', { defaultValue: 'Hour is required' });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is an issue within TDS where switching the application's language from English to French does not update the error messages for the date range field accordingly. 
This problem arises because react-components are initialized in App loading page, and the `getDefaultT()` function is invoked at the global level, which leads to the creation of a distinct i18next instance separate from the one used by TDS.

**What is the chosen solution to this problem?**
The invocation of `getDefaultT()` has been deferred, ensuring that it is called only when required, rather than at the global scope during initial loading. As a result, when getDefaultT() is eventually called, it accesses the fully initialized i18next instance instead creating its own.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
