### PR TITLE
fix(TMC-29799): highlighting selected item in side panel and opening link in new tab

### DIFF
--- a/.changeset/hot-kiwis-talk.md
+++ b/.changeset/hot-kiwis-talk.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-containers': minor
+---
+
+fix(TMC-29799): highlighting selected item in side panel and opening link in new tab

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -131,9 +131,18 @@ function getAction(id, currentRoute, state) {
  */
 function getActions(state, ownProps, currentRoute) {
 	if (ownProps.actions) {
-		const cacheAction = getCache(ownProps.componentId, currentRoute, ownProps.actions);
+		let actions = ownProps.actions;
+
+		if (window.basename && window.basename !== '/') {
+			actions = ownProps.actions.map(action => ({
+				...action,
+				href: `${window.basename}${action.href}`.replaceAll('//', '/'),
+			}));
+		}
+
+		const cacheAction = getCache(ownProps.componentId, currentRoute, actions);
 		if (!cacheAction.value) {
-			cacheAction.value = getActionsWrapped(ownProps.actions);
+			cacheAction.value = getActionsWrapped(actions);
 		}
 		return cacheAction.value;
 	} else if (ownProps.actionIds) {

--- a/packages/containers/src/SidePanel/SidePanel.connect.js
+++ b/packages/containers/src/SidePanel/SidePanel.connect.js
@@ -1,7 +1,9 @@
 import get from 'lodash/get';
+
 import cmf, { cmfConnect } from '@talend/react-cmf';
-import Container, { DEFAULT_STATE } from './SidePanel.container';
+
 import { ACTION_TYPE_LINK } from './constants';
+import Container, { DEFAULT_STATE } from './SidePanel.container';
 
 const cache = {};
 
@@ -73,7 +75,13 @@ function getActionsWrapped(actions) {
 }
 
 function getSelectedAction(currentRoute, actions) {
-	const getFullPath = href => `${window.basename || ''}${href}`.replaceAll('//', '/');
+	const getFullPath = href => {
+		if (!window.basename || window.basename === '/' || href.startsWith(window.basename)) {
+			return href;
+		}
+
+		return `${window.basename || ''}${href}`.replaceAll('//', '/');
+	};
 	return actions.find(
 		action => action.href && isBasePathOf(getFullPath(action.href), currentRoute),
 	);


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
After migrating TMC from sub domain to new domain app.int.cloud.talend.com/tmc, it uses basename (/tmc)

In order to open Side panel links in new browser window correctly, need to include base name in "href",
as it is passed down to link element in html, so, having something like "/tmc/projects".
But if using base name in href, selected item is not computed correctly, as base name is always added, so, we end up
with something like "/tmc/tmc/projects", and, selected item is not highlighted

https://jira.talendforge.org/browse/TMC-29660
https://jira.talendforge.org/browse/TMC-29799

**What is the chosen solution to this problem?**

- Add base name to href in actions
- When computing selected item, add base name only if it is not already in "href" property

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
