### PR TITLE
fix(TMC-28581): UI Form display fix with hint and required asterisk

### DIFF
--- a/.changeset/weak-boats-destroy.md
+++ b/.changeset/weak-boats-destroy.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Form field label property "required" can now be overriden by passing props

--- a/.changeset/wet-sloths-talk.md
+++ b/.changeset/wet-sloths-talk.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-forms": patch
+---
+
+UI Form fields with both hint and required asterisk are now displayed correctly

--- a/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Field/Field.tsx
@@ -47,10 +47,10 @@ const Field = forwardRef(
 
 		const LabelComponent = hideLabel ? (
 			<VisuallyHidden>
-				<Label {...labelProps} htmlFor={fieldId} required={required} />
+				<Label htmlFor={fieldId} required={required} {...labelProps} />
 			</VisuallyHidden>
 		) : (
-			<Label {...labelProps} htmlFor={fieldId} required={required} />
+			<Label htmlFor={fieldId} required={required} {...labelProps} />
 		);
 
 		const Description = () => {

--- a/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
+++ b/packages/forms/src/UIForm/fields/FieldTemplate/FieldTemplate.component.js
@@ -10,7 +10,7 @@ function FieldTemplate(props) {
 	const title = (
 		<Form.Label
 			htmlFor={props.id}
-			{...getLabelProps(props.label, props.labelProps, props.hint)}
+			{...getLabelProps(props.label, props.labelProps, props.hint, props.required)}
 			required={props.required}
 		/>
 	);

--- a/packages/forms/src/UIForm/fields/File/File.component.js
+++ b/packages/forms/src/UIForm/fields/File/File.component.js
@@ -139,7 +139,7 @@ const FileWidget = props => {
 				<SkeletonInput />
 			) : (
 				<Form.File
-					label={getLabelProps(title, labelProps, schema.hint)}
+					label={getLabelProps(title, labelProps, schema.hint, required)}
 					required={required}
 					accept={accept}
 					autoFocus={autoFocus}

--- a/packages/forms/src/UIForm/fields/Select/Select.component.js
+++ b/packages/forms/src/UIForm/fields/Select/Select.component.js
@@ -54,7 +54,7 @@ export default function Select({
 			readOnly={readOnly}
 			value={value}
 			required={schema.required}
-			label={getLabelProps(title, labelProps, schema.hint)}
+			label={getLabelProps(title, labelProps, schema.hint, schema.required)}
 			description={errorMessage || description}
 			hasError={!isValid}
 			aria-invalid={!isValid}

--- a/packages/forms/src/UIForm/fields/Text/Text.component.js
+++ b/packages/forms/src/UIForm/fields/Text/Text.component.js
@@ -50,7 +50,7 @@ export default function Text(props) {
 		readOnly,
 		type,
 		value,
-		label: getLabelProps(title, labelProps, schema.hint),
+		label: getLabelProps(title, labelProps, schema.hint, schema.required),
 		required: schema.required,
 		description: errorMessage || description,
 		hasError: !isValid,

--- a/packages/forms/src/UIForm/fields/TextArea/TextArea.component.js
+++ b/packages/forms/src/UIForm/fields/TextArea/TextArea.component.js
@@ -30,7 +30,7 @@ export default function TextArea({
 		<Form.Textarea
 			id={id}
 			autoFocus={autoFocus}
-			label={getLabelProps(title, labelProps, schema.hint)}
+			label={getLabelProps(title, labelProps, schema.hint, schema.required)}
 			required={schema.required}
 			disabled={disabled || valueIsUpdating}
 			placeholder={placeholder}

--- a/packages/forms/src/UIForm/utils/labels.js
+++ b/packages/forms/src/UIForm/utils/labels.js
@@ -1,6 +1,6 @@
 import { ButtonIcon, Popover, StackHorizontal } from '@talend/design-system';
 
-export const getLabelProps = (title, labelProps, hint) => {
+export const getLabelProps = (title, labelProps, hint, required) => {
 	if (!hint) {
 		return {
 			children: title,
@@ -9,8 +9,9 @@ export const getLabelProps = (title, labelProps, hint) => {
 	}
 	return {
 		children: (
-			<StackHorizontal gap="XS" align="center">
+			<StackHorizontal gap="XXS" align="center">
 				{title}
+				{required && '*'}
 				<Popover
 					position={hint.overlayPlacement || 'auto'}
 					data-test={hint['data-test']}
@@ -28,5 +29,6 @@ export const getLabelProps = (title, labelProps, hint) => {
 			</StackHorizontal>
 		),
 		...labelProps,
+		required: false,
 	};
 };

--- a/packages/forms/stories/json/fields/core-text.json
+++ b/packages/forms/stories/json/fields/core-text.json
@@ -23,7 +23,8 @@
       "password": {
         "type": "string"
       }
-    }
+    },
+    "required": ["text", "numberMinMax"]
   },
   "uiSchema": [
     {
@@ -32,11 +33,13 @@
       "data-test": "simple.text",
       "labelProps": {
         "data-test": "simple.text.label"
-      }
+      },
+      "hint": { "overlayComponent": "This is a simple text input" }
     },
     {
       "key": "number",
-      "title": "Number"
+      "title": "Number",
+      "hint": { "overlayComponent": "This is a simple text input" }
     },
     {
       "key": "numberMinMax",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
UI Form display fix with hint and required asterisk

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
