### PR TITLE
feat: add ThemeProvider that don't use globals

### DIFF
--- a/.changeset/warm-pumas-grin.md
+++ b/.changeset/warm-pumas-grin.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": minor
+---
+
+feat: add ThemeProvider without globals

--- a/packages/design-system/src/components/ThemeProvider/ThemProviderWithoutGlobals.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemProviderWithoutGlobals.tsx
@@ -1,0 +1,44 @@
+import { PropsWithChildren, useContext, useEffect, useState } from 'react';
+
+// eslint-disable-next-line @talend/import-depth
+import '@talend/design-tokens/dist/TalendDesignTokens.css';
+
+import ThemeContext from './ThemeContext';
+
+export type ThemeProviderProps = PropsWithChildren<{
+	theme?: string;
+	tokensOverride?: Record<string, string | number>;
+}>;
+
+export const ThemProviderWithoutGlobals = ({
+	theme = 'light',
+	children,
+	tokensOverride,
+}: ThemeProviderProps) => {
+	const [selectedTheme, setSelectedTheme] = useState(theme);
+	// Handle nested Providers: parent Provider doesn't have context, child does
+	const context = useContext(ThemeContext);
+
+	useEffect(() => {
+		document.body.dataset.theme = selectedTheme;
+	}, [selectedTheme]);
+
+	useEffect(() => {
+		setSelectedTheme(theme);
+	}, [theme]);
+
+	useEffect(() => {
+		if (tokensOverride) {
+			Object.keys(tokensOverride).forEach(key => {
+				document.body.style.setProperty(key, tokensOverride[key].toString());
+			});
+		}
+	}, [tokensOverride]);
+
+	const switchTheme = (newTheme: string) => setSelectedTheme(newTheme);
+	return (
+		<ThemeContext.Provider value={context.theme ? context : { switchTheme, theme: selectedTheme }}>
+			{children}
+		</ThemeContext.Provider>
+	);
+};

--- a/packages/design-system/src/components/ThemeProvider/ThemeProviderWithoutGlobals.tsx
+++ b/packages/design-system/src/components/ThemeProvider/ThemeProviderWithoutGlobals.tsx
@@ -1,5 +1,8 @@
 import { PropsWithChildren, useContext, useEffect, useState } from 'react';
 
+import 'typeface-inconsolata/index.css';
+import 'typeface-source-sans-pro/index.css';
+
 // eslint-disable-next-line @talend/import-depth
 import '@talend/design-tokens/dist/TalendDesignTokens.css';
 
@@ -10,7 +13,7 @@ export type ThemeProviderProps = PropsWithChildren<{
 	tokensOverride?: Record<string, string | number>;
 }>;
 
-export const ThemProviderWithoutGlobals = ({
+export const ThemeProviderWithoutGlobals = ({
 	theme = 'light',
 	children,
 	tokensOverride,

--- a/packages/design-system/src/components/ThemeProvider/index.ts
+++ b/packages/design-system/src/components/ThemeProvider/index.ts
@@ -1,7 +1,7 @@
 import { ThemeProvider as BaseThemeProvider, ThemeProviderProps } from './ThemeProvider';
 import ThemeSwitcher from './ThemeSwitcher';
 
-export { ThemProviderWithoutGlobals } from './ThemProviderWithoutGlobals';
+export { ThemeProviderWithoutGlobals } from './ThemeProviderWithoutGlobals';
 
 export const ThemeProvider = BaseThemeProvider as typeof BaseThemeProvider & {
 	ThemeSwitcher: typeof ThemeSwitcher;

--- a/packages/design-system/src/components/ThemeProvider/index.ts
+++ b/packages/design-system/src/components/ThemeProvider/index.ts
@@ -1,5 +1,7 @@
-import ThemeSwitcher from './ThemeSwitcher';
 import { ThemeProvider as BaseThemeProvider, ThemeProviderProps } from './ThemeProvider';
+import ThemeSwitcher from './ThemeSwitcher';
+
+export { ThemProviderWithoutGlobals } from './ThemProviderWithoutGlobals';
 
 export const ThemeProvider = BaseThemeProvider as typeof BaseThemeProvider & {
 	ThemeSwitcher: typeof ThemeSwitcher;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
