### PR TITLE
fix(TDC-7452/Tour): Fix tour is changing to first step when closing

### DIFF
--- a/.changeset/large-apes-compare.md
+++ b/.changeset/large-apes-compare.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+fix(TDC-7452/Tour): Fix tour is changing to first step when closing

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -77,7 +77,7 @@ function AppGuidedTour({
 				setIsAlreadyViewed(true);
 				if (importDemoContent) {
 					setImportDemoContent(false);
-					setCurrentStep(currentStep - 1);
+					setCurrentStep(Math.max(0, currentStep - 1));
 				}
 			}}
 			steps={[

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -1,11 +1,13 @@
-import { useState, useEffect } from 'react';
-import PropTypes from 'prop-types';
-import useLocalStorage from 'react-use/lib/useLocalStorage';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import GuidedTour from '../GuidedTour';
-import Toggle from '../Toggle';
-import Stepper from '../Stepper';
+import useLocalStorage from 'react-use/lib/useLocalStorage';
+
+import PropTypes from 'prop-types';
+
 import I18N_DOMAIN_COMPONENTS from '../constants';
+import GuidedTour from '../GuidedTour';
+import Stepper from '../Stepper';
+import Toggle from '../Toggle';
 import DemoContentStep from './DemoContentStep.component';
 
 const DEMO_CONTENT_STEP_ID = 1;
@@ -73,8 +75,10 @@ function AppGuidedTour({
 			onRequestClose={() => {
 				onRequestClose();
 				setIsAlreadyViewed(true);
-				setCurrentStep(0);
-				setImportDemoContent(false);
+				if (importDemoContent) {
+					setImportDemoContent(false);
+					setCurrentStep(currentStep - 1);
+				}
 			}}
 			steps={[
 				{

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.test.js
@@ -95,4 +95,21 @@ describe('AppGuidedTour', () => {
 		);
 		expect(screen.queryByText('Import demo content')).not.toBeInTheDocument();
 	});
+	it('Should stay on the last page when finished', async () => {
+		const user = userEvent.setup();
+		const steps = [
+			{
+				content: {
+					header: 'Header',
+					body: () => 'Last page',
+				},
+			},
+		];
+		render(<AppGuidedTour {...DEFAULT_PROPS} steps={steps} demoContentSteps={null} />);
+		expect(screen.queryByText(/Last page/i)).not.toBeInTheDocument();
+		const nextBtn = document.querySelector('button[data-tour-elem="right-arrow"]');
+		await user.click(nextBtn);
+		await user.click(screen.getByText('Let me try'));
+		expect(screen.queryByText(/Last page/i)).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When closing Guided Tour, the latest step is temporarily changing to 1st step
https://jira.talendforge.org/browse/TDC-7452

**What is the chosen solution to this problem?**
Stay on the last page when clicking "Let me try" button.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
