### PR TITLE
fix(security): Re-write regexes to fix re-dos threat

### DIFF
--- a/.changeset/wicked-frogs-bathe.md
+++ b/.changeset/wicked-frogs-bathe.md
@@ -1,0 +1,5 @@
+---
+'@talend/react-components': patch
+---
+
+fix(security): Re-write regexes to fix re-dos threat

--- a/packages/components/src/DateTimePickers/DateRange/Picker/__snapshots__/Picker.component.test.js.snap
+++ b/packages/components/src/DateTimePickers/DateRange/Picker/__snapshots__/Picker.component.test.js.snap
@@ -91,15 +91,6 @@ exports[`DateRange.Picker should render 1`] = `
                       tabindex="-1"
                       type="button"
                     >
-                      2021
-                    </button>
-                  </li>
-                  <li>
-                    <button
-                      class="theme-year tc-date-picker-year"
-                      tabindex="-1"
-                      type="button"
-                    >
                       2022
                     </button>
                   </li>
@@ -115,7 +106,7 @@ exports[`DateRange.Picker should render 1`] = `
                   <li>
                     <button
                       class="theme-year tc-date-picker-year"
-                      tabindex="0"
+                      tabindex="-1"
                       type="button"
                     >
                       2024
@@ -124,7 +115,7 @@ exports[`DateRange.Picker should render 1`] = `
                   <li>
                     <button
                       class="theme-year tc-date-picker-year"
-                      tabindex="-1"
+                      tabindex="0"
                       type="button"
                     >
                       2025
@@ -146,6 +137,15 @@ exports[`DateRange.Picker should render 1`] = `
                       type="button"
                     >
                       2027
+                    </button>
+                  </li>
+                  <li>
+                    <button
+                      class="theme-year tc-date-picker-year"
+                      tabindex="-1"
+                      type="button"
+                    >
+                      2028
                     </button>
                   </li>
                 </ol>

--- a/packages/components/src/DateTimePickers/Time/time-extraction.js
+++ b/packages/components/src/DateTimePickers/Time/time-extraction.js
@@ -1,7 +1,7 @@
 import getErrorMessage from '../shared/error-messages';
 
-const timePartRegex = new RegExp(/^(.*):(.*)$/);
-const timeWithSecondsPartRegex = new RegExp(/^(.*):(.*):(.*)$/);
+const timePartRegex = /^(\d{1,2}):(\d{2})$/;
+const timeWithSecondsPartRegex = /^(\d{1,2}):(\d{2}):(\d{2})$/;
 
 function TimePickerException(code, message) {
 	this.message = getErrorMessage(message);

--- a/packages/components/src/DateTimePickers/views/DateView/__snapshots__/DateView.test.js.snap
+++ b/packages/components/src/DateTimePickers/views/DateView/__snapshots__/DateView.test.js.snap
@@ -109,15 +109,6 @@ exports[`DateView should render 1`] = `
                     tabindex="-1"
                     type="button"
                   >
-                    2021
-                  </button>
-                </li>
-                <li>
-                  <button
-                    class="theme-year tc-date-picker-year"
-                    tabindex="-1"
-                    type="button"
-                  >
                     2022
                   </button>
                 </li>
@@ -133,7 +124,7 @@ exports[`DateView should render 1`] = `
                 <li>
                   <button
                     class="theme-year tc-date-picker-year"
-                    tabindex="0"
+                    tabindex="-1"
                     type="button"
                   >
                     2024
@@ -142,7 +133,7 @@ exports[`DateView should render 1`] = `
                 <li>
                   <button
                     class="theme-year tc-date-picker-year"
-                    tabindex="-1"
+                    tabindex="0"
                     type="button"
                   >
                     2025
@@ -164,6 +155,15 @@ exports[`DateView should render 1`] = `
                     type="button"
                   >
                     2027
+                  </button>
+                </li>
+                <li>
+                  <button
+                    class="theme-year tc-date-picker-year"
+                    tabindex="-1"
+                    type="button"
+                  >
+                    2028
                   </button>
                 </li>
               </ol>

--- a/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
+++ b/packages/faceted-search/src/components/Badges/BadgeDate/__snapshots__/BadgeDateForm.component.test.js.snap
@@ -159,15 +159,6 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                           tabindex="-1"
                           type="button"
                         >
-                          2021
-                        </button>
-                      </li>
-                      <li>
-                        <button
-                          class="theme-year tc-date-picker-year"
-                          tabindex="-1"
-                          type="button"
-                        >
                           2022
                         </button>
                       </li>
@@ -183,7 +174,7 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                       <li>
                         <button
                           class="theme-year tc-date-picker-year"
-                          tabindex="0"
+                          tabindex="-1"
                           type="button"
                         >
                           2024
@@ -192,7 +183,7 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                       <li>
                         <button
                           class="theme-year tc-date-picker-year"
-                          tabindex="-1"
+                          tabindex="0"
                           type="button"
                         >
                           2025
@@ -214,6 +205,15 @@ exports[`BadgeDateForm should mount a badge and change date 1`] = `
                           type="button"
                         >
                           2027
+                        </button>
+                      </li>
+                      <li>
+                        <button
+                          class="theme-year tc-date-picker-year"
+                          tabindex="-1"
+                          type="button"
+                        >
+                          2028
                         </button>
                       </li>
                     </ol>


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

Fix https://github.com/Talend/ui/security/code-scanning/2700 by restricting character set and amount of characters in the regexes to parse times

**What is the chosen solution to this problem?**

Copilot was used to change the regexes. I manually tested them in js console.

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
