### PR TITLE
feat(TMC-25993): change default UIForm collapsible panel title

### DIFF
--- a/.changeset/shiny-mirrors-fail.md
+++ b/.changeset/shiny-mirrors-fail.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-forms': minor
+---
+
+feat: Better handle collapsible fieldset title for UIForm definitions by using schema title by default

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.js
@@ -32,6 +32,10 @@ function getDrillKey(key) {
 }
 
 export function defaultTitle(formData, schema, options) {
+	if (schema.title) {
+		return schema.title;
+	}
+
 	const title = (schema.items || []).reduce((acc, item) => {
 		let value;
 		if (item.key) {
@@ -66,7 +70,7 @@ export function defaultTitle(formData, schema, options) {
 		return schema.options.emptyTitleFallback;
 	}
 
-	return schema.title;
+	return '';
 }
 
 /**

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -14,7 +14,6 @@ function customTitle(value, schema) {
 }
 
 const schema = {
-	title: 'Basic',
 	description: 'This is description',
 	items: [
 		{
@@ -68,7 +67,10 @@ const defaultTitleMockData = {
 
 const props = {
 	id: 'my-fieldset',
-	schema,
+	schema: {
+		...schema,
+		title: 'Basic',
+	},
 	value,
 	onChange: jest.fn(),
 };
@@ -91,7 +93,7 @@ describe('CollapsibleFieldset', () => {
 				<CollapsibleFieldset {...props} value={{ ...value, isClosed: true }} />
 			</WidgetContext.Provider>,
 		);
-		expect(screen.getByText('Jimmy, Somsanith')).toBeInTheDocument();
+		expect(screen.getByText('Basic')).toBeInTheDocument();
 		expect(screen.getByRole('button')).toHaveAttribute('aria-expanded', 'false');
 	});
 	it('should render a custom title', () => {
@@ -182,7 +184,7 @@ describe('CollapsibleFieldset', () => {
 });
 
 describe('defaultTitle', () => {
-	it('should return schema.title by default if no emptyTitleFallback has been provided in options', () => {
+	it('should return schema.title by default', () => {
 		// given not used in an array you have the schema.title
 		expect(defaultTitle({}, { title: 'Comment' })).toBe('Comment');
 		// given no value, you have the schema.title
@@ -218,7 +220,6 @@ describe('defaultTitle', () => {
 	});
 	it('should support recursive call on deeper objects', () => {
 		const complexSchema = {
-			title: 'Basic',
 			items: [
 				{
 					key: ['type'],

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -188,7 +188,7 @@ describe('defaultTitle', () => {
 		// given not used in an array you have the schema.title
 		expect(defaultTitle({}, { title: 'Comment' })).toBe('Comment');
 		// given no value, you have the schema.title
-		expect(defaultTitle({}, schema)).toBe('Comment');
+		expect(defaultTitle({}, schema)).toBe('');
 	});
 
 	it('should return if emptyTitleFallback has been provided and computed title is empty', () => {

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/CollapsibleFieldset.component.test.js
@@ -188,7 +188,7 @@ describe('defaultTitle', () => {
 		// given not used in an array you have the schema.title
 		expect(defaultTitle({}, { title: 'Comment' })).toBe('Comment');
 		// given no value, you have the schema.title
-		expect(defaultTitle({}, schema)).toBe(schema.title);
+		expect(defaultTitle({}, schema)).toBe('Comment');
 	});
 
 	it('should return if emptyTitleFallback has been provided and computed title is empty', () => {

--- a/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
+++ b/packages/forms/src/UIForm/fieldsets/CollapsibleFieldset/__snapshots__/CollapsibleFieldset.component.test.js.snap
@@ -34,7 +34,7 @@ exports[`CollapsibleFieldset should render 1`] = `
       <span
         class="theme-headerTitle"
       >
-        Jimmy, Somsanith
+        Basic
       </span>
     </button>
     <div


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Change default UIForm collapsible panel title to use schema title by default

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
