### PR TITLE
fix(TDS-7385/esm): fix module not found error for @talend/react-bootstrap and @talend/icons

### DIFF
--- a/.changeset/purple-poets-tan.md
+++ b/.changeset/purple-poets-tan.md
@@ -1,0 +1,6 @@
+---
+'@talend/react-bootstrap': patch
+'@talend/icons': patch
+---
+
+fix module not found error for @talend/react-bootstrap and @talend/icons

--- a/fork/react-bootstrap/package.json
+++ b/fork/react-bootstrap/package.json
@@ -30,6 +30,7 @@
   "files": [
     "CHANGELOG.md",
     "lib",
+    "lib-esm",
     "dist",
     "es"
   ],

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -40,6 +40,7 @@
   "files": [
     "index.js",
     "dist",
+    "lib-esm",
     "src"
   ],
   "keywords": [


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
After running `postinstall` on ui-ee, there is no `lib-esm` folder for `@talend/react-bootstrap` and `@talend/icons` packages, this causes  `Module not found` error when running upgrade dependencies 
https://jira.talendforge.org/browse/TDS-7385

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
