### PR TITLE
fix(TMC-28189): adapt package config for faceted-search

### DIFF
--- a/.changeset/wicked-hotels-thank.md
+++ b/.changeset/wicked-hotels-thank.md
@@ -1,0 +1,5 @@
+---
+"@talend/react-faceted-search": patch
+---
+
+Fix export for /lib/\*

--- a/packages/faceted-search/package.json
+++ b/packages/faceted-search/package.json
@@ -6,8 +6,8 @@
   "module": "./lib-esm/index.js",
   "exports": {
     "./lib/*": {
-      "import": "./lib-esm/*/index.js",
-      "require": "./lib/*/index.js"
+      "import": "./lib-esm/*",
+      "require": "./lib/*"
     },
     ".": {
       "import": "./lib-esm/index.js",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
not possible to import files not named index.js when import go deeper in lib folder

**What is the chosen solution to this problem?**
adapt package config for faceted-search (change exports for lib folder)

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
