### PR TITLE
fix(DGT-307/form):  fix EnumerationForm doesn't use the newest value to validate value

### DIFF
--- a/.changeset/eleven-moles-perform.md
+++ b/.changeset/eleven-moles-perform.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-forms": patch
+---
+
+fix EnumerationForm doesn't use the newest value to validate value

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.js
@@ -276,7 +276,7 @@ class EnumerationForm extends Component {
 	onChange(event, payload) {
 		const { schema, onFinish, onChange } = this.props;
 		onChange(event, payload);
-		onFinish(event, { schema });
+		onFinish(event, { schema, value: payload.value });
 	}
 
 	onImportAppendClick() {

--- a/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
+++ b/packages/forms/src/UIForm/fields/Enumeration/EnumerationWidget.test.js
@@ -405,6 +405,37 @@ describe('EnumerationWidget', () => {
 		expect(onChange).toHaveBeenCalledWith(expect.anything(), { schema: {}, value: [] });
 	});
 
+	it('should pass the newest value to onFinish', async () => {
+		const onFinish = jest.fn();
+		render(
+			<EnumerationWidget
+				value={[{ values: ['yoo'] }]}
+				onChange={jest.fn()}
+				onFinish={onFinish}
+				onTrigger={jest.fn()}
+				schema={{}}
+			/>,
+		);
+
+		// when
+		await userEvent.click(screen.queryByRole('link', { name: 'Add item' }));
+		await userEvent.type(screen.queryByRole('textbox', { name: 'Enter new entry name' }), 'foo');
+		await userEvent.click(screen.queryByRole('link', { name: 'Validate' }));
+		// then
+		expect(onFinish).toHaveBeenCalledWith(expect.anything(), {
+			schema: {},
+			value: [
+				{
+					values: ['yoo'],
+					displayMode: 'DISPLAY_MODE_DEFAULT',
+				},
+				{
+					values: ['foo'],
+				},
+			],
+		});
+	});
+
 	describe('upload file', () => {
 		it('should add a upload icon and set data-feature', () => {
 			// when


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the values are changed in EnumerationForm, it doesn't use the newest value to run the validation
https://jira.talendforge.org/browse/DGT-307


**What is the chosen solution to this problem?**
Using the new values instead of old value to validate.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
