### PR TITLE
fix(containers): Expose defaultRegistry through ComponentForm.kit

### DIFF
--- a/.changeset/itchy-onions-refuse.md
+++ b/.changeset/itchy-onions-refuse.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': minor
+---
+
+fix(containers): Expose defaultRegistry through ComponentForm.kit

--- a/packages/containers/src/ComponentForm/kit/index.js
+++ b/packages/containers/src/ComponentForm/kit/index.js
@@ -13,11 +13,12 @@
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
-
 import createTriggers from './createTriggers';
+import defaultRegistry from './defaultRegistry';
 import flatten from './flatten';
 
 export default {
 	createTriggers,
 	flatten,
+	defaultRegistry,
 };


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Some project need to use some functions from the defaultRegistry. 

**What is the chosen solution to this problem?**
Export them to be able to reach them with a `ComponentForm.kit.defautRegistry`

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
