### PR TITLE
fix(DGT-528): Fix the rounding issue of QualityBar percentages

### DIFF
--- a/.changeset/many-camels-agree.md
+++ b/.changeset/many-camels-agree.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+DGT-528: Fix QualityBar rounding issue when the invalid or empty percentages were rounded to 0. Set a miminum value for the rounding to prevent UI inconsistencies

--- a/packages/design-system/src/components/QualityBar/QualityRatioBar.utils.ts
+++ b/packages/design-system/src/components/QualityBar/QualityRatioBar.utils.ts
@@ -35,7 +35,7 @@ export const getQualityPercentagesRounded = (
 	empty: number = 0,
 	valid: number = 0,
 	na: number = 0,
-	placeholder = 0,
+	placeholder: number = 0,
 ): Required<QualityBarPercentages> => {
 	const output: Required<QualityBarPercentages> = {
 		empty: 0,
@@ -45,30 +45,30 @@ export const getQualityPercentagesRounded = (
 		valid: 0,
 	};
 
-	let sumValues = 0;
-	let sumRounded = 0;
 	const digitMultiplier = Math.pow(10, digits);
-	const multiplier = 100 * digitMultiplier;
-
 	const total = invalid + empty + valid + na + placeholder;
 
-	sumValues = (invalid * multiplier) / total;
-	output.invalid = Math.round(sumValues - sumRounded) / digitMultiplier;
-	sumRounded = Math.round(sumValues);
+	if (total === 0) {
+		return output;
+	}
 
-	sumValues += (empty * multiplier) / total;
-	output.empty = Math.round(sumValues - sumRounded) / digitMultiplier;
-	sumRounded = Math.round(sumValues);
+	const minPercentage = 1 / digitMultiplier;
 
-	sumValues += (valid * multiplier) / total;
-	output.valid = Math.round(sumValues - sumRounded) / digitMultiplier;
-	sumRounded = Math.round(sumValues);
+	output.invalid = +(invalid > 0 ? Math.max((invalid * 100) / total, minPercentage) : 0).toFixed(
+		digits,
+	);
 
-	sumValues += (na * multiplier) / total;
-	output.na = Math.round(sumValues - sumRounded) / digitMultiplier;
+	output.empty = +(empty > 0 ? Math.max((empty * 100) / total, minPercentage) : 0).toFixed(digits);
 
-	sumValues += (placeholder * multiplier) / total;
-	output.placeholder = Math.round(sumValues - sumRounded) / digitMultiplier;
+	output.na = +(na > 0 ? Math.max((na * 100) / total, minPercentage) : 0).toFixed(digits);
+
+	output.placeholder = +(
+		placeholder > 0 ? Math.max((placeholder * 100) / total, minPercentage) : 0
+	).toFixed(digits);
+
+	output.valid = +(100 - output.invalid - output.empty - output.na - output.placeholder).toFixed(
+		digits,
+	);
 
 	return output;
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
QualityBar percentages being rounded to 0

**What is the chosen solution to this problem?**
Setting a minimum value so that the percentage for invalid and empty values are not 0%

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
