### PR TITLE
fix(TMC-27619/cellDate): enable tz conversion with sourceTz

### DIFF
--- a/.changeset/five-ears-guess.md
+++ b/.changeset/five-ears-guess.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-components": patch
+---
+
+fix(TMC-27619/cellDate): enable tz offset conversion with sourceTz

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.component.js
@@ -35,6 +35,7 @@ export function computeValue(cellData, columnData, t) {
 		} else if (columnData.mode === 'format') {
 			if (columnData.timeZone) {
 				return dateUtils.formatToTimeZone(dateFNS, columnData.pattern || DATE_TIME_FORMAT, {
+					...(columnData.sourceTimeZone && { sourceTimeZone: columnData.sourceTimeZone }),
 					timeZone: columnData.timeZone,
 					locale: getLocale(t),
 				});

--- a/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
+++ b/packages/components/src/VirtualizedList/CellDatetime/CellDatetime.test.js
@@ -167,18 +167,22 @@ describe('CellDatetime', () => {
 			mode: 'format',
 			pattern: 'YYYY-MM-DD HH:mm:ss',
 			timeZone: 'Pacific/Niue',
+			sourceTimeZone: 'Europe/Paris',
 		};
 		const t = jest.fn();
 
 		const cellData = 1474495200000;
-		computeValue(cellData, columnData, t);
+		const expectedStrDate = '2016-09-22 09:00:00';
+		const computedStrOffset = computeValue(cellData, columnData, t);
 
 		// then
+		expect(computedStrOffset).toEqual(expectedStrDate);
 		expect(dateUtils.formatToTimeZone).toHaveBeenCalledWith(
 			new Date(cellData),
 			columnData.pattern,
 			{
 				timeZone: columnData.timeZone,
+				sourceTimeZone: columnData.sourceTimeZone,
 				locale: getLocale(t),
 			},
 		);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Dates are incorrectly displayed during the DST window for few regions
https://jira.talendforge.org/browse/TMC-27619

**What is the chosen solution to this problem?**
Allow tz conversion based upon the sourceTz for cells in List pages

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
