### PR TITLE
feat(TMC-28838/tags): add beta styled tag to the Tag component

### DIFF
--- a/.changeset/chilled-files-rest.md
+++ b/.changeset/chilled-files-rest.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': minor
+---
+
+feat(TMC-28838/tags): add beta styled tag to the Tag component

--- a/packages/components/src/TabBar/Tabs.stories.js
+++ b/packages/components/src/TabBar/Tabs.stories.js
@@ -87,6 +87,15 @@ const tabProps = {
 			'data-feature': 'action.9',
 			disabled: true,
 		},
+		{
+			key: '10',
+			label: 'Tab10',
+			badge: {
+				label: 'BETA',
+				bsStyle: 'beta',
+			},
+			'data-feature': 'action.10',
+		},
 	],
 	onSelect: action('onSelect'),
 	selectedKey: '2',

--- a/packages/components/src/Tag/Tag.component.js
+++ b/packages/components/src/Tag/Tag.component.js
@@ -1,10 +1,12 @@
 import PropTypes from 'prop-types';
+
 import {
 	Tag as CoralTag,
+	TagBeta as CoralTagBeta,
+	TagDestructive as CoralTagDestructive,
 	TagInformation as CoralTagInformation,
 	TagSuccess as CoralTagSuccess,
 	TagWarning as CoralTagWarning,
-	TagDestructive as CoralTagDestructive,
 } from '@talend/design-system';
 
 /**
@@ -24,6 +26,9 @@ const Tag = ({ bsStyle, ...rest }) => {
 			break;
 		case 'danger':
 			StyledTag = CoralTagDestructive;
+			break;
+		case 'beta':
+			StyledTag = CoralTagBeta;
 			break;
 		default:
 			break;


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Beta tag is not available under the Tag component

**What is the chosen solution to this problem?**
add beta styled tag to the Tag component

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
