### PR TITLE
feat(FacetedSearch): Add Typeahead props to QuickSearchInput

### DIFF
--- a/.changeset/fluffy-colts-sleep.md
+++ b/.changeset/fluffy-colts-sleep.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-faceted-search': patch
+---
+
+feat: Add Typeahead props to QuickSearchInput

--- a/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
+++ b/packages/faceted-search/src/components/BasicSearch/BasicSearch.component.js
@@ -45,6 +45,7 @@ const BasicSearch = ({
 	quickSearchPlaceholder,
 	quickSearchFacetsFilter,
 	quickSearchInputProps,
+	quickSearchTypeaheadProps,
 	disclosureProps,
 }) => {
 	const { id, t } = useFacetedSearchContext();
@@ -129,6 +130,7 @@ const BasicSearch = ({
 				}}
 				inputProps={quickSearchInputProps}
 				minLength={quickSearchMinLength}
+				typeaheadProps={quickSearchTypeaheadProps}
 			/>
 			<div className={styles['tc-basic-search-content']}>
 				<BadgeFacetedProvider value={badgeFacetedContextValue}>

--- a/packages/faceted-search/src/components/QuickSearchInput/QuickSearchInput.component.js
+++ b/packages/faceted-search/src/components/QuickSearchInput/QuickSearchInput.component.js
@@ -21,6 +21,7 @@ export const QuickSearchInput = ({
 	facetsFilter,
 	inputProps,
 	minLength,
+	typeaheadProps = {},
 }) => {
 	const defaultFacet = useMemo(() => getDefaultFacet(facets), [facets]);
 	const [opened, setOpened] = useState(false);
@@ -72,6 +73,7 @@ export const QuickSearchInput = ({
 			role="searchbox"
 			className={className}
 			inputProps={inputProps}
+			{...typeaheadProps}
 		/>
 	);
 };

--- a/packages/faceted-search/stories/facetedSearch.stories.js
+++ b/packages/faceted-search/stories/facetedSearch.stories.js
@@ -558,3 +558,34 @@ export const WithQuickSearchFilterCustomizableInputTriggerLength = () => {
 		</FacetedSearch.Faceted>
 	);
 };
+
+export const WithQuickSearchAsynchronousSuggestions = () => {
+	const [searching, setSearching] = useState(false);
+	const [items, setItems] = useState([]);
+	const [value, setValue] = useState('');
+	const onChange = (_, { value }) => {
+		setValue(value);
+		setSearching(true);
+		setTimeout(() => {
+			setItems([
+				{
+					title: 'Search in...',
+					suggestions: ['in Name', 'in Email', 'in Position'].map(column => value + ' ' + column),
+				},
+			]);
+			setSearching(false);
+		}, 1000);
+	};
+
+	return (
+		<FacetedSearch.Faceted id="my-faceted-search">
+			<FacetedSearch.BasicSearch
+				badgesDefinitions={badgesDefinitions}
+				callbacks={callbacks}
+				onSubmit={action('onSubmit')}
+				quickSearchInputProps={{ value }}
+				quickSearchTypeaheadProps={{ searching, items, onChange, debounceTimeout: 800 }}
+			/>
+		</FacetedSearch.Faceted>
+	);
+};


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Now you can pass typeahead props to QuickSearchInput.
One use case can be loading async suggestions.
Story: http://5367.talend.surge.sh/storybook-one/?path=/story/faceted-search-main--with-quick-search-asynchronous-suggestions
**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
