### PR TITLE
fix(CI): pass NPM_TOKEN through to setup-node composite action

### DIFF
--- a/.github/actions/setup-node/action.yml
+++ b/.github/actions/setup-node/action.yml
@@ -25,8 +25,8 @@ runs:
       shell: bash
       run: |
         echo "//npm.pkg.github.com/:always-auth=true" >> ~/.npmrc
-        if [ -n "${{ inputs.NODE_AUTH_TOKEN }}" ]; then
-          echo "//npm.pkg.github.com/:_authToken=${{ inputs.NODE_AUTH_TOKEN }}" >> ~/.npmrc
+        if [ -n "${{ inputs.NPM_TOKEN }}" ]; then
+          echo "//npm.pkg.github.com/:_authToken=${{ inputs.NPM_TOKEN }}" >> ~/.npmrc
         fi
 
     - name: Install yarn

--- a/.github/workflows/changeset.yml
+++ b/.github/workflows/changeset.yml
@@ -31,6 +31,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: has changeset file
         id: changesetfiles

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -28,6 +28,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         working-directory: ./

--- a/.github/workflows/dependencies.yml
+++ b/.github/workflows/dependencies.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Upgrade dependencies
         run: |

--- a/.github/workflows/icons.yml
+++ b/.github/workflows/icons.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Download icons
         run: npx @talend/figma-icons-downloader

--- a/.github/workflows/pr-demo.yml
+++ b/.github/workflows/pr-demo.yml
@@ -25,6 +25,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         working-directory: ./

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         run: yarn install --frozen-lockfile --ignore-scripts

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -26,6 +26,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -24,6 +24,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/.github/workflows/visual-testing.yml
+++ b/.github/workflows/visual-testing.yml
@@ -34,6 +34,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/yarn-deduplicate.yml
+++ b/.github/workflows/yarn-deduplicate.yml
@@ -30,6 +30,8 @@ jobs:
 
       - name: Use Node.js
         uses: ./.github/actions/setup-node
+        with:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: yarn-deduplicate
         id: deduplicate

--- a/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserFooter/ColumnChooserFooter.component.jsx
+++ b/packages/components/src/List/Toolbar/ColumnChooserButton/ColumnChooser/ColumnChooserFooter/ColumnChooserFooter.component.jsx
@@ -23,7 +23,7 @@ const SubmitButton = () => {
 const ColumnChooserFooter = ({ children = <SubmitButton />, className }) => (
 	<RichLayout.Footer
 		id="column-chooser-footer"
-		className={(className, theme('tc-column-chooser-footer'))}
+		className={theme(className, 'tc-column-chooser-footer')}
 	>
 		{children}
 	</RichLayout.Footer>


### PR DESCRIPTION
## Summary
- `setup-node/action.yml` declared input `NPM_TOKEN` but its "Setup npm registry" step read `inputs.NODE_AUTH_TOKEN` (typo/rename mismatch), and every calling workflow used `uses: ./.github/actions/setup-node` with no `with:` block at all.
- Net effect: `~/.npmrc` never got an `_authToken` line for `npm.pkg.github.com`, so `yarn install` fails with `401 Unauthorized` fetching scoped `@talend/*` packages — root cause of current CI install failures.
- Fix: action now reads `inputs.NPM_TOKEN`, and all 10 workflows calling it now pass `with: NPM_TOKEN: ${{ secrets.NPM_TOKEN }}`.

Note: separately, Dependabot-triggered PRs won't see this secret unless `NPM_TOKEN` is also added under **Settings → Secrets and variables → Dependabot** (Dependabot runs can't read environment or plain Actions secrets). Not addressed in this PR — tracked as follow-up.

## Test plan
- [ ] Push triggers `PR lint` / `PR tests` / `PR Demo CI` on this PR (non-Dependabot) — confirm `yarn install` step succeeds instead of `401 Unauthorized`.