### PR TITLE
chore(TMC-28658): Add a data attribute to detect DS drawer when open

### DIFF
--- a/.changeset/quiet-tigers-mate.md
+++ b/.changeset/quiet-tigers-mate.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+Design system drawer now has a data attribute to identify when it is opened

--- a/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
+++ b/packages/design-system/src/components/Drawer/__snapshots__/Drawer.test.tsx.snap
@@ -11,6 +11,7 @@ exports[`FloatingDrawer should render a11y html 1`] = `
     <div
       aria-label="label is required"
       class="theme-drawer"
+      data-drawer-visible="true"
       data-test="drawer"
       data-testid="drawer"
       id="drawer-42"

--- a/packages/design-system/src/components/Drawer/variants/FloatingDrawer/FloatingDrawer.tsx
+++ b/packages/design-system/src/components/Drawer/variants/FloatingDrawer/FloatingDrawer.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useState, cloneElement } from 'react';
+import { cloneElement, useEffect, useState } from 'react';
 import type { CSSProperties, HTMLAttributes, ReactElement, ReactNode } from 'react';
 import { Transition } from 'react-transition-group';
+
+import { useId } from '../../../../useId';
 import { PrimitiveDrawer } from '../../Primitive/PrimitiveDrawer';
 
 import theme from './FloatingDrawer.module.scss';
-import { useId } from '../../../../useId';
 
 type WithDisclosure = {
 	disclosure: ReactElement;
@@ -90,6 +91,7 @@ export const FloatingDrawer = ({
 							<div
 								data-test="drawer"
 								data-testid="drawer"
+								data-drawer-visible
 								id={uuid}
 								role="dialog"
 								aria-label={props['aria-label']}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Add a data attribute to detect DS drawer when open
Will allow some more global css styles like 
```scss
body:has(.tc-drawer-container, [data-drawer-visible])
```
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
