### PR TITLE
fix(TDC-7476/form): check onFinish and onChange before invoking for the Text component

### DIFF
--- a/.changeset/dirty-elephants-dream.md
+++ b/.changeset/dirty-elephants-dream.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-forms": patch
+---
+
+fix: check onFinish and onChange before invoking for the Text component

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -36,8 +36,16 @@ export default function Text(props) {
 		autoComplete,
 		autoFocus,
 		disabled: disabled || valueIsUpdating,
-		onBlur: event => onFinish(event, { schema }),
-		onChange: event => onChange(event, { schema, value: convertValue(type, event.target.value) }),
+		onBlur: event => {
+			if (onFinish) {
+				onFinish(event, { schema });
+			}
+		},
+		onChange: event => {
+			if (onChange) {
+				onChange(event, { schema, value: convertValue(type, event.target.value) });
+			}
+		},
 		placeholder,
 		readOnly,
 		type,


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When editing a variable name for a rule, after the input component loses the focus, the page crashes and shows the error: `the onFinish is not a function`

**What is the chosen solution to this problem?**
Checking the `onFinish` and `onChange` func before invoking it.
**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
