### PR TITLE
fix: Fix exports to allow deep imports

### DIFF
--- a/.changeset/green-geckos-sip.md
+++ b/.changeset/green-geckos-sip.md
@@ -1,0 +1,8 @@
+---
+'@talend/design-system': patch
+'@talend/react-components': patch
+'@talend/react-containers': patch
+'@talend/utils': patch
+---
+
+fix: Fix exports to allow deep imports

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -5,8 +5,8 @@
   "module": "./lib-esm/index.js",
   "exports": {
     "./lib/*": {
-      "import": "./lib-esm/*/index.js",
-      "require": "./lib/*/index.js"
+      "import": "./lib-esm/*",
+      "require": "./lib/*"
     },
     ".": {
       "import": "./lib-esm/index.js",

--- a/packages/containers/package.json
+++ b/packages/containers/package.json
@@ -6,8 +6,8 @@
   "module": "./lib-esm/index.js",
   "exports": {
     "./lib/*": {
-      "import": "./lib-esm/*/index.js",
-      "require": "./lib/*/index.js"
+      "import": "./lib-esm/*",
+      "require": "./lib/*"
     },
     ".": {
       "import": "./lib-esm/index.js",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -7,8 +7,8 @@
   "module": "./lib-esm/index.js",
   "exports": {
     "./lib/*": {
-      "import": "./lib-esm/*/index.js",
-      "require": "./lib/*/index.js"
+      "import": "./lib-esm/*",
+      "require": "./lib/*"
     },
     ".": {
       "import": "./lib-esm/index.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -7,8 +7,8 @@
   "module": "./lib-esm/index.js",
   "exports": {
     "./lib/*": {
-      "import": "./lib-esm/*/index.js",
-      "require": "./lib/*/index.js"
+      "import": "./lib-esm/*",
+      "require": "./lib/*"
     },
     ".": {
       "import": "./lib-esm/index.js",


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Exports doesn't allow deep imports, but app are using them.

**What is the chosen solution to this problem?**
Use a wildcard to allow all deep imports.

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
