### PR TITLE
fix(InlineEdit): edge case when a field is required with blank spaces

### DIFF
--- a/.changeset/ten-paws-love.md
+++ b/.changeset/ten-paws-love.md
@@ -1,0 +1,5 @@
+---
+'@talend/design-system': patch
+---
+
+InlineEdit - Fix been able to submit field when required and having blank spaces

--- a/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
+++ b/packages/design-system/src/components/InlineEditing/Primitives/InlineEditingPrimitive.tsx
@@ -140,7 +140,7 @@ const InlineEditingPrimitive = forwardRef(
 		// eslint-disable-next-line react-hooks/exhaustive-deps
 		const getValue = () => (onChangeValue ? value : internalValue);
 		const inputIsValid = () => {
-			return !required || !!getValue();
+			return !required || !!getValue()?.trim();
 		};
 
 		const toggleEditionMode = (isEditionMode: boolean) => {


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
Fix an edge case when a field is required with blank spaces

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
