### PR TITLE
fix(upgrade-deps): mock npm/yarn network calls in cli tests

### DIFF
--- a/tools/upgrade-deps/tests/cli.test.cjs
+++ b/tools/upgrade-deps/tests/cli.test.cjs
@@ -4,6 +4,7 @@ const { spawnSync } = require('child_process');
 const { readFileSync } = require('fs');
 const { rimrafSync } = require('rimraf');
 const {
+	mockEnv,
 	getLockContent,
 	getTmpDirectory,
 	isMinorGt,
@@ -33,7 +34,7 @@ describe.each(['package-lock.json', 'yarn.lock'])('talend-upgrade-deps %s', lock
 
 	it('should by default only do safe upgrade', async () => {
 		const tmp = await getTmpDirectory('basic-default', fixturePath, lock);
-		const output = spawnSync('node', [bin, '-v', '--ignore-scripts'], { cwd: tmp });
+		const output = spawnSync('node', [bin, '-v', '--ignore-scripts'], { cwd: tmp, env: mockEnv });
 		const tmpLock = getLockContent(tmp, lock);
 		expect(output.error).toBeUndefined();
 		const err = output.stderr.toString();
@@ -57,7 +58,7 @@ describe.each(['package-lock.json', 'yarn.lock'])('talend-upgrade-deps %s', lock
 
 	it('should support a --dry option where files are not updated', async () => {
 		const tmp = await getTmpDirectory('basic-dry', fixturePath, lock);
-		const output = spawnSync('node', [bin, '--dry'], { cwd: tmp });
+		const output = spawnSync('node', [bin, '--dry'], { cwd: tmp, env: mockEnv });
 		const tmpLock = getLockContent(tmp, lock);
 		// the logs should show the need to update chokidar
 		const logs = output.stdout.toString();
@@ -75,7 +76,7 @@ describe.each(['package-lock.json', 'yarn.lock'])('talend-upgrade-deps %s', lock
 
 	it('should support a --latest option', async () => {
 		const tmp = await getTmpDirectory('basic-latest', fixturePath, lock);
-		const output = spawnSync('node', [bin, '--latest'], { cwd: tmp });
+		const output = spawnSync('node', [bin, '--latest'], { cwd: tmp, env: mockEnv });
 		const err = output.stderr.toString();
 		if (err) {
 			console.error(err);
@@ -100,7 +101,7 @@ describe.each(['package-lock.json', 'yarn.lock'])('talend-upgrade-deps %s', lock
 
 	it('should support a --scope option', async () => {
 		const tmp = await getTmpDirectory('basic-scope', fixturePath, lock);
-		const output = spawnSync('node', [bin, '--scope=@talend'], { cwd: tmp });
+		const output = spawnSync('node', [bin, '--scope=@talend'], { cwd: tmp, env: mockEnv });
 		const err = output.stderr.toString();
 		if (err) {
 			console.error(err);
@@ -123,7 +124,7 @@ describe.each(['package-lock.json', 'yarn.lock'])('talend-upgrade-deps %s', lock
 
 	it('should support a --starts-with option', async () => {
 		const tmp = await getTmpDirectory('basic-startsWith', fixturePath, lock);
-		const output = spawnSync('node', [bin, '--starts-with=@talend/scripts'], { cwd: tmp });
+		const output = spawnSync('node', [bin, '--starts-with=@talend/scripts'], { cwd: tmp, env: mockEnv });
 		const err = output.stderr.toString();
 		if (err) {
 			console.error(err);

--- a/tools/upgrade-deps/tests/fixture/mock-bin/npm
+++ b/tools/upgrade-deps/tests/fixture/mock-bin/npm
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/* eslint-disable */
+// Fake npm used by tests/cli.test.cjs so no real registry call happens.
+// Only implements the subset of `npm` sub-commands talend-upgrade-deps relies on.
+const fs = require('fs');
+const path = require('path');
+const semver = require('semver');
+
+const CWD = process.cwd();
+const args = process.argv.slice(2);
+
+// `npm view <pkg> version latest` ignores the requested range, so it can't be derived
+// generically - fake it as a major bump for the packages the tests actually check.
+const LATEST = { react: '18.3.1', 'react-dom': '18.3.1', chokidar: '3.6.0' };
+
+function splitNameRange(spec) {
+	const idx = spec.startsWith('@') ? spec.indexOf('@', 1) : spec.indexOf('@');
+	if (idx === -1) return { name: spec, range: null };
+	return { name: spec.slice(0, idx), range: spec.slice(idx + 1) };
+}
+
+// Simulates `npm view <pkg>@"<range>" version --json`: an exact pin can only echo itself
+// back (that's what querying the registry for that exact version does), while a real
+// range (^, ~) resolves to the highest currently-published version still satisfying it.
+function resolveSafeUpdate(range) {
+	if (!range) return null;
+	if (/^\d/.test(range)) return range;
+	const base = semver.minVersion(range);
+	if (!base) return null;
+	return semver.inc(base.version, 'minor');
+}
+
+function stripRange(range) {
+	return range.replace(/^[\^~]/, '');
+}
+
+function syncPackageLock() {
+	const pkgPath = path.join(CWD, 'package.json');
+	const lockPath = path.join(CWD, 'package-lock.json');
+	if (!fs.existsSync(pkgPath) || !fs.existsSync(lockPath)) return;
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+	const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+	const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+	Object.entries(allDeps).forEach(([name, range]) => {
+		const version = stripRange(range);
+		if (lock.packages && lock.packages[`node_modules/${name}`]) {
+			lock.packages[`node_modules/${name}`].version = version;
+		}
+		if (lock.dependencies && lock.dependencies[name]) {
+			lock.dependencies[name].version = version;
+		}
+	});
+	fs.writeFileSync(lockPath, JSON.stringify(lock, null, 2));
+}
+
+function npmLsJson() {
+	const pkg = JSON.parse(fs.readFileSync(path.join(CWD, 'package.json'), 'utf8'));
+	const dependencies = {};
+	const packagesDir = path.join(CWD, 'packages');
+	if (pkg.workspaces && fs.existsSync(packagesDir)) {
+		fs.readdirSync(packagesDir).forEach(dir => {
+			const subPkgPath = path.join(packagesDir, dir, 'package.json');
+			if (fs.existsSync(subPkgPath)) {
+				const subPkg = JSON.parse(fs.readFileSync(subPkgPath, 'utf8'));
+				dependencies[subPkg.name] = { resolved: `file:packages/${dir}`, version: '1.0.0' };
+			}
+		});
+	}
+	process.stdout.write(JSON.stringify({ dependencies }));
+}
+
+if (args[0] === 'view') {
+	const { name, range } = splitNameRange(args[1]);
+	if (args[args.length - 1] === 'latest') {
+		process.stdout.write(`${LATEST[name] || '1.0.0'}\n`);
+	} else {
+		process.stdout.write(`${JSON.stringify(resolveSafeUpdate(range))}\n`);
+	}
+	process.exit(0);
+}
+
+if (args[0] === 'dist-tag') {
+	const name = args[args.length - 1];
+	process.stdout.write(`next: ${LATEST[name] || '1.0.0'}\n`);
+	process.exit(0);
+}
+
+if (args[0] === 'ls') {
+	npmLsJson();
+	process.exit(0);
+}
+
+if (args[0] === 'install' || args[0] === 'i' || args[0] === 'update') {
+	syncPackageLock();
+	process.exit(0);
+}
+
+process.exit(0);

--- a/tools/upgrade-deps/tests/fixture/mock-bin/package.json
+++ b/tools/upgrade-deps/tests/fixture/mock-bin/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mock-bin",
+  "private": true,
+  "type": "commonjs"
+}

--- a/tools/upgrade-deps/tests/fixture/mock-bin/yarn
+++ b/tools/upgrade-deps/tests/fixture/mock-bin/yarn
@@ -1,0 +1,66 @@
+#!/usr/bin/env node
+/* eslint-disable */
+// Fake yarn used by tests/cli.test.cjs so no real registry call happens.
+// Only implements the subset of `yarn` sub-commands talend-upgrade-deps relies on.
+const fs = require('fs');
+const path = require('path');
+const yarnpkg = require('@yarnpkg/lockfile');
+
+const CWD = process.cwd();
+const args = process.argv.slice(2);
+
+function stripRange(range) {
+	return range.replace(/^[\^~]/, '');
+}
+
+function workspacesInfo() {
+	const pkg = JSON.parse(fs.readFileSync(path.join(CWD, 'package.json'), 'utf8'));
+	const info = {};
+	const packagesDir = path.join(CWD, 'packages');
+	if (pkg.workspaces && fs.existsSync(packagesDir)) {
+		fs.readdirSync(packagesDir).forEach(dir => {
+			const subPkgPath = path.join(packagesDir, dir, 'package.json');
+			if (fs.existsSync(subPkgPath)) {
+				const subPkg = JSON.parse(fs.readFileSync(subPkgPath, 'utf8'));
+				info[subPkg.name] = {
+					location: `packages/${dir}`,
+					workspaceDependencies: [],
+					mismatchedWorkspaceDependencies: [],
+				};
+			}
+		});
+	}
+	process.stdout.write(JSON.stringify(info));
+}
+
+function syncYarnLock() {
+	const pkgPath = path.join(CWD, 'package.json');
+	const lockPath = path.join(CWD, 'yarn.lock');
+	if (!fs.existsSync(pkgPath) || !fs.existsSync(lockPath)) return;
+	const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+	const allDeps = { ...pkg.dependencies, ...pkg.devDependencies };
+	const parsed = yarnpkg.parse(fs.readFileSync(lockPath, 'utf8'));
+	const obj = parsed.object;
+	Object.entries(allDeps).forEach(([name, range]) => {
+		const version = stripRange(range);
+		Object.keys(obj).forEach(key => {
+			const isMatch = key.split(',').some(part => part.trim().startsWith(`${name}@`));
+			if (isMatch) {
+				obj[key].version = version;
+			}
+		});
+	});
+	fs.writeFileSync(lockPath, yarnpkg.stringify(obj));
+}
+
+if (args.includes('workspaces') && args.includes('info')) {
+	workspacesInfo();
+	process.exit(0);
+}
+
+if (args[0] === 'install' || args[0] === 'upgrade') {
+	syncYarnLock();
+	process.exit(0);
+}
+
+process.exit(0);

--- a/tools/upgrade-deps/tests/utils.cjs
+++ b/tools/upgrade-deps/tests/utils.cjs
@@ -14,6 +14,9 @@ const execProm = util.promisify(exec);
 const cpxProm = util.promisify(cpx.copy);
 const removeProm = target => rimraf(target);
 
+const mockBinPath = path.join(__dirname, 'fixture', 'mock-bin');
+const mockEnv = { ...process.env, PATH: `${mockBinPath}${path.delimiter}${process.env.PATH}` };
+
 async function getTmpDirectory(prefix, fixturePath, lock = 'yarn.lock') {
 	const uniqueSuffix = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 	const tmp = path.join(__dirname, `tmp-${prefix}-${lock}-${uniqueSuffix}`);
@@ -27,7 +30,7 @@ async function getTmpDirectory(prefix, fixturePath, lock = 'yarn.lock') {
 			path.join(tmp, 'package-lock.json'),
 		);
 		await removeProm(path.join(tmp, 'yarn-template.lock'));
-		await execProm('npm i', { cwd: tmp });
+		await execProm('npm i', { cwd: tmp, env: mockEnv });
 	}
 	return tmp;
 }
@@ -101,6 +104,7 @@ function isMajorLockGT(pkg, locka, lockb) {
 }
 
 module.exports = {
+	mockEnv,
 	getLockContent,
 	getTmpDirectory,
 	getVersionFromRequirement,


### PR DESCRIPTION
## Summary
- `@talend/upgrade-deps`'s `vitest:cov` script was timing out in CI. `tests/cli.test.cjs` spawns the real CLI, which shells out to real `npm view`/`npm dist-tag ls`/`npm i`/`npm install`/`npm update`/`yarn install`/`yarn upgrade`/`yarn workspaces info` — all real registry/network calls with no timeouts, which hang in CI's restricted network.
- Added fake `npm`/`yarn` binaries (`tests/fixture/mock-bin/`) put first on `PATH` for every spawned process. They answer version-check queries (`view`, `dist-tag`) using the actual requested semver range (exact pins echo back, ranges resolve to a computed "next minor"; `latest` uses a small canned major-bump map for the fixture's react/react-dom/chokidar deps), answer `npm ls --json` / `yarn workspaces info --json` from the on-disk `packages/*` layout, and make `install`/`update`/`upgrade` sync the lock file's top-level versions from the already-updated `package.json` instead of doing a real install.
- No behavior change to the shipped CLI (`src/`, `bin/`) — only the test harness.

## Test plan
- [x] `yarn vitest:cov` in `tools/upgrade-deps` — 13 passed, 2 skipped, 100% coverage, ~50s, no network calls
- [x] Manually ran the CLI against both `package-lock.json` and `yarn.lock` fixtures with mock `PATH` to confirm safe-upgrade, `--dry`, `--latest`, `--scope`, `--starts-with` all behave as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)