### PR TITLE
fix(TDC-7496/tour): Reset currentStep to 0 when tour is reopened

### DIFF
--- a/.changeset/tasty-bikes-fix.md
+++ b/.changeset/tasty-bikes-fix.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+Reset currentStep to 0 when tour is reopened

--- a/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
+++ b/packages/components/src/AppGuidedTour/AppGuidedTour.component.js
@@ -30,6 +30,12 @@ function AppGuidedTour({
 	const [isAlreadyViewed, setIsAlreadyViewed] = useLocalStorage(localStorageKey, false);
 	const [importDemoContent, setImportDemoContent] = useState(demoContentSteps && !isAlreadyViewed);
 	const [currentStep, setCurrentStep] = useState(0);
+	// Reset currentStep to 0 when tour is opened
+	useEffect(() => {
+		if (isOpen) {
+			setCurrentStep(0);
+		}
+	}, [isOpen]);
 
 	const isNavigationDisabled =
 		importDemoContent &&


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
When the tour is reopened, the value of `currentStep` is not reset to 0.
This bug is caused by this [PR](https://github.com/Talend/ui/pull/5311) ,this fix reset the currentStep to 0 when tour is reopened again.
 
https://jira.talendforge.org/browse/TDC-7496

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
