### PR TITLE
chore(deps): Revert rhf to 7.53.1

### DIFF
--- a/.changeset/pink-groups-flash.md
+++ b/.changeset/pink-groups-flash.md
@@ -1,0 +1,8 @@
+---
+'@talend/design-system': minor
+'@talend/ui-storybook-one': minor
+'@talend/design-docs': minor
+'@talend/react-forms': minor
+---
+
+Revert rhf to 7.53.1

--- a/packages/design-docs/package.json
+++ b/packages/design-docs/package.json
@@ -31,7 +31,7 @@
     "classnames": "^2.5.1",
     "color-contrast-checker": "^2.1.0",
     "figma-js": "^1.16.0",
-    "react-hook-form": "^7.58.1",
+    "react-hook-form": "7.53.1",
     "pkg-dir": "^7.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -108,7 +108,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-helmet": "^6.1.0",
-    "react-hook-form": "^7.58.1",
+    "react-hook-form": "7.53.1",
     "react-i18next": "^13.5.0",
     "react-router-dom": "~6.3.0",
     "storybook-docs-toc": "^1.7.0"

--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -61,7 +61,7 @@
     "memoize-one": "^6.0.0",
     "react-autowhatever": "10.2.0",
     "react-ace": "10.1.0",
-    "react-hook-form": "^7.58.1",
+    "react-hook-form": "7.53.1",
     "react-jsonschema-form": "0.51.0",
     "tv4": "^1.3.0"
   },

--- a/packages/storybook-one/package.json
+++ b/packages/storybook-one/package.json
@@ -30,7 +30,7 @@
     "@talend/react-dataviz": "^7.0.4",
     "lodash": "^4.17.21",
     "pkg-dir": "^7.0.0",
-    "react-hook-form": "^7.58.1"
+    "react-hook-form": "7.53.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16630,10 +16630,10 @@ react-helmet@^6.1.0:
     react-fast-compare "^3.1.1"
     react-side-effect "^2.1.0"
 
-react-hook-form@^7.58.1:
-  version "7.58.1"
-  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.58.1.tgz#b755acc1b42a19e4253c878b766e4c5ebd070fe8"
-  integrity sha512-Lml/KZYEEFfPhUVgE0RdCVpnC4yhW+PndRhbiTtdvSlQTL8IfVR+iQkBjLIvmmc6+GGoVeM11z37ktKFPAb0FA==
+react-hook-form@7.53.1:
+  version "7.53.1"
+  resolved "https://registry.yarnpkg.com/react-hook-form/-/react-hook-form-7.53.1.tgz#3f2cd1ed2b3af99416a4ac674da2d526625add67"
+  integrity sha512-6aiQeBda4zjcuaugWvim9WsGqisoUk+etmFEsSUMm451/Ic8L/UAb7sRtMj3V+Hdzm6mMjU1VhiSzYUZeBm0Vg==
 
 react-i18next@^13.5.0:
   version "13.5.0"


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**

**What is the chosen solution to this problem?**

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
