### PR TITLE
fix(TMC-29525): inlineedit tooltip position on subheader

### DIFF
--- a/.changeset/thick-peas-rest.md
+++ b/.changeset/thick-peas-rest.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: Change InlineEdit tooltip position on buttons to prevent z-index issues depending on implementation

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -267,6 +267,7 @@ const InlineEditingPrimitive = forwardRef(
 										data-test={`${dataTest ? `${dataTest}.` : ''}inlineediting.button.cancel`}
 										data-testid={`${dataTestId ? `${dataTestId}.` : ''}inlineediting.button.cancel`}
 										size="XS"
+										tooltipPlacement="bottom"
 									>
 										{t('INLINE_EDITING_CANCEL', 'Cancel')}
 									</ButtonIcon>
@@ -277,6 +278,7 @@ const InlineEditingPrimitive = forwardRef(
 										data-testid={`${dataTestId ? `${dataTestId}.` : ''}inlineediting.button.submit`}
 										{...getDataAttrFromProps(rest)}
 										size="XS"
+										tooltipPlacement="bottom"
 									>
 										{t('INLINE_EDITING_SUBMIT', 'Submit')}
 									</ButtonIcon>
@@ -305,6 +307,7 @@ const InlineEditingPrimitive = forwardRef(
 								icon="pencil"
 								disabled={loading}
 								size="XS"
+								tooltipPlacement="bottom"
 							>
 								{t('INLINE_EDITING_EDIT', 'Edit')}
 							</ButtonIcon>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Change InlineEdit tooltip position on buttons to prevent z-index issues depending on implementation

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
