### PR TITLE
fix(TMC-25993): fix DS textarea row property and static css height

### DIFF
--- a/.changeset/fuzzy-dancers-move.md
+++ b/.changeset/fuzzy-dancers-move.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+fix: allow form Textarea to changes number of rows and remove fixed css min-height

--- a/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.module.scss
+++ b/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.module.scss
@@ -4,7 +4,6 @@
 .textarea {
 	@include Form.base-input();
 	@include Form.border-styles();
-	min-height: calc(#{tokens.$coral-sizing-l} * 2);
 	max-height: tokens.$coral-sizing-xxxl;
 	resize: vertical;
 	line-height: 140%;

--- a/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
+++ b/packages/design-system/src/components/Form/Primitives/Textarea/Textarea.tsx
@@ -1,13 +1,17 @@
 import { forwardRef, Ref, TextareaHTMLAttributes } from 'react';
+
 import classnames from 'classnames';
+
 import styles from './Textarea.module.scss';
 
 export type TextareaPrimitiveProps = TextareaHTMLAttributes<any> & { hasError?: boolean };
 
 const Textarea = forwardRef((props: TextareaPrimitiveProps, ref: Ref<HTMLTextAreaElement>) => {
 	const { className, readOnly = false, disabled = false, hasError = false, ...rest } = props;
+	const defaultRowsNumber = 3;
 	return (
 		<textarea
+			rows={defaultRowsNumber}
 			{...rest}
 			ref={ref}
 			disabled={disabled}

--- a/packages/design-system/src/components/Form/__snapshots__/Form.test.tsx.snap
+++ b/packages/design-system/src/components/Form/__snapshots__/Form.test.tsx.snap
@@ -233,6 +233,7 @@ exports[`Form should render a11y html 1`] = `
             class="theme-textarea"
             id="field--mocked-uuid-8"
             name="textarea"
+            rows="3"
           />
         </div>
         <div

--- a/packages/design-system/src/stories/form/Field/Textarea/Input.Textarea.stories.tsx
+++ b/packages/design-system/src/stories/form/Field/Textarea/Input.Textarea.stories.tsx
@@ -43,6 +43,12 @@ export const Textarea = () => (
 			hasError
 			description="There is an error here"
 		/>
+		<Form.Textarea
+			rows={2}
+			placeholder="Placeholder"
+			name="time"
+			label="Textarea with custom number of rows"
+		/>
 	</StackVertical>
 );
 


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix DS textarea row property and static css height

**What is the chosen solution to this problem?**
remove css min-height 
put default textarea with 3 rows to match old css value

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
