### PR TITLE
fix: make ThemeProviderWithoutGlobals working since esm build

### DIFF
--- a/.changeset/eleven-ghosts-wait.md
+++ b/.changeset/eleven-ghosts-wait.md
@@ -1,0 +1,5 @@
+---
+"@talend/design-system": patch
+---
+
+fix: make ThemeProviderWithoutGlobals working since esm build

--- a/packages/design-system/src/components/ThemeProvider/index.ts
+++ b/packages/design-system/src/components/ThemeProvider/index.ts
@@ -1,8 +1,6 @@
 import { ThemeProvider as BaseThemeProvider, ThemeProviderProps } from './ThemeProvider';
 import ThemeSwitcher from './ThemeSwitcher';
 
-export { ThemeProviderWithoutGlobals } from './ThemeProviderWithoutGlobals';
-
 export const ThemeProvider = BaseThemeProvider as typeof BaseThemeProvider & {
 	ThemeSwitcher: typeof ThemeSwitcher;
 };

--- a/packages/design-system/src/components/ThemeProviderWithoutGlobals/ThemeProviderWithoutGlobals.tsx
+++ b/packages/design-system/src/components/ThemeProviderWithoutGlobals/ThemeProviderWithoutGlobals.tsx
@@ -6,7 +6,7 @@ import 'typeface-source-sans-pro/index.css';
 // eslint-disable-next-line @talend/import-depth
 import '@talend/design-tokens/dist/TalendDesignTokens.css';
 
-import ThemeContext from './ThemeContext';
+import ThemeContext from '../ThemeProvider/ThemeContext';
 
 export type ThemeProviderProps = PropsWithChildren<{
 	theme?: string;

--- a/packages/design-system/src/components/ThemeProviderWithoutGlobals/index.ts
+++ b/packages/design-system/src/components/ThemeProviderWithoutGlobals/index.ts
@@ -1,0 +1,1 @@
+export { ThemeProviderWithoutGlobals } from './ThemeProviderWithoutGlobals';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
