### PR TITLE
fix(DGHT-180): fix InputDateTimeRangePicker gets wrong error message for multiple errors

### DIFF
--- a/.changeset/eighty-dryers-itch.md
+++ b/.changeset/eighty-dryers-itch.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix InputDateTimeRangePicker gets wrong error message for multiple errors

--- a/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
+++ b/packages/components/src/DateTimePickers/DateTimeRange/Manager/Manager.component.js
@@ -19,6 +19,8 @@ function DateTimeRangeManager(props) {
 		endDateTime,
 	};
 	const [state, setState] = useState(initialState);
+	const [startDateErrors, setStartDateErrors] = useState([]);
+	const [endDateErrors, setEndDateErrors] = useState([]);
 
 	useEffect(() => {
 		if (!isEqual(state.startDateTime, startDateTime) || !isEqual(state.endDateTime, endDateTime)) {
@@ -29,7 +31,12 @@ function DateTimeRangeManager(props) {
 	function onRangeChange(event, nextState, origin) {
 		const errors = [...(nextState.errors || [])];
 
-		if (nextState.startDateTime && nextState.endDateTime) {
+		if (
+			nextState.startDateTime &&
+			nextState.endDateTime &&
+			!isNaN(nextState.startDateTime) &&
+			!isNaN(nextState.endDateTime)
+		) {
 			if (!isBefore(nextState.startDateTime, nextState.endDateTime)) {
 				errors.push(
 					new DateTimeRangePickerException(
@@ -49,13 +56,17 @@ function DateTimeRangeManager(props) {
 	}
 
 	function onStartChange(event, { datetime, errors }) {
-		const nextState = { ...state, startDateTime: datetime, errors };
+		setStartDateErrors(errors);
+		const allErrors = [...(errors || []), ...(endDateErrors || [])];
+		const nextState = { ...state, startDateTime: datetime, errors: allErrors };
 		setState(nextState);
 		onRangeChange(event, nextState, 'RANGE_START');
 	}
 
 	function onEndChange(event, { datetime, errors }) {
-		const nextState = { ...state, endDateTime: datetime, errors };
+		setEndDateErrors(errors);
+		const allErrors = [...(startDateErrors || []), ...(errors || [])];
+		const nextState = { ...state, endDateTime: datetime, errors: allErrors };
 		setState(nextState);
 		onRangeChange(event, nextState, 'RANGE_END');
 	}


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
InputDateTimeRangePicker component gets wrong error message for multiple errors.
To reproduce:
1.Init component with start time and end time, there is no error message.
2. Remove the date from date field for the end time, it shows "Date is required", it is ok.
3. Remove the time from time field for the start time, it shows "Time is required", it is ok.
4. Refill the time field for the start time, it shows "Start date should comes before end date", it should show the remaining error "Date is required".

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
