### PR TITLE
fix(TMC-29660/script-cmf): add capacity to override href with basename to cmf-merge

### DIFF
--- a/tools/scripts-cmf/cmf-settings.merge.js
+++ b/tools/scripts-cmf/cmf-settings.merge.js
@@ -25,6 +25,19 @@ function getCmfconfig(cmfconfigPath, onError) {
 	return cmfconfig;
 }
 
+function addBasenameToHref(obj, basename) {
+	if (typeof obj === 'object' && obj !== null && basename) {
+		Object.entries(obj).forEach(([key, value]) => {
+			if (key === 'href' && typeof value === 'string') {
+				// eslint-disable-next-line no-param-reassign
+				obj[key] = `${basename}${value}`;
+			} else {
+				addBasenameToHref(value, basename);
+			}
+		});
+	}
+}
+
 /**
  * merge write a json settings file for CMF ready to be served
  * @param {Object} options
@@ -87,6 +100,10 @@ function merge(options, errorCallback, writeToFs = true) {
 			Object.keys(settings.overrideActions).forEach(id => {
 				overrideActions(id, settings);
 			});
+		}
+
+		if (process.env.BASENAME) {
+			addBasenameToHref(settings, process.env.BASENAME);
 		}
 	}
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
in case of app use basename like tmc, url in sidepanel are not good (except if developers set value directly in json (not perfect app should able to change basename without having to change code))

**What is the chosen solution to this problem?**
add capacity to cmf-merge to scan json and rewrite href value with basename

**Please check if the PR fulfills these requirements**

- [ ] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [ ] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
