### PR TITLE
fix(TMC-28977): Allow Talend script to build .css files

### DIFF
--- a/.changeset/honest-clouds-think.md
+++ b/.changeset/honest-clouds-think.md
@@ -1,0 +1,5 @@
+---
+"@talend/scripts-core": patch
+---
+
+TMC-28977 - Allow Talend scripts to copy .css files on build

--- a/tools/scripts-core/src/scripts/build-lib.js
+++ b/tools/scripts-core/src/scripts/build-lib.js
@@ -152,7 +152,7 @@ export default async function build(env, presetApi, unsafeOptions) {
 	const copyPromise = () =>
 		new Promise((resolve, reject) => {
 			if (options.includes('--watch')) {
-				const evtEmitter = cpx.watch(`${srcFolder}/**/*.{scss,json}`, targetFolder);
+				const evtEmitter = cpx.watch(`${srcFolder}/**/*.{css,scss,json}`, targetFolder);
 				evtEmitter.on('watch-error', err => {
 					reject(err);
 				});
@@ -161,7 +161,7 @@ export default async function build(env, presetApi, unsafeOptions) {
 				});
 			} else {
 				console.log('Copying assets...');
-				cpx.copy(`${srcFolder}/**/*.{scss,json}`, targetFolder, err => {
+				cpx.copy(`${srcFolder}/**/*.{css,scss,json}`, targetFolder, err => {
 					if (err) {
 						console.error(err);
 						reject(err);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Allow Talend script to build .css files

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
