### PR TITLE
fix(containers): Fix tsconfig to have right d.ts files

### DIFF
--- a/.changeset/seven-boats-battle.md
+++ b/.changeset/seven-boats-battle.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': patch
+---
+
+fix(containers): Fix tsconfig to have right d.ts files

--- a/packages/containers/tsconfig.esm.json
+++ b/packages/containers/tsconfig.esm.json
@@ -1,6 +1,6 @@
 {
-  "extends": "@talend/scripts-config-typescript/tsconfig.json",
-  "include": ["src/**/*"],
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "src/**/*.stories.*", "src/**/*.test.*"],
   "compilerOptions": {
     "declaration": true,
     "outDir": "lib-esm",

--- a/packages/containers/tsconfig.json
+++ b/packages/containers/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "extends": "@talend/scripts-config-typescript/tsconfig.json",
+  "include": ["custom.d.ts", "src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "types": ["jest", "@testing-library/jest-dom"],
+    "allowJs": true,
+    "checkJs": false,
+    "declaration": true,
+    "noEmit": false
+  }
+}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
containers package only have an index.d.ts file containing compiler options instead of real things

**What is the chosen solution to this problem?**
adapt the ts configuration to correctly build with right declaration files

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
