### PR TITLE
feat(http): add httpDeleteWithPayload

### DIFF
--- a/.changeset/ninety-mice-work.md
+++ b/.changeset/ninety-mice-work.md
@@ -2,4 +2,4 @@
 '@talend/http': minor
 ---
 
-Add function to allow sending HTTP DELETE with request body
+Add `httpDeleteWithPayload` function to allow sending HTTP DELETE with request body

--- a/.changeset/ninety-mice-work.md
+++ b/.changeset/ninety-mice-work.md
@@ -1,0 +1,5 @@
+---
+'@talend/http': minor
+---
+
+Export httpFetch to allow sending payload in DELETE request

--- a/.changeset/ninety-mice-work.md
+++ b/.changeset/ninety-mice-work.md
@@ -2,4 +2,4 @@
 '@talend/http': minor
 ---
 
-Export httpFetch to allow sending payload in DELETE request
+Add function to allow sending HTTP DELETE with request body

--- a/packages/http/src/async.ts
+++ b/packages/http/src/async.ts
@@ -73,6 +73,24 @@ export async function httpDelete<T>(
 }
 
 /**
+ * function - fetch a url with DELETE method and request body
+ *
+ * @param  {string} url     url to request
+ * @param  {object} config  option that you want apply to the request
+ * @param  {object} payload payload to send with the request
+ * @example
+ * import { http } from '@talend/http/async';
+ * await http.delete('/foo'))
+ */
+export async function httpDeleteWithPayload<T>(
+	url: string,
+	payload: any,
+	config?: TalendRequestInit,
+): Promise<TalendHttpResponse<T>> {
+	return httpFetch<T>(url, config, HTTP_METHODS.DELETE, payload);
+}
+
+/**
  * function - fetch a url with GET method
  *
  * @param  {string} url     url to request
@@ -110,6 +128,7 @@ export const http = {
 	patch: httpPatch,
 	put: httpPut,
 	delete: httpDelete,
+	deleteWithPayload: httpDeleteWithPayload,
 	head: httpHead,
 	REQUEST_STATUS,
 };

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,6 +1,5 @@
 // eslint-disable-next-line import/prefer-default-export
 export { http } from './async';
-export { httpFetch } from './http.common';
 
 export * from './http.types';
 export * from './http.constants';

--- a/packages/http/src/index.ts
+++ b/packages/http/src/index.ts
@@ -1,5 +1,6 @@
 // eslint-disable-next-line import/prefer-default-export
 export { http } from './async';
+export { httpFetch } from './http.common';
 
 export * from './http.types';
 export * from './http.constants';


### PR DESCRIPTION
**What is the problem this PR is trying to solve?**
There is DELETE API in IAM which requires application names in request body
According to specification, it may not be perfect to have body in DELETE request, and may not be intended to do this way,
but, this API is used in TMC

It worked before with CMF http, as config was spread when calling interceptors https://github.com/Talend/ui/blob/master/packages/cmf/src/sagas/http.js#L179 , so, it was possible to pass payload in the config, and it would override undefined payload.
Probably this was not intended to pass payload in config and send body in delete request, most probably, it was kind of bug / "back door", but it worked for one API in TMC )

Now, as CMF has been removed from TMC, @talend/http package is used for now, and in @talend/http there is not such kind of "back door" to send body in delete request, so, the TMC part which call that API from IAM fails with error

**What is the chosen solution to this problem?**
For now I see few solutions
1.  Modify current [httpDelete](https://github.com/Talend/ui/blob/master/packages/cmf/src/sagas/http.js#L179) function, so, it will accept payload as argument
2. Implement separate function, something like "httpDeleteWithPayload", to not modify existing function and impact existing code
3. Use fetch API directly for that one DELETE request in TMC
4. Export "httpFetch" function, to allow specific implementation for httpDelete, which will be done in TMC

(maybe in future the DELETE API in IAM will be refactored, to accept application names as GET parameters instead of request body, in this case we will not need to send the body)

**Please check if the PR fulfills these requirements**

- [x] The PR have used `yarn changeset` to a request a release from the CI if wanted.
- [x] The PR commit message follows our [guidelines](https://github.com/talend/tools/blob/master/tools-root-github/CONTRIBUTING.md)
- [ ] Tests for the changes have been added (for bug fixes / features) And [non reg](./screenshots.md) done before need review
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] Related design / discussions / pages (not in jira), if any, are all linked or available in the PR

<!-- You can add more checkboxes here -->

**[ ] This PR introduces a breaking change**

<!-- if the PR introduces a breaking change, add the description here. So when you merge this PR, add this description into the [breaking change wiki](https://github.com/Talend/ui/wiki/BREAKING-CHANGE) in the next version -->

<!-- **Original Template** -->

<!-- https://github.com/Talend/tools/blob/master/tools-root-github/.github/PULL_REQUEST_TEMPLATE.md -->
