### PR TITLE
fix(InlineEdit): handle required property in InlineEdit

### DIFF
--- a/.changeset/spotty-ads-cheer.md
+++ b/.changeset/spotty-ads-cheer.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+InlineEdit should take into account the required property to not submit the input

--- a/packages/design-system/src/components/InlineEditing/InlineEditing.test.tsx
+++ b/packages/design-system/src/components/InlineEditing/InlineEditing.test.tsx
@@ -48,4 +48,35 @@ describe('InlineEditing', () => {
 
 		expect(screen.getByTestId('my-prefix.inlineediting.button.edit')).toBeInTheDocument();
 	});
+
+	it('should not allow to submit required input', async () => {
+		const onEdit = jest.fn();
+		render(
+			<main>
+				<InlineEditing
+					label="Edit the value"
+					placeholder="What is your Lorem Ipsum?"
+					defaultValue=""
+					onEdit={onEdit}
+					required
+				/>
+			</main>,
+		);
+
+		fireEvent.click(screen.getByTestId('inlineediting.button.edit'));
+
+		expect(
+			screen.getByRole('button', {
+				name: /submit/i,
+			}),
+		).toBeDisabled();
+
+		fireEvent.keyDown(
+			screen.getByRole('textbox', {
+				name: /edit the value\*/i,
+			}),
+			'Enter',
+		);
+		expect(onEdit).not.toHaveBeenCalled();
+	});
 });

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -139,6 +139,9 @@ const InlineEditingPrimitive = forwardRef(
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		const getValue = () => (onChangeValue ? value : internalValue);
+		const inputIsValid = () => {
+			return !required || !!getValue();
+		};
 
 		const toggleEditionMode = (isEditionMode: boolean) => {
 			editionModeControl.onChange(isEditionMode);
@@ -155,6 +158,10 @@ const InlineEditingPrimitive = forwardRef(
 
 		const handleSubmit = (event: OnEditEvent) => {
 			event.stopPropagation();
+
+			if (!inputIsValid()) {
+				return;
+			}
 
 			if (onEdit) {
 				onEdit(event, getValue() || '');
@@ -273,6 +280,7 @@ const InlineEditingPrimitive = forwardRef(
 									</ButtonIcon>
 									<ButtonIcon
 										onClick={handleSubmit}
+										disabled={!inputIsValid()}
 										icon="check-filled"
 										data-test={`${dataTest ? `${dataTest}.` : ''}inlineediting.button.submit`}
 										data-testid={`${dataTestId ? `${dataTestId}.` : ''}inlineediting.button.submit`}

--- a/packages/design-system/src/stories/form/InlineEditing.stories.tsx
+++ b/packages/design-system/src/stories/form/InlineEditing.stories.tsx
@@ -84,6 +84,18 @@ export const Default = {
 		/>
 	),
 };
+export const IsRequired = {
+	render: (props: Story) => (
+		<InlineEditing.Text
+			placeholder="Input a crawler name"
+			label="Crawler name"
+			required
+			defaultValue=""
+			onEdit={action('onEdit')}
+			{...props}
+		/>
+	),
+};
 export const WithEllipsis = {
 	render: (props: Story) => (
 		<InlineEditing.Text


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Handle required property in InlineEdit

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [x] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
