### PR TITLE
fix(eslint-config): ignorePattern only at root level for index.js

### DIFF
--- a/.changeset/strange-students-collect.md
+++ b/.changeset/strange-students-collect.md
@@ -1,0 +1,5 @@
+---
+'@talend/eslint-config': patch
+---
+
+fix: ignorePattern only at root level for index.js

--- a/tools/scripts-config-eslint/.eslintrc.json
+++ b/tools/scripts-config-eslint/.eslintrc.json
@@ -122,5 +122,5 @@
     }
   },
   // Ignore some JS at project's rool level
-  "ignorePatterns": ["index.js", ".eslintrc.js"]
+  "ignorePatterns": ["./index.js", "./.eslintrc.js"]
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
currently the ignorePattern ignore all index.js instead of only at root level

**What is the chosen solution to this problem?**
fix it using ./

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
