### PR TITLE
fix(TMC-4293): fix DS Link token to be info

### DIFF
--- a/.changeset/large-baboons-poke.md
+++ b/.changeset/large-baboons-poke.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+TMC-4293 - Design System link should not be accent/grey while using qlik-light theme

--- a/packages/design-system/src/components/Link/Link.module.scss
+++ b/packages/design-system/src/components/Link/Link.module.scss
@@ -5,7 +5,7 @@ $icon-alignment-offset-s: -0.0625rem;
 
 .link {
 	font: tokens.$coral-paragraph-m-bold;
-	color: tokens.$coral-color-accent-text;
+	color: tokens.$coral-color-info-text;
 	background: none;
 	border: none;
 	border-bottom-color: currentColor;
@@ -26,18 +26,18 @@ $icon-alignment-offset-s: -0.0625rem;
 	}
 
 	&:hover {
-		color: tokens.$coral-color-accent-text-hover;
+		color: tokens.$coral-color-info-text-hover;
 
 		.link__text {
-			border-bottom-color: tokens.$coral-color-accent-border-hover;
+			border-bottom-color: tokens.$coral-color-info-border-hover;
 		}
 	}
 
 	&:active {
-		color: tokens.$coral-color-accent-text-active;
+		color: tokens.$coral-color-info-text-active;
 
 		.link__text {
-			border-bottom-color: tokens.$coral-color-accent-border-active;
+			border-bottom-color: tokens.$coral-color-info-border-active;
 		}
 	}
 
@@ -54,11 +54,11 @@ $icon-alignment-offset-s: -0.0625rem;
 		color: tokens.$coral-color-neutral-text;
 
 		&:hover {
-			color: tokens.$coral-color-accent-text-hover;
+			color: tokens.$coral-color-info-text-hover;
 		}
 
 		&:active {
-			color: tokens.$coral-color-accent-text-active;
+			color: tokens.$coral-color-info-text-active;
 		}
 	}
 }


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
fix DS Link token to be info
DS Link was mapped to accent token but it's not compatible with qlik-light theme in some cases and links are grey ( blue on sprout )

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
